### PR TITLE
Add accelerator capability aware scheduler plugin

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -108,6 +108,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/disagg"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/single"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/acceleratorcapabilityaware"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/activerequest"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization"
@@ -487,6 +488,7 @@ func (r *Runner) registerInTreePlugins() {
 	// extra scheduling scorers
 	fwkplugin.Register(loadaware.LoadAwareType, loadaware.Factory)
 	fwkplugin.Register(sessionaffinity.SessionAffinityType, sessionaffinity.Factory)
+	fwkplugin.Register(acceleratorcapabilityaware.Type, acceleratorcapabilityaware.Factory)
 	fwkplugin.Register(contextlengthaware.ContextLengthAwareType, contextlengthaware.Factory)
 
 	// data layer models source/extractor

--- a/pkg/epp/framework/plugins/scheduling/scorer/acceleratorcapabilityaware/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/acceleratorcapabilityaware/README.md
@@ -1,0 +1,49 @@
+# Accelerator Capability Aware
+
+**Type:** `accelerator-capability-aware`
+
+Routes inference requests based on estimated request size and static accelerator
+capability ranges declared on endpoint labels. This is intended for
+heterogeneous GPU or MIG pools where larger multimodal requests should prefer
+larger accelerator profiles without depending on runtime DCGM metrics.
+
+Each pod declares its supported range via the `label` parameter. The default is
+`llm-d.ai/accelerator-capability-range`, formatted as `min-max`, where the values
+are estimated request tokens.
+
+```yaml
+metadata:
+  labels:
+    llm-d.ai/accelerator-capability-range: "0-2048"
+```
+
+The request size is read from `TokenizedPrompt.TokenCount()`, produced by
+`token-producer`. For multimodal requests, the tokenizer estimate backend can
+include image placeholder tokens, so image-heavy requests can be matched to
+larger accelerator profiles.
+
+## Parameters
+
+- `label` (string, optional, default: `llm-d.ai/accelerator-capability-range`):
+  Pod label key carrying the `min-max` range.
+- `enableFiltering` (bool, optional, default: `false`): When true, endpoints
+  with a labeled range that does not contain the request size are filtered out.
+
+Unlabeled endpoints pass through filtering and receive a neutral score, allowing
+incremental rollout.
+
+## Example
+
+```yaml
+plugins:
+  - type: accelerator-capability-aware
+    parameters:
+      label: llm-d.ai/accelerator-capability-range
+      enableFiltering: true
+
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: accelerator-capability-aware
+        weight: 3
+```

--- a/pkg/epp/framework/plugins/scheduling/scorer/acceleratorcapabilityaware/accelerator_capability_aware.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/acceleratorcapabilityaware/accelerator_capability_aware.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acceleratorcapabilityaware
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
+)
+
+const (
+	// Type is the type of the accelerator capability aware plugin.
+	Type = "accelerator-capability-aware"
+
+	// DefaultLabel is the default label name used to identify accelerator
+	// capability ranges on pods.
+	DefaultLabel = "llm-d.ai/accelerator-capability-range"
+)
+
+type parameters struct {
+	// Label is the pod label name to check for accelerator capability range.
+	// Format expected: "min-max" (e.g., "0-1024" or "1024-4096"), where min
+	// and max are estimated request tokens.
+	Label string `json:"label"`
+
+	// EnableFiltering determines whether the plugin also filters pods that do
+	// not match a request's estimated size. If false, the plugin only scores pods.
+	EnableFiltering bool `json:"enableFiltering"`
+}
+
+type capabilityRange struct {
+	min int
+	max int
+}
+
+var _ scheduling.Filter = &Plugin{}
+var _ scheduling.Scorer = &Plugin{}
+
+// Factory defines the factory function for the accelerator capability aware plugin.
+func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
+	parameters := &parameters{
+		Label:           DefaultLabel,
+		EnableFiltering: false,
+	}
+
+	if rawParameters != nil {
+		if err := rawParameters.Decode(parameters); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' plugin - %w", Type, err)
+		}
+	}
+
+	if parameters.Label == "" {
+		return nil, fmt.Errorf("invalid configuration for '%s' plugin: 'label' must be specified", Type)
+	}
+
+	return New(name, parameters), nil
+}
+
+// New creates and returns an instance of the accelerator capability aware plugin.
+func New(name string, params *parameters) *Plugin {
+	return &Plugin{
+		typedName:       plugin.TypedName{Type: Type, Name: name},
+		labelName:       params.Label,
+		enableFiltering: params.EnableFiltering,
+	}
+}
+
+// Plugin filters and scores endpoints by matching an estimated request size
+// against static accelerator capability ranges declared on endpoint labels.
+//
+// The request size is the token count from InferenceRequestBody.TokenizedPrompt,
+// populated by the token-producer. For multimodal requests, the estimate backend
+// can include image placeholder tokens, making this useful for heterogeneous MIG
+// or accelerator-profile pools without runtime DCGM metrics.
+type Plugin struct {
+	typedName       plugin.TypedName
+	labelName       string
+	enableFiltering bool
+}
+
+// TypedName returns the typed name of the plugin.
+func (p *Plugin) TypedName() plugin.TypedName {
+	return p.typedName
+}
+
+// Consumes declares the TokenizedPrompt dependency so token-producer runs before
+// this plugin and can be auto-created when no explicit producer is configured.
+func (p *Plugin) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{
+		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedPrompt{}},
+	}
+}
+
+// Filter filters out endpoints whose declared accelerator capability range does
+// not contain the request size. Unlabeled endpoints pass through so deployments
+// can adopt labels incrementally.
+func (p *Plugin) Filter(ctx context.Context, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) []scheduling.Endpoint {
+	if !p.enableFiltering {
+		return endpoints
+	}
+
+	logger := log.FromContext(ctx).V(logging.DEBUG).WithName("AcceleratorCapabilityAware.Filter")
+	requestSize := getRequestSize(request)
+	logger.V(logging.TRACE).Info("Filtering endpoints by accelerator capability", "requestSize", requestSize)
+
+	filteredEndpoints := []scheduling.Endpoint{}
+	for _, endpoint := range endpoints {
+		metadata := endpoint.GetMetadata()
+		if metadata == nil {
+			filteredEndpoints = append(filteredEndpoints, endpoint)
+			continue
+		}
+
+		rangeStr, hasLabel := metadata.Labels[p.labelName]
+		if !hasLabel {
+			filteredEndpoints = append(filteredEndpoints, endpoint)
+			continue
+		}
+
+		r, err := parseCapabilityRange(rangeStr)
+		if err != nil {
+			logger.Error(err, "Failed to parse accelerator capability range label", "endpoint", metadata.NamespacedName, "rangeStr", rangeStr)
+			continue
+		}
+
+		if requestSize >= r.min && requestSize <= r.max {
+			filteredEndpoints = append(filteredEndpoints, endpoint)
+		}
+	}
+
+	logger.V(logging.TRACE).Info("Filtered endpoints", "originalCount", len(endpoints), "filteredCount", len(filteredEndpoints))
+	return filteredEndpoints
+}
+
+// Score scores endpoints based on how well their accelerator capability range
+// fits the estimated request size. Tighter matching ranges with remaining
+// headroom score highest; unlabeled endpoints receive a neutral score.
+func (p *Plugin) Score(ctx context.Context, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64 {
+	logger := log.FromContext(ctx).V(logging.DEBUG).WithName("AcceleratorCapabilityAware.Score")
+	requestSize := getRequestSize(request)
+	logger.V(logging.TRACE).Info("Scoring endpoints by accelerator capability", "requestSize", requestSize)
+
+	scoredEndpoints := make(map[scheduling.Endpoint]float64)
+	for _, endpoint := range endpoints {
+		metadata := endpoint.GetMetadata()
+		if metadata == nil {
+			scoredEndpoints[endpoint] = 0.5
+			continue
+		}
+
+		rangeStr, hasLabel := metadata.Labels[p.labelName]
+		if !hasLabel {
+			scoredEndpoints[endpoint] = 0.5
+			continue
+		}
+
+		r, err := parseCapabilityRange(rangeStr)
+		if err != nil {
+			logger.Error(err, "Failed to parse accelerator capability range label", "endpoint", metadata.NamespacedName, "rangeStr", rangeStr)
+			scoredEndpoints[endpoint] = 0.0
+			continue
+		}
+
+		scoredEndpoints[endpoint] = calculateRangeScore(requestSize, r)
+	}
+
+	logger.V(logging.TRACE).Info("Scored endpoints", "scores", scoredEndpoints)
+	return scoredEndpoints
+}
+
+// Category returns the preference the scorer applies when scoring candidate endpoints.
+func (p *Plugin) Category() scheduling.ScorerCategory {
+	return scheduling.Balance
+}
+
+func getRequestSize(request *scheduling.InferenceRequest) int {
+	if request == nil || request.Body == nil || request.Body.TokenizedPrompt == nil {
+		return 0
+	}
+	return request.Body.TokenizedPrompt.TokenCount()
+}
+
+func parseCapabilityRange(rangeStr string) (capabilityRange, error) {
+	if rangeStr == "" {
+		return capabilityRange{}, errors.New("empty range string")
+	}
+
+	bounds := strings.Split(rangeStr, "-")
+	if len(bounds) != 2 {
+		return capabilityRange{}, fmt.Errorf("invalid range format: %s (expected 'min-max')", rangeStr)
+	}
+
+	minVal, err := strconv.Atoi(strings.TrimSpace(bounds[0]))
+	if err != nil {
+		return capabilityRange{}, fmt.Errorf("invalid min value: %s", bounds[0])
+	}
+
+	maxVal, err := strconv.Atoi(strings.TrimSpace(bounds[1]))
+	if err != nil {
+		return capabilityRange{}, fmt.Errorf("invalid max value: %s", bounds[1])
+	}
+
+	if minVal > maxVal {
+		return capabilityRange{}, fmt.Errorf("min (%d) cannot be greater than max (%d)", minVal, maxVal)
+	}
+
+	return capabilityRange{min: minVal, max: maxVal}, nil
+}
+
+func calculateRangeScore(requestSize int, r capabilityRange) float64 {
+	const maxFallbackScore = 0.3
+
+	if requestSize >= r.min && requestSize <= r.max {
+		rangeWidth := r.max - r.min
+		if rangeWidth == 0 {
+			return 1.0
+		}
+
+		widthScore := 1.0 / (1.0 + float64(rangeWidth)/10000.0)
+		headroom := float64(r.max - requestSize)
+		positionScore := headroom / float64(rangeWidth)
+		rawScore := 0.7*widthScore + 0.3*positionScore
+		return maxFallbackScore + rawScore*(1.0-maxFallbackScore)
+	}
+
+	var distance int
+	if requestSize > r.max {
+		distance = requestSize - r.max
+	} else {
+		distance = r.min - requestSize
+	}
+	return maxFallbackScore / (1.0 + float64(distance)/1000.0)
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/acceleratorcapabilityaware/accelerator_capability_aware_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/acceleratorcapabilityaware/accelerator_capability_aware_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acceleratorcapabilityaware
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/test/utils"
+)
+
+func createEndpoint(nsn k8stypes.NamespacedName, labels map[string]string) scheduling.Endpoint {
+	return scheduling.NewEndpoint(
+		&fwkdl.EndpointMetadata{
+			NamespacedName: nsn,
+			Address:        "10.0.0.1",
+			Labels:         labels,
+		},
+		nil,
+		nil,
+	)
+}
+
+func createRequest(tokenCount int) *scheduling.InferenceRequest {
+	tokenIDs := make([]uint32, tokenCount)
+	for i := range tokenIDs {
+		tokenIDs[i] = uint32(i + 1)
+	}
+	return &scheduling.InferenceRequest{
+		RequestID: "test-request",
+		Body: &fwkrh.InferenceRequestBody{
+			TokenizedPrompt: &fwkrh.TokenizedPrompt{PerPromptTokens: [][]uint32{tokenIDs}},
+		},
+	}
+}
+
+func TestFactory(t *testing.T) {
+	tests := []struct {
+		name       string
+		jsonParams string
+		expectErr  bool
+	}{
+		{
+			name:       "valid configuration with defaults",
+			jsonParams: `{}`,
+		},
+		{
+			name:       "empty label should error",
+			jsonParams: `{"label": ""}`,
+			expectErr:  true,
+		},
+		{
+			name:       "malformed JSON should error",
+			jsonParams: `{"label": "test"`,
+			expectErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin, err := Factory("accel-aware", fwkplugin.StrictDecoder(json.RawMessage(tt.jsonParams)), nil)
+			if tt.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, plugin)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, plugin)
+			}
+		})
+	}
+}
+
+func TestFilter(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	endpoints := []scheduling.Endpoint{
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "small-mig"},
+			map[string]string{DefaultLabel: "0-1000"}),
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "medium-mig"},
+			map[string]string{DefaultLabel: "1000-4000"}),
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "full-gpu"},
+			map[string]string{DefaultLabel: "4000-32000"}),
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "unlabeled"},
+			map[string]string{}),
+	}
+
+	plugin := New("test-filter", &parameters{Label: DefaultLabel, EnableFiltering: true})
+	filteredEndpoints := plugin.Filter(ctx, createRequest(2500), endpoints)
+
+	gotNames := make([]string, len(filteredEndpoints))
+	for i, endpoint := range filteredEndpoints {
+		gotNames[i] = endpoint.GetMetadata().NamespacedName.Name
+	}
+	assert.ElementsMatch(t, []string{"medium-mig", "unlabeled"}, gotNames)
+}
+
+func TestScore(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	endpoints := []scheduling.Endpoint{
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "tight-match"},
+			map[string]string{DefaultLabel: "2000-3000"}),
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "wide-match"},
+			map[string]string{DefaultLabel: "0-32000"}),
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "too-small"},
+			map[string]string{DefaultLabel: "0-1000"}),
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "unlabeled"},
+			map[string]string{}),
+	}
+
+	plugin := New("test-scorer", &parameters{Label: DefaultLabel})
+	scores := plugin.Score(ctx, createRequest(2500), endpoints)
+
+	assert.Greater(t, scores[endpoints[0]], scores[endpoints[1]], "tighter matching range should score higher")
+	assert.Greater(t, scores[endpoints[0]], 0.3, "in-range score must be above fallback tier")
+	assert.Greater(t, scores[endpoints[1]], 0.3, "wide in-range score must be above fallback tier")
+	assert.Greater(t, scores[endpoints[2]], 0.0, "out-of-range endpoints should get a proximity fallback score")
+	assert.Less(t, scores[endpoints[2]], 0.3, "out-of-range fallback must stay below in-range tier")
+	assert.Equal(t, 0.5, scores[endpoints[3]], "unlabeled endpoints should score neutral")
+}
+
+func TestParseCapabilityRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		rangeStr  string
+		expected  capabilityRange
+		expectErr bool
+	}{
+		{
+			name:     "valid range",
+			rangeStr: "0-100",
+			expected: capabilityRange{min: 0, max: 100},
+		},
+		{
+			name:      "empty string",
+			rangeStr:  "",
+			expectErr: true,
+		},
+		{
+			name:      "invalid format with three parts",
+			rangeStr:  "0-100-200",
+			expectErr: true,
+		},
+		{
+			name:      "min greater than max",
+			rangeStr:  "100-50",
+			expectErr: true,
+		},
+		{
+			name:      "non-numeric value",
+			rangeStr:  "abc-100",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := parseCapabilityRange(tt.rangeStr)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, r)
+			}
+		})
+	}
+}
+
+func TestNilTokenizedPromptIsUnknownSize(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	endpoints := []scheduling.Endpoint{
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "zero-range"},
+			map[string]string{DefaultLabel: "0-100"}),
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "larger-range"},
+			map[string]string{DefaultLabel: "100-1000"}),
+	}
+
+	plugin := New("test-no-tokens", &parameters{Label: DefaultLabel, EnableFiltering: true})
+	request := &scheduling.InferenceRequest{RequestID: "test-request", Body: &fwkrh.InferenceRequestBody{}}
+
+	filteredEndpoints := plugin.Filter(ctx, request, endpoints)
+	require.Len(t, filteredEndpoints, 1)
+	assert.Equal(t, "zero-range", filteredEndpoints[0].GetMetadata().NamespacedName.Name)
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/acceleratorcapabilityaware/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/acceleratorcapabilityaware/doc.go
@@ -1,0 +1,3 @@
+// Package acceleratorcapabilityaware provides a scheduler plugin for matching
+// request size to statically labeled accelerator capability ranges.
+package acceleratorcapabilityaware


### PR DESCRIPTION
## What

Adds a draft `accelerator-capability-aware` scheduling plugin for heterogeneous accelerator pools.

- Matches estimated request size from `TokenizedPrompt.TokenCount()` against endpoint label ranges.
- Uses `llm-d.ai/accelerator-capability-range` as the default static capability label.
- Supports scorer mode by default and optional filtering via `enableFiltering`.
- Treats unlabeled endpoints neutrally so the label can be rolled out incrementally.
- Registers the plugin in the EPP runner and documents configuration.

## Why

This keeps static MIG / accelerator-profile routing separate from the runtime DCGM utilization work in #1706. It follows the narrower design proposed in #1868 and reuses the same request-size dependency pattern as `context-length-aware`.

Closes #1868.

## Validation

- `go test ./pkg/epp/framework/plugins/scheduling/scorer/acceleratorcapabilityaware`
- `go test ./cmd/epp/runner`
