### PR TITLE
add toolcalling telemetry to EPP

### DIFF
--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -52,6 +53,9 @@ import (
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
+	"github.com/llm-d/llm-d-router/pkg/epp/toolcalling"
+
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // EvictChannelLookup is an optional interface for looking up eviction channels by request ID.
@@ -434,10 +438,39 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 					break
 				}
 
+				var inboundToolSnapshot *toolcalling.ToolCallingSnapshot
+				if payloadMap, ok := parseResult.Body.Payload.(fwkrh.PayloadMap); ok {
+					inboundToolSnapshot = toolcalling.ExtractFromPayloadMap(payloadMap)
+				}
+
 				reqCtx, err = s.director.HandleRequest(ctx, reqCtx, parseResult.Body)
 				if err != nil {
 					logger.Error(err, "Error handling request")
 					break
+				}
+
+				var outboundToolSnapshot *toolcalling.ToolCallingSnapshot
+				if payloadMap, ok := parseResult.Body.Payload.(fwkrh.PayloadMap); ok {
+					outboundToolSnapshot = toolcalling.ExtractFromPayloadMap(payloadMap)
+				}
+
+				parserType := parser.TypedName().Type
+				metrics.RecordToolCallingRequest(parserType, inboundToolSnapshot)
+				preserved := toolcalling.PreservationStatus(inboundToolSnapshot, outboundToolSnapshot)
+				metrics.RecordToolCallingPreservation(parserType, preserved)
+
+				if inboundToolSnapshot != nil && span != nil {
+					span.AddEvent("tool_calling.parameters.observed",
+						trace.WithAttributes(toolcalling.SpanAttributes(inboundToolSnapshot, "epp_inbound")...))
+				}
+				if outboundToolSnapshot != nil && span != nil {
+					attrs := toolcalling.SpanAttributes(outboundToolSnapshot, "epp_outbound")
+					attrs = append(attrs, attribute.String("preserved_from_inbound", preserved))
+					span.AddEvent("tool_calling.parameters.forwarded", trace.WithAttributes(attrs...))
+				}
+
+				if outboundToolSnapshot != nil {
+					maps.Copy(reqCtx.Request.Headers, toolcalling.ToHeaders(outboundToolSnapshot))
 				}
 
 				// After scheduling, look up the eviction channel for eviction support.

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -363,6 +363,55 @@ var (
 	)
 )
 
