### PR TITLE
feat: add opt-in GenAI payload capture (PayloadStore Phase 1)

### DIFF
--- a/docs/payload-capture.md
+++ b/docs/payload-capture.md
@@ -1,0 +1,58 @@
+# GenAI Payload Capture (opt-in)
+
+The EPP can record the prompt of each scheduled request on its `gateway.request`
+tracing span, following the upstream
+[GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/):
+the span carries a `gen_ai.client.inference.operation.details` event with
+`gen_ai.input.messages` and `gen_ai.system_instructions` attributes (both
+`Opt-In` / `Development` stability upstream).
+
+The feature is **off by default** and is Phase 1 of the
+[GenAI payload events proposal](https://github.com/llm-d/llm-d/blob/main/docs/proposals/genai-payload-events.md)
+in the llm-d repository — see the proposal for the full design (object-store
+backends, redaction, vLLM-native capture) landing in later phases.
+
+## Configuration
+
+| Environment variable | Default | Description |
+| --- | --- | --- |
+| `LLMD_PAYLOAD_CAPTURE_ENABLED` | `false` | Master switch. Capture is opt-in. |
+| `LLMD_PAYLOAD_BACKEND` | `noop` | `noop` emits nothing (secondary kill switch); `inline` attaches payloads to span events. `gcs`, `s3` and `filesystem` are reserved for Phase 2 and currently fall back to `noop` with a warning. |
+| `LLMD_PAYLOAD_INLINE_THRESHOLD` | `4096` | Largest serialised payload (bytes) attached inline. Larger payloads are dropped and the event is marked `llm_d.payload.truncated: true`. |
+
+Example (EPP container env):
+
+```yaml
+env:
+  - name: LLMD_PAYLOAD_CAPTURE_ENABLED
+    value: "true"
+  - name: LLMD_PAYLOAD_BACKEND
+    value: "inline"
+```
+
+Payload events are only recorded on sampled spans, so OTel tracing must be
+enabled (`OTEL_TRACES_EXPORTER=otlp`) and the request must be sampled.
+
+## What is captured
+
+- **Chat completions** (`/v1/chat/completions`): messages as `role`/`parts`;
+  `system` and `developer` messages are recorded as `gen_ai.system_instructions`.
+- **Completions** (`/v1/completions`): the prompt as a single `user` message.
+- **Anthropic messages** (`/v1/messages`): messages plus the top-level `system`
+  field.
+- Multimodal parts referencing external URLs are recorded as schema-standard
+  `uri` parts. Raw inline bytes (data URLs, base64 audio/images) are **blob**
+  parts and require an object-store backend (Phase 2); until then they are
+  dropped and the event carries `llm_d.payload.truncated: true`. Other request
+  types (embeddings, responses, generate) are not captured yet.
+
+The `llm_d.payload.*` attributes are llm-d extensions defined by the proposal;
+they are kept out of the reserved `gen_ai.*` namespace.
+
+## Security
+
+Captured payloads contain user data. Before enabling, ensure TLS on OTLP
+endpoints, restrict collector access, and treat trace storage with the same
+classification as the underlying request data. The redaction pipeline arrives
+in Phase 3; until then do not enable capture on workloads carrying regulated
+data unless the trace backend itself is appropriately controlled.

--- a/docs/payload-capture.md
+++ b/docs/payload-capture.md
@@ -2,10 +2,16 @@
 
 The EPP can record the prompt of each scheduled request on its `gateway.request`
 tracing span, following the upstream
-[GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/):
-the span carries a `gen_ai.client.inference.operation.details` event with
-`gen_ai.input.messages` and `gen_ai.system_instructions` attributes (both
-`Opt-In` / `Development` stability upstream).
+[GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai)
+(these live in a dedicated repo now; the entries at
+[`opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/)
+are `Deprecated` pointers to the same names). The span carries a
+`gen_ai.client.inference.operation.details` event with `gen_ai.input.messages`
+and `gen_ai.system_instructions` attributes (both `Opt-In` / `Development`
+stability upstream). Both attributes are JSON-serialised arrays that follow the
+schemas under
+[`model/gen-ai/`](https://github.com/open-telemetry/semantic-conventions-genai/tree/main/model/gen-ai)
+in the semconv-genai repo.
 
 The feature is **off by default** and is Phase 1 of the
 [GenAI payload events proposal](https://github.com/llm-d/llm-d/blob/main/docs/proposals/genai-payload-events.md)
@@ -37,14 +43,25 @@ enabled (`OTEL_TRACES_EXPORTER=otlp`) and the request must be sampled.
 
 - **Chat completions** (`/v1/chat/completions`): messages as `role`/`parts`;
   `system` and `developer` messages are recorded as `gen_ai.system_instructions`.
+  The SystemInstructions schema only allows `TextPart` / `GenericPart`, so
+  non-text content on a system-role message is dropped and marks the event
+  `llm_d.payload.truncated: true`.
 - **Completions** (`/v1/completions`): the prompt as a single `user` message.
 - **Anthropic messages** (`/v1/messages`): messages plus the top-level `system`
   field.
 - Multimodal parts referencing external URLs are recorded as schema-standard
   `uri` parts. Raw inline bytes (data URLs, base64 audio/images) are **blob**
   parts and require an object-store backend (Phase 2); until then they are
-  dropped and the event carries `llm_d.payload.truncated: true`. Other request
-  types (embeddings, responses, generate) are not captured yet.
+  dropped and the event carries `llm_d.payload.truncated: true`.
+- **Anthropic tool blocks** (`tool_use` / `tool_result` / `thinking`) will map to
+  semconv `ToolCallRequestPart` / `ToolCallResponsePart` / `ReasoningPart`
+  respectively; the part-type constants and struct scaffolding are in place, but
+  wiring waits on
+  [llm-d/llm-d-router#2389](https://github.com/llm-d/llm-d-router/pull/2389),
+  which extends `AnthropicContentBlock` with the required fields. Until then
+  they mark truncated. Same story for OpenAI assistant `tool_calls`: the field
+  is typed `[]any` at the parser layer, so we mark truncated when present.
+- Other request types (embeddings, responses, generate) are not captured yet.
 
 The `llm_d.payload.*` attributes are llm-d extensions defined by the proposal;
 they are kept out of the reserved `gen_ai.*` namespace.

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -52,6 +52,7 @@ import (
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
+	"github.com/llm-d/llm-d-router/pkg/epp/payload"
 )
 
 // EvictChannelLookup is an optional interface for looking up eviction channels by request ID.
@@ -88,6 +89,12 @@ func (s *StreamingServer) SetEmitEndpointScores(enabled bool) {
 	s.emitEndpointScores = enabled
 }
 
+// SetPayloadCapturer enables opt-in GenAI payload capture on the request path.
+// A nil capturer (the default) captures nothing.
+func (s *StreamingServer) SetPayloadCapturer(c *payload.Capturer) {
+	s.payloadCapturer = c
+}
+
 type Director interface {
 	HandleRequest(ctx context.Context, reqCtx *RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) (*RequestContext, error)
 	HandleResponseHeader(ctx context.Context, reqCtx *RequestContext) *RequestContext
@@ -106,6 +113,7 @@ type StreamingServer struct {
 	director          Director
 	parserRegistry    *ParserRegistry
 	evictionLookup    EvictChannelLookup // optional, set for eviction support
+	payloadCapturer   *payload.Capturer  // optional, nil unless payload capture is enabled
 	bufferPool        sync.Pool
 	maxPoolBufferSize int
 	// emitEndpointScores enables emitting per-endpoint scheduler scores in the request-path
@@ -490,6 +498,10 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				if reqCtx.SchedulingRequest != nil && reqCtx.SchedulingRequest.Body != nil {
 					reqCtx.modelServerStreaming = reqCtx.SchedulingRequest.Body.Stream
 				}
+
+				// Opt-in GenAI payload capture: record the prompt on the gateway
+				// span once the request has been scheduled. Never fails the request.
+				s.payloadCapturer.CaptureRequest(ctx, parseResult.Body)
 
 				reqCtx.reqHeaderResp = s.generateRequestHeaderResponse(ctx, reqCtx)
 				reqCtx.reqBodyResp = envoy.GenerateRequestBodyResponses(reqCtx.Request.RawBody)

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -500,8 +500,12 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 				}
 
 				// Opt-in GenAI payload capture: record the prompt on the gateway
-				// span once the request has been scheduled. Never fails the request.
-				s.payloadCapturer.CaptureRequest(ctx, parseResult.Body)
+				// span once the request has been scheduled. Never fails the
+				// request. The nil check makes the disabled path explicit at
+				// the callsite (Capturer.CaptureRequest also guards internally).
+				if s.payloadCapturer != nil {
+					s.payloadCapturer.CaptureRequest(ctx, parseResult.Body)
+				}
 
 				reqCtx.reqHeaderResp = s.generateRequestHeaderResponse(ctx, reqCtx)
 				reqCtx.reqBodyResp = envoy.GenerateRequestBodyResponses(reqCtx.Request.RawBody)

--- a/pkg/epp/payload/capture.go
+++ b/pkg/epp/payload/capture.go
@@ -1,0 +1,320 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package payload
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+)
+
+// Attribute and event names. The gen_ai.* names are the upstream GenAI
+// semantic-convention attributes (Opt-In, Development stability); the
+// llm_d.payload.* names are llm-d extensions defined in the proposal, kept
+// outside the reserved gen_ai.* namespace.
+// https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/
+const (
+	// EventInferenceDetails is the upstream GenAI event that carries payload
+	// attributes: gen_ai.client.inference.operation.details.
+	EventInferenceDetails = "gen_ai.client.inference.operation.details"
+
+	// AttrInputMessages is gen_ai.input.messages: the structured request
+	// messages (role/parts), serialised to JSON when recorded on a span event.
+	AttrInputMessages = "gen_ai.input.messages"
+	// AttrSystemInstructions is gen_ai.system_instructions: system message(s)
+	// supplied separately from the chat history.
+	AttrSystemInstructions = "gen_ai.system_instructions"
+
+	// AttrTruncated is llm_d.payload.truncated (llm-d extension): true when
+	// content was dropped or truncated during capture.
+	AttrTruncated = "llm_d.payload.truncated"
+)
+
+// Part types and modalities from the upstream input-messages schema.
+// https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-input-messages.json
+const (
+	partTypeText = "text"
+	partTypeURI  = "uri"
+
+	modalityImage = "image"
+	modalityVideo = "video"
+)
+
+// blockTypeText is the "text" content-block type shared by the OpenAI and
+// Anthropic request schemas.
+const blockTypeText = "text"
+
+// chatMessage mirrors one entry of the upstream gen_ai.input.messages schema.
+type chatMessage struct {
+	Role  string `json:"role"`
+	Parts []part `json:"parts"`
+}
+
+// part mirrors the upstream message-part schema. Exactly one of Content or
+// URI is set, per the part Type.
+type part struct {
+	Type     string `json:"type"`
+	Content  string `json:"content,omitempty"`
+	URI      string `json:"uri,omitempty"`
+	MimeType string `json:"mime_type,omitempty"`
+	Modality string `json:"modality,omitempty"`
+}
+
+// extraction is the intermediate result of converting a parsed request body
+// into semantic-convention form.
+type extraction struct {
+	messages []chatMessage
+	system   []part
+	// truncated is set when content was dropped: inline blob parts (no offload
+	// backend exists in Phase 1) or non-textual prompts (token IDs).
+	truncated bool
+}
+
+func (e extraction) empty() bool {
+	return len(e.messages) == 0 && len(e.system) == 0 && !e.truncated
+}
+
+// Capturer records request payloads as GenAI span events on the active
+// gateway span. A nil *Capturer is valid and captures nothing.
+type Capturer struct {
+	store  PayloadStore
+	logger logr.Logger
+}
+
+// NewCapturer returns a Capturer for the given configuration, or nil when the
+// configuration produces no events (capture disabled, or the noop backend,
+// which is the proposal's secondary kill switch).
+func NewCapturer(cfg Config, logger logr.Logger) *Capturer {
+	if !cfg.Enabled || cfg.Backend != BackendInline {
+		return nil
+	}
+	return &Capturer{
+		store:  InlineStore{MaxBytes: cfg.InlineSizeThresholdBytes},
+		logger: logger.WithName("payload-capture"),
+	}
+}
+
+// NewCapturerFromEnv builds a Capturer from the LLMD_PAYLOAD_* environment
+// variables; nil when capture is disabled.
+func NewCapturerFromEnv(logger logr.Logger) *Capturer {
+	cfg := LoadConfigFromEnv(logger)
+	c := NewCapturer(cfg, logger)
+	if c != nil {
+		logger.Info("GenAI payload capture enabled",
+			"backend", cfg.Backend, "inlineSizeThresholdBytes", cfg.InlineSizeThresholdBytes)
+	}
+	return c
+}
+
+// CaptureRequest records the request payload as a GenAI span event on the
+// span carried by ctx. It never fails the request: on any capture problem the
+// event is degraded (llm_d.payload.truncated=true) or skipped entirely.
+func (c *Capturer) CaptureRequest(ctx context.Context, body *fwkrh.InferenceRequestBody) {
+	if c == nil || body == nil {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if !span.SpanContext().IsValid() || !span.IsRecording() {
+		return
+	}
+
+	ext := extract(body)
+	if ext.empty() {
+		return
+	}
+
+	ref := PayloadRef{
+		TraceID:   span.SpanContext().TraceID().String(),
+		SpanID:    span.SpanContext().SpanID().String(),
+		Kind:      KindPrompt,
+		MediaType: "application/json",
+	}
+
+	attrs := make([]attribute.KeyValue, 0, 3)
+	if kv, ok := c.inlineJSON(ctx, ref, AttrInputMessages, ext.messages, len(ext.messages) > 0, &ext.truncated); ok {
+		attrs = append(attrs, kv)
+	}
+	if kv, ok := c.inlineJSON(ctx, ref, AttrSystemInstructions, ext.system, len(ext.system) > 0, &ext.truncated); ok {
+		attrs = append(attrs, kv)
+	}
+	if ext.truncated {
+		attrs = append(attrs, attribute.Bool(AttrTruncated, true))
+	}
+	if len(attrs) == 0 {
+		return
+	}
+	span.AddEvent(EventInferenceDetails, trace.WithAttributes(attrs...))
+}
+
+// inlineJSON serialises v and offers it to the backend. It returns the
+// attribute to attach when the backend accepts the payload inline; on
+// ErrPayloadTooLarge the attribute is dropped and *truncated is set (Phase 1
+// has no offload backend to fall back to).
+func (c *Capturer) inlineJSON(ctx context.Context, ref PayloadRef, key string, v any, present bool, truncated *bool) (attribute.KeyValue, bool) {
+	if !present {
+		return attribute.KeyValue{}, false
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		c.logger.Error(err, "failed to serialise payload attribute", "attribute", key)
+		*truncated = true
+		return attribute.KeyValue{}, false
+	}
+	if _, err := c.store.Store(ctx, ref, data); err != nil {
+		*truncated = true
+		return attribute.KeyValue{}, false
+	}
+	return attribute.String(key, string(data)), true
+}
+
+// extract converts the parsed request body into semantic-convention messages.
+// Phase 1 covers the chat-completions, completions and Anthropic-messages
+// shapes; other request types produce no event.
+func extract(body *fwkrh.InferenceRequestBody) extraction {
+	switch {
+	case body.ChatCompletions != nil:
+		return extractChatCompletions(body.ChatCompletions)
+	case body.Completions != nil:
+		return extractCompletions(body.Completions)
+	case body.Messages != nil:
+		return extractAnthropicMessages(body.Messages)
+	default:
+		return extraction{}
+	}
+}
+
+func extractChatCompletions(req *fwkrh.ChatCompletionsRequest) extraction {
+	var ext extraction
+	for _, msg := range req.Messages {
+		parts := contentToParts(msg.Content, &ext.truncated)
+		if len(parts) == 0 {
+			continue
+		}
+		// System-level guidance is recorded as gen_ai.system_instructions, not
+		// as an input message, per the upstream convention.
+		if msg.Role == "system" || msg.Role == "developer" {
+			ext.system = append(ext.system, parts...)
+			continue
+		}
+		ext.messages = append(ext.messages, chatMessage{Role: msg.Role, Parts: parts})
+	}
+	return ext
+}
+
+func contentToParts(content fwkrh.Content, truncated *bool) []part {
+	if content.Raw != "" {
+		return []part{{Type: partTypeText, Content: content.Raw}}
+	}
+	var parts []part
+	for _, block := range content.Structured {
+		switch block.Type {
+		case blockTypeText:
+			parts = append(parts, part{Type: partTypeText, Content: block.Text})
+		case "image_url":
+			parts = appendMediaURI(parts, block.ImageURL.URL, modalityImage, truncated)
+		case "video_url":
+			parts = appendMediaURI(parts, block.VideoURL.URL, modalityVideo, truncated)
+		case "input_audio":
+			// Audio arrives as raw base64 bytes (a blob part). Phase 1 has no
+			// object-store backend to offload blobs to, so the part is dropped.
+			*truncated = true
+		default:
+			*truncated = true
+		}
+	}
+	return parts
+}
+
+// appendMediaURI records an external media reference as a uri part. Data URLs
+// carry raw bytes inline (blob parts under the upstream schema); Phase 1 has
+// no object-store backend to offload them to, so they are dropped and the
+// event is marked truncated.
+func appendMediaURI(parts []part, url, modality string, truncated *bool) []part {
+	if url == "" {
+		return parts
+	}
+	if strings.HasPrefix(url, "data:") {
+		*truncated = true
+		return parts
+	}
+	return append(parts, part{Type: partTypeURI, URI: url, Modality: modality})
+}
+
+func extractCompletions(req *fwkrh.CompletionsRequest) extraction {
+	var ext extraction
+	var parts []part
+	if req.Prompt.Raw != "" {
+		parts = []part{{Type: partTypeText, Content: req.Prompt.Raw}}
+	} else {
+		for _, s := range req.Prompt.Strings {
+			parts = append(parts, part{Type: partTypeText, Content: s})
+		}
+	}
+	if len(parts) == 0 {
+		// Pre-tokenised prompts (token IDs) have no capturable text.
+		if len(req.Prompt.TokenIDs) > 0 {
+			ext.truncated = true
+		}
+		return ext
+	}
+	ext.messages = []chatMessage{{Role: "user", Parts: parts}}
+	return ext
+}
+
+func extractAnthropicMessages(req *fwkrh.MessagesRequest) extraction {
+	var ext extraction
+	ext.system = anthropicContentToParts(req.System, &ext.truncated)
+	for _, msg := range req.Messages {
+		parts := anthropicContentToParts(msg.Content, &ext.truncated)
+		if len(parts) == 0 {
+			continue
+		}
+		ext.messages = append(ext.messages, chatMessage{Role: msg.Role, Parts: parts})
+	}
+	return ext
+}
+
+func anthropicContentToParts(content fwkrh.AnthropicContent, truncated *bool) []part {
+	if content.Raw != "" {
+		return []part{{Type: partTypeText, Content: content.Raw}}
+	}
+	var parts []part
+	for _, block := range content.Structured {
+		switch {
+		case block.Type == blockTypeText:
+			parts = append(parts, part{Type: partTypeText, Content: block.Text})
+		case block.Type == "image" && block.Source != nil && block.Source.URL != "":
+			parts = append(parts, part{
+				Type:     partTypeURI,
+				URI:      block.Source.URL,
+				MimeType: block.Source.MediaType,
+				Modality: modalityImage,
+			})
+		default:
+			// base64 image sources are blob parts (no offload backend in
+			// Phase 1) and unrecognised block types are not representable.
+			*truncated = true
+		}
+	}
+	return parts
+}

--- a/pkg/epp/payload/capture.go
+++ b/pkg/epp/payload/capture.go
@@ -19,6 +19,7 @@ package payload
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -41,8 +42,11 @@ const (
 	// AttrInputMessages is gen_ai.input.messages: the structured request
 	// messages (role/parts), serialised to JSON when recorded on a span event.
 	AttrInputMessages = "gen_ai.input.messages"
-	// AttrSystemInstructions is gen_ai.system_instructions: system message(s)
-	// supplied separately from the chat history.
+	// AttrSystemInstructions is gen_ai.system_instructions: system-level
+	// instruction *text*, per the upstream semantic convention. Non-text
+	// system content (e.g. images in a system message) is dropped and marked
+	// on llm_d.payload.truncated; multiple system-role messages and multiple
+	// text parts within one message are joined with "\n\n".
 	AttrSystemInstructions = "gen_ai.system_instructions"
 
 	// AttrTruncated is llm_d.payload.truncated (llm-d extension): true when
@@ -81,17 +85,52 @@ type part struct {
 }
 
 // extraction is the intermediate result of converting a parsed request body
-// into semantic-convention form.
+// into semantic-convention form. system is a plain string (concatenation of
+// text-only system content) per the semconv definition of
+// gen_ai.system_instructions.
 type extraction struct {
 	messages []chatMessage
-	system   []part
+	system   string
 	// truncated is set when content was dropped: inline blob parts (no offload
-	// backend exists in Phase 1) or non-textual prompts (token IDs).
+	// backend exists in Phase 1), non-textual prompts (token IDs), or non-text
+	// content on a system-role message (system instructions are text-only).
 	truncated bool
 }
 
 func (e extraction) empty() bool {
-	return len(e.messages) == 0 && len(e.system) == 0 && !e.truncated
+	return len(e.messages) == 0 && e.system == "" && !e.truncated
+}
+
+// partsToTextString extracts the concatenated text of parts, joining multiple
+// text parts with a blank line. Non-text parts (uri, blob, etc.) are dropped
+// and mark *truncated. This is how system-role content is normalised into the
+// plain-string value required by gen_ai.system_instructions.
+func partsToTextString(parts []part, truncated *bool) string {
+	var texts []string
+	for _, p := range parts {
+		if p.Type == partTypeText {
+			if p.Content != "" {
+				texts = append(texts, p.Content)
+			}
+			continue
+		}
+		*truncated = true
+	}
+	return strings.Join(texts, "\n\n")
+}
+
+// appendSystemText joins additional system-instruction text with any already
+// captured, using a blank-line separator so multiple system messages remain
+// legible.
+func appendSystemText(existing, next string) string {
+	switch {
+	case next == "":
+		return existing
+	case existing == "":
+		return next
+	default:
+		return existing + "\n\n" + next
+	}
 }
 
 // Capturer records request payloads as GenAI span events on the active
@@ -154,7 +193,7 @@ func (c *Capturer) CaptureRequest(ctx context.Context, body *fwkrh.InferenceRequ
 	if kv, ok := c.inlineJSON(ctx, ref, AttrInputMessages, ext.messages, len(ext.messages) > 0, &ext.truncated); ok {
 		attrs = append(attrs, kv)
 	}
-	if kv, ok := c.inlineJSON(ctx, ref, AttrSystemInstructions, ext.system, len(ext.system) > 0, &ext.truncated); ok {
+	if kv, ok := c.inlineString(ctx, ref, AttrSystemInstructions, ext.system, &ext.truncated); ok {
 		attrs = append(attrs, kv)
 	}
 	if ext.truncated {
@@ -169,7 +208,9 @@ func (c *Capturer) CaptureRequest(ctx context.Context, body *fwkrh.InferenceRequ
 // inlineJSON serialises v and offers it to the backend. It returns the
 // attribute to attach when the backend accepts the payload inline; on
 // ErrPayloadTooLarge the attribute is dropped and *truncated is set (Phase 1
-// has no offload backend to fall back to).
+// has no offload backend to fall back to). Any other Store error is logged
+// so unexpected backend failures aren't lost silently — the attribute is
+// still dropped and *truncated set to keep the request path infallible.
 func (c *Capturer) inlineJSON(ctx context.Context, ref PayloadRef, key string, v any, present bool, truncated *bool) (attribute.KeyValue, bool) {
 	if !present {
 		return attribute.KeyValue{}, false
@@ -181,10 +222,31 @@ func (c *Capturer) inlineJSON(ctx context.Context, ref PayloadRef, key string, v
 		return attribute.KeyValue{}, false
 	}
 	if _, err := c.store.Store(ctx, ref, data); err != nil {
+		if !errors.Is(err, ErrPayloadTooLarge) {
+			c.logger.Error(err, "payload store rejected attribute", "attribute", key)
+		}
 		*truncated = true
 		return attribute.KeyValue{}, false
 	}
 	return attribute.String(key, string(data)), true
+}
+
+// inlineString attaches v as a plain string attribute after offering its bytes
+// to the backend for the size check. Used for attributes whose semantic
+// convention is a plain string (gen_ai.system_instructions). Follows the same
+// error contract as inlineJSON.
+func (c *Capturer) inlineString(ctx context.Context, ref PayloadRef, key, v string, truncated *bool) (attribute.KeyValue, bool) {
+	if v == "" {
+		return attribute.KeyValue{}, false
+	}
+	if _, err := c.store.Store(ctx, ref, []byte(v)); err != nil {
+		if !errors.Is(err, ErrPayloadTooLarge) {
+			c.logger.Error(err, "payload store rejected attribute", "attribute", key)
+		}
+		*truncated = true
+		return attribute.KeyValue{}, false
+	}
+	return attribute.String(key, v), true
 }
 
 // extract converts the parsed request body into semantic-convention messages.
@@ -207,13 +269,14 @@ func extractChatCompletions(req *fwkrh.ChatCompletionsRequest) extraction {
 	var ext extraction
 	for _, msg := range req.Messages {
 		parts := contentToParts(msg.Content, &ext.truncated)
-		if len(parts) == 0 {
+		// System-level guidance is recorded as gen_ai.system_instructions, a
+		// plain string per the upstream convention; non-text parts (media,
+		// blobs) are dropped and flagged via llm_d.payload.truncated.
+		if msg.Role == "system" || msg.Role == "developer" {
+			ext.system = appendSystemText(ext.system, partsToTextString(parts, &ext.truncated))
 			continue
 		}
-		// System-level guidance is recorded as gen_ai.system_instructions, not
-		// as an input message, per the upstream convention.
-		if msg.Role == "system" || msg.Role == "developer" {
-			ext.system = append(ext.system, parts...)
+		if len(parts) == 0 {
 			continue
 		}
 		ext.messages = append(ext.messages, chatMessage{Role: msg.Role, Parts: parts})
@@ -283,7 +346,10 @@ func extractCompletions(req *fwkrh.CompletionsRequest) extraction {
 
 func extractAnthropicMessages(req *fwkrh.MessagesRequest) extraction {
 	var ext extraction
-	ext.system = anthropicContentToParts(req.System, &ext.truncated)
+	// Anthropic's `system` field is text-oriented (either a bare string or a
+	// list of content blocks); non-text blocks are dropped as truncated to
+	// match the semconv definition of gen_ai.system_instructions.
+	ext.system = partsToTextString(anthropicContentToParts(req.System, &ext.truncated), &ext.truncated)
 	for _, msg := range req.Messages {
 		parts := anthropicContentToParts(msg.Content, &ext.truncated)
 		if len(parts) == 0 {

--- a/pkg/epp/payload/capture.go
+++ b/pkg/epp/payload/capture.go
@@ -32,21 +32,25 @@ import (
 // Attribute and event names. The gen_ai.* names are the upstream GenAI
 // semantic-convention attributes (Opt-In, Development stability); the
 // llm_d.payload.* names are llm-d extensions defined in the proposal, kept
-// outside the reserved gen_ai.* namespace.
-// https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/
+// outside the reserved gen_ai.* namespace. The GenAI conventions live in
+// the dedicated semantic-conventions-genai repo:
+// https://github.com/open-telemetry/semantic-conventions-genai .
 const (
 	// EventInferenceDetails is the upstream GenAI event that carries payload
-	// attributes: gen_ai.client.inference.operation.details.
+	// attributes: gen_ai.client.inference.operation.details (still at
+	// opt_in / development stability as of 2026-08).
 	EventInferenceDetails = "gen_ai.client.inference.operation.details"
 
 	// AttrInputMessages is gen_ai.input.messages: the structured request
-	// messages (role/parts), serialised to JSON when recorded on a span event.
+	// messages (role/parts), serialised to JSON when recorded on a span
+	// event. Value follows the ChatMessage schema (model/gen-ai/
+	// gen-ai-input-messages.json in the semconv-genai repo).
 	AttrInputMessages = "gen_ai.input.messages"
-	// AttrSystemInstructions is gen_ai.system_instructions: system-level
-	// instruction *text*, per the upstream semantic convention. Non-text
-	// system content (e.g. images in a system message) is dropped and marked
-	// on llm_d.payload.truncated; multiple system-role messages and multiple
-	// text parts within one message are joined with "\n\n".
+	// AttrSystemInstructions is gen_ai.system_instructions: the current
+	// authoritative schema (model/gen-ai/gen-ai-system-instructions.json)
+	// defines this as an array of TextPart / GenericPart, NOT a plain
+	// instruction string. Same JSON-serialised part shape as
+	// gen_ai.input.messages, with a narrower part-type vocabulary.
 	AttrSystemInstructions = "gen_ai.system_instructions"
 
 	// AttrTruncated is llm_d.payload.truncated (llm-d extension): true when
@@ -54,11 +58,17 @@ const (
 	AttrTruncated = "llm_d.payload.truncated"
 )
 
-// Part types and modalities from the upstream input-messages schema.
-// https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-input-messages.json
+// Part types and modalities from the upstream input-messages schema:
+// https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/gen-ai-input-messages.json
+// Only the part types llm-d emits are named here; other schema types
+// (BlobPart, FilePart, ServerToolCallPart, CompactionPart, GenericPart)
+// are recognised implicitly via the Part struct's optional fields.
 const (
-	partTypeText = "text"
-	partTypeURI  = "uri"
+	partTypeText             = "text"
+	partTypeURI              = "uri"
+	partTypeToolCall         = "tool_call"
+	partTypeToolCallResponse = "tool_call_response"
+	partTypeReasoning        = "reasoning"
 
 	modalityImage = "image"
 	modalityVideo = "video"
@@ -74,62 +84,60 @@ type chatMessage struct {
 	Parts []part `json:"parts"`
 }
 
-// part mirrors the upstream message-part schema. Exactly one of Content or
-// URI is set, per the part Type.
+// part mirrors the upstream message-part schema. Field sets are disjoint
+// by Type:
+//   - text / reasoning: Content
+//   - uri:              URI, MimeType, Modality
+//   - tool_call:        ID, Name, Arguments
+//   - tool_call_response: ID, Response
+//
+// Arguments and Response are raw JSON so the model's own key order survives
+// downstream re-serialization (matches the upstream ToolCallRequestPart /
+// ToolCallResponsePart definitions).
 type part struct {
-	Type     string `json:"type"`
-	Content  string `json:"content,omitempty"`
-	URI      string `json:"uri,omitempty"`
-	MimeType string `json:"mime_type,omitempty"`
-	Modality string `json:"modality,omitempty"`
+	Type      string          `json:"type"`
+	Content   string          `json:"content,omitempty"`
+	URI       string          `json:"uri,omitempty"`
+	MimeType  string          `json:"mime_type,omitempty"`
+	Modality  string          `json:"modality,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+	Response  json.RawMessage `json:"response,omitempty"`
 }
 
 // extraction is the intermediate result of converting a parsed request body
-// into semantic-convention form. system is a plain string (concatenation of
-// text-only system content) per the semconv definition of
-// gen_ai.system_instructions.
+// into semantic-convention form. Both messages and system carry the same
+// TextPart / GenericPart structured shape that the semconv schema requires;
+// system is emitted as gen_ai.system_instructions, messages as
+// gen_ai.input.messages.
 type extraction struct {
 	messages []chatMessage
-	system   string
+	system   []part
 	// truncated is set when content was dropped: inline blob parts (no offload
-	// backend exists in Phase 1), non-textual prompts (token IDs), or non-text
-	// content on a system-role message (system instructions are text-only).
+	// backend exists in Phase 1), non-textual prompts (token IDs), or opaque
+	// tool-call payloads (OpenAI assistant tool_calls, which the parser
+	// currently exposes as []any and we can't semantic-extract without a
+	// bespoke re-parse).
 	truncated bool
 }
 
 func (e extraction) empty() bool {
-	return len(e.messages) == 0 && e.system == "" && !e.truncated
+	return len(e.messages) == 0 && len(e.system) == 0 && !e.truncated
 }
 
-// partsToTextString extracts the concatenated text of parts, joining multiple
-// text parts with a blank line. Non-text parts (uri, blob, etc.) are dropped
-// and mark *truncated. This is how system-role content is normalised into the
-// plain-string value required by gen_ai.system_instructions.
-func partsToTextString(parts []part, truncated *bool) string {
-	var texts []string
+// appendSystemParts adds parts to ext.system, filtering to the part-type
+// vocabulary the SystemInstructions schema allows (TextPart today; the
+// schema also permits GenericPart for forward-compat, but llm-d emits only
+// text at that carrier). Non-text parts mark the event truncated so
+// consumers can tell a media / tool part was dropped rather than never sent.
+func appendSystemParts(ext *extraction, parts []part) {
 	for _, p := range parts {
 		if p.Type == partTypeText {
-			if p.Content != "" {
-				texts = append(texts, p.Content)
-			}
+			ext.system = append(ext.system, p)
 			continue
 		}
-		*truncated = true
-	}
-	return strings.Join(texts, "\n\n")
-}
-
-// appendSystemText joins additional system-instruction text with any already
-// captured, using a blank-line separator so multiple system messages remain
-// legible.
-func appendSystemText(existing, next string) string {
-	switch {
-	case next == "":
-		return existing
-	case existing == "":
-		return next
-	default:
-		return existing + "\n\n" + next
+		ext.truncated = true
 	}
 }
 
@@ -193,7 +201,7 @@ func (c *Capturer) CaptureRequest(ctx context.Context, body *fwkrh.InferenceRequ
 	if kv, ok := c.inlineJSON(ctx, ref, AttrInputMessages, ext.messages, len(ext.messages) > 0, &ext.truncated); ok {
 		attrs = append(attrs, kv)
 	}
-	if kv, ok := c.inlineString(ctx, ref, AttrSystemInstructions, ext.system, &ext.truncated); ok {
+	if kv, ok := c.inlineJSON(ctx, ref, AttrSystemInstructions, ext.system, len(ext.system) > 0, &ext.truncated); ok {
 		attrs = append(attrs, kv)
 	}
 	if ext.truncated {
@@ -231,24 +239,6 @@ func (c *Capturer) inlineJSON(ctx context.Context, ref PayloadRef, key string, v
 	return attribute.String(key, string(data)), true
 }
 
-// inlineString attaches v as a plain string attribute after offering its bytes
-// to the backend for the size check. Used for attributes whose semantic
-// convention is a plain string (gen_ai.system_instructions). Follows the same
-// error contract as inlineJSON.
-func (c *Capturer) inlineString(ctx context.Context, ref PayloadRef, key, v string, truncated *bool) (attribute.KeyValue, bool) {
-	if v == "" {
-		return attribute.KeyValue{}, false
-	}
-	if _, err := c.store.Store(ctx, ref, []byte(v)); err != nil {
-		if !errors.Is(err, ErrPayloadTooLarge) {
-			c.logger.Error(err, "payload store rejected attribute", "attribute", key)
-		}
-		*truncated = true
-		return attribute.KeyValue{}, false
-	}
-	return attribute.String(key, v), true
-}
-
 // extract converts the parsed request body into semantic-convention messages.
 // Phase 1 covers the chat-completions, completions and Anthropic-messages
 // shapes; other request types produce no event.
@@ -269,11 +259,21 @@ func extractChatCompletions(req *fwkrh.ChatCompletionsRequest) extraction {
 	var ext extraction
 	for _, msg := range req.Messages {
 		parts := contentToParts(msg.Content, &ext.truncated)
-		// System-level guidance is recorded as gen_ai.system_instructions, a
-		// plain string per the upstream convention; non-text parts (media,
-		// blobs) are dropped and flagged via llm_d.payload.truncated.
+		// OpenAI models assistant tool-call requests as a separate ToolCalls
+		// field (typed []any at the parser layer) rather than as content
+		// parts. We don't semantic-extract those into tool_call parts yet —
+		// mark the event truncated so consumers know assistant-side tool
+		// history was elided.
+		if len(msg.ToolCalls) > 0 {
+			ext.truncated = true
+		}
+		// System-level guidance is recorded as gen_ai.system_instructions,
+		// which follows the SystemInstructions schema (array of TextPart /
+		// GenericPart) — the same structured shape as input.messages, with a
+		// narrower part-type vocabulary. appendSystemParts enforces that
+		// narrower vocabulary.
 		if msg.Role == "system" || msg.Role == "developer" {
-			ext.system = appendSystemText(ext.system, partsToTextString(parts, &ext.truncated))
+			appendSystemParts(&ext, parts)
 			continue
 		}
 		if len(parts) == 0 {
@@ -346,10 +346,9 @@ func extractCompletions(req *fwkrh.CompletionsRequest) extraction {
 
 func extractAnthropicMessages(req *fwkrh.MessagesRequest) extraction {
 	var ext extraction
-	// Anthropic's `system` field is text-oriented (either a bare string or a
-	// list of content blocks); non-text blocks are dropped as truncated to
-	// match the semconv definition of gen_ai.system_instructions.
-	ext.system = partsToTextString(anthropicContentToParts(req.System, &ext.truncated), &ext.truncated)
+	// Same schema restriction as ChatCompletions: system content is limited
+	// to TextPart / GenericPart.
+	appendSystemParts(&ext, anthropicContentToParts(req.System, &ext.truncated))
 	for _, msg := range req.Messages {
 		parts := anthropicContentToParts(msg.Content, &ext.truncated)
 		if len(parts) == 0 {
@@ -378,7 +377,16 @@ func anthropicContentToParts(content fwkrh.AnthropicContent, truncated *bool) []
 			})
 		default:
 			// base64 image sources are blob parts (no offload backend in
-			// Phase 1) and unrecognised block types are not representable.
+			// Phase 1).
+			//
+			// tool_use / tool_result / thinking blocks land with
+			// llm-d/llm-d-router#2389 (which extends AnthropicContentBlock
+			// with ID / Name / Input / ToolUseID / Content / Thinking
+			// fields). Once that PR lands, wire them here as semconv
+			// ToolCallRequestPart / ToolCallResponsePart / ReasoningPart —
+			// the part-type constants and Part struct fields are already
+			// in place. Until then unrecognised block types mark truncated
+			// so consumers can tell the event isn't the whole request.
 			*truncated = true
 		}
 	}

--- a/pkg/epp/payload/capture_test.go
+++ b/pkg/epp/payload/capture_test.go
@@ -108,16 +108,54 @@ func TestCaptureChatCompletions(t *testing.T) {
 		t.Fatalf("unexpected user parts: %+v", msgs[0].Parts)
 	}
 
-	sysJSON, ok := eventAttr(t, stub, AttrSystemInstructions)
+	sys, ok := eventAttr(t, stub, AttrSystemInstructions)
 	if !ok {
 		t.Fatal("event missing gen_ai.system_instructions")
 	}
-	if !strings.Contains(sysJSON, "You are terse.") {
-		t.Fatalf("system instructions missing content: %s", sysJSON)
+	// gen_ai.system_instructions is a plain string per the upstream semconv,
+	// not a JSON-serialised []part. Guard against regressing to the old shape.
+	if sys != "You are terse." {
+		t.Fatalf("system instructions want plain string %q, got %q", "You are terse.", sys)
 	}
 
 	if _, ok := eventAttr(t, stub, AttrTruncated); ok {
 		t.Error("unexpected llm_d.payload.truncated on fully-inline capture")
+	}
+}
+
+// TestCaptureSystemInstructionsPlainString covers the semconv-compliance path:
+// multiple system messages are joined into one plain-string attribute, and
+// non-text system content is dropped and flagged as truncated.
+func TestCaptureSystemInstructionsPlainString(t *testing.T) {
+	body := &fwkrh.InferenceRequestBody{
+		ChatCompletions: &fwkrh.ChatCompletionsRequest{
+			Messages: []fwkrh.Message{
+				{Role: "system", Content: fwkrh.Content{Raw: "You are terse."}},
+				{Role: "developer", Content: fwkrh.Content{Structured: []fwkrh.ContentBlock{
+					{Type: "text", Text: "Answer in French."},
+					{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "https://example.com/style-guide.png"}},
+				}}},
+				{Role: "user", Content: fwkrh.Content{Raw: "Bonjour."}},
+			},
+		},
+	}
+
+	stub := captureOnSpan(t, inlineCapturer(4096), body)
+
+	sys, ok := eventAttr(t, stub, AttrSystemInstructions)
+	if !ok {
+		t.Fatal("event missing gen_ai.system_instructions")
+	}
+	// Multiple system-role messages are joined with a blank-line separator.
+	want := "You are terse.\n\nAnswer in French."
+	if sys != want {
+		t.Fatalf("system instructions want %q, got %q", want, sys)
+	}
+	// Any content that isn't a text part (e.g. an image on a system message)
+	// is dropped and must mark the event truncated so operators know the
+	// captured value isn't the whole system message.
+	if v, ok := eventAttr(t, stub, AttrTruncated); !ok || v != truncatedTrue {
+		t.Error("expected llm_d.payload.truncated=true when non-text system content is dropped")
 	}
 }
 

--- a/pkg/epp/payload/capture_test.go
+++ b/pkg/epp/payload/capture_test.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package payload
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+)
+
+// truncatedTrue is the emitted string form of llm_d.payload.truncated=true.
+const truncatedTrue = "true"
+
+// captureOnSpan runs CaptureRequest against a recording span and returns the
+// finished span for inspection.
+func captureOnSpan(t *testing.T, c *Capturer, body *fwkrh.InferenceRequestBody) tracetest.SpanStub {
+	t.Helper()
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	ctx, span := tp.Tracer("test").Start(context.Background(), "gateway.request", trace.WithSpanKind(trace.SpanKindServer))
+	c.CaptureRequest(ctx, body)
+	span.End()
+
+	spans := recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("recorded %d spans, want 1", len(spans))
+	}
+	return tracetest.SpanStubsFromReadOnlySpans(spans)[0]
+}
+
+func eventAttr(t *testing.T, stub tracetest.SpanStub, key string) (string, bool) {
+	t.Helper()
+	for _, ev := range stub.Events {
+		if ev.Name != EventInferenceDetails {
+			continue
+		}
+		for _, kv := range ev.Attributes {
+			if string(kv.Key) == key {
+				return kv.Value.String(), true
+			}
+		}
+	}
+	return "", false
+}
+
+func hasDetailsEvent(stub tracetest.SpanStub) bool {
+	for _, ev := range stub.Events {
+		if ev.Name == EventInferenceDetails {
+			return true
+		}
+	}
+	return false
+}
+
+func inlineCapturer(threshold int) *Capturer {
+	return NewCapturer(Config{Enabled: true, Backend: BackendInline, InlineSizeThresholdBytes: threshold}, logr.Discard())
+}
+
+func TestCaptureChatCompletions(t *testing.T) {
+	body := &fwkrh.InferenceRequestBody{
+		ChatCompletions: &fwkrh.ChatCompletionsRequest{
+			Messages: []fwkrh.Message{
+				{Role: "system", Content: fwkrh.Content{Raw: "You are terse."}},
+				{Role: "user", Content: fwkrh.Content{Raw: "What is the capital of France?"}},
+				{Role: "assistant", Content: fwkrh.Content{Raw: "Paris."}},
+			},
+		},
+	}
+
+	stub := captureOnSpan(t, inlineCapturer(4096), body)
+
+	msgJSON, ok := eventAttr(t, stub, AttrInputMessages)
+	if !ok {
+		t.Fatal("event missing gen_ai.input.messages")
+	}
+	var msgs []chatMessage
+	if err := json.Unmarshal([]byte(msgJSON), &msgs); err != nil {
+		t.Fatalf("gen_ai.input.messages is not valid JSON: %v", err)
+	}
+	if len(msgs) != 2 || msgs[0].Role != "user" || msgs[1].Role != "assistant" {
+		t.Fatalf("unexpected input messages: %s", msgJSON)
+	}
+	if msgs[0].Parts[0].Type != "text" || msgs[0].Parts[0].Content != "What is the capital of France?" {
+		t.Fatalf("unexpected user parts: %+v", msgs[0].Parts)
+	}
+
+	sysJSON, ok := eventAttr(t, stub, AttrSystemInstructions)
+	if !ok {
+		t.Fatal("event missing gen_ai.system_instructions")
+	}
+	if !strings.Contains(sysJSON, "You are terse.") {
+		t.Fatalf("system instructions missing content: %s", sysJSON)
+	}
+
+	if _, ok := eventAttr(t, stub, AttrTruncated); ok {
+		t.Error("unexpected llm_d.payload.truncated on fully-inline capture")
+	}
+}
+
+func TestCaptureMultimodalParts(t *testing.T) {
+	body := &fwkrh.InferenceRequestBody{
+		ChatCompletions: &fwkrh.ChatCompletionsRequest{
+			Messages: []fwkrh.Message{
+				{Role: "user", Content: fwkrh.Content{Structured: []fwkrh.ContentBlock{
+					{Type: "text", Text: "Describe this image."},
+					{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "https://example.com/cat.png"}},
+					{Type: "image_url", ImageURL: fwkrh.ImageBlock{URL: "data:image/png;base64,iVBORw0KGgo="}},
+				}}},
+			},
+		},
+	}
+
+	stub := captureOnSpan(t, inlineCapturer(4096), body)
+
+	msgJSON, ok := eventAttr(t, stub, AttrInputMessages)
+	if !ok {
+		t.Fatal("event missing gen_ai.input.messages")
+	}
+	var msgs []chatMessage
+	if err := json.Unmarshal([]byte(msgJSON), &msgs); err != nil {
+		t.Fatalf("gen_ai.input.messages is not valid JSON: %v", err)
+	}
+	parts := msgs[0].Parts
+	if len(parts) != 2 {
+		t.Fatalf("got %d parts, want 2 (text + external uri; data URL dropped): %s", len(parts), msgJSON)
+	}
+	if parts[1].Type != "uri" || parts[1].URI != "https://example.com/cat.png" || parts[1].Modality != "image" {
+		t.Fatalf("unexpected uri part: %+v", parts[1])
+	}
+
+	// The data-URL image is a blob part with no offload backend in Phase 1.
+	if v, ok := eventAttr(t, stub, AttrTruncated); !ok || v != truncatedTrue {
+		t.Error("expected llm_d.payload.truncated=true when a blob part is dropped")
+	}
+}
+
+func TestCaptureCompletionsPrompt(t *testing.T) {
+	body := &fwkrh.InferenceRequestBody{
+		Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "Once upon a time"}},
+	}
+
+	stub := captureOnSpan(t, inlineCapturer(4096), body)
+
+	msgJSON, ok := eventAttr(t, stub, AttrInputMessages)
+	if !ok {
+		t.Fatal("event missing gen_ai.input.messages")
+	}
+	var msgs []chatMessage
+	if err := json.Unmarshal([]byte(msgJSON), &msgs); err != nil {
+		t.Fatalf("gen_ai.input.messages is not valid JSON: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].Role != "user" || msgs[0].Parts[0].Content != "Once upon a time" {
+		t.Fatalf("unexpected messages: %s", msgJSON)
+	}
+}
+
+func TestCaptureAnthropicMessages(t *testing.T) {
+	body := &fwkrh.InferenceRequestBody{
+		Messages: &fwkrh.MessagesRequest{
+			System: fwkrh.AnthropicContent{Raw: "Answer in French."},
+			Messages: []fwkrh.AnthropicMessage{
+				{Role: "user", Content: fwkrh.AnthropicContent{Structured: []fwkrh.AnthropicContentBlock{
+					{Type: "text", Text: "Hello"},
+					{Type: "image", Source: &fwkrh.AnthropicImageSource{Type: "url", MediaType: "image/jpeg", URL: "https://example.com/dog.jpg"}},
+				}}},
+			},
+		},
+	}
+
+	stub := captureOnSpan(t, inlineCapturer(4096), body)
+
+	msgJSON, ok := eventAttr(t, stub, AttrInputMessages)
+	if !ok {
+		t.Fatal("event missing gen_ai.input.messages")
+	}
+	var msgs []chatMessage
+	if err := json.Unmarshal([]byte(msgJSON), &msgs); err != nil {
+		t.Fatalf("gen_ai.input.messages is not valid JSON: %v", err)
+	}
+	parts := msgs[0].Parts
+	if len(parts) != 2 || parts[1].Type != "uri" || parts[1].MimeType != "image/jpeg" {
+		t.Fatalf("unexpected parts: %s", msgJSON)
+	}
+
+	if sysJSON, ok := eventAttr(t, stub, AttrSystemInstructions); !ok || !strings.Contains(sysJSON, "Answer in French.") {
+		t.Fatalf("missing or wrong system instructions: %q", sysJSON)
+	}
+}
+
+func TestCaptureOverThresholdTruncates(t *testing.T) {
+	body := &fwkrh.InferenceRequestBody{
+		Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: strings.Repeat("x", 4096)}},
+	}
+
+	stub := captureOnSpan(t, inlineCapturer(64), body)
+
+	if _, ok := eventAttr(t, stub, AttrInputMessages); ok {
+		t.Error("gen_ai.input.messages should be dropped when over the inline threshold")
+	}
+	if v, ok := eventAttr(t, stub, AttrTruncated); !ok || v != truncatedTrue {
+		t.Error("expected llm_d.payload.truncated=true when payload exceeds inline threshold")
+	}
+}
+
+func TestCaptureTokenIDPromptMarksTruncated(t *testing.T) {
+	body := &fwkrh.InferenceRequestBody{
+		Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{TokenIDs: []uint32{1, 2, 3}}},
+	}
+
+	stub := captureOnSpan(t, inlineCapturer(4096), body)
+
+	if _, ok := eventAttr(t, stub, AttrInputMessages); ok {
+		t.Error("token-ID prompts have no capturable text")
+	}
+	if v, ok := eventAttr(t, stub, AttrTruncated); !ok || v != truncatedTrue {
+		t.Error("expected llm_d.payload.truncated=true for token-ID prompt")
+	}
+}
+
+func TestCaptureSkipsUnsupportedAndNil(t *testing.T) {
+	c := inlineCapturer(4096)
+
+	// Unsupported request type: no event.
+	stub := captureOnSpan(t, c, &fwkrh.InferenceRequestBody{Embeddings: &fwkrh.EmbeddingsRequest{}})
+	if hasDetailsEvent(stub) {
+		t.Error("unsupported request types should not emit a details event")
+	}
+
+	// Nil body: no event.
+	stub = captureOnSpan(t, c, nil)
+	if hasDetailsEvent(stub) {
+		t.Error("nil body should not emit a details event")
+	}
+
+	// Nil capturer: must be a safe no-op.
+	var nilCapturer *Capturer
+	nilCapturer.CaptureRequest(context.Background(), &fwkrh.InferenceRequestBody{})
+}
+
+func TestCaptureWithoutSpanIsNoop(t *testing.T) {
+	// No span in context: nothing to attach to, and no panic.
+	inlineCapturer(4096).CaptureRequest(context.Background(), &fwkrh.InferenceRequestBody{
+		Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "hello"}},
+	})
+}

