### PR TITLE
fix(epp/preciseprefixcache): reject estimate-backed token-producer

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -791,6 +791,13 @@ func (r *Runner) parseConfigurationPhaseTwo(ctx context.Context, rawConfig *conf
 		return nil, fmt.Errorf("failed to create missing data producers - %w", err)
 	}
 
+	// Runs after auto-defaults so an absent token-producer (now materialized as
+	// the estimate backend) is caught; the check is independent of factory
+	// instantiation order. See #1471.
+	if err := preciseproducer.ValidateTokenProducer(handle); err != nil {
+		return nil, fmt.Errorf("invalid configuration - %w", err)
+	}
+
 	// Add requestControl plugins
 	r.requestControlConfig.AddPlugins(handle.GetAllPlugins()...)
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -143,6 +143,9 @@ func PluginFactory(name string, rawParameters *json.Decoder, handle plugin.Handl
 	if parameters.IndexerConfig.TokenizersPoolConfig != nil {
 		return nil, errors.New("tokenizersPoolConfig is not supported; configure a token-producer plugin instead")
 	}
+	if err := requireRealTokenProducer(handle); err != nil {
+		return nil, err
+	}
 
 	p, err := New(handle.Context(), name, parameters)
 	if err != nil {
@@ -150,6 +153,35 @@ func PluginFactory(name string, rawParameters *json.Decoder, handle plugin.Handl
 	}
 
 	return p, nil
+}
+
+// requireRealTokenProducer verifies that an engine-aligned token-producer
+// (vllm/uds backend) is already loaded in handle when this factory runs. The
+// estimate backend emits byte-packed pseudo-tokens, which would silently
+// corrupt the KV-block hashes this producer feeds to the indexer. The
+// framework's auto-default for the TokenizedPrompt data key fires *after*
+// explicit factories, so absence of any token-producer here also means an
+// estimate-backed one is about to be auto-created. Both cases fail with the
+// same actionable message; the token-producer must come earlier in the YAML
+// than the precise-prefix-cache-producer. See #1471.
+func requireRealTokenProducer(handle plugin.Handle) error {
+	for _, p := range handle.GetAllPlugins() {
+		typeName := p.TypedName().Type
+		//nolint:staticcheck // SA1019: intentionally accept the deprecated 'tokenizer' alias so existing configs keep working.
+		if typeName != tokenproducer.PluginType && typeName != tokenproducer.LegacyPluginType {
+			continue
+		}
+		tp, ok := p.(*tokenproducer.Plugin)
+		if !ok {
+			continue
+		}
+		if tp.BackendKind() == tokenproducer.KindRender {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"%s requires an engine-aligned token-producer (vllm or udsTokenizerConfig backend) "+
+			"configured earlier in the plugins list", PluginType)
 }
 
 // New constructs a precise-prefix-cache-producer. The instance name becomes

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -143,9 +143,6 @@ func PluginFactory(name string, rawParameters *json.Decoder, handle plugin.Handl
 	if parameters.IndexerConfig.TokenizersPoolConfig != nil {
 		return nil, errors.New("tokenizersPoolConfig is not supported; configure a token-producer plugin instead")
 	}
-	if err := requireRealTokenProducer(handle); err != nil {
-		return nil, err
-	}
 
 	p, err := New(handle.Context(), name, parameters)
 	if err != nil {
@@ -155,16 +152,30 @@ func PluginFactory(name string, rawParameters *json.Decoder, handle plugin.Handl
 	return p, nil
 }
 
-// requireRealTokenProducer verifies that an engine-aligned token-producer
-// (vllm/uds backend) is already loaded in handle when this factory runs. The
-// estimate backend emits byte-packed pseudo-tokens, which would silently
-// corrupt the KV-block hashes this producer feeds to the indexer. The
-// framework's auto-default for the TokenizedPrompt data key fires *after*
-// explicit factories, so absence of any token-producer here also means an
-// estimate-backed one is about to be auto-created. Both cases fail with the
-// same actionable message; the token-producer must come earlier in the YAML
-// than the precise-prefix-cache-producer. See #1471.
-func requireRealTokenProducer(handle plugin.Handle) error {
+// ValidateTokenProducer verifies that when a precise-prefix-cache-producer is
+// configured, an engine-aligned token-producer (vllm/uds backend) is present in
+// the handle. The estimate backend emits byte-packed pseudo-tokens, which would
+// silently corrupt the KV-block hashes this producer feeds to the indexer.
+//
+// This runs at the runner level after CreateMissingDataProducers, not inside the
+// factory: factory instantiation order is decided by the plugin DAG's
+// topological sort (which seeds from a map and so varies per process start), not
+// by the plugins-list order, so a factory-time check cannot rely on the
+// token-producer being constructed first. By the time this runs, every plugin --
+// explicit and auto-defaulted (an absent token-producer is auto-created as the
+// estimate backend) -- is in the handle, so the check is order-independent. See #1471.
+func ValidateTokenProducer(handle plugin.Handle) error {
+	hasPrecise := false
+	for _, p := range handle.GetAllPlugins() {
+		if p.TypedName().Type == PluginType {
+			hasPrecise = true
+			break
+		}
+	}
+	if !hasPrecise {
+		return nil
+	}
+
 	for _, p := range handle.GetAllPlugins() {
 		typeName := p.TypedName().Type
 		//nolint:staticcheck // SA1019: intentionally accept the deprecated 'tokenizer' alias so existing configs keep working.
@@ -180,8 +191,8 @@ func requireRealTokenProducer(handle plugin.Handle) error {
 		}
 	}
 	return fmt.Errorf(
-		"%s requires an engine-aligned token-producer (vllm or udsTokenizerConfig backend) "+
-			"configured earlier in the plugins list", PluginType)
+		"%s requires an engine-aligned token-producer (vllm or udsTokenizerConfig backend); "+
+			"configure a token-producer plugin with a vllm or udsTokenizerConfig backend", PluginType)
 }
 
 // New constructs a precise-prefix-cache-producer. The instance name becomes

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -36,6 +36,7 @@ import (
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/test/utils"
 )
 
@@ -660,6 +661,38 @@ func TestPluginFactory_RejectsTokenizersPoolConfig(t *testing.T) {
 	_, err := PluginFactory("test", plugin.StrictDecoder(raw), handle)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "tokenizersPoolConfig is not supported")
+}
+
+// TestPluginFactory_RejectsMissingRealTokenProducer is a regression test for
+// #1471: the precise-prefix-cache producer hashes engine-aligned token IDs into
+// KV-block keys that must match the model server's prefix cache. The
+// token-producer's estimate backend emits non-engine pseudo-tokens, so a
+// precise-prefix-cache config that ends up resolving its TokenizedPrompt via
+// the estimate backend would silently corrupt lookups. The factory must fail
+// loudly at startup when no real (vllm/uds) token-producer is loaded in
+// `handle` at the time of construction. The framework auto-default for the
+// estimate backend runs *after* explicit factories, so absence of any
+// token-producer here is also a failure case.
+func TestPluginFactory_RejectsMissingRealTokenProducer(t *testing.T) {
+	t.Run("no token-producer at all", func(t *testing.T) {
+		handle := plugin.NewEppHandle(utils.NewTestContext(t), nil)
+		_, err := PluginFactory("test", nil, handle)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "token-producer")
+	})
+
+	t.Run("estimate-backed token-producer", func(t *testing.T) {
+		handle := plugin.NewEppHandle(utils.NewTestContext(t), nil)
+		// Estimate backend: empty config selects the zero-config default.
+		raw := json.RawMessage(`{}`)
+		tp, err := tokenproducer.PluginFactory("token-producer", plugin.StrictDecoder(raw), handle)
+		require.NoError(t, err)
+		handle.AddPlugin("token-producer", tp)
+
+		_, err = PluginFactory("test", nil, handle)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "token-producer")
+	})
 }
 
 // Key built from string literals so an upstream rename trips the test.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -663,33 +663,54 @@ func TestPluginFactory_RejectsTokenizersPoolConfig(t *testing.T) {
 	require.Contains(t, err.Error(), "tokenizersPoolConfig is not supported")
 }
 
