### PR TITLE
feat(epp/parsers/openai): make claimed path suffixes configurable

### DIFF
--- a/pkg/epp/framework/plugins/requesthandling/parsers/README.md
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/README.md
@@ -86,3 +86,17 @@ requestHandler:
   - pluginRef: openaiParser
   - pluginRef: anthropicParser
 ```
+
+### Custom path claims for `openai-parser`
+
+`openai-parser` accepts an `additionalPathClaims` parameter listing extra path suffixes to route to it, for OpenAI-compatible providers that expose sub-paths or prefixed variants of the canonical endpoints. Each claim must sit under a canonical OpenAI endpoint (`chat/completions`, `completions`, `embeddings`, `responses`, `conversations`) as a complete run of path segments; the request body is then parsed as that endpoint's API type. Matching is segment-aware, so `chat/completions/pipeline` is parsed as `chat/completions` rather than bare `completions`. A claim that sits under no canonical endpoint fails configuration loading.
+
+```yaml
+plugins:
+- name: openaiParser
+  type: openai-parser
+  parameters:
+    additionalPathClaims:
+    - chat/completions/pipeline
+    - myservice/embeddings
+```

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -65,6 +66,61 @@ var _ fwkrh.Parser = &OpenAIParser{}
 // https://developers.openai.com/api/reference/overview
 type OpenAIParser struct {
 	typedName fwkplugin.TypedName
+	// customClaims holds operator-configured path claims, sorted deepest-first
+	// so the most specific claim wins at dispatch time.
+	customClaims []customClaim
+}
+
+// Parameters is the user-facing plugin configuration block.
+type Parameters struct {
+	// AdditionalPathClaims lists extra path suffixes routed to this parser.
+	// Each claim must sit under a canonical OpenAI endpoint (segment-aware, so
+	// "chat/completions/pipeline" dispatches as chat/completions rather than
+	// bare completions) and is parsed as that endpoint's API type.
+	AdditionalPathClaims []string `json:"additionalPathClaims,omitempty"`
+}
+
+// customClaim maps a configured path claim to the API type of the canonical
+// endpoint it sits under.
+type customClaim struct {
+	path    string
+	apiType string
+}
+
+// canonicalAPIEndpoints is ordered deepest-first so "chat/completions/x"
+// resolves to chat/completions rather than bare completions.
+var canonicalAPIEndpoints = []string{
+	chatCompletionsAPI,
+	conversationsAPI,
+	responsesAPI,
+	completionsAPI,
+	embeddingsAPI,
+}
+
+// resolveClaimAPIType returns the API type of the deepest canonical endpoint
+// the claim sits under, or an error when it sits under none.
+func resolveClaimAPIType(claim string) (string, error) {
+	normalized := strings.Trim(strings.TrimSpace(claim), "/")
+	if normalized == "" {
+		return "", fmt.Errorf("%s: additionalPathClaims entry %q is empty", OpenAIParserType, claim)
+	}
+	for _, endpoint := range canonicalAPIEndpoints {
+		if sitsUnder(normalized, endpoint) {
+			return endpoint, nil
+		}
+	}
+	return "", fmt.Errorf("%s: additionalPathClaims entry %q does not sit under any canonical OpenAI endpoint (%s)",
+		OpenAIParserType, claim, strings.Join(canonicalAPIEndpoints, ", "))
+}
+
+// sitsUnder reports whether path contains endpoint as a complete run of path
+// segments, so "chat/completions" is found in "v2/chat/completions/stream" but
+// not in "fancycompletions".
+func sitsUnder(path, endpoint string) bool {
+	return path == endpoint ||
+		strings.HasPrefix(path, endpoint+"/") ||
+		strings.HasSuffix(path, "/"+endpoint) ||
+		strings.Contains(path, "/"+endpoint+"/")
 }
 
 // NewOpenAIParser creates a new OpenAIParser.
@@ -83,22 +139,53 @@ func (p *OpenAIParser) TypedName() fwkplugin.TypedName {
 }
 
 func (p *OpenAIParser) Claims() fwkrh.Claims {
+	paths := append(make([]string, 0, 7+len(p.customClaims)),
+		chatCompletionsAPI,
+		completionsAPI,
+		embeddingsAPI,
+		responsesAPI,
+		conversationsAPI,
+		chatCompletionsAPI+"/render",
+		completionsAPI+"/render",
+	)
+	for _, claim := range p.customClaims {
+		paths = append(paths, claim.path)
+	}
 	return fwkrh.Claims{
-		Paths: []string{
-			chatCompletionsAPI,
-			completionsAPI,
-			embeddingsAPI,
-			responsesAPI,
-			conversationsAPI,
-			chatCompletionsAPI + "/render",
-			completionsAPI + "/render",
-		},
+		Paths:     paths,
 		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
 	}
 }
 
-func OpenAIParserPluginFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
-	return NewOpenAIParser().WithName(name), nil
+func OpenAIParserPluginFactory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	var params Parameters
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&params); err != nil {
+			return nil, fmt.Errorf("%s: failed to decode parameters: %w", OpenAIParserType, err)
+		}
+	}
+
+	parser := NewOpenAIParser().WithName(name)
+	for _, claim := range params.AdditionalPathClaims {
+		apiType, err := resolveClaimAPIType(claim)
+		if err != nil {
+			return nil, err
+		}
+		parser.customClaims = append(parser.customClaims, customClaim{
+			path:    strings.Trim(strings.TrimSpace(claim), "/"),
+			apiType: apiType,
+		})
+	}
+	// Deepest claim wins when a path matches several; ties broken
+	// lexicographically for determinism.
+	sort.SliceStable(parser.customClaims, func(i, j int) bool {
+		di, dj := strings.Count(parser.customClaims[i].path, "/"), strings.Count(parser.customClaims[j].path, "/")
+		if di != dj {
+			return di > dj
+		}
+		return parser.customClaims[i].path < parser.customClaims[j].path
+	})
+	return parser, nil
 }
 
 func (p *OpenAIParser) WithName(name string) *OpenAIParser {
@@ -112,7 +199,7 @@ func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers ma
 	if err := json.Unmarshal(body, &bodyMap); err != nil {
 		return nil, fmt.Errorf("error unmarshaling request bodyMap: %w", err)
 	}
-	apiType := determineAPITypeFromPath(request.GetRequestPath(headers))
+	apiType := p.apiTypeFromPath(request.GetRequestPath(headers))
 	extractedBody, err := extractRequestBody(apiType, body)
 	if err != nil {
 		return nil, err
@@ -173,6 +260,17 @@ func (p *OpenAIParser) parseStreamResponse(chunk []byte) (*fwkrh.ParsedResponse,
 	return &fwkrh.ParsedResponse{
 		Usage: usage,
 	}, nil
+}
+
+// apiTypeFromPath resolves the API type for a request path, consulting the
+// operator-configured claims (deepest first) before the canonical suffix chain.
+func (p *OpenAIParser) apiTypeFromPath(path string) string {
+	for _, claim := range p.customClaims {
+		if request.MatchPathSuffix(path, claim.path) {
+			return claim.apiType
+		}
+	}
+	return determineAPITypeFromPath(path)
 }
 
 // determineAPITypeFromPath determines the API type based on the request path.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -1454,3 +1454,141 @@ func TestOpenAIParser_ParseRequest_MaxOutputTokens(t *testing.T) {
 		})
 	}
 }
+
+func TestOpenAIParserPluginFactory_AdditionalPathClaims(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		wantErr    bool
+		wantExtras []string
+	}{
+		{
+			name:       "extras merged into claims",
+			raw:        `{"additionalPathClaims":["chat/completions/pipeline","myservice/embeddings"]}`,
+			wantExtras: []string{"chat/completions/pipeline", "myservice/embeddings"},
+		},
+		{
+			name: "no parameters keeps default claims",
+		},
+		{
+			name:    "claim under no canonical endpoint rejected",
+			raw:     `{"additionalPathClaims":["foo/bar"]}`,
+			wantErr: true,
+		},
+		{
+			name:    "bare-suffix overlap without segment boundary rejected",
+			raw:     `{"additionalPathClaims":["fancycompletions"]}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty claim rejected",
+			raw:     `{"additionalPathClaims":["/"]}`,
+			wantErr: true,
+		},
+		{
+			name:    "unknown field rejected",
+			raw:     `{"additionalPathClaim":["completions/x"]}`,
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var decoder *json.Decoder
+			if tc.raw != "" {
+				decoder = fwkplugin.StrictDecoder(json.RawMessage(tc.raw))
+			}
+			plg, err := OpenAIParserPluginFactory("test-parser", decoder, nil)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("OpenAIParserPluginFactory() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("OpenAIParserPluginFactory() unexpected error: %v", err)
+			}
+			want := append([]string{
+				chatCompletionsAPI,
+				completionsAPI,
+				embeddingsAPI,
+				responsesAPI,
+				conversationsAPI,
+				chatCompletionsAPI + "/render",
+				completionsAPI + "/render",
+			}, tc.wantExtras...)
+			got := plg.(*OpenAIParser).Claims().Paths
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("Claims().Paths mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestResolveClaimAPIType(t *testing.T) {
+	tests := []struct {
+		claim   string
+		want    string
+		wantErr bool
+	}{
+		{claim: "chat/completions/pipeline", want: chatCompletionsAPI},
+		{claim: "v2/chat/completions/stream", want: chatCompletionsAPI},
+		{claim: "myservice/completions", want: completionsAPI},
+		{claim: "conversations/archive", want: conversationsAPI},
+		{claim: "embeddings", want: embeddingsAPI},
+		{claim: "/responses/", want: responsesAPI},
+		{claim: "completionsfoo", wantErr: true},
+		{claim: "foo/bar", wantErr: true},
+		{claim: "", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.claim, func(t *testing.T) {
+			got, err := resolveClaimAPIType(tc.claim)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("resolveClaimAPIType(%q) expected error, got %q", tc.claim, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveClaimAPIType(%q) unexpected error: %v", tc.claim, err)
+			}
+			if got != tc.want {
+				t.Errorf("resolveClaimAPIType(%q) = %q, want %q", tc.claim, got, tc.want)
+			}
+		})
+	}
+}
+
+// A request on a configured custom sub-path must parse as the canonical
+// endpoint the claim sits under; without the claim mapping, the same path
+// falls through to the completions default and misparses a chat body.
+func TestOpenAIParser_ParseRequest_CustomClaimDispatch(t *testing.T) {
+	raw := json.RawMessage(`{"additionalPathClaims":["chat/completions/pipeline"]}`)
+	plg, err := OpenAIParserPluginFactory("test-parser", fwkplugin.StrictDecoder(raw), nil)
+	if err != nil {
+		t.Fatalf("OpenAIParserPluginFactory() unexpected error: %v", err)
+	}
+	parser := plg.(*OpenAIParser)
+
+	body := map[string]any{
+		"model": "test",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "hello"},
+		},
+	}
+	jsonBytes, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got, err := parser.ParseRequest(context.Background(), jsonBytes, map[string]string{":path": "/v1/chat/completions/pipeline"})
+	if err != nil {
+		t.Fatalf("ParseRequest() unexpected error: %v", err)
+	}
+	if got.Body.ChatCompletions == nil {
+		t.Fatalf("ParseRequest() dispatched custom claim path as %+v, want chat/completions extraction", got.Body)
+	}
+	wantMessages := []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Raw: "hello"}}}
+	if diff := cmp.Diff(wantMessages, got.Body.ChatCompletions.Messages); diff != "" {
+		t.Errorf("ChatCompletions.Messages mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Makes the OpenAI parser's claimed path suffixes configurable, per the shape discussed on the issue:

- **Config**: `additionalPathClaims` on `openai-parser` parameters (mirrors `preadmitter/agentidentity`'s configurable-list-plus-defaults pattern; the factory now consumes its previously-discarded decoder). Extras merge into `Claims()` so the parser registry routes them to this parser.
- **Dispatch**: each claim is resolved at config-decode time to the deepest canonical endpoint it sits under, segment-aware -- `chat/completions/pipeline` parses as chat/completions, not bare completions -- via small unexported helpers in the openai package. Request-time dispatch consults the configured claims (deepest first) before the existing canonical suffix chain, which is untouched.
- **Validation**: a claim that sits under no canonical endpoint fails configuration loading with an error naming the claim and the valid endpoints, rather than silently dispatching as completions.

**Which issue(s) this PR fixes**:
Fixes #1524

**Test plan**
- [x] Factory config table: extras merged into claims; strict decode rejects unknown fields; claims under no canonical endpoint, without a segment boundary (`fancycompletions`), or empty are rejected
- [x] Claim-resolution table incl. prefixed (`myservice/completions`), nested (`v2/chat/completions/stream`), and slash-wrapped forms
- [x] End-to-end regression: chat body on a configured custom sub-path parses as chat/completions (previously fell through to the completions default and misparsed)
- [x] `go test ./pkg/...`
- [x] `make test-integration-hermetic` (130 tests)
- [x] `make presubmit`

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The openai-parser now accepts an `additionalPathClaims` parameter listing extra path suffixes to route to it. Each claim must sit under a canonical OpenAI endpoint (segment-aware) and is parsed as that endpoint's API type; claims under no canonical endpoint fail configuration loading.
```