--- a/pkg/epp/payload/capture_test.go
+++ b/pkg/epp/payload/capture_test.go
@@ -108,14 +108,21 @@ func TestCaptureChatCompletions(t *testing.T) {
 		t.Fatalf("unexpected user parts: %+v", msgs[0].Parts)
 	}
 
-	sys, ok := eventAttr(t, stub, AttrSystemInstructions)
+	sysJSON, ok := eventAttr(t, stub, AttrSystemInstructions)
 	if !ok {
 		t.Fatal("event missing gen_ai.system_instructions")
 	}
-	// gen_ai.system_instructions is a plain string per the upstream semconv,
-	// not a JSON-serialised []part. Guard against regressing to the old shape.
-	if sys != "You are terse." {
-		t.Fatalf("system instructions want plain string %q, got %q", "You are terse.", sys)
+	// gen_ai.system_instructions is an array of TextPart / GenericPart per
+	// the current semantic-conventions-genai schema
+	// (model/gen-ai/gen-ai-system-instructions.json). Guard against
+	// regressing to the plain-string emission an earlier Copilot review
+	// asked for based on an outdated snapshot of the semconv.
+	var sysParts []part
+	if err := json.Unmarshal([]byte(sysJSON), &sysParts); err != nil {
+		t.Fatalf("gen_ai.system_instructions is not valid JSON: %v", err)
+	}
+	if len(sysParts) != 1 || sysParts[0].Type != "text" || sysParts[0].Content != "You are terse." {
+		t.Fatalf("unexpected system instructions: %s", sysJSON)
 	}
 
 	if _, ok := eventAttr(t, stub, AttrTruncated); ok {
@@ -123,10 +130,12 @@ func TestCaptureChatCompletions(t *testing.T) {
 	}
 }
 
-// TestCaptureSystemInstructionsPlainString covers the semconv-compliance path:
-// multiple system messages are joined into one plain-string attribute, and
-// non-text system content is dropped and flagged as truncated.
-func TestCaptureSystemInstructionsPlainString(t *testing.T) {
+// TestCaptureSystemInstructionsStructured covers the current semconv path:
+// gen_ai.system_instructions is emitted as a JSON array of parts (same
+// TextPart shape as gen_ai.input.messages entries), not a joined plain
+// string. Multiple system-role messages append into one attribute; non-text
+// system content is dropped and marks truncated.
+func TestCaptureSystemInstructionsStructured(t *testing.T) {
 	body := &fwkrh.InferenceRequestBody{
 		ChatCompletions: &fwkrh.ChatCompletionsRequest{
 			Messages: []fwkrh.Message{
@@ -142,20 +151,56 @@ func TestCaptureSystemInstructionsPlainString(t *testing.T) {
 
 	stub := captureOnSpan(t, inlineCapturer(4096), body)
 
-	sys, ok := eventAttr(t, stub, AttrSystemInstructions)
+	sysJSON, ok := eventAttr(t, stub, AttrSystemInstructions)
 	if !ok {
 		t.Fatal("event missing gen_ai.system_instructions")
 	}
-	// Multiple system-role messages are joined with a blank-line separator.
-	want := "You are terse.\n\nAnswer in French."
-	if sys != want {
-		t.Fatalf("system instructions want %q, got %q", want, sys)
+	var sysParts []part
+	if err := json.Unmarshal([]byte(sysJSON), &sysParts); err != nil {
+		t.Fatalf("gen_ai.system_instructions is not valid JSON: %v", err)
 	}
-	// Any content that isn't a text part (e.g. an image on a system message)
-	// is dropped and must mark the event truncated so operators know the
-	// captured value isn't the whole system message.
+	// System / developer text lines each become one TextPart, in message
+	// order; the image on the developer message is dropped and marks
+	// truncated. Also asserts the URI attached to the earlier user
+	// message never leaks into system_instructions.
+	if len(sysParts) != 2 {
+		t.Fatalf("want 2 system TextParts (system+developer text), got %d: %s", len(sysParts), sysJSON)
+	}
+	if sysParts[0].Type != "text" || sysParts[0].Content != "You are terse." {
+		t.Fatalf("unexpected first system part: %+v", sysParts[0])
+	}
+	if sysParts[1].Type != "text" || sysParts[1].Content != "Answer in French." {
+		t.Fatalf("unexpected second system part: %+v", sysParts[1])
+	}
 	if v, ok := eventAttr(t, stub, AttrTruncated); !ok || v != truncatedTrue {
 		t.Error("expected llm_d.payload.truncated=true when non-text system content is dropped")
+	}
+}
+
+// TestCaptureOpenAIAssistantToolCallsMarksTruncated documents the current
+// gap: OpenAI's Message.ToolCalls field is typed []any at the parser layer,
+// so we can't semantic-extract it into semconv tool_call parts without a
+// bespoke re-parse. Until the parser exposes typed tool-call structs, an
+// assistant message that carries tool_calls records the visible content but
+// flags truncation so consumers know the assistant turn isn't complete.
+func TestCaptureOpenAIAssistantToolCallsMarksTruncated(t *testing.T) {
+	body := &fwkrh.InferenceRequestBody{
+		ChatCompletions: &fwkrh.ChatCompletionsRequest{
+			Messages: []fwkrh.Message{
+				{Role: "user", Content: fwkrh.Content{Raw: "What's the weather in NYC?"}},
+				{
+					Role:      "assistant",
+					Content:   fwkrh.Content{Raw: ""},
+					ToolCalls: []any{map[string]any{"id": "call_1", "type": "function"}},
+				},
+			},
+		},
+	}
+
+	stub := captureOnSpan(t, inlineCapturer(4096), body)
+
+	if v, ok := eventAttr(t, stub, AttrTruncated); !ok || v != truncatedTrue {
+		t.Error("expected llm_d.payload.truncated=true when assistant.tool_calls is present but not semantic-extracted")
 	}
 }
 

--- a/pkg/epp/payload/config.go
+++ b/pkg/epp/payload/config.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package payload
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/go-logr/logr"
+)
+
+// Environment variables forming the Phase 1 operator surface. They are the
+// env-var aliases of the canonical payloadCapture.* fields defined in the
+// proposal; the Kustomize overlay surface adopts the same names.
+const (
+	// EnvEnabled toggles payload capture (payloadCapture.enabled). Default false.
+	EnvEnabled = "LLMD_PAYLOAD_CAPTURE_ENABLED"
+	// EnvBackend selects the payload backend (payloadCapture.backend).
+	// Phase 1 supports "noop" and "inline". Default "noop".
+	EnvBackend = "LLMD_PAYLOAD_BACKEND"
+	// EnvInlineThreshold caps the size of payloads carried inline as span-event
+	// attributes (payloadCapture.inlineSizeThresholdBytes). Default 4096.
+	EnvInlineThreshold = "LLMD_PAYLOAD_INLINE_THRESHOLD"
+)
+
+// Backend names accepted by EnvBackend in Phase 1. gcs, s3 and filesystem are
+// reserved by the proposal for Phase 2 and fall back to noop with a warning.
+const (
+	BackendNoop   = "noop"
+	BackendInline = "inline"
+)
+
+// DefaultInlineSizeThresholdBytes is the default value of
+// payloadCapture.inlineSizeThresholdBytes (4 KiB, per the proposal).
+const DefaultInlineSizeThresholdBytes = 4096
+
+// Config is the Phase 1 subset of the payloadCapture configuration block.
+type Config struct {
+	// Enabled is the master switch; capture is opt-in and defaults to off.
+	Enabled bool
+	// Backend selects the PayloadStore implementation (noop | inline).
+	Backend string
+	// InlineSizeThresholdBytes is the largest serialised payload attached
+	// inline to a span event.
+	InlineSizeThresholdBytes int
+}
+
+// LoadConfigFromEnv reads the payload-capture configuration from the
+// LLMD_PAYLOAD_* environment variables, applying proposal defaults and
+// falling back safely (capture disabled / noop backend) on invalid input.
+func LoadConfigFromEnv(logger logr.Logger) Config {
+	cfg := Config{
+		Enabled:                  false,
+		Backend:                  BackendNoop,
+		InlineSizeThresholdBytes: DefaultInlineSizeThresholdBytes,
+	}
+
+	if v, ok := os.LookupEnv(EnvEnabled); ok {
+		enabled, err := strconv.ParseBool(v)
+		if err != nil {
+			logger.Info("invalid value for payload capture enabled flag, capture stays disabled",
+				"env", EnvEnabled, "value", v)
+		} else {
+			cfg.Enabled = enabled
+		}
+	}
+
+	if v, ok := os.LookupEnv(EnvBackend); ok && v != "" {
+		switch v {
+		case BackendNoop, BackendInline:
+			cfg.Backend = v
+		case "gcs", "s3", "filesystem":
+			logger.Info("payload backend is not implemented yet (Phase 2), falling back to noop",
+				"env", EnvBackend, "value", v)
+		default:
+			logger.Info("unknown payload backend, falling back to noop",
+				"env", EnvBackend, "value", v)
+		}
+	}
+
+	if v, ok := os.LookupEnv(EnvInlineThreshold); ok {
+		threshold, err := strconv.Atoi(v)
+		if err != nil || threshold <= 0 {
+			logger.Info("invalid payload inline threshold, using default",
+				"env", EnvInlineThreshold, "value", v, "default", DefaultInlineSizeThresholdBytes)
+		} else {
+			cfg.InlineSizeThresholdBytes = threshold
+		}
+	}
+
+	if cfg.Enabled && cfg.Backend == BackendNoop {
+		logger.Info("payload capture is enabled with the noop backend; no payload events will be emitted")
+	}
+
+	return cfg
+}

--- a/pkg/epp/payload/config_test.go
+++ b/pkg/epp/payload/config_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package payload
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestLoadConfigFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want Config
+	}{
+		{
+			name: "defaults",
+			env:  map[string]string{},
+			want: Config{Enabled: false, Backend: BackendNoop, InlineSizeThresholdBytes: DefaultInlineSizeThresholdBytes},
+		},
+		{
+			name: "enabled inline with threshold",
+			env: map[string]string{
+				EnvEnabled:         "true",
+				EnvBackend:         "inline",
+				EnvInlineThreshold: "1024",
+			},
+			want: Config{Enabled: true, Backend: BackendInline, InlineSizeThresholdBytes: 1024},
+		},
+		{
+			name: "invalid enabled flag stays disabled",
+			env:  map[string]string{EnvEnabled: "yep"},
+			want: Config{Enabled: false, Backend: BackendNoop, InlineSizeThresholdBytes: DefaultInlineSizeThresholdBytes},
+		},
+		{
+			name: "phase 2 backend falls back to noop",
+			env:  map[string]string{EnvEnabled: "true", EnvBackend: "gcs"},
+			want: Config{Enabled: true, Backend: BackendNoop, InlineSizeThresholdBytes: DefaultInlineSizeThresholdBytes},
+		},
+		{
+			name: "unknown backend falls back to noop",
+			env:  map[string]string{EnvEnabled: "true", EnvBackend: "carrier-pigeon"},
+			want: Config{Enabled: true, Backend: BackendNoop, InlineSizeThresholdBytes: DefaultInlineSizeThresholdBytes},
+		},
+		{
+			name: "invalid threshold uses default",
+			env:  map[string]string{EnvBackend: "inline", EnvInlineThreshold: "-1"},
+			want: Config{Enabled: false, Backend: BackendInline, InlineSizeThresholdBytes: DefaultInlineSizeThresholdBytes},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			got := LoadConfigFromEnv(logr.Discard())
+			if got != tt.want {
+				t.Errorf("LoadConfigFromEnv() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewCapturerGating(t *testing.T) {
+	if c := NewCapturer(Config{Enabled: false, Backend: BackendInline, InlineSizeThresholdBytes: 4096}, logr.Discard()); c != nil {
+		t.Error("NewCapturer with capture disabled should return nil")
+	}
+	if c := NewCapturer(Config{Enabled: true, Backend: BackendNoop, InlineSizeThresholdBytes: 4096}, logr.Discard()); c != nil {
+		t.Error("NewCapturer with noop backend should return nil (secondary kill switch)")
+	}
+	if c := NewCapturer(Config{Enabled: true, Backend: BackendInline, InlineSizeThresholdBytes: 4096}, logr.Discard()); c == nil {
+		t.Error("NewCapturer with inline backend enabled should return a capturer")
+	}
+}

--- a/pkg/epp/payload/store.go
+++ b/pkg/epp/payload/store.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package payload implements opt-in capture of GenAI request payloads as
+// OpenTelemetry span events, following the upstream GenAI semantic conventions
+// (gen_ai.input.messages / gen_ai.system_instructions) as specified in the
+// llm-d proposal docs/proposals/genai-payload-events.md (llm-d/llm-d).
+//
+// This package is Phase 1 of the proposal's phased implementation plan: the
+// PayloadStore interface, the noop and inline backends, and the gateway
+// capture wiring. Object-store backends (gcs, s3, filesystem) and the
+// redaction pipeline arrive in later phases.
+package payload
+
+import (
+	"context"
+	"errors"
+)
+
+// PayloadKind distinguishes the request (prompt) payload from the response
+// (completion) payload of the same span.
+type PayloadKind string
+
+const (
+	// KindPrompt identifies the request-side payload.
+	KindPrompt PayloadKind = "prompt"
+	// KindCompletion identifies the response-side payload. Not produced by the
+	// gateway capture layer (which sees prompts only); defined here because the
+	// store contract is shared with later capture layers.
+	KindCompletion PayloadKind = "completion"
+)
+
+// PayloadRef identifies one payload part. PartIndex is zero for the text
+// payload itself and >= 1 for each non-text content part associated with the
+// same span. MediaType is an IANA media type (e.g. "application/json",
+// "image/png") and drives both the storage-path extension and Content-Type on
+// uploads for URI-producing backends.
+type PayloadRef struct {
+	TraceID   string
+	SpanID    string
+	Kind      PayloadKind
+	PartIndex int
+	MediaType string
+}
+
+// ErrPayloadTooLarge is returned by backends that cannot accept a payload of
+// the offered size (e.g. InlineStore when the payload exceeds its threshold).
+// Callers emit the span event with llm_d.payload.truncated=true instead of
+// the payload content.
+var ErrPayloadTooLarge = errors.New("payload exceeds backend size limit")
+
+// PayloadStore persists a payload and returns a retrieval URI.
+//
+// URI-producing backends (gcs, s3, filesystem — later phases) return a
+// non-empty URI recorded as llm_d.payload.storage_uri. Backends that do not
+// externalise the payload (noop, inline) return an empty URI: NoopStore
+// silently discards, and InlineStore signals that the payload may be carried
+// inline on the span event itself.
+type PayloadStore interface {
+	Store(ctx context.Context, ref PayloadRef, data []byte) (uri string, err error)
+}
+
+// NoopStore discards every payload. It backs `backend: noop`, the secondary
+// kill switch: the capture pipeline short-circuits before any span event is
+// emitted, so NoopStore.Store is only reachable through direct use of the
+// interface.
+type NoopStore struct{}
+
+// Store discards the payload and returns no URI.
+func (NoopStore) Store(context.Context, PayloadRef, []byte) (string, error) {
+	return "", nil
+}
+
+// InlineStore carries payloads inline as span-event attributes, subject to a
+// size threshold. It produces no URI; a nil error means the caller may attach
+// the payload inline.
+type InlineStore struct {
+	// MaxBytes is the largest payload accepted for inline attachment
+	// (payloadCapture.inlineSizeThresholdBytes).
+	MaxBytes int
+}
+
+// Store accepts the payload for inline attachment or rejects it with
+// ErrPayloadTooLarge. In later phases oversized payloads auto-offload to the
+// configured offloadBackend; in Phase 1 there is none, so the caller records
+// llm_d.payload.truncated=true instead.
+func (s InlineStore) Store(_ context.Context, _ PayloadRef, data []byte) (string, error) {
+	if len(data) > s.MaxBytes {
+		return "", ErrPayloadTooLarge
+	}
+	return "", nil
+}

--- a/pkg/epp/payload/store_test.go
+++ b/pkg/epp/payload/store_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package payload
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestNoopStoreDiscards(t *testing.T) {
+	uri, err := NoopStore{}.Store(context.Background(), PayloadRef{}, []byte("anything"))
+	if err != nil {
+		t.Fatalf("NoopStore.Store returned error: %v", err)
+	}
+	if uri != "" {
+		t.Fatalf("NoopStore.Store returned URI %q, want empty", uri)
+	}
+}
+
+func TestInlineStoreThreshold(t *testing.T) {
+	store := InlineStore{MaxBytes: 8}
+
+	uri, err := store.Store(context.Background(), PayloadRef{}, []byte("12345678"))
+	if err != nil {
+		t.Fatalf("Store at threshold returned error: %v", err)
+	}
+	if uri != "" {
+		t.Fatalf("InlineStore.Store returned URI %q, want empty", uri)
+	}
+
+	_, err = store.Store(context.Background(), PayloadRef{}, []byte("123456789"))
+	if !errors.Is(err, ErrPayloadTooLarge) {
+		t.Fatalf("Store above threshold returned %v, want ErrPayloadTooLarge", err)
+	}
+}

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -45,6 +45,7 @@ import (
 	fwkfc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/handlers"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
+	"github.com/llm-d/llm-d-router/pkg/epp/payload"
 	"github.com/llm-d/llm-d-router/pkg/epp/requestcontrol"
 )
 
@@ -234,6 +235,9 @@ func (r *ExtProcServerRunner) AsRunnable(logger logr.Logger) manager.Runnable {
 		extProcServer.SetEmitEndpointScores(r.EmitEndpointScores)
 		if r.EvictChannelLookup != nil {
 			extProcServer.SetEvictChannelLookup(r.EvictChannelLookup)
+		}
+		if capturer := payload.NewCapturerFromEnv(logger); capturer != nil {
+			extProcServer.SetPayloadCapturer(capturer)
 		}
 		extProcPb.RegisterExternalProcessorServer(srv, extProcServer)
 


### PR DESCRIPTION
## Summary

First implementation PR (**Phase 1**) of the [GenAI payload events proposal](https://github.com/llm-d/llm-d/pull/1206) (llm-d/llm-d#1206, closes llm-d/llm-d#1108 design): the `PayloadStore` interface, the `noop`/`inline` backends, and opt-in prompt capture on the EPP gateway span — all behind a default-off flag.

## What's in this PR

| Piece | Where |
| --- | --- |
| `PayloadStore` interface, `PayloadRef`/`PayloadKind`, `NoopStore`, `InlineStore` | `pkg/epp/payload/store.go` |
| Env-var config surface (`LLMD_PAYLOAD_CAPTURE_ENABLED`, `LLMD_PAYLOAD_BACKEND`, `LLMD_PAYLOAD_INLINE_THRESHOLD`) with safe fallbacks | `pkg/epp/payload/config.go` |
| `Capturer`: converts the parsed request body to `gen_ai.input.messages` / `gen_ai.system_instructions` and records the `gen_ai.client.inference.operation.details` span event | `pkg/epp/payload/capture.go` |
| Wiring into the ext_proc `Process()` loop after scheduling, nil-safe and default-off | `pkg/epp/handlers/server.go`, `pkg/epp/server/runserver.go` |
| Operator docs | `docs/payload-capture.md` |
| Unit tests (stores, config, capture incl. multimodal/truncation paths) | `pkg/epp/payload/*_test.go` |

Note: the proposal sketches the interface at `pkg/telemetry/payload_store.go`; it lands here as `pkg/epp/payload` to match this repo's layout (EPP-owned per the proposal's ownership section).

## Behaviour

- **Default off.** With `LLMD_PAYLOAD_CAPTURE_ENABLED=false` (or the `noop` backend, the proposal's secondary kill switch) no events are emitted and the request path gains one nil check.
- When enabled with `backend: inline`, the gateway records the prompt on the sampled `gateway.request` span per the upstream [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) (`Opt-In`/`Development` attributes). Chat-completions, completions, and Anthropic-messages request shapes are covered.
- Payloads above `inlineSizeThresholdBytes` (default 4096) and blob media parts (data URLs, base64 audio — no object-store backend until Phase 2) are dropped with `llm_d.payload.truncated: true`; external media URLs are kept as schema-standard `uri` parts. Capture never fails the request.
- `gcs`/`s3`/`filesystem` backends are recognised but fall back to `noop` with a startup warning until Phase 2.

## Testing

- `go test ./pkg/epp/payload/... ./pkg/epp/handlers/... ./pkg/epp/server/...` — pass
- `golangci-lint run` (v2.8.0, the CI-pinned version) on the touched packages — 0 issues
- `go build ./...` — pass

## Follow-ups (per the proposal's phased plan)

- **Phase 2**: `GCSStore`/`S3Store`/`FilesystemStore` + blob offload with in-place `blob`→`uri` rewrite
- **Phase 3**: redaction pipeline
- **Phase 4**: vLLM-native capture (Python mirror)

🤖 Generated with [Claude Code](https://claude.com/claude-code)