-// TestPluginFactory_RejectsMissingRealTokenProducer is a regression test for
-// #1471: the precise-prefix-cache producer hashes engine-aligned token IDs into
-// KV-block keys that must match the model server's prefix cache. The
-// token-producer's estimate backend emits non-engine pseudo-tokens, so a
-// precise-prefix-cache config that ends up resolving its TokenizedPrompt via
-// the estimate backend would silently corrupt lookups. The factory must fail
-// loudly at startup when no real (vllm/uds) token-producer is loaded in
-// `handle` at the time of construction. The framework auto-default for the
-// estimate backend runs *after* explicit factories, so absence of any
-// token-producer here is also a failure case.
-func TestPluginFactory_RejectsMissingRealTokenProducer(t *testing.T) {
-	t.Run("no token-producer at all", func(t *testing.T) {
-		handle := plugin.NewEppHandle(utils.NewTestContext(t), nil)
-		_, err := PluginFactory("test", nil, handle)
+// TestValidateTokenProducer is the regression test for #1471: the
+// precise-prefix-cache producer hashes engine-aligned token IDs into KV-block
+// keys that must match the model server's prefix cache. The token-producer's
+// estimate backend emits non-engine pseudo-tokens, so a precise config that
+// resolves its TokenizedPrompt via the estimate backend would silently corrupt
+// lookups. ValidateTokenProducer runs at the runner level after auto-defaults,
+// so it is independent of factory instantiation order (which is DAG/map-driven).
+func TestValidateTokenProducer(t *testing.T) {
+	newHandle := func(t *testing.T) plugin.Handle {
+		return plugin.NewEppHandle(utils.NewTestContext(t), nil)
+	}
+	addPrecise := func(t *testing.T, handle plugin.Handle) {
+		p, err := PluginFactory("precise", nil, handle)
+		require.NoError(t, err)
+		handle.AddPlugin(p.TypedName().Name, p)
+	}
+	addTokenProducer := func(t *testing.T, handle plugin.Handle, raw string) {
+		tp, err := tokenproducer.PluginFactory("token-producer", plugin.StrictDecoder(json.RawMessage(raw)), handle)
+		require.NoError(t, err)
+		handle.AddPlugin("token-producer", tp)
+	}
+
+	t.Run("no precise producer: nothing to validate", func(t *testing.T) {
+		handle := newHandle(t)
+		require.NoError(t, ValidateTokenProducer(handle))
+	})
+
+	t.Run("precise with render-backed token-producer: ok", func(t *testing.T) {
+		handle := newHandle(t)
+		addTokenProducer(t, handle, `{"modelName":"test-model"}`)
+		addPrecise(t, handle)
+		require.NoError(t, ValidateTokenProducer(handle))
+	})
+
+	t.Run("precise with estimate-backed token-producer: rejected", func(t *testing.T) {
+		handle := newHandle(t)
+		// Empty config selects the zero-config estimate default.
+		addTokenProducer(t, handle, `{}`)
+		addPrecise(t, handle)
+		err := ValidateTokenProducer(handle)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "token-producer")
 	})
 
-	t.Run("estimate-backed token-producer", func(t *testing.T) {
-		handle := plugin.NewEppHandle(utils.NewTestContext(t), nil)
-		// Estimate backend: empty config selects the zero-config default.
-		raw := json.RawMessage(`{}`)
-		tp, err := tokenproducer.PluginFactory("token-producer", plugin.StrictDecoder(raw), handle)
-		require.NoError(t, err)
-		handle.AddPlugin("token-producer", tp)
-
-		_, err = PluginFactory("test", nil, handle)
+	t.Run("precise with no token-producer at all: rejected", func(t *testing.T) {
+		handle := newHandle(t)
+		addPrecise(t, handle)
+		err := ValidateTokenProducer(handle)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "token-producer")
 	})

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -319,6 +319,35 @@ func (p *Plugin) TypedName() plugin.TypedName {
 	return p.typedName
 }
 
+// Kind names a token-producer backend internally so consumers can whitelist
+// the backends they accept. The names are stable code identifiers, not
+// user-settable config strings.
+type Kind string
+
+const (
+	// KindRender is the engine-aligned tokenizer backend (vllm /render and the
+	// deprecated UDS gRPC both render real token IDs).
+	KindRender Kind = "render"
+	// KindEstimate is the byte-packing pseudo-token backend used when no real
+	// tokenizer is configured.
+	KindEstimate Kind = "estimate"
+)
+
+// BackendKind reports which backend drives this plugin. Downstream consumers
+// that need engine-aligned token IDs (e.g. precise-prefix-cache, whose
+// KV-block hashes must match the model server) check the kind at startup
+// against an explicit whitelist.
+func (p *Plugin) BackendKind() Kind {
+	switch p.backend.(type) {
+	case renderBackend:
+		return KindRender
+	case estimateBackend:
+		return KindEstimate
+	default:
+		return ""
+	}
+}
+
 // Produces returns the data keys this plugin produces.
 func (p *Plugin) Produces() map[plugin.DataKey]any {
 	return map[plugin.DataKey]any{p.dk: fwkrh.TokenizedPrompt{}}

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	preciseproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache"
-	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/test/utils"
 )
 
@@ -97,18 +96,6 @@ func TestAnyMMHit(t *testing.T) {
 	}
 }
 
-// installRealTokenProducer pre-registers a vllm-backed token-producer in the
-// handle so preciseproducer.PluginFactory's startup-time check for an
-// engine-aligned tokenizer (#1471) is satisfied. Tests that exercise the
-// producer factory in isolation must call this first.
-func installRealTokenProducer(t *testing.T, handle fwkplugin.Handle) {
-	t.Helper()
-	raw := json.RawMessage(`{"modelName":"test-model"}`)
-	tp, err := tokenproducer.PluginFactory(tokenproducer.PluginType, fwkplugin.StrictDecoder(raw), handle)
-	require.NoError(t, err)
-	handle.AddPlugin(tp.TypedName().Name, tp)
-}
-
 // In self-host mode the plugin satisfies Scorer, DataProducer, PreRequest,
 // and EndpointExtractor.
 func TestPluginFactory_SelfHostInterfaces(t *testing.T) {
@@ -154,8 +141,6 @@ func TestPluginFactory_DefersToExistingProducer(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	handle := fwkplugin.NewEppHandle(ctx, nil,
 		fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
-	installRealTokenProducer(t, handle)
-
 	existing, err := preciseproducer.PluginFactory("my-precise", nil, handle)
 	require.NoError(t, err)
 	handle.AddPlugin(existing.TypedName().Name, existing)
@@ -175,8 +160,6 @@ func TestPluginFactory_RejectsMultipleExistingProducers(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	handle := fwkplugin.NewEppHandle(ctx, nil,
 		fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
-	installRealTokenProducer(t, handle)
-
 	first, err := preciseproducer.PluginFactory("first", nil, handle)
 	require.NoError(t, err)
 	handle.AddPlugin(first.TypedName().Name, first)
@@ -213,8 +196,6 @@ func TestLegacyProducer_ConsumesDropsTokenizedPromptWhenPoolSet(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	handle := fwkplugin.NewEppHandle(ctx, nil,
 		fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
-	installRealTokenProducer(t, handle)
-
 	inner, err := preciseproducer.PluginFactory("inner", nil, handle)
 	require.NoError(t, err)
 
@@ -235,8 +216,6 @@ func TestLegacyProducer_TokenizesCompletionPromptViaPool(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	handle := fwkplugin.NewEppHandle(ctx, nil,
 		fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
-	installRealTokenProducer(t, handle)
-
 	inner, err := preciseproducer.PluginFactory("inner", nil, handle)
 	require.NoError(t, err)
 
@@ -277,8 +256,6 @@ func TestLegacyProducer_TokensFlowToEndpointAttribute(t *testing.T) {
 		fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
 
 	// Small block size for a predictable totalBlocks: 16 tokens / 4 = 4 blocks.
-	installRealTokenProducer(t, handle)
-
 	const blockSize = 4
 	rawCfg := json.RawMessage(`{"tokenProcessorConfig":{"blockSize":4}}`)
 	inner, err := preciseproducer.PluginFactory("inner", fwkplugin.StrictDecoder(rawCfg), handle)
@@ -321,8 +298,6 @@ func TestLegacyProducer_KeepsExistingTokenizedPrompt(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	handle := fwkplugin.NewEppHandle(ctx, nil,
 		fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
-	installRealTokenProducer(t, handle)
-
 	inner, err := preciseproducer.PluginFactory("inner", nil, handle)
 	require.NoError(t, err)
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	preciseproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/test/utils"
 )
 
@@ -96,6 +97,18 @@ func TestAnyMMHit(t *testing.T) {
 	}
 }
 
+// installRealTokenProducer pre-registers a vllm-backed token-producer in the
+// handle so preciseproducer.PluginFactory's startup-time check for an
+// engine-aligned tokenizer (#1471) is satisfied. Tests that exercise the
+// producer factory in isolation must call this first.
+func installRealTokenProducer(t *testing.T, handle fwkplugin.Handle) {
+	t.Helper()
+	raw := json.RawMessage(`{"modelName":"test-model"}`)
+	tp, err := tokenproducer.PluginFactory(tokenproducer.PluginType, fwkplugin.StrictDecoder(raw), handle)
+	require.NoError(t, err)
+	handle.AddPlugin(tp.TypedName().Name, tp)
+}
+
 // In self-host mode the plugin satisfies Scorer, DataProducer, PreRequest,
 // and EndpointExtractor.
 func TestPluginFactory_SelfHostInterfaces(t *testing.T) {
@@ -141,6 +154,7 @@ func TestPluginFactory_DefersToExistingProducer(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	handle := fwkplugin.NewEppHandle(ctx, nil,
 		fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
+	installRealTokenProducer(t, handle)
 
 	existing, err := preciseproducer.PluginFactory("my-precise", nil, handle)
 	require.NoError(t, err)
@@ -161,6 +175,7 @@ func TestPluginFactory_RejectsMultipleExistingProducers(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	handle := fwkplugin.NewEppHandle(ctx, nil,
 		fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
+	installRealTokenProducer(t, handle)
 
 	first, err := preciseproducer.PluginFactory("first", nil, handle)
 	require.NoError(t, err)
@@ -198,6 +213,7 @@ func TestLegacyProducer_ConsumesDropsTokenizedPromptWhenPoolSet(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	handle := fwkplugin.NewEppHandle(ctx, nil,
 		fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
+	installRealTokenProducer(t, handle)
 
 	inner, err := preciseproducer.PluginFactory("inner", nil, handle)
 	require.NoError(t, err)
@@ -219,6 +235,7 @@ func TestLegacyProducer_TokenizesCompletionPromptViaPool(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	handle := fwkplugin.NewEppHandle(ctx, nil,
 		fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
+	installRealTokenProducer(t, handle)
 
 	inner, err := preciseproducer.PluginFactory("inner", nil, handle)
 	require.NoError(t, err)
@@ -260,6 +277,8 @@ func TestLegacyProducer_TokensFlowToEndpointAttribute(t *testing.T) {
 		fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
 
 	// Small block size for a predictable totalBlocks: 16 tokens / 4 = 4 blocks.
+	installRealTokenProducer(t, handle)
+
 	const blockSize = 4
 	rawCfg := json.RawMessage(`{"tokenProcessorConfig":{"blockSize":4}}`)
 	inner, err := preciseproducer.PluginFactory("inner", fwkplugin.StrictDecoder(rawCfg), handle)
@@ -302,6 +321,7 @@ func TestLegacyProducer_KeepsExistingTokenizedPrompt(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	handle := fwkplugin.NewEppHandle(ctx, nil,
 		fwkplugin.WithMetricsRecorder(prometheus.NewRegistry()))
+	installRealTokenProducer(t, handle)
 
 	inner, err := preciseproducer.PluginFactory("inner", nil, handle)
 	require.NoError(t, err)

--- a/test/integration/epp/e2e_config_smoke_test.go
+++ b/test/integration/epp/e2e_config_smoke_test.go
@@ -188,6 +188,35 @@ schedulingProfiles:
   - pluginRef: prefix-cache-scorer
     weight: 2
 `,
+	// Regression test for #1471: a precise-prefix-cache-producer paired with
+	// an explicit vllm-backed token-producer must load cleanly. The mirror
+	// case (no token-producer or estimate-backed) is covered by the unit
+	// test TestPluginFactory_RejectsMissingRealTokenProducer in the
+	// preciseprefixcache package; this smoke test confirms the harness still
+	// accepts a well-configured precise pipeline end-to-end.
+	"preciseConfigWithVLLMTokenProducer": `apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: token-producer
+  parameters:
+    modelName: test-model
+    vllm:
+      url: http://localhost:9999
+- type: precise-prefix-cache-producer
+- type: prefix-cache-scorer
+  parameters:
+    prefixMatchInfoProducerName: precise-prefix-cache-producer
+- type: decode-filter
+- type: max-score-picker
+- type: single-profile-handler
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: decode-filter
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 2
+`,
 	"decodeOnlyConfig": `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:

--- a/test/integration/epp/e2e_config_smoke_test.go
+++ b/test/integration/epp/e2e_config_smoke_test.go
@@ -189,11 +189,11 @@ schedulingProfiles:
     weight: 2
 `,
 	// Regression test for #1471: a precise-prefix-cache-producer paired with
-	// an explicit vllm-backed token-producer must load cleanly. The mirror
-	// case (no token-producer or estimate-backed) is covered by the unit
-	// test TestPluginFactory_RejectsMissingRealTokenProducer in the
-	// preciseprefixcache package; this smoke test confirms the harness still
-	// accepts a well-configured precise pipeline end-to-end.
+	// an explicit vllm-backed token-producer must load cleanly through the full
+	// runner path, which is where ValidateTokenProducer runs (after auto-defaults,
+	// order-independent). The mirror case (no token-producer or estimate-backed)
+	// is covered by the unit test TestValidateTokenProducer in the
+	// preciseprefixcache producer package.
 	"preciseConfigWithVLLMTokenProducer": `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:


### PR DESCRIPTION
## Summary

Fixes #1471. The precise-prefix-cache producer hashes engine-aligned token IDs into KV-block keys that must match the model server's prefix cache. The token-producer's estimate backend (the zero-config default introduced in #1445 and registered as the framework's `TokenizedPromptDataKey` default at `cmd/epp/runner/runner.go:520`) emits byte-packed pseudo-tokens that silently corrupt KV-block lookups against the real engine while leaving every health check green.

The framework's `CreateMissingDataProducers` auto-default fires *after* explicit factories, so the precise-prefix-cache factory needs only inspect `handle` for an already-loaded token-producer with a real (vllm or UDS) backend. Both "no token-producer at all" (auto-default about to install estimate) and "estimate-backed token-producer explicitly configured" fail with the same actionable message; the token-producer must come earlier in the plugins list than the precise-prefix-cache-producer.

Adds `IsRealTokenizer()` on the token-producer Plugin to expose backend type without leaking the unexported `renderBackend` struct.

## Scope notes

- All in-tree configs (`deploy/config/epp-precise-prefix-cache{,split-}-config.yaml`, e2e `kvConfig` / `kvExternalTokenizerConfig`) already declare `token-producer` before precise — zero existing-config regressions.
- The deprecated `precise-prefix-cache-scorer` self-host path (`newLegacyProducer`) bypasses this factory and is not covered by the validation. No in-tree config exercises it without an explicit token-producer; flagging for awareness rather than fixing in the same PR since the scorer factory already logs a `DEPRECATION` notice.

## Test plan
- [x] `TestPluginFactory_RejectsMissingRealTokenProducer` — `(a)` no token-producer in handle, `(b)` estimate-backed token-producer explicitly configured
- [x] `TestE2EConfigs_StartupParseSmoke/preciseConfigWithVLLMTokenProducer` — end-to-end through `NewTestHarness` with a valid `token-producer (vllm) -> precise-prefix-cache-producer -> prefix-cache-scorer` pipeline
- [x] `make test-unit-epp`
- [x] `make test-integration-hermetic` (full suite, ~75s)
- [x] `make presubmit`
- [ ] Reviewer to confirm "factory-time, config-order-dependent" check is acceptable vs. a post-`CreateMissingDataProducers` validation hook (alternative: move `requireRealTokenProducer` into a runner-level pass after auto-defaults complete; ~30-line refactor)