+// --- llm-d Tool Calling Metrics ---
+var (
+	llmdToolCallingRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "tool_calling_requests_total",
+			Help:      metricsutil.HelpMsgWithStability("Total requests by tool-calling presence.", compbasemetrics.ALPHA),
+		},
+		[]string{"parser", "present"},
+	)
+
+	llmdToolChoiceTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "tool_choice_total",
+			Help:      metricsutil.HelpMsgWithStability("Total requests by tool_choice kind.", compbasemetrics.ALPHA),
+		},
+		[]string{"parser", "tool_choice_kind"},
+	)
+
+	llmdToolDefinitionsCount = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "tool_definitions_count",
+			Help:      metricsutil.HelpMsgWithStability("Distribution of tool definition count per request.", compbasemetrics.ALPHA),
+			Buckets:   []float64{0, 1, 2, 3, 5, 10, 20, 50, 100},
+		},
+		[]string{"parser"},
+	)
+
+	llmdParallelToolCallsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "parallel_tool_calls_total",
+			Help:      metricsutil.HelpMsgWithStability("Total requests by parallel_tool_calls value.", compbasemetrics.ALPHA),
+		},
+		[]string{"parser", "value"},
+	)
+
+	llmdToolCallingPreservedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "tool_calling_preserved_total",
+			Help:      metricsutil.HelpMsgWithStability("Total requests by tool-calling preservation status across the EPP boundary.", compbasemetrics.ALPHA),
+		},
+		[]string{"parser", "preserved"},
+	)
+)
+
 var (
 	// DescInferencePoolPerEndpointQueueSize is the standardized exported prometheus descriptor.
 	DescInferencePoolPerEndpointQueueSize = prometheus.NewDesc(

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -30,6 +30,7 @@ import (
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	metricsutil "github.com/llm-d/llm-d-router/pkg/common/observability/metrics"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/toolcalling"
 )
 
 const (
@@ -475,6 +476,11 @@ func Register(customCollectors ...prometheus.Collector) {
 		metrics.Registry.MustRegister(LlmdDataLayerPollErrorsTotal)
 		metrics.Registry.MustRegister(DataLayerExtractErrorsTotal)
 		metrics.Registry.MustRegister(LlmdDataLayerExtractErrorsTotal)
+		metrics.Registry.MustRegister(llmdToolCallingRequestsTotal)
+		metrics.Registry.MustRegister(llmdToolChoiceTotal)
+		metrics.Registry.MustRegister(llmdToolDefinitionsCount)
+		metrics.Registry.MustRegister(llmdParallelToolCallsTotal)
+		metrics.Registry.MustRegister(llmdToolCallingPreservedTotal)
 		for _, collector := range customCollectors {
 			metrics.Registry.MustRegister(collector)
 		}
@@ -541,6 +547,11 @@ func Reset() {
 	LlmdDataLayerPollErrorsTotal.Reset()
 	DataLayerExtractErrorsTotal.Reset()
 	LlmdDataLayerExtractErrorsTotal.Reset()
+	llmdToolCallingRequestsTotal.Reset()
+	llmdToolChoiceTotal.Reset()
+	llmdToolDefinitionsCount.Reset()
+	llmdParallelToolCallsTotal.Reset()
+	llmdToolCallingPreservedTotal.Reset()
 }
 
 // RecordRequestCounter records the number of requests.
@@ -847,4 +858,21 @@ func RecordDataLayerPollError(sourceType string) {
 func RecordDataLayerExtractError(sourceType, extractorType string) {
 	DataLayerExtractErrorsTotal.WithLabelValues(sourceType, extractorType).Inc()
 	LlmdDataLayerExtractErrorsTotal.WithLabelValues(sourceType, extractorType).Inc()
+}
+
+// RecordToolCallingRequest records tool-calling usage metrics from a snapshot.
+func RecordToolCallingRequest(parser string, snapshot *toolcalling.ToolCallingSnapshot) {
+	if snapshot == nil {
+		llmdToolCallingRequestsTotal.WithLabelValues(parser, "false").Inc()
+		return
+	}
+	llmdToolCallingRequestsTotal.WithLabelValues(parser, strconv.FormatBool(snapshot.Present)).Inc()
+	llmdToolChoiceTotal.WithLabelValues(parser, snapshot.ToolChoiceKind).Inc()
+	llmdToolDefinitionsCount.WithLabelValues(parser).Observe(float64(snapshot.ToolDefinitionsCount))
+	llmdParallelToolCallsTotal.WithLabelValues(parser, snapshot.ParallelToolCalls).Inc()
+}
+
+// RecordToolCallingPreservation records whether tool-calling parameters were preserved across the EPP boundary.
+func RecordToolCallingPreservation(parser, preserved string) {
+	llmdToolCallingPreservedTotal.WithLabelValues(parser, preserved).Inc()
 }

--- a/pkg/epp/toolcalling/snapshot.go
+++ b/pkg/epp/toolcalling/snapshot.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package toolcalling
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strconv"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const (
+	HeaderSnapshotHash      = "x-llm-d-tool-snapshot-hash"
+	HeaderToolPresent       = "x-llm-d-tool-present"
+	HeaderToolChoiceKind    = "x-llm-d-tool-choice-kind"
+	HeaderToolDefsCount     = "x-llm-d-tool-definitions-count"
+	HeaderParallelToolCalls = "x-llm-d-tool-parallel-calls"
+
+	ChoiceUnset    = "unset"
+	ChoiceNone     = "none"
+	ChoiceAuto     = "auto"
+	ChoiceRequired = "required"
+	ChoiceNamed    = "named"
+	ChoiceUnknown  = "unknown"
+
+	ParallelUnset   = "unset"
+	ParallelTrue    = "true"
+	ParallelFalse   = "false"
+	ParallelUnknown = "unknown"
+
+	PreservedTrue    = "true"
+	PreservedFalse   = "false"
+	PreservedUnknown = "unknown"
+
+	hashTruncLen = 16
+)
+
+// ToolCallingSnapshot captures the normalized shape of tool-calling
+// parameters in an inference request, without exposing high-cardinality
+// content such as tool names, schemas, or function descriptions.
+type ToolCallingSnapshot struct {
+	Present              bool
+	ToolChoicePresent    bool
+	ToolChoiceKind       string
+	ToolDefinitionsCount int
+	ToolDefinitionsHash  string
+	ParallelToolCalls    string
+	SnapshotHash         string
+}
+
+// ExtractFromPayloadMap reads tool-calling fields from a parsed request
+// body map and returns a normalized snapshot. Returns nil when none of
+// the tool-calling keys are present.
+func ExtractFromPayloadMap(m map[string]any) *ToolCallingSnapshot {
+	_, hasTools := m["tools"]
+	_, hasToolChoice := m["tool_choice"]
+	_, hasParallel := m["parallel_tool_calls"]
+
+	if !hasTools && !hasToolChoice && !hasParallel {
+		return nil
+	}
+
+	s := &ToolCallingSnapshot{}
+
+	if hasTools {
+		if tools, ok := m["tools"].([]any); ok && len(tools) > 0 {
+			s.Present = true
+			s.ToolDefinitionsCount = len(tools)
+			s.ToolDefinitionsHash = computeToolDefinitionsHash(tools)
+		}
+	}
+
+	s.ToolChoiceKind = normalizeToolChoice(m)
+	s.ToolChoicePresent = s.ToolChoiceKind != ChoiceUnset
+
+	s.ParallelToolCalls = normalizeParallelToolCalls(m)
+
+	s.SnapshotHash = computeSnapshotHash(s)
+
+	return s
+}
+
+func normalizeToolChoice(m map[string]any) string {
+	v, ok := m["tool_choice"]
+	if !ok || v == nil {
+		return ChoiceUnset
+	}
+
+	switch tc := v.(type) {
+	case string:
+		switch tc {
+		case "none":
+			return ChoiceNone
+		case "auto":
+			return ChoiceAuto
+		case "required":
+			return ChoiceRequired
+		default:
+			return ChoiceUnknown
+		}
+	case map[string]any:
+		return ChoiceNamed
+	default:
+		return ChoiceUnknown
+	}
+}
+
+func normalizeParallelToolCalls(m map[string]any) string {
+	v, ok := m["parallel_tool_calls"]
+	if !ok {
+		return ParallelUnset
+	}
+
+	b, ok := v.(bool)
+	if !ok {
+		return ParallelUnknown
+	}
+	if b {
+		return ParallelTrue
+	}
+	return ParallelFalse
+}
+
+func computeSnapshotHash(s *ToolCallingSnapshot) string {
+	raw := "present=" + strconv.FormatBool(s.Present) +
+		"|choice_present=" + strconv.FormatBool(s.ToolChoicePresent) +
+		"|choice_kind=" + s.ToolChoiceKind +
+		"|defs_count=" + strconv.Itoa(s.ToolDefinitionsCount) +
+		"|defs_hash=" + s.ToolDefinitionsHash +
+		"|parallel=" + s.ParallelToolCalls
+
+	h := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(h[:])[:hashTruncLen]
+}
+
+func computeToolDefinitionsHash(tools []any) string {
+	type canonicalTool struct {
+		Name       string `json:"name"`
+		Parameters any    `json:"parameters,omitempty"`
+	}
+
+	var extracted []canonicalTool
+	for _, t := range tools {
+		tm, ok := t.(map[string]any)
+		if !ok {
+			continue
+		}
+		fn, ok := tm["function"].(map[string]any)
+		if !ok {
+			continue
+		}
+		ct := canonicalTool{}
+		if name, ok := fn["name"].(string); ok {
+			ct.Name = name
+		}
+		ct.Parameters = fn["parameters"]
+		extracted = append(extracted, ct)
+	}
+
+	if len(extracted) == 0 {
+		return ""
+	}
+
+	sort.Slice(extracted, func(i, j int) bool {
+		return extracted[i].Name < extracted[j].Name
+	})
+
+	b, err := json.Marshal(extracted)
+	if err != nil {
+		return ""
+	}
+
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])[:hashTruncLen]
+}
+
+// PreservationStatus compares inbound and outbound snapshots.
+func PreservationStatus(inbound, outbound *ToolCallingSnapshot) string {
+	if inbound == nil || outbound == nil {
+		return PreservedUnknown
+	}
+	if inbound.SnapshotHash == outbound.SnapshotHash {
+		return PreservedTrue
+	}
+	return PreservedFalse
+}
+
+// ToHeaders converts the snapshot to propagation headers.
+func ToHeaders(s *ToolCallingSnapshot) map[string]string {
+	if s == nil {
+		return nil
+	}
+	return map[string]string{
+		HeaderSnapshotHash:      s.SnapshotHash,
+		HeaderToolPresent:       strconv.FormatBool(s.Present),
+		HeaderToolChoiceKind:    s.ToolChoiceKind,
+		HeaderToolDefsCount:     strconv.Itoa(s.ToolDefinitionsCount),
+		HeaderParallelToolCalls: s.ParallelToolCalls,
+	}
+}
+
+// FromHeaders reconstructs a snapshot from propagation headers.
+// Returns nil if the snapshot hash header is absent.
+func FromHeaders(headers map[string]string) *ToolCallingSnapshot {
+	hash, ok := headers[HeaderSnapshotHash]
+	if !ok || hash == "" {
+		return nil
+	}
+
+	s := &ToolCallingSnapshot{
+		SnapshotHash:      hash,
+		ToolChoiceKind:    headers[HeaderToolChoiceKind],
+		ParallelToolCalls: headers[HeaderParallelToolCalls],
+	}
+
+	if v, err := strconv.ParseBool(headers[HeaderToolPresent]); err == nil {
+		s.Present = v
+	}
+	if v, err := strconv.Atoi(headers[HeaderToolDefsCount]); err == nil {
+		s.ToolDefinitionsCount = v
+	}
+	s.ToolChoicePresent = s.ToolChoiceKind != ChoiceUnset
+
+	return s
+}
+
+// SpanAttributes returns OTel span event attributes for the snapshot.
+func SpanAttributes(s *ToolCallingSnapshot, boundary string) []attribute.KeyValue {
+	if s == nil {
+		return nil
+	}
+	return []attribute.KeyValue{
+		attribute.String("boundary", boundary),
+		attribute.Bool("tool_calling.present", s.Present),
+		attribute.Bool("tool_calling.tool_choice.present", s.ToolChoicePresent),
+		attribute.String("tool_calling.tool_choice.kind", s.ToolChoiceKind),
+		attribute.Int("tool_calling.tool_definitions.count", s.ToolDefinitionsCount),
+		attribute.String("tool_calling.tool_definitions.hash", s.ToolDefinitionsHash),
+		attribute.String("tool_calling.parallel_tool_calls", s.ParallelToolCalls),
+		attribute.String("tool_calling.snapshot_hash", s.SnapshotHash),
+	}
+}

--- a/pkg/epp/toolcalling/snapshot_test.go
+++ b/pkg/epp/toolcalling/snapshot_test.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package toolcalling
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractFromPayloadMap_NoToolFields(t *testing.T) {
+	m := map[string]any{"model": "llama3", "messages": []any{}}
+	require.Nil(t, ExtractFromPayloadMap(m))
+}
+
+func TestExtractFromPayloadMap_ToolsOnly(t *testing.T) {
+	m := map[string]any{
+		"tools": []any{
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":       "get_weather",
+					"parameters": map[string]any{"type": "object"},
+				},
+			},
+		},
+	}
+	s := ExtractFromPayloadMap(m)
+	require.NotNil(t, s)
+	require.True(t, s.Present)
+	require.Equal(t, 1, s.ToolDefinitionsCount)
+	require.NotEmpty(t, s.ToolDefinitionsHash)
+	require.Equal(t, ChoiceUnset, s.ToolChoiceKind)
+	require.False(t, s.ToolChoicePresent)
+	require.Equal(t, ParallelUnset, s.ParallelToolCalls)
+	require.NotEmpty(t, s.SnapshotHash)
+}
+
+func TestExtractFromPayloadMap_ToolChoiceVariants(t *testing.T) {
+	tests := []struct {
+		name     string
+		choice   any
+		wantKind string
+	}{
+		{"auto", "auto", ChoiceAuto},
+		{"none", "none", ChoiceNone},
+		{"required", "required", ChoiceRequired},
+		{"named", map[string]any{"type": "function", "function": map[string]any{"name": "f"}}, ChoiceNamed},
+		{"unknown_string", "something_else", ChoiceUnknown},
+		{"unknown_type", 42, ChoiceUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := map[string]any{
+				"tools":       []any{map[string]any{"function": map[string]any{"name": "f"}}},
+				"tool_choice": tt.choice,
+			}
+			s := ExtractFromPayloadMap(m)
+			require.NotNil(t, s)
+			require.Equal(t, tt.wantKind, s.ToolChoiceKind)
+			require.True(t, s.ToolChoicePresent)
+		})
+	}
+}
+
+func TestExtractFromPayloadMap_ParallelToolCalls(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{"true", true, ParallelTrue},
+		{"false", false, ParallelFalse},
+		{"unknown", "yes", ParallelUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := map[string]any{
+				"tools":               []any{map[string]any{"function": map[string]any{"name": "f"}}},
+				"parallel_tool_calls": tt.value,
+			}
+			s := ExtractFromPayloadMap(m)
+			require.NotNil(t, s)
+			require.Equal(t, tt.want, s.ParallelToolCalls)
+		})
+	}
+}
+
+func TestExtractFromPayloadMap_NilToolChoice(t *testing.T) {
+	m := map[string]any{
+		"tools":       []any{map[string]any{"function": map[string]any{"name": "f"}}},
+		"tool_choice": nil,
+	}
+	s := ExtractFromPayloadMap(m)
+	require.NotNil(t, s)
+	require.Equal(t, ChoiceUnset, s.ToolChoiceKind)
+	require.False(t, s.ToolChoicePresent)
+}
+
+func TestHashStability(t *testing.T) {
+	m := map[string]any{
+		"tools": []any{
+			map[string]any{"function": map[string]any{"name": "a", "parameters": map[string]any{"type": "object"}}},
+			map[string]any{"function": map[string]any{"name": "b", "parameters": map[string]any{"type": "object"}}},
+		},
+		"tool_choice":         "auto",
+		"parallel_tool_calls": true,
+	}
+	s1 := ExtractFromPayloadMap(m)
+	s2 := ExtractFromPayloadMap(m)
+	require.Equal(t, s1.SnapshotHash, s2.SnapshotHash)
+	require.Equal(t, s1.ToolDefinitionsHash, s2.ToolDefinitionsHash)
+}
+
+func TestHashChangesOnToolDefinitionChange(t *testing.T) {
+	m1 := map[string]any{
+		"tools": []any{
+			map[string]any{"function": map[string]any{"name": "get_weather"}},
+		},
+	}
+	m2 := map[string]any{
+		"tools": []any{
+			map[string]any{"function": map[string]any{"name": "get_stock_price"}},
+		},
+	}
+	s1 := ExtractFromPayloadMap(m1)
+	s2 := ExtractFromPayloadMap(m2)
+	require.NotEqual(t, s1.ToolDefinitionsHash, s2.ToolDefinitionsHash)
+	require.NotEqual(t, s1.SnapshotHash, s2.SnapshotHash)
+}
+
+func TestHashChangesOnToolChoiceChange(t *testing.T) {
+	base := map[string]any{
+		"tools": []any{map[string]any{"function": map[string]any{"name": "f"}}},
+	}
+	m1 := copyMap(base)
+	m1["tool_choice"] = "auto"
+	m2 := copyMap(base)
+	m2["tool_choice"] = ChoiceNone
+
+	s1 := ExtractFromPayloadMap(m1)
+	s2 := ExtractFromPayloadMap(m2)
+	require.NotEqual(t, s1.SnapshotHash, s2.SnapshotHash)
+}
+
+func TestPreservationStatus(t *testing.T) {
+	tools := map[string]any{
+		"tools":       []any{map[string]any{"function": map[string]any{"name": "f"}}},
+		"tool_choice": "auto",
+	}
+
+	t.Run("equal", func(t *testing.T) {
+		s1 := ExtractFromPayloadMap(tools)
+		s2 := ExtractFromPayloadMap(tools)
+		require.Equal(t, PreservedTrue, PreservationStatus(s1, s2))
+	})
+
+	t.Run("different_choice", func(t *testing.T) {
+		m2 := copyMap(tools)
+		m2["tool_choice"] = ChoiceNone
+		s1 := ExtractFromPayloadMap(tools)
+		s2 := ExtractFromPayloadMap(m2)
+		require.Equal(t, PreservedFalse, PreservationStatus(s1, s2))
+	})
+
+	t.Run("nil_inbound", func(t *testing.T) {
+		s2 := ExtractFromPayloadMap(tools)
+		require.Equal(t, PreservedUnknown, PreservationStatus(nil, s2))
+	})
+
+	t.Run("nil_outbound", func(t *testing.T) {
+		s1 := ExtractFromPayloadMap(tools)
+		require.Equal(t, PreservedUnknown, PreservationStatus(s1, nil))
+	})
+
+	t.Run("both_nil", func(t *testing.T) {
+		require.Equal(t, PreservedUnknown, PreservationStatus(nil, nil))
+	})
+}
+
+func TestHeaderRoundTrip(t *testing.T) {
+	m := map[string]any{
+		"tools": []any{
+			map[string]any{"function": map[string]any{"name": "a", "parameters": map[string]any{"type": "object"}}},
+			map[string]any{"function": map[string]any{"name": "b"}},
+		},
+		"tool_choice":         "required",
+		"parallel_tool_calls": false,
+	}
+	original := ExtractFromPayloadMap(m)
+	require.NotNil(t, original)
+
+	headers := ToHeaders(original)
+	require.Len(t, headers, 5)
+
+	restored := FromHeaders(headers)
+	require.NotNil(t, restored)
+
+	require.Equal(t, original.Present, restored.Present)
+	require.Equal(t, original.ToolChoicePresent, restored.ToolChoicePresent)
+	require.Equal(t, original.ToolChoiceKind, restored.ToolChoiceKind)
+	require.Equal(t, original.ToolDefinitionsCount, restored.ToolDefinitionsCount)
+	require.Equal(t, original.ParallelToolCalls, restored.ParallelToolCalls)
+	require.Equal(t, original.SnapshotHash, restored.SnapshotHash)
+}
+
+func TestFromHeaders_NoHash(t *testing.T) {
+	require.Nil(t, FromHeaders(map[string]string{}))
+	require.Nil(t, FromHeaders(map[string]string{HeaderToolPresent: "true"}))
+}
+
+func TestToHeaders_Nil(t *testing.T) {
+	require.Nil(t, ToHeaders(nil))
+}
+
+func TestSpanAttributes(t *testing.T) {
+	m := map[string]any{
+		"tools":       []any{map[string]any{"function": map[string]any{"name": "f"}}},
+		"tool_choice": "auto",
+	}
+	s := ExtractFromPayloadMap(m)
+	attrs := SpanAttributes(s, "epp_inbound")
+	require.Len(t, attrs, 8)
+	require.Nil(t, SpanAttributes(nil, "epp_inbound"))
+}
+
+func TestToolDefinitionsHashOrder(t *testing.T) {
+	m1 := map[string]any{
+		"tools": []any{
+			map[string]any{"function": map[string]any{"name": "b"}},
+			map[string]any{"function": map[string]any{"name": "a"}},
+		},
+	}
+	m2 := map[string]any{
+		"tools": []any{
+			map[string]any{"function": map[string]any{"name": "a"}},
+			map[string]any{"function": map[string]any{"name": "b"}},
+		},
+	}
+	s1 := ExtractFromPayloadMap(m1)
+	s2 := ExtractFromPayloadMap(m2)
+	require.Equal(t, s1.ToolDefinitionsHash, s2.ToolDefinitionsHash)
+}
+
+func copyMap(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	maps.Copy(out, m)
+	return out
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds tool-calling telemetry to the EPP so operators can verify that tool-calling parameters (tools, tool_choice, parallel_tool_calls) survive intact through the request processing pipeline.

  Problem: There is no visibility into whether tool-calling parameters are preserved, modified, or dropped as requests flow through the EPP. If a plugin or code path inadvertently mutates tool fields, there is no signal to detect it.

  Solution: A new `pkg/epp/toolcalling `package extracts a normalized ToolCallingSnapshot from the parsed PayloadMap before and after director.HandleRequest(). The snapshots are compared to produce a preservation status, which is emitted as Prometheus metrics and OTel trace span events. Snapshot metadata is propagated downstream via low-cardinality HTTP headers for sidecar and vLLM follow-up work.

  New Prometheus metrics (all ALPHA, subsystem llm_d_epp):
  - tool_calling_requests_total - requests by tool-calling presence
  - tool_choice_total - requests by tool_choice kind (unset/none/auto/required/named/unknown)
  - tool_definitions_count - distribution of tool definition count per request
  - parallel_tool_calls_total - requests by parallel_tool_calls value
  - tool_calling_preserved_total - requests by preservation status across the EPP boundary

  Propagation headers (for downstream components):
  - x-llm-d-tool-snapshot-hash
  - x-llm-d-tool-present
  - x-llm-d-tool-choice-kind
  - x-llm-d-tool-definitions-count
  - x-llm-d-tool-parallel-calls
