### PR TITLE
Add declared-cost load tracking and scoring for diffusion requests

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -62,6 +62,7 @@ import (
 	fwkfc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
+	attrdiffusion "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/diffusion"
 	attrgpu "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/gpu"
 	attrlatency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrmodels "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/models"
@@ -94,6 +95,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter"
 	reqdataprodprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload"
 	mmproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource"
@@ -127,6 +129,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/single"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/activerequest"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/headerlabelaffinity"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization"
@@ -634,6 +637,7 @@ func (r *Runner) registerInTreePlugins() {
 	// Alpha
 	fwkplugin.Register(headerprofile.HeaderProfileHandlerType, fwkplugin.StabilityAlpha, headerprofile.HeaderProfileHandlerFactory)
 	fwkplugin.Register(endpointattribute.EndpointAttributeScorerType, fwkplugin.StabilityAlpha, endpointattribute.EndpointAttributeScorerFactory)
+	fwkplugin.Register(diffusioncost.DiffusionCostScorerType, fwkplugin.StabilityAlpha, diffusioncost.Factory)
 	fwkplugin.Register(topologyaffinityscorer.ScorerType, fwkplugin.StabilityAlpha, topologyaffinityscorer.Factory)
 	fwkplugin.Register(burstprefix.PluginType, fwkplugin.StabilityAlpha, burstprefix.Factory)
 	fwkplugin.Register(p2psource.PluginType, fwkplugin.StabilityAlpha, p2psource.PluginFactory)
@@ -668,6 +672,8 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.RegisterAsDefaultProducer(mmproducer.ProducerType, fwkplugin.StabilityBeta, mmproducer.Factory, mmproducer.ProducedKey)
 	fwkplugin.RegisterAsDefaultProducer(tokenizer.PluginType, fwkplugin.StabilityBeta, tokenizer.PluginFactory, tokenizer.TokenizedPromptDataKey)
 	fwkplugin.RegisterAsDefaultProducer(sessionid.SessionIDProducerType, fwkplugin.StabilityBeta, sessionid.Factory, attrsession.SessionIDDataKey)
+	// Alpha
+	fwkplugin.RegisterAsDefaultProducer(diffusionload.DiffusionLoadProducerType, fwkplugin.StabilityAlpha, diffusionload.DiffusionLoadProducerFactory, attrdiffusion.DiffusionLoadDataKey)
 
 	// Latency predictor plugins
 	// Beta

--- a/pkg/epp/framework/plugins/datalayer/attribute/diffusion/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/diffusion/data_types.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diffusion
+
+import (
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	diffusionloadconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/constants"
+)
+
+// DiffusionLoadDataKey carries the per-endpoint in-flight diffusion cost
+// snapshot used by cost-aware scorers. Populated dynamically by
+// DiffusionLoadProducer on endpoint registration and never overwritten
+// during a scheduling cycle.
+var DiffusionLoadDataKey = plugin.NewDataKey("DiffusionLoadDataKey", diffusionloadconstants.DiffusionLoadProducerType)
+
+// DiffusionLoad captures the outstanding declared diffusion work an endpoint
+// has committed to, as tracked by the EPP.
+type DiffusionLoad struct {
+	// CostUnits is the sum of the declared cost of in-flight image generation
+	// requests routed to this endpoint, in step-megapixel units
+	// (inference steps x output megapixels x image count). Updated by
+	// PreRequest (when an endpoint is chosen) and released when the request's
+	// response stream ends.
+	CostUnits int64
+}
+
+// Clone returns an independent copy of the DiffusionLoad.
+func (l *DiffusionLoad) Clone() fwkdl.Cloneable {
+	if l == nil {
+		return nil
+	}
+	cp := *l
+	return &cp
+}

--- a/pkg/epp/framework/plugins/datalayer/attribute/diffusion/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/diffusion/data_types.go
@@ -23,9 +23,8 @@ import (
 )
 
 // DiffusionLoadDataKey carries the per-endpoint in-flight diffusion cost
-// snapshot used by cost-aware scorers. Populated dynamically by
-// DiffusionLoadProducer on endpoint registration and never overwritten
-// during a scheduling cycle.
+// snapshot used by cost-aware scorers. Published per request by
+// DiffusionLoadProducer.Produce onto each candidate endpoint.
 var DiffusionLoadDataKey = plugin.NewDataKey("DiffusionLoadDataKey", diffusionloadconstants.DiffusionLoadProducerType)
 
 // DiffusionLoad captures the outstanding declared diffusion work an endpoint

--- a/pkg/epp/framework/plugins/datalayer/attribute/diffusion/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/diffusion/data_types.go
@@ -30,12 +30,12 @@ var DiffusionLoadDataKey = plugin.NewDataKey("DiffusionLoadDataKey", diffusionlo
 // DiffusionLoad captures the outstanding declared diffusion work an endpoint
 // has committed to, as tracked by the EPP.
 type DiffusionLoad struct {
-	// CostUnits is the sum of the declared cost of in-flight image generation
-	// requests routed to this endpoint, in step-megapixel units
-	// (inference steps x output megapixels x image count). Updated by
-	// PreRequest (when an endpoint is chosen) and released when the request's
-	// response stream ends.
-	CostUnits int64
+	// Cost is the sum of the declared cost of in-flight diffusion requests
+	// routed to this endpoint. The unit is defined by the producing plugin;
+	// scoring only compares values from the same producer, so any consistent
+	// unit works. Updated by PreRequest (when an endpoint is chosen) and
+	// released when the request's response stream ends.
+	Cost int64
 }
 
 // Clone returns an independent copy of the DiffusionLoad.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/README.md
@@ -1,0 +1,28 @@
+# Diffusion Load Producer
+
+**Type:** `diffusion-load-producer`
+
+Tracks the outstanding declared cost of in-flight image generation requests per endpoint and publishes it as the `DiffusionLoad` endpoint attribute, consumed by the `diffusion-cost-scorer`.
+
+Unlike LLM requests, whose output length is unknown at admission, an image generation request declares its compute cost in the body. The producer converts the declared fields into step-megapixel cost units:
+
+```
+cost = num_inference_steps x (width x height / 1024^2) x n
+```
+
+clamped to a minimum of one unit. Fields the client omitted fall back to the configured defaults. The cost is committed to the chosen endpoint when the request is scheduled and released when its response stream ends (with the plugin-state janitor as a TTL backstop, matching `inflight-load-producer`). Requests without an image generation body contribute no cost.
+
+The producer is registered as the default for the `DiffusionLoad` data key, so configuring a consumer (e.g. `diffusion-cost-scorer`) auto-creates it with defaults.
+
+**Parameters:**
+- `defaultNumInferenceSteps` (int, optional, default: `50`): Step count assumed when a request omits `num_inference_steps`. Match it to the served model's default (e.g. a low value for turbo/distilled models).
+- `defaultSize` (string, optional, default: `"1024x1024"`): Output resolution (`WIDTHxHEIGHT`) assumed when a request omits `size`.
+
+**Configuration Example:**
+```yaml
+plugins:
+  - type: diffusion-load-producer
+    parameters:
+      defaultNumInferenceSteps: 9
+      defaultSize: "1024x1024"
+```

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/README.md
@@ -2,15 +2,15 @@
 
 **Type:** `diffusion-load-producer`
 
-Tracks the outstanding declared cost of in-flight image generation requests per endpoint and publishes it as the `DiffusionLoad` endpoint attribute, consumed by the `diffusion-cost-scorer`.
+Tracks the outstanding declared cost of in-flight diffusion requests per endpoint and publishes it as the `DiffusionLoad` endpoint attribute, consumed by the `diffusion-cost-scorer`.
 
-Unlike LLM requests, whose output length is unknown at admission, an image generation request declares its compute cost in the body. The producer converts the declared fields into step-megapixel cost units:
+Unlike LLM requests, whose output length is unknown at admission, a diffusion request declares its compute cost in the body. Image generation is the only diffusion request type currently recognized; its declared cost is:
 
 ```
-cost = num_inference_steps x (width x height / 1024^2) x n
+cost = num_inference_steps x width x height x n
 ```
 
-clamped to a minimum of one unit. Fields the client omitted fall back to the configured defaults. The cost is committed to the chosen endpoint when the request is scheduled and released when its response stream ends (with the plugin-state janitor as a TTL backstop, matching `inflight-load-producer`). Requests without an image generation body contribute no cost.
+Fields the client omitted fall back to the configured defaults. The cost is committed to the chosen endpoint when the request is scheduled and released when its response stream ends. Requests without a recognized diffusion body contribute no cost.
 
 The producer is registered as the default for the `DiffusionLoad` data key, so configuring a consumer (e.g. `diffusion-cost-scorer`) auto-creates it with defaults.
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/constants/constants.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/constants/constants.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package constants holds identifiers shared between the diffusion-load
+// producer and the attribute package it populates, avoiding an import cycle.
+package constants
+
+// DiffusionLoadProducerType is the type of the DiffusionLoadProducer plugin.
+const DiffusionLoadProducerType = "diffusion-load-producer"

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/producer.go
@@ -1,0 +1,409 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package diffusionload tracks the outstanding declared cost of in-flight
+// image generation requests per endpoint. Unlike LLM requests, whose output
+// length is unknown at admission, a diffusion request declares its compute
+// cost in the body (inference steps x output resolution x image count), so
+// the tracked load reflects actual GPU work rather than request count.
+package diffusionload
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrdiffusion "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/diffusion"
+	sourcenotifications "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
+	diffusionloadconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/constants"
+)
+
+const (
+	DiffusionLoadProducerType = diffusionloadconstants.DiffusionLoadProducerType
+
+	// pixelsPerCostUnit normalizes declared pixel counts into megapixel-scale
+	// cost units so a 1024x1024 single-image request costs one unit per step.
+	pixelsPerCostUnit = 1024 * 1024
+
+	defaultNumInferenceSteps = 50
+	defaultSize              = "1024x1024"
+)
+
+// Config controls the defaults used when a request does not declare a cost field.
+type Config struct {
+	// DefaultNumInferenceSteps is the step count assumed when a request omits
+	// num_inference_steps. Match it to the served model's default (e.g. a low
+	// value for turbo/distilled models). Must be positive. Defaults to 50.
+	DefaultNumInferenceSteps int64 `json:"defaultNumInferenceSteps,omitempty"`
+	// DefaultSize is the output resolution ("WIDTHxHEIGHT") assumed when a
+	// request omits size. Defaults to "1024x1024".
+	DefaultSize string `json:"defaultSize,omitempty"`
+}
+
+func DiffusionLoadProducerFactory(name string, decoder *json.Decoder, handle fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	if handle == nil {
+		return nil, errors.New("handle is nil")
+	}
+	ctx := handle.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cfg := Config{}
+	if decoder != nil {
+		if err := decoder.Decode(&cfg); err != nil {
+			return nil, fmt.Errorf("failed to decode diffusion-load-producer parameters: %w", err)
+		}
+	}
+
+	steps := int64(defaultNumInferenceSteps)
+	if cfg.DefaultNumInferenceSteps != 0 {
+		if cfg.DefaultNumInferenceSteps < 0 {
+			return nil, fmt.Errorf("defaultNumInferenceSteps must be positive, got %d", cfg.DefaultNumInferenceSteps)
+		}
+		steps = cfg.DefaultNumInferenceSteps
+	}
+
+	size := defaultSize
+	if cfg.DefaultSize != "" {
+		size = cfg.DefaultSize
+	}
+	pixels, err := parseSizePixels(size)
+	if err != nil {
+		return nil, fmt.Errorf("invalid defaultSize %q: %w", size, err)
+	}
+
+	return &DiffusionLoadProducer{
+		typedName:     fwkplugin.TypedName{Type: DiffusionLoadProducerType, Name: name},
+		costTracker:   newCostTracker(),
+		defaultSteps:  steps,
+		defaultPixels: pixels,
+		dk:            attrdiffusion.DiffusionLoadDataKey.WithNonEmptyProducerName(name),
+		PluginState:   fwkplugin.NewPluginState(ctx),
+	}, nil
+}
+
+var (
+	_ requestcontrol.PreRequest            = &DiffusionLoadProducer{}
+	_ requestcontrol.ResponseBodyProcessor = &DiffusionLoadProducer{}
+	_ requestcontrol.DataProducer          = &DiffusionLoadProducer{}
+	_ datalayer.EndpointExtractor          = (*DiffusionLoadProducer)(nil)
+	_ datalayer.Registrant                 = &DiffusionLoadProducer{}
+)
+
+// DiffusionLoadProducer tracks per-endpoint outstanding declared diffusion
+// cost and publishes it as the DiffusionLoad endpoint attribute.
+type DiffusionLoadProducer struct {
+	typedName           fwkplugin.TypedName
+	costTracker         *costTracker
+	defaultSteps        int64
+	defaultPixels       int64
+	dk                  fwkplugin.DataKey
+	PluginState         *fwkplugin.PluginState
+	registeredEndpoints sync.Map // key: string (NamespacedName), value: datalayer.Endpoint
+}
+
+// addedCostEntry tracks a request's contribution to an endpoint's cost
+// counter. OnEvicted rolls back the contribution exactly once, whether
+// triggered by explicit release at end-of-stream or by the janitor's TTL
+// reaper: whichever swaps first does the decrement, the other sees 0 and is
+// a no-op. The counter pointer targets the exact instance incremented in
+// PreRequest so a release always lands on it, even after an endpoint flap.
+type addedCostEntry struct {
+	cost        atomic.Int64
+	costCounter *atomic.Int64
+}
+
+var _ fwkplugin.EvictableStateData = (*addedCostEntry)(nil)
+
+// Clone returns a distinct copy of the entry with the current atomic value.
+// The counter-instance pointer stays shared so the clone releases against the
+// same counter the original incremented.
+func (e *addedCostEntry) Clone() fwkplugin.StateData {
+	if e == nil {
+		return nil
+	}
+	clone := &addedCostEntry{costCounter: e.costCounter}
+	clone.cost.Store(e.cost.Load())
+	return clone
+}
+
+func (e *addedCostEntry) OnEvicted(_ string, _ fwkplugin.StateKey) {
+	if c := e.cost.Swap(0); c != 0 {
+		decrementClamped(e.costCounter, c)
+	}
+}
+
+func (p *DiffusionLoadProducer) TypedName() fwkplugin.TypedName {
+	return p.typedName
+}
+
+// RegisterDependencies declares that this plugin needs an endpoint-notification-source
+// to track endpoint lifecycle events. The source is auto-created if not already configured.
+func (p *DiffusionLoadProducer) RegisterDependencies(r datalayer.Registrar) error {
+	return r.Register(datalayer.PendingRegistration{
+		Owner:         p.TypedName(),
+		SourceType:    sourcenotifications.EndpointNotificationSourceType,
+		Extractor:     p,
+		DefaultSource: sourcenotifications.NewEndpointDataSource(sourcenotifications.EndpointNotificationSourceType, sourcenotifications.EndpointNotificationSourceType),
+	})
+}
+
+// Extract handles endpoint lifecycle events to manage the dynamic attribute.
+func (p *DiffusionLoadProducer) Extract(ctx context.Context, event datalayer.EndpointEvent) error {
+	if event.Endpoint == nil || event.Endpoint.GetMetadata() == nil {
+		return nil
+	}
+
+	id := event.Endpoint.GetMetadata().ID.String()
+
+	switch event.Type {
+	case datalayer.EventDelete:
+		// Assumes the datalayer delivers the same Endpoint pointer for delete as
+		// for the preceding add; see InFlightLoadProducer.Extract for details.
+		if registered, ok := p.registeredEndpoints.Load(id); ok && registered != event.Endpoint {
+			log.FromContext(ctx).V(logutil.DEFAULT).Info("Ignoring stale delete for replaced endpoint", "endpoint", id)
+			break
+		}
+		p.registeredEndpoints.Delete(id)
+		p.costTracker.delete(id)
+		log.FromContext(ctx).V(logutil.DEFAULT).Info("Cleaned up diffusion load for deleted endpoint", "endpoint", id)
+	case datalayer.EventAddOrUpdate:
+		p.registeredEndpoints.Store(id, event.Endpoint)
+		event.Endpoint.GetAttributes().Put(p.dk, &datalayer.DynamicAttribute{
+			Get: func() datalayer.Cloneable {
+				return &attrdiffusion.DiffusionLoad{
+					CostUnits: p.costTracker.get(id),
+				}
+			},
+		})
+		log.FromContext(ctx).V(logutil.DEFAULT).Info("Injected dynamic attribute into endpoint", "key", p.dk.String(), "endpoint", id)
+	}
+	return nil
+}
+
+// Produce is a no-op: the DiffusionLoad attribute is published dynamically on
+// endpoint registration and reflects live counters at read time.
+func (p *DiffusionLoadProducer) Produce(_ context.Context, _ *fwksched.InferenceRequest, _ []fwksched.Endpoint) error {
+	return nil
+}
+
+func (p *DiffusionLoadProducer) Produces() map[fwkplugin.DataKey]any {
+	return map[fwkplugin.DataKey]any{
+		p.dk: attrdiffusion.DiffusionLoad{},
+	}
+}
+
+func (p *DiffusionLoadProducer) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, result *fwksched.SchedulingResult) error {
+	if result == nil || len(result.ProfileResults) == 0 {
+		return nil
+	}
+	if request == nil || request.RequestID == "" || p.PluginState == nil {
+		return nil
+	}
+
+	cost := p.requestCost(request)
+	if cost == 0 {
+		// Not an image generation request; nothing to track.
+		return nil
+	}
+
+	for profileName, profileResult := range result.ProfileResults {
+		if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
+			continue
+		}
+		// Only track the primary target, consistent with InFlightLoadProducer.
+		endpoint := profileResult.TargetEndpoints[0]
+		if endpoint == nil || endpoint.GetMetadata() == nil {
+			continue
+		}
+		eid := endpoint.GetMetadata().ID.String()
+		counter := p.costTracker.add(eid, cost)
+
+		entry := &addedCostEntry{costCounter: counter}
+		entry.cost.Store(cost)
+		p.PluginState.Write(
+			request.RequestID,
+			fwkplugin.StateKey(addedCostKey(eid, profileName)),
+			entry,
+		)
+	}
+
+	log.FromContext(ctx).V(logutil.DEBUG).Info("Tracked diffusion request cost", "requestID", request.RequestID, "costUnits", cost)
+	return nil
+}
+
+// ResponseBody releases the request's cost contribution when the response
+// stream ends. Intermediate chunks extend the janitor lifetime.
+func (p *DiffusionLoadProducer) ResponseBody(
+	_ context.Context,
+	request *fwksched.InferenceRequest,
+	resp *requestcontrol.Response,
+	_ *datalayer.EndpointMetadata,
+) {
+	if request == nil || resp == nil || request.RequestID == "" || p.PluginState == nil {
+		return
+	}
+
+	if resp.EndOfStream {
+		p.PluginState.Delete(request.RequestID)
+	} else {
+		p.PluginState.Touch(request.RequestID)
+	}
+}
+
+// requestCost returns the declared cost of the request in step-megapixel
+// units, or 0 when the request is not an image generation request. Fields the
+// client omitted fall back to the configured defaults.
+func (p *DiffusionLoadProducer) requestCost(request *fwksched.InferenceRequest) int64 {
+	if request.Body == nil || request.Body.Images == nil {
+		return 0
+	}
+	images := request.Body.Images
+
+	steps := p.defaultSteps
+	if images.NumInferenceSteps != nil && *images.NumInferenceSteps > 0 {
+		steps = *images.NumInferenceSteps
+	}
+
+	pixels := p.defaultPixels
+	if images.Size != "" {
+		if parsed, err := parseSizePixels(images.Size); err == nil {
+			pixels = parsed
+		}
+	}
+
+	n := int64(1)
+	if images.N != nil && *images.N > 0 {
+		n = *images.N
+	}
+
+	cost := steps * n * pixels / pixelsPerCostUnit
+	if cost < 1 {
+		cost = 1
+	}
+	return cost
+}
+
+// parseSizePixels parses a "WIDTHxHEIGHT" size string into a pixel count.
+func parseSizePixels(size string) (int64, error) {
+	parts := strings.SplitN(strings.ToLower(strings.TrimSpace(size)), "x", 2)
+	if len(parts) != 2 {
+		return 0, fmt.Errorf("size must be WIDTHxHEIGHT, got %q", size)
+	}
+	width, err := strconv.ParseInt(strings.TrimSpace(parts[0]), 10, 64)
+	if err != nil || width <= 0 {
+		return 0, fmt.Errorf("invalid width in size %q", size)
+	}
+	height, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+	if err != nil || height <= 0 {
+		return 0, fmt.Errorf("invalid height in size %q", size)
+	}
+	return width * height, nil
+}
+
+func addedCostKey(endpointID, profileName string) string {
+	return endpointID + "|" + profileName + "|addedCost"
+}
+
+func (p *DiffusionLoadProducer) GetCostUnits(eid string) int64 {
+	return p.costTracker.get(eid)
+}
+
+// costTracker manages thread-safe per-endpoint cost counters, following the
+// captured-instance pattern of inflightload.concurrencyTracker.
+type costTracker struct {
+	mu     sync.RWMutex
+	counts map[string]*atomic.Int64
+}
+
+func newCostTracker() *costTracker {
+	return &costTracker{counts: make(map[string]*atomic.Int64)}
+}
+
+func (t *costTracker) get(endpointID string) int64 {
+	t.mu.RLock()
+	counter, exists := t.counts[endpointID]
+	t.mu.RUnlock()
+
+	if !exists {
+		return 0
+	}
+	return counter.Load()
+}
+
+// add applies delta to the endpoint's counter, creating it if absent, and
+// returns the exact counter instance mutated so the matching decrement always
+// lands on it, even after an endpoint flap.
+func (t *costTracker) add(endpointID string, delta int64) *atomic.Int64 {
+	t.mu.RLock()
+	counter, exists := t.counts[endpointID]
+	t.mu.RUnlock()
+
+	if exists {
+		counter.Add(delta)
+		return counter
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if counter, exists = t.counts[endpointID]; exists {
+		counter.Add(delta)
+		return counter
+	}
+
+	counter = &atomic.Int64{}
+	counter.Store(delta)
+	t.counts[endpointID] = counter
+	return counter
+}
+
+func (t *costTracker) delete(endpointID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.counts, endpointID)
+}
+
+// decrementClamped subtracts delta from counter with a hard floor at zero;
+// see inflightload.decrementClamped for the rationale of the CAS floor.
+func decrementClamped(counter *atomic.Int64, delta int64) {
+	for {
+		current := counter.Load()
+		if current <= 0 {
+			return
+		}
+		next := current - delta
+		if next < 0 {
+			next = 0
+		}
+		if counter.CompareAndSwap(current, next) {
+			return
+		}
+	}
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/producer.go
@@ -174,7 +174,7 @@ func (p *DiffusionLoadProducer) RegisterDependencies(r datalayer.Registrar) erro
 	})
 }
 
