### PR TITLE
Merge routed_experts across prefill/decode in the P/D sidecar

### DIFF
--- a/pkg/sidecar/proxy/connector_mooncake.go
+++ b/pkg/sidecar/proxy/connector_mooncake.go
@@ -34,6 +34,10 @@ import (
 
 const mooncakeBootstrapTimeout = 5 * time.Second // set to same value as the other timeout on vllm
 
+// Safety bound on waiting for the concurrent prefill's routed_experts at decode
+// finalize; prefill is normally done well before decode finishes.
+const mooncakeRoutedExpertsTimeout = 30 * time.Second
+
 const mooncakeDataParallelRankHeader = "X-data-parallel-rank" // to send rank id in header to prefill
 
 func (s *Server) handleMooncake(w http.ResponseWriter, r *http.Request, prefillPodHostPort string) {
@@ -215,6 +219,10 @@ func (s *Server) handleMooncakeConcurrentRequests(w http.ResponseWriter, r *http
 		return
 	}
 
+	// Carries the prefill's routed_experts to the decode finalizer to splice over
+	// the decode response's invalid prompt-region rows. Buffered (cap 1) and always
+	// sent once, so the finalizer never blocks on a non-capturing/failed prefill.
+	prefillRoutedExperts := make(chan map[int]string, 1)
 	go func() {
 		defer prefillSpan.End()
 		defer func() {
@@ -230,9 +238,16 @@ func (s *Server) handleMooncakeConcurrentRequests(w http.ResponseWriter, r *http
 			attribute.Int("llm_d.pd_proxy.prefill.status_code", pw.statusCode),
 			attribute.Float64("llm_d.pd_proxy.prefill.duration_ms", float64(prefillDuration.Milliseconds())),
 		)
+		var routedExperts map[int]string
 		if isHTTPError(pw.statusCode) {
 			prefillSpan.SetStatus(codes.Error, "prefill request failed")
+		} else {
+			var prefillerResponse map[string]any
+			if err := json.Unmarshal(pw.bodyBytes(), &prefillerResponse); err == nil {
+				routedExperts = extractRoutedExperts(prefillerResponse)
+			}
 		}
+		prefillRoutedExperts <- routedExperts
 		s.logger.V(5).Info("mooncake prefill request completed", "status", pw.statusCode)
 	}()
 
@@ -249,7 +264,21 @@ func (s *Server) handleMooncakeConcurrentRequests(w http.ResponseWriter, r *http
 	decodeStart := time.Now()
 
 	decodeReq = decodeReq.WithContext(ctx)
-	s.decoderProxy.ServeHTTP(w, decodeReq)
+	// Resolve the prefill routing at finalize (it is ready by then, since decode
+	// pulled its KV); the timeout just forwards unspliced rather than blocking.
+	decodeWriter, finalizeRoutedExperts := newDeferredRoutedExpertsResponseWriter(w, func() map[int]string {
+		select {
+		case re := <-prefillRoutedExperts:
+			return re
+		case <-time.After(mooncakeRoutedExpertsTimeout):
+			s.logger.Info("timed out waiting for prefill routed_experts; forwarding decode response unspliced")
+			return nil
+		}
+	})
+	s.decoderProxy.ServeHTTP(decodeWriter, decodeReq)
+	if err := finalizeRoutedExperts(); err != nil {
+		s.logger.Error(err, "failed to flush routed experts response writer")
+	}
 
 	decodeDuration := time.Since(decodeStart)
 	decodeSpan.SetAttributes(

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -226,6 +226,9 @@ retryLoop:
 		// so treat a missing prefiller cached_tokens value as zero.
 		pCachedTokens = 0
 	}
+	// Prefill routing to splice over the decode response's invalid prompt-region
+	// rows (D never forwards the prompt). Empty when capture is off.
+	prefillRoutedExperts := extractRoutedExperts(prefillerResponse)
 
 	s.logger.V(5).Info("received prefiller response", requestFieldKVTransferParams, pKVTransferParams)
 
@@ -289,6 +292,7 @@ retryLoop:
 
 	s.logger.V(5).Info("sending request to decoder", "body", string(dbody))
 	decodeWriter, finalizeDecodeWriter := newCachedTokensResponseWriterWithFinalize(w, pCachedTokens)
+	decodeWriter, finalizeRoutedExperts := newRoutedExpertsResponseWriterWithFinalize(decodeWriter, prefillRoutedExperts)
 	dataParallelUsed := s.forwardDataParallel && s.dataParallelHandler(decodeWriter, dreq)
 	decodeSpan.SetAttributes(attribute.Bool("llm_d.pd_proxy.decode.data_parallel", dataParallelUsed))
 
@@ -296,6 +300,12 @@ retryLoop:
 		s.logger.V(4).Info("sending request to decoder", "to", s.config.DecoderURL.Host)
 		decodeSpan.SetAttributes(attribute.String("llm_d.pd_proxy.decode.target", s.config.DecoderURL.Host))
 		s.dispatchDecode(decodeWriter, dreq, completionRequest)
+	}
+	// Splice routed_experts into the cached-tokens writer before flushing it.
+	if err := finalizeRoutedExperts(); err != nil {
+		s.logger.Error(err, "failed to flush routed experts response writer")
+		decodeSpan.SetStatus(codes.Error, "failed to flush routed experts response writer")
+		return
 	}
 	if err := finalizeDecodeWriter(); err != nil {
 		s.logger.Error(err, "failed to flush cached token response writer")

--- a/pkg/sidecar/proxy/routed_experts_merge.go
+++ b/pkg/sidecar/proxy/routed_experts_merge.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+// Routed-experts merging for P/D disaggregation.
+//
+// With --enable-return-routed-experts each response choice carries a
+// "routed_experts" field: a base64-encoded NumPy .npy blob of shape
+// (num_tokens-1, num_layers, num_experts_per_tok). Under P/D the decode replica
+// pulls the prompt KV and never forwards the prompt, so its prompt-region rows
+// are invalid; we splice the prefill replica's rows over them. Connector-agnostic,
+// non-streaming only.
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+const requestFieldRoutedExperts = "routed_experts"
+
+type npyHeader struct {
+	descr      string
+	shape      []int
+	dataOffset int
+}
+
+// itemsize derives the element size in bytes from descr ("|u1" -> 1, "<u2" -> 2).
+func (h npyHeader) itemsize() int {
+	n := 0
+	for _, c := range h.descr {
+		if c >= '0' && c <= '9' {
+			n = n*10 + int(c-'0')
+		}
+	}
+	if n == 0 {
+		return 1
+	}
+	return n
+}
+
+func (h npyHeader) rowBytes() int {
+	n := 1
+	for _, d := range h.shape[1:] {
+		n *= d
+	}
+	return n * h.itemsize()
+}
+
+// parseNpyHeader parses a numpy v1.0 .npy header, assuming the well-formed
+// payload vLLM emits (magic/version not re-checked, 2-byte header length).
+func parseNpyHeader(buf []byte) npyHeader {
+	dataOffset := 10 + int(binary.LittleEndian.Uint16(buf[8:10]))
+	header := string(buf[10:dataOffset])
+
+	var shape []int
+	if open := strings.Index(header, "("); open >= 0 {
+		if end := strings.Index(header[open:], ")"); end >= 0 {
+			for _, part := range strings.Split(header[open+1:open+end], ",") {
+				if part = strings.TrimSpace(part); part != "" {
+					d, _ := strconv.Atoi(part)
+					shape = append(shape, d)
+				}
+			}
+		}
+	}
+	return npyHeader{descr: quoted(header, "descr"), shape: shape, dataOffset: dataOffset}
+}
+
+// quoted returns the single-quoted value for key (e.g. "descr" -> "<u2").
+func quoted(header, key string) string {
+	rest := header
+	if i := strings.Index(rest, "'"+key+"':"); i >= 0 {
+		rest = rest[i+len(key)+3:]
+	} else {
+		return ""
+	}
+	start := strings.Index(rest, "'")
+	if start < 0 {
+		return ""
+	}
+	rest = rest[start+1:]
+	end := strings.Index(rest, "'")
+	if end < 0 {
+		return ""
+	}
+	return rest[:end]
+}
+
+// spliceRoutedExpertsNpy splices the prefill array's rows over the decode array's
+// invalid prompt-region prefix. Inputs are base64 .npy blobs from a P/D pair
+// (same dtype/trailing shape, prefill rows <= decode rows); the result reuses
+// decode's header with its leading rows replaced by prefill's.
+func spliceRoutedExpertsNpy(prefillB64, decodeB64 string) (string, error) {
+	pBuf, err := base64.StdEncoding.DecodeString(prefillB64)
+	if err != nil {
+		return "", err
+	}
+	dBuf, err := base64.StdEncoding.DecodeString(decodeB64)
+	if err != nil {
+		return "", err
+	}
+	ph := parseNpyHeader(pBuf)
+	dh := parseNpyHeader(dBuf)
+
+	// Output keeps decode's header (shape unchanged); only the leading Lp rows
+	// of payload come from prefill, the rest from decode.
+	split := ph.shape[0] * dh.rowBytes()
+	out := make([]byte, 0, len(dBuf))
+	out = append(out, dBuf[:dh.dataOffset]...)
+	out = append(out, pBuf[ph.dataOffset:ph.dataOffset+split]...)
+	out = append(out, dBuf[dh.dataOffset+split:]...)
+	return base64.StdEncoding.EncodeToString(out), nil
+}
+
+// extractRoutedExperts returns a map from choice index to that choice's
+// base64-encoded routed_experts string, for any choice that carries one.
+func extractRoutedExperts(response map[string]any) map[int]string {
+	choices, ok := response["choices"].([]any)
+	if !ok {
+		return nil
+	}
+	out := map[int]string{}
+	for i, c := range choices {
+		choice, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		re, ok := choice[requestFieldRoutedExperts].(string)
+		if !ok || re == "" {
+			continue
+		}
+		idx := i
+		if v, ok := intValue(choice["index"]); ok {
+			idx = v
+		}
+		out[idx] = re
+	}
+	return out
+}
+
+// mergeRoutedExpertsJSON splices prefill routed_experts (keyed by choice index)
+// into a decode response body. Returns the rewritten body and whether any choice
+// was merged. On a per-choice splice error the choice is left unchanged.
+func mergeRoutedExpertsJSON(prefillByIdx map[int]string, body []byte) ([]byte, bool) {
+	if len(prefillByIdx) == 0 {
+		return body, false
+	}
+	var response map[string]any
+	if err := json.Unmarshal(body, &response); err != nil {
+		return body, false
+	}
+	choices, ok := response["choices"].([]any)
+	if !ok {
+		return body, false
+	}
+
+	merged := false
+	for i, c := range choices {
+		choice, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		decodeRE, ok := choice[requestFieldRoutedExperts].(string)
+		if !ok || decodeRE == "" {
+			continue
+		}
+		idx := i
+		if v, ok := intValue(choice["index"]); ok {
+			idx = v
+		}
+		prefillRE, ok := prefillByIdx[idx]
+		if !ok {
+			continue
+		}
+		spliced, err := spliceRoutedExpertsNpy(prefillRE, decodeRE)
+		if err != nil {
+			continue
+		}
+		choice[requestFieldRoutedExperts] = spliced
+		merged = true
+	}
+	if !merged {
+		return body, false
+	}
+	updated, err := json.Marshal(response)
+	if err != nil {
+		return body, false
+	}
+	return updated, true
+}

--- a/pkg/sidecar/proxy/routed_experts_merge_test.go
+++ b/pkg/sidecar/proxy/routed_experts_merge_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// makeNpyU8 builds a tiny C-order .npy v1.0 blob for a (n, l, k) uint8 array
+// where every element of row r equals base+r, so rows are distinguishable.
+func makeNpyU8(n, l, k int, base byte) []byte {
+	header := fmt.Sprintf("{'descr': '|u1', 'fortran_order': False, 'shape': (%d, %d, %d), }", n, l, k)
+	h := []byte(header)
+	total := 10 + len(h) + 1
+	pad := (64 - (total % 64)) % 64
+	for i := 0; i < pad; i++ {
+		h = append(h, ' ')
+	}
+	h = append(h, '\n')
+
+	buf := []byte("\x93NUMPY")
+	buf = append(buf, 1, 0)
+	lenField := make([]byte, 2)
+	binary.LittleEndian.PutUint16(lenField, uint16(len(h)))
+	buf = append(buf, lenField...)
+	buf = append(buf, h...)
+	for r := 0; r < n; r++ {
+		for i := 0; i < l*k; i++ {
+			buf = append(buf, base+byte(r))
+		}
+	}
+	return buf
+}
+
+func b64(v []byte) string { return base64.StdEncoding.EncodeToString(v) }
+
+func TestParseNpyHeader(t *testing.T) {
+	h := parseNpyHeader(makeNpyU8(3, 2, 4, 0))
+	if h.descr != "|u1" {
+		t.Fatalf("descr wrong: %+v", h)
+	}
+	if len(h.shape) != 3 || h.shape[0] != 3 || h.shape[1] != 2 || h.shape[2] != 4 {
+		t.Fatalf("shape wrong: %v", h.shape)
+	}
+	if h.itemsize() != 1 {
+		t.Fatalf("itemsize wrong: %d", h.itemsize())
+	}
+	if h.rowBytes() != 8 {
+		t.Fatalf("rowBytes wrong: %d", h.rowBytes())
+	}
+}
+
+func TestSpliceReplacesPrefixOnly(t *testing.T) {
+	l, k := 2, 3
+	prefill := makeNpyU8(2, l, k, 100)
+	decode := makeNpyU8(5, l, k, 0)
+	out, err := spliceRoutedExpertsNpy(b64(prefill), b64(decode))
+	if err != nil {
+		t.Fatalf("splice: %v", err)
+	}
+	merged, _ := base64.StdEncoding.DecodeString(out)
+	h := parseNpyHeader(merged)
+	if h.shape[0] != 5 {
+		t.Fatalf("merged keeps decode rows, got %d", h.shape[0])
+	}
+	rb := l * k
+	data := merged[h.dataOffset:]
+	// rows 0,1 from prefill (100,101); rows 2,3,4 from decode (2,3,4).
+	for r, want := range []byte{100, 101, 2, 3, 4} {
+		if got := data[r*rb]; got != want {
+			t.Fatalf("row %d: got %d want %d", r, got, want)
+		}
+	}
+}
+
+func TestSpliceEqualLengthsUsesAllPrefill(t *testing.T) {
+	out, err := spliceRoutedExpertsNpy(b64(makeNpyU8(4, 1, 1, 50)), b64(makeNpyU8(4, 1, 1, 0)))
+	if err != nil {
+		t.Fatalf("splice: %v", err)
+	}
+	merged, _ := base64.StdEncoding.DecodeString(out)
+	h := parseNpyHeader(merged)
+	data := merged[h.dataOffset:]
+	for i, want := range []byte{50, 51, 52, 53} {
+		if data[i] != want {
+			t.Fatalf("byte %d: got %d want %d", i, data[i], want)
+		}
+	}
+}
+
+func TestMergeRoutedExpertsJSON(t *testing.T) {
+	l, k := 2, 2
+	prefillBody, _ := json.Marshal(map[string]any{
+		"choices": []any{map[string]any{"index": 0, "routed_experts": b64(makeNpyU8(2, l, k, 100))}},
+	})
+	decodeBody, _ := json.Marshal(map[string]any{
+		"choices": []any{map[string]any{"index": 0, "routed_experts": b64(makeNpyU8(5, l, k, 0))}},
+	})
+
+	var prefillResp map[string]any
+	_ = json.Unmarshal(prefillBody, &prefillResp)
+	prefillByIdx := extractRoutedExperts(prefillResp)
+	if len(prefillByIdx) != 1 {
+		t.Fatalf("extract: got %d", len(prefillByIdx))
+	}
+
+	out, merged := mergeRoutedExpertsJSON(prefillByIdx, decodeBody)
+	if !merged {
+		t.Fatal("expected merge")
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(out, &resp)
+	re := resp["choices"].([]any)[0].(map[string]any)["routed_experts"].(string)
+	mergedBytes, _ := base64.StdEncoding.DecodeString(re)
+	h := parseNpyHeader(mergedBytes)
+	if h.shape[0] != 5 {
+		t.Fatalf("merged shape rows: got %d", h.shape[0])
+	}
+	if mergedBytes[h.dataOffset] != 100 {
+		t.Fatalf("first row not from prefill: got %d", mergedBytes[h.dataOffset])
+	}
+}
+
+func TestMergeNoOpWhenAbsent(t *testing.T) {
+	decodeBody, _ := json.Marshal(map[string]any{"choices": []any{map[string]any{"index": 0}}})
+	if _, merged := mergeRoutedExpertsJSON(map[int]string{0: "x"}, decodeBody); merged {
+		t.Fatal("expected no merge when decode choice has no routed_experts")
+	}
+	if _, merged := mergeRoutedExpertsJSON(nil, decodeBody); merged {
+		t.Fatal("expected no merge with empty prefill map")
+	}
+}

--- a/pkg/sidecar/proxy/routed_experts_rewriter.go
+++ b/pkg/sidecar/proxy/routed_experts_rewriter.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/felixge/httpsnoop"
+)
+
+// routedExpertsRewriter splices prefill routed_experts over the decode response.
+// routed_experts only appears in non-streaming responses, so SSE passes through
+// untouched while non-streaming bodies are buffered and spliced at finalize.
+type routedExpertsRewriter struct {
+	header    http.Header
+	resolve   func() map[int]string
+	streaming bool
+	buf       []byte
+}
+
+// newRoutedExpertsResponseWriterWithFinalize wraps w to merge the prefill's
+// routed_experts into the decode response (sequential P/D, routing already
+// known). With nothing to merge it returns w unchanged and a no-op finalize.
+func newRoutedExpertsResponseWriterWithFinalize(
+	w http.ResponseWriter,
+	prefillByIdx map[int]string,
+) (http.ResponseWriter, func() error) {
+	if len(prefillByIdx) == 0 {
+		return w, func() error { return nil }
+	}
+	return newDeferredRoutedExpertsResponseWriter(w, func() map[int]string { return prefillByIdx })
+}
+
+// newDeferredRoutedExpertsResponseWriter resolves the prefill routing lazily at
+// finalize, for concurrent P/D paths (e.g. Mooncake) where it isn't known when
+// the decode response starts. Non-streaming bodies are always buffered; if
+// resolve returns no routing the buffer is forwarded unchanged.
+func newDeferredRoutedExpertsResponseWriter(
+	w http.ResponseWriter,
+	resolve func() map[int]string,
+) (http.ResponseWriter, func() error) {
+	r := &routedExpertsRewriter{header: w.Header(), resolve: resolve}
+	writer := httpsnoop.Wrap(w, httpsnoop.Hooks{
+		WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+			return func(statusCode int) { r.writeHeader(next, statusCode) }
+		},
+		Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+			return func(body []byte) (int, error) { return r.write(next, body) }
+		},
+		ReadFrom: func(_ httpsnoop.ReadFromFunc) httpsnoop.ReadFromFunc {
+			return func(src io.Reader) (int64, error) { return r.readFrom(w.Write, src) }
+		},
+	})
+	return writer, func() error { return r.flush(w.Write) }
+}
+
+func (r *routedExpertsRewriter) writeHeader(next httpsnoop.WriteHeaderFunc, statusCode int) {
+	// Re-marshaling changes the body size, so any upstream Content-Length is stale.
+	r.header.Del("Content-Length")
+	r.isSSE(nil)
+	next(statusCode)
+}
+
+func (r *routedExpertsRewriter) write(next httpsnoop.WriteFunc, body []byte) (int, error) {
+	if r.isSSE(body) {
+		return next(body)
+	}
+	// Buffer non-streaming body; the full document is spliced at finalize.
+	r.buf = append(r.buf, body...)
+	return len(body), nil
+}
+
+func (r *routedExpertsRewriter) readFrom(next httpsnoop.WriteFunc, src io.Reader) (int64, error) {
+	if r.isSSE(nil) {
+		n, err := io.Copy(routedExpertsStreamWriter{forward: next}, src)
+		return n, err
+	}
+	body, err := io.ReadAll(src)
+	if err != nil {
+		return 0, err
+	}
+	r.buf = append(r.buf, body...)
+	return int64(len(body)), nil
+}
+
+func (r *routedExpertsRewriter) flush(next httpsnoop.WriteFunc) error {
+	if r.streaming || len(r.buf) == 0 {
+		return nil
+	}
+	body := r.buf
+	r.buf = nil
+	if prefillByIdx := r.resolve(); len(prefillByIdx) > 0 {
+		body, _ = mergeRoutedExpertsJSON(prefillByIdx, body)
+	}
+	_, err := next(body)
+	return err
+}
+
+func (r *routedExpertsRewriter) isSSE(body []byte) bool {
+	if r.streaming {
+		return true
+	}
+	contentType := r.header.Get("Content-Type")
+	if strings.Contains(contentType, "text/event-stream") || bytes.HasPrefix(body, []byte("data:")) {
+		r.streaming = true
+		return true
+	}
+	return false
+}
+
+type routedExpertsStreamWriter struct {
+	forward httpsnoop.WriteFunc
+}
+
+func (w routedExpertsStreamWriter) Write(body []byte) (int, error) {
+	return w.forward(body)
+}


### PR DESCRIPTION
## Merge `routed_experts` across prefill/decode in the P/D sidecar

### Background
vLLM can capture, per generated token, which MoE experts each token was routed to
("routed experts capture", used for routing replay / reproducible RL). When a
backend is launched with `--enable-return-routed-experts`, every response *choice*
carries a `routed_experts` field — a base64-encoded NumPy `.npy` blob of shape
`(num_tokens - 1, num_layers, num_experts_per_tok)` (dtype `uint8`/`uint16`), on
`/v1/completions`, `/v1/chat/completions`, and `/inference/v1/generate`.

### Problem
Under P/D disaggregation the **decode** replica pulls the prompt's KV cache from
the **prefill** replica and never *forwards* the prompt tokens, so the
prompt-region rows of the decode response's `routed_experts` are invalid. The
prefill replica returns the correct prompt-region routing.

### Fix
The pd-sidecar splices the prefill's prompt routing over the decode response's
invalid prefix:

```
merged = concat( prefill_rows[0:Lp], decode_rows[Lp:Ld] )      # keeps decode shape/dtype
```

A pure response-body splice keyed on array lengths, independent of the KV
connector. It is wired into the buffered (non-streaming) decode finalize path;
streaming responses (which never carry `routed_experts`) pass through untouched.

### Implementation
- New `pkg/sidecar/proxy/routed_experts_merge.go`: a minimal `.npy` parser, the
  byte-level row splice (`spliceRoutedExpertsNpy`), `extractRoutedExperts`, and
  `mergeRoutedExpertsJSON`. Table-tested (`go test ./pkg/sidecar/proxy/`).
- New `pkg/sidecar/proxy/routed_experts_rewriter.go`: a response-writer wrapper
  mirroring `cached_tokens_usage_rewriter.go`. It buffers the non-streaming decode
  body and splices at finalize; when there is nothing to merge it returns the
  underlying writer unchanged (zero overhead).
- **NIXL v2** (`connector_nixlv2.go`, sequential): extracts the prefill routing
  from the already-parsed prefill response and wraps the decode writer.
- **Mooncake** (`connector_mooncake.go`, concurrent): captures the prefill routing
  from the otherwise-discarded prefill response via a channel and resolves it at
  decode finalize (with a safety timeout). SGLang and Shared-Storage reach the
  same finalize path by construction.

### Verification
Verified end-to-end by running the pd-sidecar standalone against a 2-node
prefill/decode deployment of Qwen3-30B-A3B (NIXL v2 and Mooncake connectors),
across `/v1/completions` and `/v1/chat/completions`. The sidecar-merged
`routed_experts` matches a non-disaggregated oracle replica elementwise under
greedy decoding, while the raw decode response differs in the prompt region —
confirming the merge is correct and necessary.

Companion changes: vLLM relaxes its routed-experts/KV-connector rejection to a
warning (vllm-project/vllm), and vllm-project/router gets the equivalent merge.

---
**Related PRs:** vllm-project/vllm#45419 (relax the capture/KV-connector check) · vllm-project/router#184 (equivalent merge in the vLLM router)