-// Extract handles endpoint lifecycle events to manage the dynamic attribute.
+// Extract releases per-endpoint cost state when an endpoint is removed.
 func (p *DiffusionLoadProducer) Extract(ctx context.Context, event datalayer.EndpointEvent) error {
 	if event.Endpoint == nil || event.Endpoint.GetMetadata() == nil {
 		return nil
@@ -185,7 +185,9 @@ func (p *DiffusionLoadProducer) Extract(ctx context.Context, event datalayer.End
 	switch event.Type {
 	case datalayer.EventDelete:
 		// Assumes the datalayer delivers the same Endpoint pointer for delete as
-		// for the preceding add; see InFlightLoadProducer.Extract for details.
+		// for the preceding add. When the endpoint was replaced under the same
+		// NamespacedName, the pointers differ and the stale delete is ignored so
+		// it does not drop the live endpoint's counter.
 		if registered, ok := p.registeredEndpoints.Load(id); ok && registered != event.Endpoint {
 			log.FromContext(ctx).V(logutil.DEFAULT).Info("Ignoring stale delete for replaced endpoint", "endpoint", id)
 			break
@@ -194,22 +196,24 @@ func (p *DiffusionLoadProducer) Extract(ctx context.Context, event datalayer.End
 		p.costTracker.delete(id)
 		log.FromContext(ctx).V(logutil.DEFAULT).Info("Cleaned up diffusion load for deleted endpoint", "endpoint", id)
 	case datalayer.EventAddOrUpdate:
+		// Track the endpoint pointer so a later EventDelete can be recognized as
+		// stale (and ignored) when the endpoint was replaced under the same name.
 		p.registeredEndpoints.Store(id, event.Endpoint)
-		event.Endpoint.GetAttributes().Put(p.dk, &datalayer.DynamicAttribute{
-			Get: func() datalayer.Cloneable {
-				return &attrdiffusion.DiffusionLoad{
-					CostUnits: p.costTracker.get(id),
-				}
-			},
-		})
-		log.FromContext(ctx).V(logutil.DEFAULT).Info("Injected dynamic attribute into endpoint", "key", p.dk.String(), "endpoint", id)
 	}
 	return nil
 }
 
-// Produce is a no-op: the DiffusionLoad attribute is published dynamically on
-// endpoint registration and reflects live counters at read time.
-func (p *DiffusionLoadProducer) Produce(_ context.Context, _ *fwksched.InferenceRequest, _ []fwksched.Endpoint) error {
+// Produce publishes each candidate endpoint's current outstanding declared
+// diffusion cost as the DiffusionLoad attribute, read by the diffusion-cost
+// scorer. The value is a snapshot of the live counter at scheduling time.
+func (p *DiffusionLoadProducer) Produce(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+	for _, endpoint := range endpoints {
+		if endpoint == nil || endpoint.GetMetadata() == nil {
+			continue
+		}
+		id := endpoint.GetMetadata().ID.String()
+		endpoint.Put(p.dk, &attrdiffusion.DiffusionLoad{CostUnits: p.costTracker.get(id)})
+	}
 	return nil
 }
 
@@ -237,7 +241,7 @@ func (p *DiffusionLoadProducer) PreRequest(ctx context.Context, request *fwksche
 		if profileResult == nil || len(profileResult.TargetEndpoints) == 0 {
 			continue
 		}
-		// Only track the primary target, consistent with InFlightLoadProducer.
+		// Only track the primary target endpoint of each profile.
 		endpoint := profileResult.TargetEndpoints[0]
 		if endpoint == nil || endpoint.GetMetadata() == nil {
 			continue
@@ -335,8 +339,7 @@ func (p *DiffusionLoadProducer) GetCostUnits(eid string) int64 {
 	return p.costTracker.get(eid)
 }
 
-// costTracker manages thread-safe per-endpoint cost counters, following the
-// captured-instance pattern of inflightload.concurrencyTracker.
+// costTracker manages thread-safe per-endpoint cost counters.
 type costTracker struct {
 	mu     sync.RWMutex
 	counts map[string]*atomic.Int64
@@ -390,8 +393,9 @@ func (t *costTracker) delete(endpointID string) {
 	delete(t.counts, endpointID)
 }
 
-// decrementClamped subtracts delta from counter with a hard floor at zero;
-// see inflightload.decrementClamped for the rationale of the CAS floor.
+// decrementClamped subtracts delta from counter with a hard floor at zero. The
+// CAS loop keeps the floor race-safe against a concurrent increment on the same
+// instance, which a plain Add followed by Store(0) could clobber.
 func decrementClamped(counter *atomic.Int64, delta int64) {
 	for {
 		current := counter.Load()

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/producer.go
@@ -15,10 +15,12 @@ limitations under the License.
 */
 
 // Package diffusionload tracks the outstanding declared cost of in-flight
-// image generation requests per endpoint. Unlike LLM requests, whose output
-// length is unknown at admission, a diffusion request declares its compute
-// cost in the body (inference steps x output resolution x image count), so
-// the tracked load reflects actual GPU work rather than request count.
+// diffusion requests per endpoint. Unlike LLM requests, whose output length
+// is unknown at admission, a diffusion request declares its compute cost in
+// the body, so the tracked load reflects actual GPU work rather than request
+// count. Image generation is the only diffusion request type currently
+// recognized; its cost is measured in step-pixels (inference steps x output
+// pixels x image count).
 package diffusionload
 
 import (
@@ -45,10 +47,6 @@ import (
 
 const (
 	DiffusionLoadProducerType = diffusionloadconstants.DiffusionLoadProducerType
-
-	// pixelsPerCostUnit normalizes declared pixel counts into megapixel-scale
-	// cost units so a 1024x1024 single-image request costs one unit per step.
-	pixelsPerCostUnit = 1024 * 1024
 
 	defaultNumInferenceSteps = 50
 	defaultSize              = "1024x1024"
@@ -112,7 +110,7 @@ var (
 	_ requestcontrol.PreRequest            = &DiffusionLoadProducer{}
 	_ requestcontrol.ResponseBodyProcessor = &DiffusionLoadProducer{}
 	_ requestcontrol.DataProducer          = &DiffusionLoadProducer{}
-	_ datalayer.EndpointExtractor          = (*DiffusionLoadProducer)(nil)
+	_ datalayer.EndpointExtractor          = &DiffusionLoadProducer{}
 	_ datalayer.Registrant                 = &DiffusionLoadProducer{}
 )
 
@@ -184,10 +182,6 @@ func (p *DiffusionLoadProducer) Extract(ctx context.Context, event datalayer.End
 
 	switch event.Type {
 	case datalayer.EventDelete:
-		// Assumes the datalayer delivers the same Endpoint pointer for delete as
-		// for the preceding add. When the endpoint was replaced under the same
-		// NamespacedName, the pointers differ and the stale delete is ignored so
-		// it does not drop the live endpoint's counter.
 		if registered, ok := p.registeredEndpoints.Load(id); ok && registered != event.Endpoint {
 			log.FromContext(ctx).V(logutil.DEFAULT).Info("Ignoring stale delete for replaced endpoint", "endpoint", id)
 			break
@@ -212,7 +206,7 @@ func (p *DiffusionLoadProducer) Produce(_ context.Context, _ *fwksched.Inference
 			continue
 		}
 		id := endpoint.GetMetadata().ID.String()
-		endpoint.Put(p.dk, &attrdiffusion.DiffusionLoad{CostUnits: p.costTracker.get(id)})
+		endpoint.Put(p.dk, &attrdiffusion.DiffusionLoad{Cost: p.costTracker.get(id)})
 	}
 	return nil
 }
@@ -233,7 +227,7 @@ func (p *DiffusionLoadProducer) PreRequest(ctx context.Context, request *fwksche
 
 	cost := p.requestCost(request)
 	if cost == 0 {
-		// Not an image generation request; nothing to track.
+		// Not a diffusion request; nothing to track.
 		return nil
 	}
 
@@ -258,7 +252,7 @@ func (p *DiffusionLoadProducer) PreRequest(ctx context.Context, request *fwksche
 		)
 	}
 
-	log.FromContext(ctx).V(logutil.DEBUG).Info("Tracked diffusion request cost", "requestID", request.RequestID, "costUnits", cost)
+	log.FromContext(ctx).V(logutil.DEBUG).Info("Tracked diffusion request cost", "requestID", request.RequestID, "cost", cost)
 	return nil
 }
 
@@ -281,14 +275,19 @@ func (p *DiffusionLoadProducer) ResponseBody(
 	}
 }
 
-// requestCost returns the declared cost of the request in step-megapixel
-// units, or 0 when the request is not an image generation request. Fields the
-// client omitted fall back to the configured defaults.
+// requestCost returns the declared cost of the request, or 0 when the request
+// does not carry a recognized diffusion body. Fields the client omitted fall
+// back to the configured defaults.
 func (p *DiffusionLoadProducer) requestCost(request *fwksched.InferenceRequest) int64 {
-	if request.Body == nil || request.Body.Images == nil {
+	if request.Body == nil {
 		return 0
 	}
 	images := request.Body.Images
+	if images == nil {
+		// Only diffusion requests declare a cost; all other request types
+		// are left untracked.
+		return 0
+	}
 
 	steps := p.defaultSteps
 	if images.NumInferenceSteps != nil && *images.NumInferenceSteps > 0 {
@@ -307,11 +306,7 @@ func (p *DiffusionLoadProducer) requestCost(request *fwksched.InferenceRequest) 
 		n = *images.N
 	}
 
-	cost := steps * n * pixels / pixelsPerCostUnit
-	if cost < 1 {
-		cost = 1
-	}
-	return cost
+	return steps * n * pixels
 }
 
 // parseSizePixels parses a "WIDTHxHEIGHT" size string into a pixel count.
@@ -335,7 +330,7 @@ func addedCostKey(endpointID, profileName string) string {
 	return endpointID + "|" + profileName + "|addedCost"
 }
 
-func (p *DiffusionLoadProducer) GetCostUnits(eid string) int64 {
+func (p *DiffusionLoadProducer) GetCost(eid string) int64 {
 	return p.costTracker.get(eid)
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/producer_test.go
@@ -250,24 +250,42 @@ func TestDiffusionLoadProducer_Extract(t *testing.T) {
 	endpoint := newStubSchedulingEndpoint("pod-a")
 	eid := endpoint.GetMetadata().ID.String()
 
-	// Registration injects the dynamic attribute.
+	// Registration does not publish an attribute; Produce does that per request.
 	require.NoError(t, producer.Extract(ctx, datalayer.EndpointEvent{Type: datalayer.EventAddOrUpdate, Endpoint: endpoint}))
-	val, ok := endpoint.Get(producer.dk)
-	require.True(t, ok)
-	load, ok := val.(*attrdiffusion.DiffusionLoad)
-	require.True(t, ok)
-	require.Equal(t, int64(0), load.CostUnits)
+	_, ok := endpoint.Get(producer.dk)
+	require.False(t, ok)
 
-	// The attribute reflects live counters.
+	// Commit some cost, then deletion cleans up the tracker.
 	request := makeImagesRequest("req-1", &fwkrh.ImagesGenerationsRequest{Prompt: "p", NumInferenceSteps: ptr.To[int64](30)})
 	require.NoError(t, producer.PreRequest(ctx, request, makeSchedulingResult(endpoint)))
+	require.Equal(t, int64(30), producer.GetCostUnits(eid))
+
+	require.NoError(t, producer.Extract(ctx, datalayer.EndpointEvent{Type: datalayer.EventDelete, Endpoint: endpoint}))
+	require.Equal(t, int64(0), producer.GetCostUnits(eid))
+}
+
+func TestDiffusionLoadProducer_Produce(t *testing.T) {
+	t.Parallel()
+
+	producer := newTestProducer(t, Config{})
+	ctx := context.Background()
+
+	endpoint := newStubSchedulingEndpoint("pod-a")
+
+	// Before any cost is committed, Produce publishes a zero snapshot.
+	require.NoError(t, producer.Produce(ctx, nil, []fwksched.Endpoint{endpoint}))
+	val, ok := endpoint.Get(producer.dk)
+	require.True(t, ok)
+	require.Equal(t, int64(0), val.(*attrdiffusion.DiffusionLoad).CostUnits)
+
+	// After committing cost, Produce publishes the live snapshot.
+	request := makeImagesRequest("req-1", &fwkrh.ImagesGenerationsRequest{Prompt: "p", NumInferenceSteps: ptr.To[int64](30)})
+	require.NoError(t, producer.PreRequest(ctx, request, makeSchedulingResult(endpoint)))
+
+	require.NoError(t, producer.Produce(ctx, nil, []fwksched.Endpoint{endpoint}))
 	val, ok = endpoint.Get(producer.dk)
 	require.True(t, ok)
 	require.Equal(t, int64(30), val.(*attrdiffusion.DiffusionLoad).CostUnits)
-
-	// Deletion cleans up the tracker.
-	require.NoError(t, producer.Extract(ctx, datalayer.EndpointEvent{Type: datalayer.EventDelete, Endpoint: endpoint}))
-	require.Equal(t, int64(0), producer.GetCostUnits(eid))
 }
 
 func TestDiffusionLoadProducer_Produces(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/producer_test.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diffusionload
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrdiffusion "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/diffusion"
+	testutils "github.com/llm-d/llm-d-router/test/utils"
+)
+
+func newTestProducer(t testing.TB, cfg Config) *DiffusionLoadProducer {
+	raw, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	p, err := DiffusionLoadProducerFactory(DiffusionLoadProducerType, json.NewDecoder(bytes.NewReader(raw)), testutils.NewTestHandle(ctx))
+	require.NoError(t, err)
+	return p.(*DiffusionLoadProducer)
+}
+
+type stubSchedulingEndpoint struct {
+	metadata *datalayer.EndpointMetadata
+	attr     datalayer.AttributeMap
+}
+
+func newStubSchedulingEndpoint(name string) *stubSchedulingEndpoint {
+	return &stubSchedulingEndpoint{
+		metadata: &datalayer.EndpointMetadata{ID: types.NamespacedName{Name: name, Namespace: "default"}},
+		attr:     datalayer.NewAttributes(),
+	}
+}
+
+func (f *stubSchedulingEndpoint) GetMetadata() *datalayer.EndpointMetadata           { return f.metadata }
+func (f *stubSchedulingEndpoint) UpdateMetadata(*datalayer.EndpointMetadata)         {}
+func (f *stubSchedulingEndpoint) GetMetrics() *datalayer.Metrics                     { return nil }
+func (f *stubSchedulingEndpoint) UpdateMetrics(*datalayer.Metrics)                   {}
+func (f *stubSchedulingEndpoint) GetAttributes() datalayer.AttributeMap              { return f.attr }
+func (f *stubSchedulingEndpoint) String() string                                     { return f.metadata.ID.String() }
+func (f *stubSchedulingEndpoint) Put(key fwkplugin.DataKey, val datalayer.Cloneable) { f.attr.Put(key, val) }
+func (f *stubSchedulingEndpoint) Get(key fwkplugin.DataKey) (datalayer.Cloneable, bool) {
+	return f.attr.Get(key)
+}
+func (f *stubSchedulingEndpoint) Keys() []fwkplugin.DataKey     { return f.attr.Keys() }
+func (f *stubSchedulingEndpoint) Clone() datalayer.AttributeMap { return f.attr.Clone() }
+
+func makeImagesRequest(id string, images *fwkrh.ImagesGenerationsRequest) *fwksched.InferenceRequest {
+	return &fwksched.InferenceRequest{
+		RequestID: id,
+		Body:      &fwkrh.InferenceRequestBody{Images: images},
+	}
+}
+
+func makeSchedulingResult(endpoint fwksched.Endpoint) *fwksched.SchedulingResult {
+	return &fwksched.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"default": {TargetEndpoints: []fwksched.Endpoint{endpoint}},
+		},
+	}
+}
+
+func TestDiffusionLoadProducer_RequestCost(t *testing.T) {
+	t.Parallel()
+
+	producer := newTestProducer(t, Config{})
+
+	tests := []struct {
+		name    string
+		request *fwksched.InferenceRequest
+		want    int64
+	}{
+		{
+			name:    "non-image request costs nothing",
+			request: &fwksched.InferenceRequest{RequestID: "r", Body: &fwkrh.InferenceRequestBody{}},
+			want:    0,
+		},
+		{
+			name:    "nil body costs nothing",
+			request: &fwksched.InferenceRequest{RequestID: "r"},
+			want:    0,
+		},
+		{
+			name: "declared fields",
+			request: makeImagesRequest("r", &fwkrh.ImagesGenerationsRequest{
+				Prompt:            "p",
+				NumInferenceSteps: ptr.To[int64](30),
+				Size:              "1024x1024",
+				N:                 ptr.To[int64](2),
+			}),
+			want: 60, // 30 steps x 1 MP x 2 images
+		},
+		{
+			name: "all fields defaulted",
+			request: makeImagesRequest("r", &fwkrh.ImagesGenerationsRequest{
+				Prompt: "p",
+			}),
+			want: 50, // 50 default steps x 1 MP default size x 1 image
+		},
+		{
+			name: "sub-megapixel size scales down",
+			request: makeImagesRequest("r", &fwkrh.ImagesGenerationsRequest{
+				Prompt:            "p",
+				NumInferenceSteps: ptr.To[int64](20),
+				Size:              "512x512",
+			}),
+			want: 5, // 20 steps x 0.25 MP
+		},
+		{
+			name: "malformed size falls back to default",
+			request: makeImagesRequest("r", &fwkrh.ImagesGenerationsRequest{
+				Prompt:            "p",
+				NumInferenceSteps: ptr.To[int64](10),
+				Size:              "huge",
+			}),
+			want: 10,
+		},
+		{
+			name: "tiny request clamps to one unit",
+			request: makeImagesRequest("r", &fwkrh.ImagesGenerationsRequest{
+				Prompt:            "p",
+				NumInferenceSteps: ptr.To[int64](1),
+				Size:              "64x64",
+			}),
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, producer.requestCost(tt.request))
+		})
+	}
+}
+
+func TestDiffusionLoadProducer_ConfiguredDefaults(t *testing.T) {
+	t.Parallel()
+
+	producer := newTestProducer(t, Config{DefaultNumInferenceSteps: 8, DefaultSize: "512x512"})
+
+	cost := producer.requestCost(makeImagesRequest("r", &fwkrh.ImagesGenerationsRequest{Prompt: "p"}))
+	require.Equal(t, int64(2), cost) // 8 steps x 0.25 MP
+}
+
+func TestDiffusionLoadProducerFactory_InvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	raw, err := json.Marshal(Config{DefaultSize: "not-a-size"})
+	require.NoError(t, err)
+	_, err = DiffusionLoadProducerFactory(DiffusionLoadProducerType, json.NewDecoder(bytes.NewReader(raw)), testutils.NewTestHandle(ctx))
+	require.Error(t, err)
+
+	raw, err = json.Marshal(Config{DefaultNumInferenceSteps: -1})
+	require.NoError(t, err)
+	_, err = DiffusionLoadProducerFactory(DiffusionLoadProducerType, json.NewDecoder(bytes.NewReader(raw)), testutils.NewTestHandle(ctx))
+	require.Error(t, err)
+}
+
+func TestDiffusionLoadProducer_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	producer := newTestProducer(t, Config{})
+	ctx := context.Background()
+
+	endpoint := newStubSchedulingEndpoint("pod-a")
+	eid := endpoint.GetMetadata().ID.String()
+	result := makeSchedulingResult(endpoint)
+
+	request := makeImagesRequest("req-1", &fwkrh.ImagesGenerationsRequest{
+		Prompt:            "p",
+		NumInferenceSteps: ptr.To[int64](30),
+		Size:              "1024x1024",
+	})
+
+	// PreRequest commits the declared cost to the chosen endpoint.
+	require.NoError(t, producer.PreRequest(ctx, request, result))
+	require.Equal(t, int64(30), producer.GetCostUnits(eid))
+
+	// A second request accumulates.
+	request2 := makeImagesRequest("req-2", &fwkrh.ImagesGenerationsRequest{
+		Prompt:            "p",
+		NumInferenceSteps: ptr.To[int64](10),
+	})
+	require.NoError(t, producer.PreRequest(ctx, request2, result))
+	require.Equal(t, int64(40), producer.GetCostUnits(eid))
+
+	// Intermediate chunk does not release.
+	producer.ResponseBody(ctx, request, &requestcontrol.Response{RequestID: "req-1"}, nil)
+	require.Equal(t, int64(40), producer.GetCostUnits(eid))
+
+	// EndOfStream releases exactly the request's own contribution.
+	producer.ResponseBody(ctx, request, &requestcontrol.Response{RequestID: "req-1", EndOfStream: true}, nil)
+	require.Equal(t, int64(10), producer.GetCostUnits(eid))
+
+	// Releasing the same request again is a no-op.
+	producer.ResponseBody(ctx, request, &requestcontrol.Response{RequestID: "req-1", EndOfStream: true}, nil)
+	require.Equal(t, int64(10), producer.GetCostUnits(eid))
+
+	producer.ResponseBody(ctx, request2, &requestcontrol.Response{RequestID: "req-2", EndOfStream: true}, nil)
+	require.Equal(t, int64(0), producer.GetCostUnits(eid))
+}
+
+func TestDiffusionLoadProducer_NonImageRequestNotTracked(t *testing.T) {
+	t.Parallel()
+
+	producer := newTestProducer(t, Config{})
+	endpoint := newStubSchedulingEndpoint("pod-a")
+	eid := endpoint.GetMetadata().ID.String()
+
+	request := &fwksched.InferenceRequest{RequestID: "req-1", Body: &fwkrh.InferenceRequestBody{}}
+	require.NoError(t, producer.PreRequest(context.Background(), request, makeSchedulingResult(endpoint)))
+	require.Equal(t, int64(0), producer.GetCostUnits(eid))
+}
+
+func TestDiffusionLoadProducer_Extract(t *testing.T) {
+	t.Parallel()
+
+	producer := newTestProducer(t, Config{})
+	ctx := context.Background()
+
+	endpoint := newStubSchedulingEndpoint("pod-a")
+	eid := endpoint.GetMetadata().ID.String()
+
+	// Registration injects the dynamic attribute.
+	require.NoError(t, producer.Extract(ctx, datalayer.EndpointEvent{Type: datalayer.EventAddOrUpdate, Endpoint: endpoint}))
+	val, ok := endpoint.Get(producer.dk)
+	require.True(t, ok)
+	load, ok := val.(*attrdiffusion.DiffusionLoad)
+	require.True(t, ok)
+	require.Equal(t, int64(0), load.CostUnits)
+
+	// The attribute reflects live counters.
+	request := makeImagesRequest("req-1", &fwkrh.ImagesGenerationsRequest{Prompt: "p", NumInferenceSteps: ptr.To[int64](30)})
+	require.NoError(t, producer.PreRequest(ctx, request, makeSchedulingResult(endpoint)))
+	val, ok = endpoint.Get(producer.dk)
+	require.True(t, ok)
+	require.Equal(t, int64(30), val.(*attrdiffusion.DiffusionLoad).CostUnits)
+
+	// Deletion cleans up the tracker.
+	require.NoError(t, producer.Extract(ctx, datalayer.EndpointEvent{Type: datalayer.EventDelete, Endpoint: endpoint}))
+	require.Equal(t, int64(0), producer.GetCostUnits(eid))
+}
+
+func TestDiffusionLoadProducer_Produces(t *testing.T) {
+	t.Parallel()
+
+	producer := newTestProducer(t, Config{})
+	produces := producer.Produces()
+	require.Contains(t, produces, producer.dk)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/producer_test.go
@@ -114,23 +114,23 @@ func TestDiffusionLoadProducer_RequestCost(t *testing.T) {
 				Size:              "1024x1024",
 				N:                 ptr.To[int64](2),
 			}),
-			want: 60, // 30 steps x 1 MP x 2 images
+			want: 30 * 2 * 1024 * 1024, // 30 steps x 2 images x 1024x1024 pixels
 		},
 		{
 			name: "all fields defaulted",
 			request: makeImagesRequest("r", &fwkrh.ImagesGenerationsRequest{
 				Prompt: "p",
 			}),
-			want: 50, // 50 default steps x 1 MP default size x 1 image
+			want: 50 * 1024 * 1024, // 50 default steps x default 1024x1024 x 1 image
 		},
 		{
-			name: "sub-megapixel size scales down",
+			name: "smaller size scales down",
 			request: makeImagesRequest("r", &fwkrh.ImagesGenerationsRequest{
 				Prompt:            "p",
 				NumInferenceSteps: ptr.To[int64](20),
 				Size:              "512x512",
 			}),
-			want: 5, // 20 steps x 0.25 MP
+			want: 20 * 512 * 512,
 		},
 		{
 			name: "malformed size falls back to default",
@@ -139,16 +139,16 @@ func TestDiffusionLoadProducer_RequestCost(t *testing.T) {
 				NumInferenceSteps: ptr.To[int64](10),
 				Size:              "huge",
 			}),
-			want: 10,
+			want: 10 * 1024 * 1024,
 		},
 		{
-			name: "tiny request clamps to one unit",
+			name: "tiny request keeps its exact declared cost",
 			request: makeImagesRequest("r", &fwkrh.ImagesGenerationsRequest{
 				Prompt:            "p",
 				NumInferenceSteps: ptr.To[int64](1),
 				Size:              "64x64",
 			}),
-			want: 1,
+			want: 64 * 64,
 		},
 	}
 
@@ -165,7 +165,7 @@ func TestDiffusionLoadProducer_ConfiguredDefaults(t *testing.T) {
 	producer := newTestProducer(t, Config{DefaultNumInferenceSteps: 8, DefaultSize: "512x512"})
 
 	cost := producer.requestCost(makeImagesRequest("r", &fwkrh.ImagesGenerationsRequest{Prompt: "p"}))
-	require.Equal(t, int64(2), cost) // 8 steps x 0.25 MP
+	require.Equal(t, int64(8*512*512), cost)
 }
 
 func TestDiffusionLoadProducerFactory_InvalidConfig(t *testing.T) {
@@ -201,9 +201,11 @@ func TestDiffusionLoadProducer_Lifecycle(t *testing.T) {
 		Size:              "1024x1024",
 	})
 
+	const pixels = int64(1024 * 1024)
+
 	// PreRequest commits the declared cost to the chosen endpoint.
 	require.NoError(t, producer.PreRequest(ctx, request, result))
-	require.Equal(t, int64(30), producer.GetCostUnits(eid))
+	require.Equal(t, 30*pixels, producer.GetCost(eid))
 
 	// A second request accumulates.
 	request2 := makeImagesRequest("req-2", &fwkrh.ImagesGenerationsRequest{
@@ -211,22 +213,22 @@ func TestDiffusionLoadProducer_Lifecycle(t *testing.T) {
 		NumInferenceSteps: ptr.To[int64](10),
 	})
 	require.NoError(t, producer.PreRequest(ctx, request2, result))
-	require.Equal(t, int64(40), producer.GetCostUnits(eid))
+	require.Equal(t, 40*pixels, producer.GetCost(eid))
 
 	// Intermediate chunk does not release.
 	producer.ResponseBody(ctx, request, &requestcontrol.Response{RequestID: "req-1"}, nil)
-	require.Equal(t, int64(40), producer.GetCostUnits(eid))
+	require.Equal(t, 40*pixels, producer.GetCost(eid))
 
 	// EndOfStream releases exactly the request's own contribution.
 	producer.ResponseBody(ctx, request, &requestcontrol.Response{RequestID: "req-1", EndOfStream: true}, nil)
-	require.Equal(t, int64(10), producer.GetCostUnits(eid))
+	require.Equal(t, 10*pixels, producer.GetCost(eid))
 
 	// Releasing the same request again is a no-op.
 	producer.ResponseBody(ctx, request, &requestcontrol.Response{RequestID: "req-1", EndOfStream: true}, nil)
-	require.Equal(t, int64(10), producer.GetCostUnits(eid))
+	require.Equal(t, 10*pixels, producer.GetCost(eid))
 
 	producer.ResponseBody(ctx, request2, &requestcontrol.Response{RequestID: "req-2", EndOfStream: true}, nil)
-	require.Equal(t, int64(0), producer.GetCostUnits(eid))
+	require.Equal(t, int64(0), producer.GetCost(eid))
 }
 
 func TestDiffusionLoadProducer_NonImageRequestNotTracked(t *testing.T) {
@@ -238,7 +240,7 @@ func TestDiffusionLoadProducer_NonImageRequestNotTracked(t *testing.T) {
 
 	request := &fwksched.InferenceRequest{RequestID: "req-1", Body: &fwkrh.InferenceRequestBody{}}
 	require.NoError(t, producer.PreRequest(context.Background(), request, makeSchedulingResult(endpoint)))
-	require.Equal(t, int64(0), producer.GetCostUnits(eid))
+	require.Equal(t, int64(0), producer.GetCost(eid))
 }
 
 func TestDiffusionLoadProducer_Extract(t *testing.T) {
@@ -258,10 +260,10 @@ func TestDiffusionLoadProducer_Extract(t *testing.T) {
 	// Commit some cost, then deletion cleans up the tracker.
 	request := makeImagesRequest("req-1", &fwkrh.ImagesGenerationsRequest{Prompt: "p", NumInferenceSteps: ptr.To[int64](30)})
 	require.NoError(t, producer.PreRequest(ctx, request, makeSchedulingResult(endpoint)))
-	require.Equal(t, int64(30), producer.GetCostUnits(eid))
+	require.Equal(t, int64(30*1024*1024), producer.GetCost(eid))
 
 	require.NoError(t, producer.Extract(ctx, datalayer.EndpointEvent{Type: datalayer.EventDelete, Endpoint: endpoint}))
-	require.Equal(t, int64(0), producer.GetCostUnits(eid))
+	require.Equal(t, int64(0), producer.GetCost(eid))
 }
 
 func TestDiffusionLoadProducer_Produce(t *testing.T) {
@@ -276,7 +278,7 @@ func TestDiffusionLoadProducer_Produce(t *testing.T) {
 	require.NoError(t, producer.Produce(ctx, nil, []fwksched.Endpoint{endpoint}))
 	val, ok := endpoint.Get(producer.dk)
 	require.True(t, ok)
-	require.Equal(t, int64(0), val.(*attrdiffusion.DiffusionLoad).CostUnits)
+	require.Equal(t, int64(0), val.(*attrdiffusion.DiffusionLoad).Cost)
 
 	// After committing cost, Produce publishes the live snapshot.
 	request := makeImagesRequest("req-1", &fwkrh.ImagesGenerationsRequest{Prompt: "p", NumInferenceSteps: ptr.To[int64](30)})
@@ -285,7 +287,7 @@ func TestDiffusionLoadProducer_Produce(t *testing.T) {
 	require.NoError(t, producer.Produce(ctx, nil, []fwksched.Endpoint{endpoint}))
 	val, ok = endpoint.Get(producer.dk)
 	require.True(t, ok)
-	require.Equal(t, int64(30), val.(*attrdiffusion.DiffusionLoad).CostUnits)
+	require.Equal(t, int64(30*1024*1024), val.(*attrdiffusion.DiffusionLoad).Cost)
 }
 
 func TestDiffusionLoadProducer_Produces(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/diffusionload/producer_test.go
@@ -50,9 +50,9 @@ type stubSchedulingEndpoint struct {
 	attr     datalayer.AttributeMap
 }
 
-func newStubSchedulingEndpoint(name string) *stubSchedulingEndpoint {
+func newStubSchedulingEndpoint() *stubSchedulingEndpoint {
 	return &stubSchedulingEndpoint{
-		metadata: &datalayer.EndpointMetadata{ID: types.NamespacedName{Name: name, Namespace: "default"}},
+		metadata: &datalayer.EndpointMetadata{ID: types.NamespacedName{Name: "pod-a", Namespace: "default"}},
 		attr:     datalayer.NewAttributes(),
 	}
 }
@@ -191,7 +191,7 @@ func TestDiffusionLoadProducer_Lifecycle(t *testing.T) {
 	producer := newTestProducer(t, Config{})
 	ctx := context.Background()
 
-	endpoint := newStubSchedulingEndpoint("pod-a")
+	endpoint := newStubSchedulingEndpoint()
 	eid := endpoint.GetMetadata().ID.String()
 	result := makeSchedulingResult(endpoint)
 
@@ -235,7 +235,7 @@ func TestDiffusionLoadProducer_NonImageRequestNotTracked(t *testing.T) {
 	t.Parallel()
 
 	producer := newTestProducer(t, Config{})
-	endpoint := newStubSchedulingEndpoint("pod-a")
+	endpoint := newStubSchedulingEndpoint()
 	eid := endpoint.GetMetadata().ID.String()
 
 	request := &fwksched.InferenceRequest{RequestID: "req-1", Body: &fwkrh.InferenceRequestBody{}}
@@ -249,7 +249,7 @@ func TestDiffusionLoadProducer_Extract(t *testing.T) {
 	producer := newTestProducer(t, Config{})
 	ctx := context.Background()
 
-	endpoint := newStubSchedulingEndpoint("pod-a")
+	endpoint := newStubSchedulingEndpoint()
 	eid := endpoint.GetMetadata().ID.String()
 
 	// Registration does not publish an attribute; Produce does that per request.
@@ -272,7 +272,7 @@ func TestDiffusionLoadProducer_Produce(t *testing.T) {
 	producer := newTestProducer(t, Config{})
 	ctx := context.Background()
 
-	endpoint := newStubSchedulingEndpoint("pod-a")
+	endpoint := newStubSchedulingEndpoint()
 
 	// Before any cost is committed, Produce publishes a zero snapshot.
 	require.NoError(t, producer.Produce(ctx, nil, []fwksched.Endpoint{endpoint}))

--- a/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost/README.md
@@ -1,0 +1,24 @@
+# Diffusion Cost Scorer
+
+**Type:** `diffusion-cost-scorer`
+
+Scores endpoints by the outstanding declared cost of their in-flight image generation requests, consumed from the `diffusion-load-producer`. Where active-request scoring treats every request as equal work, this scorer weighs each request by its declared diffusion cost (inference steps x output resolution x image count), so two queued low-step thumbnails do not count the same as one queued high-step full-size render.
+
+Endpoints with no outstanding cost receive the maximum score (`1.0`). Loaded endpoints are scored proportionally, with the most-loaded endpoint scoring `0`.
+
+Requests that are not image generation requests contribute no cost; on a mixed-traffic pool, pair this scorer with `active-request-scorer` or `load-aware-scorer` so non-diffusion load is still visible.
+
+**Parameters:**
+- `diffusionLoadProducerName` (string, optional): Instance name of the `diffusion-load-producer` whose attribute to read. Defaults to the producer registered under its type name.
+
+**Configuration Example:**
+```yaml
+plugins:
+  - type: diffusion-cost-scorer
+    name: diffusionCost
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: diffusionCost
+        weight: 5
+```

--- a/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost/README.md
@@ -2,11 +2,11 @@
 
 **Type:** `diffusion-cost-scorer`
 
-Scores endpoints by the outstanding declared cost of their in-flight image generation requests, consumed from the `diffusion-load-producer`. Where active-request scoring treats every request as equal work, this scorer weighs each request by its declared diffusion cost (inference steps x output resolution x image count), so two queued low-step thumbnails do not count the same as one queued high-step full-size render.
+Scores endpoints by the outstanding declared cost of their in-flight diffusion requests, consumed from the `diffusion-load-producer`. Where active-request scoring treats every request as equal work, this scorer weighs each request by its declared diffusion cost, so two queued low-step thumbnails do not count the same as one queued high-step full-size render.
 
 Endpoints with no outstanding cost receive the maximum score (`1.0`). Loaded endpoints are scored proportionally, with the most-loaded endpoint scoring `0`.
 
-Requests that are not image generation requests contribute no cost; on a mixed-traffic pool, pair this scorer with `active-request-scorer` or `load-aware-scorer` so non-diffusion load is still visible.
+Requests that are not diffusion requests contribute no cost; on a mixed-traffic pool, pair this scorer with `active-request-scorer` or `load-aware-scorer` so non-diffusion load is still visible.
 
 **Parameters:**
 - `diffusionLoadProducerName` (string, optional): Instance name of the `diffusion-load-producer` whose attribute to read. Defaults to the producer registered under its type name.

--- a/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost/scorer.go
@@ -127,7 +127,8 @@ func (s *DiffusionCost) Score(ctx context.Context, _ *scheduling.InferenceReques
 		}
 	}
 
-	log.FromContext(ctx).V(logutil.TRACE).Info("Diffusion cost units", "endpointCosts", logCosts, "maxCost", maxCost)
+	// TODO: change the log level before submission
+	log.FromContext(ctx).V(logutil.DEFAULT).Info("Diffusion cost units", "endpointCosts", logCosts, "maxCost", maxCost)
 
 	scoredEndpointsMap := make(map[scheduling.Endpoint]float64, len(endpoints))
 	for _, endpoint := range endpoints {

--- a/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost/scorer.go
@@ -15,11 +15,11 @@ limitations under the License.
 */
 
 // Package diffusioncost scores endpoints by the outstanding declared cost of
-// their in-flight image generation requests, produced by the
-// diffusion-load-producer. Where active-request scoring treats every request
-// as equal work, this scorer weighs requests by declared diffusion cost
-// (inference steps x resolution x image count), so two queued low-step
-// thumbnails do not count the same as one queued high-step full-size render.
+// their in-flight diffusion requests, produced by the diffusion-load-producer.
+// Where active-request scoring treats every request as equal work, this
+// scorer weighs requests by their declared diffusion cost, so two queued
+// low-step thumbnails do not count the same as one queued high-step
+// full-size render.
 package diffusioncost
 
 import (
@@ -119,7 +119,7 @@ func (s *DiffusionCost) Score(ctx context.Context, _ *scheduling.InferenceReques
 	maxCost := int64(0)
 
 	for _, endpoint := range endpoints {
-		cost := s.costUnits(ctx, endpoint)
+		cost := s.declaredCost(ctx, endpoint)
 		costs[endpoint] = cost
 		logCosts[endpoint.GetMetadata().ID.String()] = cost
 		if cost > maxCost {
@@ -127,8 +127,7 @@ func (s *DiffusionCost) Score(ctx context.Context, _ *scheduling.InferenceReques
 		}
 	}
 
-	// TODO: change the log level before submission
-	log.FromContext(ctx).V(logutil.DEFAULT).Info("Diffusion cost units", "endpointCosts", logCosts, "maxCost", maxCost)
+	log.FromContext(ctx).V(logutil.TRACE).Info("Diffusion load", "endpointCosts", logCosts, "maxCost", maxCost)
 
 	scoredEndpointsMap := make(map[scheduling.Endpoint]float64, len(endpoints))
 	for _, endpoint := range endpoints {
@@ -143,7 +142,7 @@ func (s *DiffusionCost) Score(ctx context.Context, _ *scheduling.InferenceReques
 	return scoredEndpointsMap
 }
 
-func (s *DiffusionCost) costUnits(ctx context.Context, endpoint scheduling.Endpoint) int64 {
+func (s *DiffusionCost) declaredCost(ctx context.Context, endpoint scheduling.Endpoint) int64 {
 	val, ok := endpoint.Get(s.diffusionLoadDataKey)
 	if !ok {
 		return 0
@@ -156,5 +155,5 @@ func (s *DiffusionCost) costUnits(ctx context.Context, endpoint scheduling.Endpo
 			"attributeType", fmt.Sprintf("%T", val))
 		return 0
 	}
-	return load.CostUnits
+	return load.Cost
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost/scorer.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package diffusioncost scores endpoints by the outstanding declared cost of
+// their in-flight image generation requests, produced by the
+// diffusion-load-producer. Where active-request scoring treats every request
+// as equal work, this scorer weighs requests by declared diffusion cost
+// (inference steps x resolution x image count), so two queued low-step
+// thumbnails do not count the same as one queued high-step full-size render.
+package diffusioncost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrdiffusion "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/diffusion"
+)
+
+const (
+	// DiffusionCostScorerType is the type of the DiffusionCost scorer.
+	DiffusionCostScorerType = "diffusion-cost-scorer"
+)
+
+// Parameters defines the parameters for the DiffusionCost scorer.
+type Parameters struct {
+	// DiffusionLoadProducerName selects which diffusion-load-producer
+	// instance's DiffusionLoad attribute to read. Empty defaults to the
+	// producer registered under its type name.
+	DiffusionLoadProducerName string `json:"diffusionLoadProducerName,omitempty"`
+}
+
+// compile-time type assertions
+var (
+	_ scheduling.Scorer     = &DiffusionCost{}
+	_ plugin.ConsumerPlugin = &DiffusionCost{}
+)
+
+// Factory defines the factory function for the DiffusionCost scorer.
+func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
+	parameters := Parameters{}
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&parameters); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' scorer - %w", DiffusionCostScorerType, err)
+		}
+	}
+
+	return NewDiffusionCost(&parameters).WithName(name), nil
+}
+
+// NewDiffusionCost creates a new DiffusionCost scorer.
+func NewDiffusionCost(params *Parameters) *DiffusionCost {
+	var producerName string
+	if params != nil {
+		producerName = params.DiffusionLoadProducerName
+	}
+
+	return &DiffusionCost{
+		typedName:            plugin.TypedName{Type: DiffusionCostScorerType},
+		diffusionLoadDataKey: attrdiffusion.DiffusionLoadDataKey.WithNonEmptyProducerName(producerName),
+	}
+}
+
+// DiffusionCost scores endpoints based on the outstanding declared diffusion
+// cost produced by the diffusion-load-producer.
+type DiffusionCost struct {
+	typedName            plugin.TypedName
+	diffusionLoadDataKey plugin.DataKey
+}
+
+// TypedName returns the typed name of the plugin.
+func (s *DiffusionCost) TypedName() plugin.TypedName {
+	return s.typedName
+}
+
+// WithName sets the name of the plugin.
+func (s *DiffusionCost) WithName(name string) *DiffusionCost {
+	s.typedName.Name = name
+	return s
+}
+
+// Category returns the preference the scorer applies when scoring candidate endpoints.
+func (s *DiffusionCost) Category() scheduling.ScorerCategory {
+	return scheduling.Distribution
+}
+
+// Consumes returns the diffusion load attribute required for scoring.
+func (s *DiffusionCost) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{
+		Required: map[plugin.DataKey]any{s.diffusionLoadDataKey: attrdiffusion.DiffusionLoad{}},
+	}
+}
+
+// Score scores the given endpoints by outstanding declared cost, normalized
+// to 0-1. Endpoints with no outstanding cost get the maximum score; the most
+// loaded endpoint gets 0.
+func (s *DiffusionCost) Score(ctx context.Context, _ *scheduling.InferenceRequest,
+	endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64 {
+	costs := make(map[scheduling.Endpoint]int64, len(endpoints))
+	logCosts := make(map[string]int64, len(endpoints))
+	maxCost := int64(0)
+
+	for _, endpoint := range endpoints {
+		cost := s.costUnits(ctx, endpoint)
+		costs[endpoint] = cost
+		logCosts[endpoint.GetMetadata().ID.String()] = cost
+		if cost > maxCost {
+			maxCost = cost
+		}
+	}
+
+	log.FromContext(ctx).V(logutil.TRACE).Info("Diffusion cost units", "endpointCosts", logCosts, "maxCost", maxCost)
+
+	scoredEndpointsMap := make(map[scheduling.Endpoint]float64, len(endpoints))
+	for _, endpoint := range endpoints {
+		cost := costs[endpoint]
+		if cost == 0 {
+			scoredEndpointsMap[endpoint] = 1.0
+			continue
+		}
+		scoredEndpointsMap[endpoint] = float64(maxCost-cost) / float64(maxCost)
+	}
+
+	return scoredEndpointsMap
+}
+
+func (s *DiffusionCost) costUnits(ctx context.Context, endpoint scheduling.Endpoint) int64 {
+	val, ok := endpoint.Get(s.diffusionLoadDataKey)
+	if !ok {
+		return 0
+	}
+
+	load, ok := val.(*attrdiffusion.DiffusionLoad)
+	if !ok || load == nil {
+		log.FromContext(ctx).V(logutil.TRACE).Info("Ignoring diffusion load attribute with unexpected type or nil value",
+			"endpoint", endpoint.GetMetadata().ID.String(),
+			"attributeType", fmt.Sprintf("%T", val))
+		return 0
+	}
+	return load.CostUnits
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost/scorer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost/scorer_test.go
@@ -61,9 +61,9 @@ func newTestEndpoint(name string) scheduling.Endpoint {
 	return newStubEndpoint(name)
 }
 
-func newTestEndpointWithCost(name string, costUnits int64) scheduling.Endpoint {
+func newTestEndpointWithCost(name string, cost int64) scheduling.Endpoint {
 	ep := newStubEndpoint(name)
-	ep.Put(attrdiffusion.DiffusionLoadDataKey, &attrdiffusion.DiffusionLoad{CostUnits: costUnits})
+	ep.Put(attrdiffusion.DiffusionLoadDataKey, &attrdiffusion.DiffusionLoad{Cost: cost})
 	return ep
 }
 
@@ -126,10 +126,10 @@ func TestDiffusionCostScorer_ProducerName(t *testing.T) {
 
 	// Cost under the named key is read; cost under the default key is ignored.
 	ep := newStubEndpoint("pod-a")
-	ep.Put(namedKey, &attrdiffusion.DiffusionLoad{CostUnits: 7})
-	require.Equal(t, int64(7), scorer.costUnits(context.Background(), ep))
+	ep.Put(namedKey, &attrdiffusion.DiffusionLoad{Cost: 7})
+	require.Equal(t, int64(7), scorer.declaredCost(context.Background(), ep))
 
 	other := newStubEndpoint("pod-b")
-	other.Put(attrdiffusion.DiffusionLoadDataKey, &attrdiffusion.DiffusionLoad{CostUnits: 7})
-	require.Equal(t, int64(0), scorer.costUnits(context.Background(), other))
+	other.Put(attrdiffusion.DiffusionLoadDataKey, &attrdiffusion.DiffusionLoad{Cost: 7})
+	require.Equal(t, int64(0), scorer.declaredCost(context.Background(), other))
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost/scorer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/diffusioncost/scorer_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diffusioncost
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrdiffusion "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/diffusion"
+)
+
+type stubEndpoint struct {
+	metadata *datalayer.EndpointMetadata
+	attr     datalayer.AttributeMap
+}
+
+func newStubEndpoint(name string) *stubEndpoint {
+	return &stubEndpoint{
+		metadata: &datalayer.EndpointMetadata{ID: k8stypes.NamespacedName{Name: name, Namespace: "default"}},
+		attr:     datalayer.NewAttributes(),
+	}
+}
+
+func (f *stubEndpoint) GetMetadata() *datalayer.EndpointMetadata           { return f.metadata }
+func (f *stubEndpoint) UpdateMetadata(*datalayer.EndpointMetadata)         {}
+func (f *stubEndpoint) GetMetrics() *datalayer.Metrics                     { return nil }
+func (f *stubEndpoint) UpdateMetrics(*datalayer.Metrics)                   {}
+func (f *stubEndpoint) GetAttributes() datalayer.AttributeMap              { return f.attr }
+func (f *stubEndpoint) String() string                                     { return f.metadata.ID.String() }
+func (f *stubEndpoint) Put(key fwkplugin.DataKey, val datalayer.Cloneable) { f.attr.Put(key, val) }
+func (f *stubEndpoint) Get(key fwkplugin.DataKey) (datalayer.Cloneable, bool) {
+	return f.attr.Get(key)
+}
+func (f *stubEndpoint) Keys() []fwkplugin.DataKey     { return f.attr.Keys() }
+func (f *stubEndpoint) Clone() datalayer.AttributeMap { return f.attr.Clone() }
+
+func newTestEndpoint(name string) scheduling.Endpoint {
+	return newStubEndpoint(name)
+}
+
+func newTestEndpointWithCost(name string, costUnits int64) scheduling.Endpoint {
+	ep := newStubEndpoint(name)
+	ep.Put(attrdiffusion.DiffusionLoadDataKey, &attrdiffusion.DiffusionLoad{CostUnits: costUnits})
+	return ep
+}
+
+func TestDiffusionCostScorer_Score(t *testing.T) {
+	tests := []struct {
+		name      string
+		endpoints []scheduling.Endpoint
+		want      []float64
+	}{
+		{
+			name: "no load attribute set",
+			endpoints: []scheduling.Endpoint{
+				newTestEndpoint("pod-a"),
+				newTestEndpoint("pod-b"),
+			},
+			want: []float64{1.0, 1.0},
+		},
+		{
+			name: "endpoints with different outstanding cost",
+			endpoints: []scheduling.Endpoint{
+				newTestEndpointWithCost("pod-a", 50),
+				newTestEndpointWithCost("pod-b", 0),
+				newTestEndpointWithCost("pod-c", 100),
+			},
+			want: []float64{0.5, 1.0, 0.0},
+		},
+		{
+			name: "some endpoints have cost data",
+			endpoints: []scheduling.Endpoint{
+				newTestEndpointWithCost("pod-a", 40),
+				newTestEndpoint("pod-b"),
+				newTestEndpointWithCost("pod-c", 10),
+			},
+			want: []float64{0.0, 1.0, 0.75},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scorer := NewDiffusionCost(nil).WithName(DiffusionCostScorerType)
+			scores := scorer.Score(context.Background(), nil, tt.endpoints)
+			require.Len(t, scores, len(tt.endpoints))
+			for i, endpoint := range tt.endpoints {
+				assert.InDelta(t, tt.want[i], scores[endpoint], 1e-9, "endpoint %s", endpoint.GetMetadata().ID.Name)
+			}
+		})
+	}
+}
+
+func TestDiffusionCostScorer_ProducerName(t *testing.T) {
+	const producerName = "my-diffusion-producer"
+	raw, err := json.Marshal(Parameters{DiffusionLoadProducerName: producerName})
+	require.NoError(t, err)
+	p, err := Factory(DiffusionCostScorerType, json.NewDecoder(bytes.NewReader(raw)), nil)
+	require.NoError(t, err)
+	scorer := p.(*DiffusionCost)
+
+	namedKey := attrdiffusion.DiffusionLoadDataKey.WithNonEmptyProducerName(producerName)
+	require.Contains(t, scorer.Consumes().Required, namedKey)
+
+	// Cost under the named key is read; cost under the default key is ignored.
+	ep := newStubEndpoint("pod-a")
+	ep.Put(namedKey, &attrdiffusion.DiffusionLoad{CostUnits: 7})
+	require.Equal(t, int64(7), scorer.costUnits(context.Background(), ep))
+
+	other := newStubEndpoint("pod-b")
+	other.Put(attrdiffusion.DiffusionLoadDataKey, &attrdiffusion.DiffusionLoad{CostUnits: 7})
+	require.Equal(t, int64(0), scorer.costUnits(context.Background(), other))
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds cost-aware routing for diffusion requests. Diffusion requests declare their cost in the request body (`size`, `num_inference_steps`, `n`), so the router can compute it up front instead of estimating: `cost = steps x pixels x n`.

Two new plugins:
- `diffusion-load-producer`: tracks outstanding declared cost per endpoint and publishes it as a snapshot at Produce time
- `diffusion-cost-scorer`: prefers the endpoint with the least outstanding declared cost


**Benchmark**

Full report: [benchmark report](https://docs.google.com/document/d/1wrkJfFtDUtXXgjoif8DO56iSqEHGHH9PS5N9nqVj3v4/edit?tab=t.0). Raw results and reproduction setup: [guides/diffusion-serving](https://github.com/zetxqx/llm-d/tree/guide/diffusion-serving/guides/diffusion-serving).

[Dataset C](https://github.com/vllm-project/vllm-omni/blob/1b318d11d17804c54c6ffa482efdd7abcb03657c/benchmarks/diffusion/performance_dashboard/qwen_image_serving_performance.md#dataset-c-mix-resolution) (the vLLM-Omni dashboard's mixed-resolution t2i workload, 512^2 to 1536^2), capacity ~0.64 req/s:

| offered rate (req/s) | p99 k8s Service -> cost-aware (s) | mean k8s Service -> cost-aware (s) |
|---|---|---|
| 0.25 | 19.1 -> 14.7 (-23%) | 5.3 -> 4.4 (-18%) |
| 0.45 | 26.8 -> 17.0 (-37%) | 8.9 -> 5.3 (-40%) |
| 0.64 | 21.1 -> 21.3 (-1%) | 8.7 -> 7.7 (-11%) |

Bimodal workload (85% 512^2 x 20 steps, 15% 1536^2 x 50 steps — the worst case for cost-blind routing):

| offered rate (req/s) | p99 k8s Service -> cost-aware (s) | mean k8s Service -> cost-aware (s) |
|---|---|---|
| 0.25 | 35.6 -> 19.8 (-44%) | 5.9 -> 3.9 (-35%) |
| 0.45 | 30.0 -> 20.4 (-32%) | 7.5 -> 4.9 (-35%) |
| 0.64 | 41.3 -> 21.7 (-47%) | 9.6 -> 5.5 (-43%) |

**Which issue(s) this PR fixes**:
Part of #1935

**Release note**:
```release-note
Add diffusion-load-producer and diffusion-cost-scorer plugins for cost-aware routing of diffusion (image generation) requests based on declared cost (steps x resolution x image count).
```
