### PR TITLE
Add support for ZMQ metrics updates

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -71,10 +71,12 @@ import (
 	extractormetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	extmodels "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/models"
 	exttopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/topology"
+	extractorzmq "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/zmqmetrics"
 	srcdcgm "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/dcgm"
 	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
 	srcmodels "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/models"
 	sourcenotifications "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
+	sourcezmq "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/zmqmetrics"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict"
 	programaware "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin"
@@ -640,6 +642,8 @@ func (r *Runner) registerInTreePlugins() {
 	// register datalayer metrics collection plugins
 	fwkplugin.Register(sourcemetrics.MetricsDataSourceType, sourcemetrics.MetricsDataSourceFactory)
 	fwkplugin.Register(extractormetrics.MetricsExtractorType, extractormetrics.CoreMetricsExtractorFactory)
+	fwkplugin.Register(sourcezmq.ZMQDataSourceType, sourcezmq.ZMQDataSourceFactory)
+	fwkplugin.Register(extractorzmq.ZMQExtractorType, extractorzmq.ZMQExtractorFactory)
 	// register datalayer notification source plugins
 	fwkplugin.Register(sourcenotifications.NotificationSourceType, sourcenotifications.NotificationSourceFactory)
 	fwkplugin.Register(sourcenotifications.EndpointNotificationSourceType, sourcenotifications.EndpointSourceFactory)

--- a/pkg/epp/config/loader/defaults.go
+++ b/pkg/epp/config/loader/defaults.go
@@ -27,6 +27,7 @@ import (
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	extractormetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
+	sourcezmq "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/zmqmetrics"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/anthropic"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
@@ -302,7 +303,7 @@ func ensureDataLayer(cfg *configapi.EndpointPickerConfig, handle fwkplugin.Handl
 	if cfg.DataLayer != nil && cfg.DataLayer.InjectDefaults != nil && !*cfg.DataLayer.InjectDefaults {
 		return nil
 	}
-	if cfg.DataLayer != nil && hasSourceOfType(cfg.DataLayer, sourcemetrics.MetricsDataSourceType) {
+	if cfg.DataLayer != nil && (hasSourceOfType(cfg.DataLayer, sourcemetrics.MetricsDataSourceType) || hasSourceOfType(cfg.DataLayer, sourcezmq.ZMQDataSourceType)) {
 		return nil
 	}
 

--- a/pkg/epp/config/loader/defaults_test.go
+++ b/pkg/epp/config/loader/defaults_test.go
@@ -105,6 +105,23 @@ func TestEnsureDataLayer(t *testing.T) {
 		require.Len(t, cfg.DataLayer.Sources, 1, "no duplicate metrics source")
 	})
 
+	t.Run("existing zmq-metrics-data-source suppresses default metrics-data-source injection", func(t *testing.T) {
+		cfg := &configapi.EndpointPickerConfig{
+			DataLayer: &configapi.DataLayerConfig{
+				Sources: []configapi.DataLayerSource{
+					{PluginRef: "zmq-metrics-data-source"},
+				},
+			},
+		}
+		handle := testutils.NewTestHandle(context.Background())
+
+		err := ensureDataLayer(cfg, handle, metricsPlugins())
+
+		require.NoError(t, err)
+		require.Len(t, cfg.DataLayer.Sources, 1)
+		require.Equal(t, "zmq-metrics-data-source", cfg.DataLayer.Sources[0].PluginRef)
+	})
+
 	t.Run("injectDefaults: false suppresses injection", func(t *testing.T) {
 		cfg := &configapi.EndpointPickerConfig{
 			DataLayer: &configapi.DataLayerConfig{

--- a/pkg/epp/datalayer/collector.go
+++ b/pkg/epp/datalayer/collector.go
@@ -75,14 +75,24 @@ func NewCollector() *Collector {
 	return &Collector{done: make(chan struct{})}
 }
 
-// Start launches the collection goroutine.
-// Each PollingDispatcher owns its extractors; the Collector calls Dispatch per tick.
-func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, dispatchers []fwkdl.PollingDispatcher) error {
-	if len(dispatchers) == 0 {
+// Start launches the collection goroutines for polling and streaming dispatchers.
+func (c *Collector) Start(
+	ctx context.Context,
+	pollingTicker Ticker,
+	ep fwkdl.Endpoint,
+	pollers []fwkdl.PollingDispatcher,
+	streamers []fwkdl.StreamingDispatcher,
+) error {
+	if len(pollers) == 0 && len(streamers) == 0 {
 		return errors.New("cannot start collector with empty dispatchers")
 	}
-	for _, d := range dispatchers {
-		if d == nil {
+	for _, p := range pollers {
+		if p == nil {
+			return errors.New("cannot add nil dispatcher")
+		}
+	}
+	for _, s := range streamers {
+		if s == nil {
 			return errors.New("cannot add nil dispatcher")
 		}
 	}
@@ -97,11 +107,11 @@ func (c *Collector) Start(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint,
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	c.cancel = cancel
-	go c.run(ctx, ticker, ep, dispatchers)
+	go c.run(ctx, pollingTicker, ep, pollers, streamers)
 	return nil
 }
 
-// Stop cancels the collection goroutine and blocks until it has exited. Idempotent.
+// Stop cancels the collection goroutines and blocks until all have exited. Idempotent.
 func (c *Collector) Stop() {
 	c.mu.Lock()
 	cancel := c.cancel
@@ -112,18 +122,49 @@ func (c *Collector) Stop() {
 	}
 }
 
-func (c *Collector) run(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, dispatchers []fwkdl.PollingDispatcher) {
-	defer func() {
+func (c *Collector) run(
+	ctx context.Context,
+	pollingTicker Ticker,
+	ep fwkdl.Endpoint,
+	pollers []fwkdl.PollingDispatcher,
+	streamers []fwkdl.StreamingDispatcher,
+) {
+	var wg sync.WaitGroup
+
+	if len(pollers) > 0 && pollingTicker != nil {
+		wg.Add(1)
+		go c.runPolling(ctx, pollingTicker, ep, pollers, &wg)
+	}
+
+	for _, s := range streamers {
+		wg.Add(1)
+		go c.runStreaming(ctx, ep, s, &wg)
+	}
+
+	go func() {
+		wg.Wait()
+		if pollingTicker != nil {
+			pollingTicker.Stop()
+		}
 		close(c.done)
-		ticker.Stop()
 	}()
+}
+
+func (c *Collector) runPolling(
+	ctx context.Context,
+	pollingTicker Ticker,
+	ep fwkdl.Endpoint,
+	dispatchers []fwkdl.PollingDispatcher,
+	wg *sync.WaitGroup,
+) {
+	defer wg.Done()
 	logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().GetIPAddress())
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.Channel():
+		case <-pollingTicker.Channel():
 			for _, disp := range dispatchers {
 				if ctx.Err() != nil {
 					return
@@ -137,5 +178,21 @@ func (c *Collector) run(ctx context.Context, ticker Ticker, ep fwkdl.Endpoint, d
 				cancel()
 			}
 		}
+	}
+}
+
+func (c *Collector) runStreaming(
+	ctx context.Context,
+	ep fwkdl.Endpoint,
+	disp fwkdl.StreamingDispatcher,
+	wg *sync.WaitGroup,
+) {
+	defer wg.Done()
+	logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().GetIPAddress())
+
+	if err := disp.Start(ctx, ep); err != nil && ctx.Err() == nil {
+		tn := disp.TypedName()
+		metrics.RecordDataLayerPollError(tn.Type)
+		logger.V(logging.DEBUG).Info("streaming failed", "source", tn, "err", err)
 	}
 }

--- a/pkg/epp/datalayer/collector_test.go
+++ b/pkg/epp/datalayer/collector_test.go
@@ -122,12 +122,15 @@ func TestCollectorStartInputs(t *testing.T) {
 		name        string
 		ctxCanceled bool
 		sources     []fwkdl.PollingDispatcher
+		streamers   []fwkdl.StreamingDispatcher
 		wantErr     bool
 		wantErrIs   error
 	}{
 		{name: "valid sources, live ctx", sources: sources},
-		{name: "empty sources", sources: []fwkdl.PollingDispatcher{}, wantErr: true},
-		{name: "nil source", sources: []fwkdl.PollingDispatcher{nil}, wantErr: true},
+		{name: "valid streamers, live ctx", streamers: []fwkdl.StreamingDispatcher{&mockStreamingDispatcher{kind: "stream"}}},
+		{name: "empty sources and streamers", sources: []fwkdl.PollingDispatcher{}, wantErr: true},
+		{name: "nil poller", sources: []fwkdl.PollingDispatcher{nil}, wantErr: true},
+		{name: "nil streamer", streamers: []fwkdl.StreamingDispatcher{nil}, wantErr: true},
 		{name: "cancelled parent ctx", ctxCanceled: true, sources: sources, wantErr: true, wantErrIs: context.Canceled},
 	}
 
@@ -141,13 +144,13 @@ func TestCollectorStartInputs(t *testing.T) {
 
 			c := NewCollector()
 			ticker := mocks.NewTicker()
-			err := c.Start(ctx, ticker, endpoint, tt.sources)
+			err := c.Start(ctx, ticker, endpoint, tt.sources, tt.streamers)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.wantErrIs != nil {
 					assert.ErrorIs(t, err, tt.wantErrIs)
 				}
-				require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources),
+				require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, nil),
 					"retry after failed Start should succeed")
 			} else {
 				require.NoError(t, err)
@@ -162,8 +165,8 @@ func TestCollectorCanStartOnlyOnce(t *testing.T) {
 	ticker := mocks.NewTicker()
 	ctx := context.Background()
 
-	require.NoError(t, c.Start(ctx, ticker, endpoint, sources))
-	assert.Error(t, c.Start(ctx, ticker, endpoint, sources),
+	require.NoError(t, c.Start(ctx, ticker, endpoint, sources, nil))
+	assert.Error(t, c.Start(ctx, ticker, endpoint, sources, nil),
 		"second Start after success should error")
 	c.Stop()
 }
@@ -182,7 +185,7 @@ func TestCollectorStop(t *testing.T) {
 			setup: func(t *testing.T) *Collector {
 				c := NewCollector()
 				ticker := mocks.NewTicker()
-				_ = c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDispatcher{})
+				_ = c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDispatcher{}, nil)
 				return c
 			},
 		},
@@ -191,7 +194,7 @@ func TestCollectorStop(t *testing.T) {
 			setup: func(t *testing.T) *Collector {
 				c := NewCollector()
 				ticker := mocks.NewTicker()
-				require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources))
+				require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, nil))
 				return c
 			},
 		},
@@ -213,7 +216,7 @@ func TestCollectorCollectsOnTicks(t *testing.T) {
 	c := NewCollector()
 	ticker := mocks.NewTicker()
 
-	require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDispatcher{source}))
+	require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDispatcher{source}, nil))
 	defer c.Stop()
 
 	ticker.Tick()
@@ -223,6 +226,47 @@ func TestCollectorCollectsOnTicks(t *testing.T) {
 		return atomic.LoadInt64(&source.CallCount) == 2
 	}, 1*time.Second, 2*time.Millisecond, "expected 2 collections")
 }
+
+// TestCollectorStreamingDispatcher verifies the streaming dispatcher lifecycle in Collector.
+func TestCollectorStreamingDispatcher(t *testing.T) {
+	started := make(chan struct{})
+	streamer := &mockStreamingDispatcher{kind: "zmq-test", started: started}
+
+	c := NewCollector()
+	ticker := mocks.NewTicker()
+	require.NoError(t, c.Start(context.Background(), ticker, endpoint, nil, []fwkdl.StreamingDispatcher{streamer}))
+
+	select {
+	case <-started:
+	case <-time.After(1 * time.Second):
+		t.Fatal("expected streaming dispatcher to start")
+	}
+
+	c.Stop()
+}
+
+type mockStreamingDispatcher struct {
+	kind     string
+	started  chan struct{}
+	stopWait chan struct{}
+	err      error
+}
+
+func (m *mockStreamingDispatcher) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: m.kind, Name: m.kind}
+}
+func (m *mockStreamingDispatcher) Start(ctx context.Context, _ fwkdl.Endpoint) error {
+	if m.started != nil {
+		close(m.started)
+	}
+	if m.stopWait != nil {
+		<-m.stopWait
+	} else {
+		<-ctx.Done()
+	}
+	return m.err
+}
+func (m *mockStreamingDispatcher) AppendExtractor(_ fwkplugin.Plugin) error { return nil }
 
 // TestCollectorErrorMetrics confirms Poll/Extract errors increment per-event
 // counters (no transition dedup) and successes do not.
@@ -285,7 +329,7 @@ func TestCollectorErrorMetrics(t *testing.T) {
 
 			c := NewCollector()
 			ticker := mocks.NewTicker()
-			require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDispatcher{src}))
+			require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDispatcher{src}, nil))
 			defer c.Stop()
 
 			for i := 0; i < tt.ticks; i++ {
@@ -324,7 +368,7 @@ func TestCollectorRapidStartStopRaceFree(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		c := NewCollector()
 		ticker := mocks.NewTicker()
-		require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDispatcher{src}))
+		require.NoError(t, c.Start(context.Background(), ticker, endpoint, []fwkdl.PollingDispatcher{src}, nil))
 		ticker.Tick()
 		c.Stop()
 	}
@@ -335,7 +379,7 @@ func TestCollectorRapidStartStopRaceFree(t *testing.T) {
 func TestCollectorConcurrentStopRaceFree(t *testing.T) {
 	c := NewCollector()
 	ticker := mocks.NewTicker()
-	require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources))
+	require.NoError(t, c.Start(context.Background(), ticker, endpoint, sources, nil))
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {

--- a/pkg/epp/datalayer/manager.go
+++ b/pkg/epp/datalayer/manager.go
@@ -175,6 +175,47 @@ func (p *pollingDispatchers) Dispatchers() map[string]fwkdl.PollingDispatcher {
 func (p *pollingDispatchers) Count() int    { p.mu.RLock(); defer p.mu.RUnlock(); return len(p.m) }
 func (p *pollingDispatchers) IsEmpty() bool { return p.Count() == 0 }
 
+// streamingDispatchers stores StreamingDispatchers keyed by source name.
+type streamingDispatchers struct {
+	mu sync.RWMutex
+	m  map[string]fwkdl.StreamingDispatcher
+}
+
+func newStreamingDispatchers() *streamingDispatchers {
+	return &streamingDispatchers{m: make(map[string]fwkdl.StreamingDispatcher)}
+}
+
+func (s *streamingDispatchers) Register(disp fwkdl.StreamingDispatcher) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	name := disp.TypedName().Name
+	if _, exists := s.m[name]; exists {
+		return fmt.Errorf("duplicate %s source name %q", variantStreaming, name)
+	}
+	s.m[name] = disp
+	return nil
+}
+
+func (s *streamingDispatchers) Get(name string) (fwkdl.StreamingDispatcher, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	d, ok := s.m[name]
+	return d, ok
+}
+
+func (s *streamingDispatchers) Dispatchers() map[string]fwkdl.StreamingDispatcher {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]fwkdl.StreamingDispatcher, len(s.m))
+	for k, v := range s.m {
+		out[k] = v
+	}
+	return out
+}
+
+func (s *streamingDispatchers) Count() int    { s.mu.RLock(); defer s.mu.RUnlock(); return len(s.m) }
+func (s *streamingDispatchers) IsEmpty() bool { return s.Count() == 0 }
+
 // notificationManager owns the registered NotificationSources.
 // GVK uniqueness is enforced per-Configure-call by a caller-owned gvk tracker
 // (see runtime.go); the manager itself is pure typed storage.

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -30,17 +30,21 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
+	sourcezmq "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/zmqmetrics"
 )
 
 var (
-	ErrSourceTypeCollision    = errors.New("source type registered across variants")
-	ErrDuplicateExtractorType = errors.New("duplicate extractor type configured for the same source")
+	ErrSourceTypeCollision       = errors.New("source type registered across variants")
+	ErrDuplicateExtractorType    = errors.New("duplicate extractor type configured for the same source")
+	ErrConflictingMetricsSources = errors.New("conflicting metrics sources configured")
 )
 
 type sourceVariant string
 
 const (
 	variantPolling      sourceVariant = "polling"
+	variantStreaming    sourceVariant = "streaming"
 	variantNotification sourceVariant = "notification"
 	variantEndpoint     sourceVariant = "endpoint"
 )
@@ -50,6 +54,7 @@ type Runtime struct {
 	pollingInterval time.Duration // used for polling sources
 
 	dispatchers  *pollingDispatchers
+	streaming    *streamingDispatchers
 	notification *notificationManager
 	endpoint     *endpointManager
 	extractors   *extractorMap
@@ -57,7 +62,7 @@ type Runtime struct {
 	pendingMu            sync.Mutex
 	pendingRegistrations []fwkdl.PendingRegistration // code-registered (source-type, extractor) pairs, resolved by Configure()
 
-	collectors *collectorManager // per-endpoint poller, keyed by namespaced name
+	collectors *collectorManager // per-endpoint poller and streamer, keyed by namespaced name
 	logger     logr.Logger       // Set in Configure; used where no context is available (e.g. ReleaseEndpoint).
 }
 
@@ -75,6 +80,7 @@ func NewRuntime(pollingInterval time.Duration) *Runtime {
 	return &Runtime{
 		pollingInterval: interval,
 		dispatchers:     newPollingDispatchers(),
+		streaming:       newStreamingDispatchers(),
 		notification:    newNotificationManager(),
 		endpoint:        newEndpointManager(),
 		extractors:      newExtractorMap(),
@@ -124,8 +130,16 @@ func (r *Runtime) Configure(cfg *Config, logger logr.Logger) error {
 				return err
 			}
 
-			// PollingDispatchers own their extractors; notification/endpoint use extractorMap.
+			// PollingDispatchers and StreamingDispatchers own their extractors; notification/endpoint use extractorMap.
 			if disp, ok := src.(fwkdl.PollingDispatcher); ok {
+				for _, ext := range srcCfg.Extractors {
+					if err := disp.AppendExtractor(ext); err != nil {
+						return fmt.Errorf("dispatcher %s rejected extractor %s: %w",
+							src.TypedName(), ext.TypedName(), err)
+					}
+					markBound(srcName, ext.TypedName().Type)
+				}
+			} else if disp, ok := src.(fwkdl.StreamingDispatcher); ok {
 				for _, ext := range srcCfg.Extractors {
 					if err := disp.AppendExtractor(ext); err != nil {
 						return fmt.Errorf("dispatcher %s rejected extractor %s: %w",
@@ -149,6 +163,9 @@ func (r *Runtime) Configure(cfg *Config, logger logr.Logger) error {
 	}
 
 	if err := r.validateNoCrossVariantCollisions(); err != nil {
+		return err
+	}
+	if err := r.validateMetricSourceConflicts(); err != nil {
 		return err
 	}
 
@@ -197,6 +214,11 @@ func (r *Runtime) Configure(cfg *Config, logger logr.Logger) error {
 				return fmt.Errorf("dispatcher %s rejected pending extractor %s: %w",
 					matchedSrc.TypedName(), pending.Extractor.TypedName(), err)
 			}
+		} else if disp, ok := matchedSrc.(fwkdl.StreamingDispatcher); ok {
+			if err := disp.AppendExtractor(pending.Extractor); err != nil {
+				return fmt.Errorf("dispatcher %s rejected pending extractor %s: %w",
+					matchedSrc.TypedName(), pending.Extractor.TypedName(), err)
+			}
 		} else {
 			r.extractors.Append(srcName, pending.Extractor)
 		}
@@ -205,6 +227,7 @@ func (r *Runtime) Configure(cfg *Config, logger logr.Logger) error {
 
 	logger.Info("Datalayer runtime configured",
 		"pollers", r.dispatchers.Count(),
+		"streamers", r.streaming.Count(),
 		"notifiers", r.notification.Count(),
 		"endpointSources", r.endpoint.Count())
 	return nil
@@ -234,6 +257,9 @@ func (r *Runtime) registerSource(src fwkplugin.Plugin, g *gvk) error {
 	if _, ok := src.(fwkdl.PollingDispatcher); ok {
 		variants = append(variants, string(variantPolling))
 	}
+	if _, ok := src.(fwkdl.StreamingDispatcher); ok {
+		variants = append(variants, string(variantStreaming))
+	}
 	if _, ok := src.(fwkdl.NotificationSource); ok {
 		variants = append(variants, string(variantNotification))
 	}
@@ -241,13 +267,15 @@ func (r *Runtime) registerSource(src fwkplugin.Plugin, g *gvk) error {
 		variants = append(variants, string(variantEndpoint))
 	}
 	if len(variants) > 1 {
-		return fmt.Errorf("source %s implements multiple variant interfaces (%v); a source must implement exactly one of PollingDispatcher, NotificationSource, EndpointSource",
+		return fmt.Errorf("source %s implements multiple variant interfaces (%v); a source must implement exactly one of PollingDispatcher, StreamingDispatcher, NotificationSource, EndpointSource",
 			src.TypedName().String(), variants)
 	}
 
 	switch s := src.(type) {
 	case fwkdl.PollingDispatcher:
 		return r.dispatchers.Register(s)
+	case fwkdl.StreamingDispatcher:
+		return r.streaming.Register(s)
 	case fwkdl.NotificationSource:
 		if err := g.Check(s); err != nil {
 			return err
@@ -288,6 +316,11 @@ func (r *Runtime) validateNoCrossVariantCollisions() error {
 			return err
 		}
 	}
+	for name, disp := range r.streaming.Dispatchers() {
+		if err := check(name, disp, variantStreaming); err != nil {
+			return err
+		}
+	}
 
 	var firstErr error
 	r.notification.Range(func(name string, src fwkdl.NotificationSource) bool {
@@ -308,6 +341,25 @@ func (r *Runtime) validateNoCrossVariantCollisions() error {
 		return true
 	})
 	return firstErr
+}
+
+func (r *Runtime) validateMetricSourceConflicts() error {
+	var hasHTTP, hasZMQ bool
+	for _, disp := range r.dispatchers.Dispatchers() {
+		if disp.TypedName().Type == sourcemetrics.MetricsDataSourceType {
+			hasHTTP = true
+		}
+	}
+	for _, disp := range r.streaming.Dispatchers() {
+		if disp.TypedName().Type == sourcezmq.ZMQDataSourceType {
+			hasZMQ = true
+		}
+	}
+	if hasHTTP && hasZMQ {
+		return fmt.Errorf("%w: cannot configure both %q and %q concurrently",
+			ErrConflictingMetricsSources, sourcemetrics.MetricsDataSourceType, sourcezmq.ZMQDataSourceType)
+	}
+	return nil
 }
 
 // findSourceByType walks every variant manager and returns the matching source.
@@ -337,8 +389,17 @@ func (r *Runtime) findSourceByType(sourceType string, gvkFilter *schema.GroupVer
 		}
 	}
 
+	var streamingHit sourceHit
+	for name, disp := range r.streaming.Dispatchers() {
+		if matches(disp) {
+			streamingHit = sourceHit{variant: variantStreaming, name: name, src: disp}
+			break
+		}
+	}
+
 	matched, err := findUnique(sourceType,
 		pollingHit,
+		streamingHit,
 		r.notification.findFirst(matches),
 		r.endpoint.findFirst(matches),
 	)
@@ -373,12 +434,17 @@ func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.Endpo
 
 	endpoint := fwkdl.NewEndpoint(endpointMetadata, nil)
 
-	dispatchers := make([]fwkdl.PollingDispatcher, 0, r.dispatchers.Count())
+	pollers := make([]fwkdl.PollingDispatcher, 0, r.dispatchers.Count())
 	for _, d := range r.dispatchers.Dispatchers() {
-		dispatchers = append(dispatchers, d)
+		pollers = append(pollers, d)
 	}
-	if len(dispatchers) == 0 {
-		logger.Info("No polling sources configured, creating endpoint without collector")
+	streamers := make([]fwkdl.StreamingDispatcher, 0, r.streaming.Count())
+	for _, s := range r.streaming.Dispatchers() {
+		streamers = append(streamers, s)
+	}
+
+	if len(pollers) == 0 && len(streamers) == 0 {
+		logger.Info("No polling or streaming sources configured, creating endpoint without collector")
 		r.dispatchEndpointEvent(ctx, logger, fwkdl.EndpointEvent{Type: fwkdl.EventAddOrUpdate, Endpoint: endpoint})
 		return endpoint
 	}
@@ -392,7 +458,7 @@ func (r *Runtime) NewEndpoint(ctx context.Context, endpointMetadata *fwkdl.Endpo
 	}
 
 	ticker := NewTimeTicker(r.pollingInterval)
-	if err := collector.Start(ctx, ticker, endpoint, dispatchers); err != nil {
+	if err := collector.Start(ctx, ticker, endpoint, pollers, streamers); err != nil {
 		logger.Error(err, "failed to start collector for endpoint", "endpoint", key)
 		r.collectors.Remove(key)
 		return nil

--- a/pkg/epp/datalayer/runtime_validate_test.go
+++ b/pkg/epp/datalayer/runtime_validate_test.go
@@ -146,3 +146,22 @@ func TestRuntimeConfigure_SourceImplementingMultipleVariants_Rejected(t *testing
 	require.Error(t, err, "a source that implements multiple variant interfaces must be rejected")
 	assert.Contains(t, err.Error(), "multiple variant")
 }
+
+func TestRuntimeConfigure_ConflictingMetricsSources_Rejected(t *testing.T) {
+	logger := newTestLogger(t)
+	r := NewRuntime(1)
+
+	httpSrc := mocks.NewDataSource(fwkplugin.TypedName{Type: "metrics-data-source", Name: "metrics-data-source"})
+	zmqSrc := &mockStreamingDispatcher{kind: "zmq-metrics-data-source"}
+
+	cfg := &Config{
+		Sources: []DataSourceConfig{
+			{Plugin: httpSrc},
+			{Plugin: zmqSrc},
+		},
+	}
+
+	err := r.Configure(cfg, logger)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrConflictingMetricsSources)
+}

--- a/pkg/epp/framework/interface/datalayer/plugin.go
+++ b/pkg/epp/framework/interface/datalayer/plugin.go
@@ -50,11 +50,20 @@ type PollInput[D any] struct {
 	Endpoint Endpoint
 }
 
+// StreamInput pairs the stream payload with the endpoint being monitored.
+type StreamInput[D any] struct {
+	Payload  D
+	Endpoint Endpoint
+}
+
 // EndpointExtractor is the typed contract for endpoint-lifecycle extractors.
 type EndpointExtractor = Extractor[EndpointEvent]
 
 // PollingExtractor is the typed contract for poll-based extractors.
 type PollingExtractor[T any] = Extractor[PollInput[T]]
+
+// StreamingExtractor is the typed contract for stream-based extractors.
+type StreamingExtractor[T any] = Extractor[StreamInput[T]]
 
 // NotificationExtractor is the typed contract for k8s-event extractors.
 // GVK identifies the kind this extractor handles; it must match the paired
@@ -77,6 +86,15 @@ type NotificationExtractor interface {
 type PollingDispatcher interface {
 	plugin.Plugin
 	Dispatch(ctx context.Context, ep Endpoint) error
+	AppendExtractor(ext plugin.Plugin) error
+}
+
+// StreamingDispatcher is the framework's contract for push/stream sources (e.g. ZMQ).
+// The source owns its extractors, receives continuous message streams for an endpoint,
+// and dispatches incoming payloads to its bound extractors in insertion order.
+type StreamingDispatcher interface {
+	plugin.Plugin
+	Start(ctx context.Context, ep Endpoint) error
 	AppendExtractor(ext plugin.Plugin) error
 }
 

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -185,7 +185,7 @@ func (ext *Extractor) Extract(ctx context.Context, in fwkdl.PollInput[sourcemetr
 	logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().NamespacedName)
 	if updated {
 		clone.UpdateTime = time.Now()
-		logger.V(logutil.TRACE).Info("Refreshed metrics",
+		logger.V(logutil.DEBUG).Info("Refreshed metrics",
 			"metrics", mapping.MetricNames(),
 			"updated", clone,
 		)
@@ -243,7 +243,6 @@ func populateLoRAMetrics(clone *fwkdl.Metrics, metric *dto.Metric, errs *[]error
 // blockSizeLabelName and numBlocksLabelName allow engines to use different label names
 // (e.g. SGLang uses "page_size" and "num_pages" instead of "block_size" and "num_gpu_blocks").
 func populateCacheInfoMetrics(clone *fwkdl.Metrics, metric *dto.Metric, blockSizeLabelName, numBlocksLabelName string, errs *[]error) {
-	clone.CacheBlockSize = 0
 	for _, label := range metric.GetLabel() {
 		switch label.GetName() {
 		case blockSizeLabelName:
@@ -263,6 +262,9 @@ func populateCacheInfoMetrics(clone *fwkdl.Metrics, metric *dto.Metric, blockSiz
 				}
 			}
 		}
+	}
+	if clone.CacheBlockSize > 0 && clone.CacheNumBlocks > 0 {
+		clone.KvCacheMaxTokenCapacity = clone.CacheBlockSize * clone.CacheNumBlocks
 	}
 }
 

--- a/pkg/epp/framework/plugins/datalayer/extractor/zmqmetrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/zmqmetrics/extractor.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zmqmetrics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/vmihailenco/msgpack/v5"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	sourcezmq "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/zmqmetrics"
+)
+
+const ZMQExtractorType = "zmq-state-extractor"
+
+// Extractor implements ZMQ msgpack metrics extraction.
+type Extractor struct {
+	typedName fwkplugin.TypedName
+}
+
+var _ fwkdl.StreamingExtractor[[]byte] = (*Extractor)(nil)
+
+// NewZMQMetricsExtractor returns a new ZMQ metrics extractor.
+func NewZMQMetricsExtractor(name string) *Extractor {
+	if name == "" {
+		name = ZMQExtractorType
+	}
+	return &Extractor{
+		typedName: fwkplugin.TypedName{
+			Type: ZMQExtractorType,
+			Name: name,
+		},
+	}
+}
+
+// ZMQExtractorFactory is a factory function used to instantiate ZMQ extractor plugins.
+func ZMQExtractorFactory(name string, _ *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	return NewZMQMetricsExtractor(name), nil
+}
+
+// TypedName returns the type and name of the Extractor.
+func (ext *Extractor) TypedName() fwkplugin.TypedName {
+	return ext.typedName
+}
+
+// Extract decodes the msgpack payload and updates endpoint metrics.
+func (ext *Extractor) Extract(ctx context.Context, in fwkdl.StreamInput[[]byte]) error {
+	payload := in.Payload
+	var stats sourcezmq.ZmqMetricsStats
+
+	if err := decodeMsgpackPayload(payload, &stats); err != nil {
+		return fmt.Errorf("failed to unmarshal msgpack (len=%d, hex=%x): %w", len(payload), truncateBytes(payload, 32), err)
+	}
+
+	ep := in.Endpoint
+	current := ep.GetMetrics()
+	clone := current.Clone()
+
+	clone.RunningRequestsSize = stats.NumRequestsRunning
+	clone.WaitingQueueSize = stats.NumRequestsWaiting
+	clone.KVCacheUsagePercent = stats.KVCacheUsagePerc
+
+	if stats.CacheConfigInfo != nil {
+		if val, ok := parseToInt(stats.CacheConfigInfo["block_size"]); ok {
+			clone.CacheBlockSize = val
+		}
+		if val, ok := parseToInt(stats.CacheConfigInfo["num_gpu_blocks"]); ok {
+			clone.CacheNumBlocks = val
+		}
+		if val, ok := parseToInt(stats.CacheConfigInfo["kv_cache_size_tokens"]); ok {
+			clone.KvCacheMaxTokenCapacity = val
+		} else if clone.CacheBlockSize > 0 && clone.CacheNumBlocks > 0 {
+			clone.KvCacheMaxTokenCapacity = clone.CacheBlockSize * clone.CacheNumBlocks
+		}
+	}
+
+	clone.UpdateTime = time.Now()
+
+	logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().NamespacedName)
+	logger.V(logutil.DEBUG).Info("Refreshed metrics via ZMQ", "updated", clone)
+
+	ep.UpdateMetrics(clone)
+	return nil
+}
+
+func decodeMsgpackPayload(payload []byte, target *sourcezmq.ZmqMetricsStats) error {
+	if len(payload) == 0 {
+		return fmt.Errorf("empty payload")
+	}
+
+	// 1. Try direct struct unmarshal
+	if err := msgpack.Unmarshal(payload, target); err == nil {
+		return nil
+	}
+
+	// 2. Try generic map[string]any
+	var rawMap map[string]any
+	if err := msgpack.Unmarshal(payload, &rawMap); err == nil {
+		populateStatsFromMap(rawMap, target)
+		return nil
+	}
+
+	// 3. Try slice/tuple unmarshal ([]any)
+	var rawSlice []any
+	if err := msgpack.Unmarshal(payload, &rawSlice); err == nil {
+		populateStatsFromSlice(rawSlice, target)
+		return nil
+	}
+
+	return fmt.Errorf("invalid msgpack format")
+}
+
+func populateStatsFromMap(m map[string]any, target *sourcezmq.ZmqMetricsStats) {
+	if val, ok := parseToInt(m["num_requests_running"]); ok {
+		target.NumRequestsRunning = val
+	}
+	if val, ok := parseToInt(m["num_requests_waiting"]); ok {
+		target.NumRequestsWaiting = val
+	}
+	if val, ok := parseToFloat(m["kv_cache_usage_perc"]); ok {
+		target.KVCacheUsagePerc = val
+	}
+	if cfgMap, ok := m["cache_config_info"].(map[string]any); ok {
+		target.CacheConfigInfo = cfgMap
+	}
+	if engineID, ok := m["engine_id"].(string); ok {
+		target.EngineID = engineID
+	}
+}
+
+func populateStatsFromSlice(s []any, target *sourcezmq.ZmqMetricsStats) {
+	if len(s) > 0 {
+		if val, ok := parseToInt(s[0]); ok {
+			target.NumRequestsRunning = val
+		}
+	}
+	if len(s) > 1 {
+		if val, ok := parseToInt(s[1]); ok {
+			target.NumRequestsWaiting = val
+		}
+	}
+	if len(s) > 2 {
+		if val, ok := parseToFloat(s[2]); ok {
+			target.KVCacheUsagePerc = val
+		}
+	}
+	if len(s) > 3 {
+		if cfgMap, ok := s[3].(map[string]any); ok {
+			target.CacheConfigInfo = cfgMap
+		}
+	}
+	if len(s) > 4 {
+		if engineID, ok := s[4].(string); ok {
+			target.EngineID = engineID
+		}
+	}
+}
+
+func truncateBytes(b []byte, n int) []byte {
+	if len(b) > n {
+		return b[:n]
+	}
+	return b
+}
+
+func parseToFloat(val any) (float64, bool) {
+	if val == nil {
+		return 0, false
+	}
+	switch v := val.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case string:
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f, true
+		}
+	}
+	return 0, false
+}
+
+func parseToInt(val any) (int, bool) {
+	if val == nil {
+		return 0, false
+	}
+	switch v := val.(type) {
+	case int:
+		return v, true
+	case int8:
+		return int(v), true
+	case int16:
+		return int(v), true
+	case int32:
+		return int(v), true
+	case int64:
+		return int(v), true
+	case uint:
+		return int(v), true
+	case uint8:
+		return int(v), true
+	case uint16:
+		return int(v), true
+	case uint32:
+		return int(v), true
+	case uint64:
+		return int(v), true
+	case float32:
+		return int(v), true
+	case float64:
+		return int(v), true
+	case string:
+		if i, err := strconv.Atoi(v); err == nil {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/pkg/epp/framework/plugins/datalayer/extractor/zmqmetrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/zmqmetrics/extractor.go
@@ -19,6 +19,7 @@ package zmqmetrics
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -106,7 +107,7 @@ func (ext *Extractor) Extract(ctx context.Context, in fwkdl.StreamInput[[]byte])
 
 func decodeMsgpackPayload(payload []byte, target *sourcezmq.ZmqMetricsStats) error {
 	if len(payload) == 0 {
-		return fmt.Errorf("empty payload")
+		return errors.New("empty payload")
 	}
 
 	// 1. Try direct struct unmarshal
@@ -128,7 +129,7 @@ func decodeMsgpackPayload(payload []byte, target *sourcezmq.ZmqMetricsStats) err
 		return nil
 	}
 
-	return fmt.Errorf("invalid msgpack format")
+	return errors.New("invalid msgpack format")
 }
 
 func populateStatsFromMap(m map[string]any, target *sourcezmq.ZmqMetricsStats) {

--- a/pkg/epp/framework/plugins/datalayer/extractor/zmqmetrics/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/zmqmetrics/extractor_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zmqmetrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	sourcezmq "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/zmqmetrics"
+)
+
+func TestZMQExtractor_Extract(t *testing.T) {
+	ext := NewZMQMetricsExtractor("test-extractor")
+	assert.Equal(t, ZMQExtractorType, ext.TypedName().Type)
+
+	t.Run("int and string cache config info", func(t *testing.T) {
+		stats := sourcezmq.ZmqMetricsStats{
+			NumRequestsRunning: 5,
+			NumRequestsWaiting: 12,
+			KVCacheUsagePerc:   0.45,
+			CacheConfigInfo: map[string]any{
+				"block_size":           "16",
+				"num_gpu_blocks":       "7605",
+				"kv_cache_size_tokens": "121680",
+			},
+			EngineID: "engine-1",
+		}
+
+		payload, err := msgpack.Marshal(stats)
+		require.NoError(t, err)
+
+		ep := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+			Address: "10.0.0.1",
+		}, nil)
+
+		in := fwkdl.StreamInput[[]byte]{
+			Payload:  payload,
+			Endpoint: ep,
+		}
+
+		err = ext.Extract(context.Background(), in)
+		require.NoError(t, err)
+
+		m := ep.GetMetrics()
+		assert.Equal(t, 5, m.RunningRequestsSize)
+		assert.Equal(t, 12, m.WaitingQueueSize)
+		assert.Equal(t, 0.45, m.KVCacheUsagePercent)
+		assert.Equal(t, 16, m.CacheBlockSize)
+		assert.Equal(t, 7605, m.CacheNumBlocks)
+		assert.Equal(t, 121680, m.KvCacheMaxTokenCapacity)
+	})
+
+	t.Run("tuple slice msgpack", func(t *testing.T) {
+		tuplePayload, err := msgpack.Marshal([]any{
+			3, 7, 0.25, map[string]any{"block_size": 16, "num_gpu_blocks": 1000}, "engine-2",
+		})
+		require.NoError(t, err)
+
+		ep := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{Address: "10.0.0.2"}, nil)
+		err = ext.Extract(context.Background(), fwkdl.StreamInput[[]byte]{Payload: tuplePayload, Endpoint: ep})
+		require.NoError(t, err)
+
+		m := ep.GetMetrics()
+		assert.Equal(t, 3, m.RunningRequestsSize)
+		assert.Equal(t, 7, m.WaitingQueueSize)
+		assert.Equal(t, 0.25, m.KVCacheUsagePercent)
+		assert.Equal(t, 16, m.CacheBlockSize)
+		assert.Equal(t, 1000, m.CacheNumBlocks)
+	})
+}
+
+func TestZMQExtractor_InvalidPayload(t *testing.T) {
+	ext := NewZMQMetricsExtractor("test-extractor")
+	ep := fwkdl.NewEndpoint(nil, nil)
+
+	in := fwkdl.StreamInput[[]byte]{
+		Payload:  []byte("not-msgpack"),
+		Endpoint: ep,
+	}
+
+	err := ext.Extract(context.Background(), in)
+	assert.Error(t, err)
+}

--- a/pkg/epp/framework/plugins/datalayer/source/zmqmetrics/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/zmqmetrics/datasource.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zmqmetrics
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"runtime/debug"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/go-zeromq/zmq4"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
+)
+
+const ZMQDataSourceType = "zmq-metrics-data-source"
+
+const defaultZMQPort = "5556"
+
+var ErrExtractorTypeMismatch = errors.New("extractor type mismatch")
+
+type zmqDatasourceParams struct {
+	Port string `json:"port"`
+}
+
+// ZMQDataSource is a typed streaming dispatcher that connects to a model server's
+// ZMQ publisher and dispatches incoming byte frames to bound extractors.
+type ZMQDataSource struct {
+	typedName fwkplugin.TypedName
+	port      string
+
+	mu   sync.RWMutex
+	exts []fwkdl.StreamingExtractor[[]byte]
+}
+
+var (
+	_ fwkdl.StreamingDispatcher = (*ZMQDataSource)(nil)
+	_ fwkdl.DataSource          = (*ZMQDataSource)(nil)
+)
+
+// NewZMQDataSource returns a new ZMQDataSource instance.
+func NewZMQDataSource(port, name string) (*ZMQDataSource, error) {
+	if name == "" {
+		name = ZMQDataSourceType
+	}
+	if port == "" {
+		port = defaultZMQPort
+	}
+	return &ZMQDataSource{
+		typedName: fwkplugin.TypedName{Type: ZMQDataSourceType, Name: name},
+		port:      port,
+	}, nil
+}
+
+// ZMQDataSourceFactory is a factory function used to instantiate ZMQ data source plugins.
+func ZMQDataSourceFactory(name string, parameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	cfg := &zmqDatasourceParams{Port: defaultZMQPort}
+	if parameters != nil {
+		if err := parameters.Decode(cfg); err != nil {
+			return nil, err
+		}
+	}
+	return NewZMQDataSource(cfg.Port, name)
+}
+
+func (s *ZMQDataSource) TypedName() fwkplugin.TypedName {
+	return s.typedName
+}
+
+// Start connects to the endpoint's ZMQ publisher and streams incoming messages to extractors.
+// If the connection drops or fails, it will attempt to reconnect with exponential backoff.
+func (s *ZMQDataSource) Start(ctx context.Context, ep fwkdl.Endpoint) error {
+	ip := ep.GetMetadata().GetIPAddress()
+	if ip == "" {
+		ip = ep.GetMetadata().Address
+	}
+	address := "tcp://" + net.JoinHostPort(ip, s.port)
+	logger := log.FromContext(ctx).WithValues("endpoint", ip)
+
+	backoff := 1 * time.Second
+	maxBackoff := 30 * time.Second
+
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		if err := s.stream(ctx, address, ep); err != nil {
+			if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+				return nil
+			}
+			logger.Error(err, "ZMQ streaming error, retrying", "backoff", backoff)
+
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(backoff):
+				backoff *= 2
+				if backoff > maxBackoff {
+					backoff = maxBackoff
+				}
+			}
+		} else {
+			backoff = 1 * time.Second
+		}
+	}
+}
+
+func (s *ZMQDataSource) stream(ctx context.Context, address string, ep fwkdl.Endpoint) error {
+	sub := zmq4.NewSub(ctx)
+	defer sub.Close()
+
+	if err := sub.Dial(address); err != nil {
+		return fmt.Errorf("zmq dial %s: %w", address, err)
+	}
+
+	if err := sub.SetOption(zmq4.OptionSubscribe, ""); err != nil {
+		return fmt.Errorf("zmq subscribe: %w", err)
+	}
+
+	for {
+		msg, err := sub.Recv()
+		if err != nil {
+			return err
+		}
+
+		var payload []byte
+		if len(msg.Frames) > 0 {
+			payload = msg.Frames[len(msg.Frames)-1]
+		}
+
+		in := fwkdl.StreamInput[[]byte]{
+			Payload:  payload,
+			Endpoint: ep,
+		}
+
+		s.mu.RLock()
+		exts := slices.Clone(s.exts)
+		s.mu.RUnlock()
+
+		for _, ext := range exts {
+			if ctx.Err() != nil {
+				return nil
+			}
+			s.runExtractor(ctx, ext, in)
+		}
+	}
+}
+
+func (s *ZMQDataSource) runExtractor(ctx context.Context, ext fwkdl.StreamingExtractor[[]byte], in fwkdl.StreamInput[[]byte]) {
+	logger := log.FromContext(ctx)
+	srcType := s.typedName.Type
+	extType := ext.TypedName().Type
+	defer func() {
+		if r := recover(); r != nil {
+			metrics.RecordDataLayerExtractError(srcType, extType)
+			logger.Error(fmt.Errorf("%v", r), "extractor panicked",
+				"source", s.typedName, "extractor", ext.TypedName(), "stack", string(debug.Stack()))
+		}
+	}()
+	if err := ext.Extract(ctx, in); err != nil {
+		metrics.RecordDataLayerExtractError(srcType, extType)
+		logger.V(logging.DEBUG).Info("extract failed", "source", s.typedName, "extractor", ext.TypedName(), "err", err)
+	}
+}
+
+// AppendExtractor binds ext as a typed StreamingExtractor[[]byte].
+func (s *ZMQDataSource) AppendExtractor(ext fwkplugin.Plugin) error {
+	typed, ok := ext.(fwkdl.StreamingExtractor[[]byte])
+	if !ok {
+		return fmt.Errorf("%w: extractor %s: expected %s, got %T",
+			ErrExtractorTypeMismatch, ext.TypedName(), reflect.TypeFor[fwkdl.StreamingExtractor[[]byte]](), ext)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.exts = append(s.exts, typed)
+	return nil
+}

--- a/pkg/epp/framework/plugins/datalayer/source/zmqmetrics/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/zmqmetrics/datasource_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zmqmetrics
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-zeromq/zmq4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+type testStreamingExtractor struct {
+	count   int32
+	payload []byte
+}
+
+func (t *testStreamingExtractor) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "test-extractor", Name: "test-extractor"}
+}
+
+func (t *testStreamingExtractor) Extract(_ context.Context, in fwkdl.StreamInput[[]byte]) error {
+	t.payload = in.Payload
+	atomic.AddInt32(&t.count, 1)
+	return nil
+}
+
+func TestZMQDataSourceFactory(t *testing.T) {
+	t.Run("default port", func(t *testing.T) {
+		p, err := ZMQDataSourceFactory("zmq-test", nil, nil)
+		require.NoError(t, err)
+		ds, ok := p.(*ZMQDataSource)
+		require.True(t, ok)
+		assert.Equal(t, defaultZMQPort, ds.port)
+	})
+
+	t.Run("custom port", func(t *testing.T) {
+		params := []byte(`{"port": "9999"}`)
+		dec := json.NewDecoder(bytes.NewReader(params))
+		p, err := ZMQDataSourceFactory("zmq-test", dec, nil)
+		require.NoError(t, err)
+		ds, ok := p.(*ZMQDataSource)
+		require.True(t, ok)
+		assert.Equal(t, "9999", ds.port)
+	})
+}
+
+func TestZMQDataSource_Start(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := strconv.Itoa(l.Addr().(*net.TCPAddr).Port)
+	l.Close()
+
+	pub := zmq4.NewPub(ctx)
+	defer pub.Close()
+
+	addr := "tcp://127.0.0.1:" + port
+	require.NoError(t, pub.Listen(addr))
+
+	src, err := NewZMQDataSource(port, "test-zmq")
+	require.NoError(t, err)
+
+	extractor := &testStreamingExtractor{}
+	require.NoError(t, src.AppendExtractor(extractor))
+
+	ep := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{Address: "127.0.0.1"}, nil)
+
+	go func() {
+		_ = src.Start(ctx, ep)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	msgData := []byte("zmq-payload-test")
+	msg := zmq4.NewMsg(msgData)
+	require.NoError(t, pub.Send(msg))
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&extractor.count) > 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, msgData, extractor.payload)
+}

--- a/pkg/epp/framework/plugins/datalayer/source/zmqmetrics/types.go
+++ b/pkg/epp/framework/plugins/datalayer/source/zmqmetrics/types.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zmqmetrics
+
+// ZmqMetricsStats represents the Msgpack serialization schema
+// sent by the model server's ZMQ publisher.
+type ZmqMetricsStats struct {
+	NumRequestsRunning int            `msgpack:"num_requests_running"`
+	NumRequestsWaiting int            `msgpack:"num_requests_waiting"`
+	KVCacheUsagePerc   float64        `msgpack:"kv_cache_usage_perc"`
+	CacheConfigInfo    map[string]any `msgpack:"cache_config_info"`
+	EngineID           string         `msgpack:"engine_id"`
+}


### PR DESCRIPTION
**Update (2026-09-16):** The ZMQ extractor is now engine-based, selected by a required `engine` parameter. The first supported engine is SGLang, using its native ZMQ LoadStat stream (sgl-project/sglang#34608). The vLLM decoder will return as `engine: vllm` once vllm-project/vllm#48969 settles, so this PR no longer waits on the vLLM side. New benchmark results (EPP CPU, freshness, model server load) are in this comment: https://github.com/llm-d/llm-d-router/pull/2067#issuecomment-5693345709


**What type of PR is this?**
<!--
Add one of the following kinds:

/kind feature


Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

/kind feature

**What this PR does / why we need it**:

Detailed Report: [link](https://docs.google.com/document/d/10Juqz_a-LhrOdpezV--NesW1KRHHIIEGV0of8xR7OX0/edit?tab=t.0)

## Summary & Proposal
This PR introduces an asynchronous, event-driven ZeroMQ (ZMQ) metrics streaming architecture over persistent TCP sockets (`tcp://<pod_ip>:5556`) to push state updates directly from model servers (specifically vLLM) to the EPP router.

### Problem Statement
The existing pull-based HTTP polling approach periodically issues GET requests to each model server's `/metrics` endpoint (at a default 50ms interval). Because model server state mutates exclusively at GPU step boundaries, HTTP polling creates two critical failure modes:
1. **Redundant Duplication:** Polling during long prefills fetches identical unmutated state repeatedly (95.4% duplicate messages in our experiments).
2. **Telemetry Blind Spots & Stalls:** Polling cannot align with fast decode iterations or sudden traffic bursts, delaying state visibility. Attempting to lower the polling interval to 6ms actually triggers large number of state update messages contented the network bandwidth and CPU thread contention, spiking P95 update latency to **131.8 ms** (and peak stalls to **798.9 ms**).

### Proposed Solution
With this push-based technique, the model server streams a lightweight binary update (`msgspec` Msgpack) to EPP immediately after each GPU execution step when engine state actually changes. In addition to improving state freshness, this push-based mechanism drastically reduces CPU utilization on both EPP and model servers by eliminating continuous HTTP status check parsing and string formatting during idle and active periods alike.

---

## Key Performance Results
Empirical evaluation on a 3-pod vLLM cluster running `Qwen/Qwen3-32B` under a 300 QPS burst workload demonstrates significant throughput, latency, and resource improvements:
- **Increased Throughput:** Cluster token throughput increased by **+18.44%** (from 31,177 to 36,925 tokens/s).
- **Lower Tail Latency:** P99 TTFT improved by **-16.20%** (reducing tail prompt wait time from 54.92s to 46.02s). P99 End-to-End latency improved by **-15.18%**.
- **Drastic CPU Savings:** Active EPP router CPU usage dropped by **-64.51%** (from 324.87 to 115.30 mcores). Zero-traffic idle CPU dropped by **-95.96%** on EPP (from 108.71 to 4.39 mcores/endpoint) and **-81.02%** on vLLM engines (from 91.48 to 17.36 mcores/pod).

**Macro results:**

Throughput and CPU utilization

<img width="1933" height="1022" alt="image" src="https://github.com/user-attachments/assets/91650988-2ecb-46c9-b340-5de3f0551260" />

Latency CDF

<img width="2925" height="873" alt="image" src="https://github.com/user-attachments/assets/6619da2f-4b88-4ad4-a91f-6430f3f6d375" />

Idle CPU utilization

<img width="2582" height="1450" alt="image" src="https://github.com/user-attachments/assets/f2b85f03-ccf7-40ec-a8bc-aaadc25abe53" />


### Architecture & Design Changes

Overall Design

<img width="2488" height="1324" alt="image" src="https://github.com/user-attachments/assets/1416c45f-2303-42c0-a372-09061950ec69" />


#### 1. Data Layer Runtime & Collector Orchestration
- Updated `Collector.Start()` to manage concurrent goroutines for interval-based polling (`runPolling`) and persistent socket streaming (`runStreaming`).
- Integrated `streamingDispatchers` registry into source registration, configuration binding, and endpoint provisioning (`NewEndpoint`).
- Added `validateMetricSourceConflicts()` to prevent configuring both HTTP polling (`metrics-data-source`) and ZMQ streaming (`zmq-metrics-data-source`) metrics sources concurrently.

#### 2. ZeroMQ Data Source Plugin (`pkg/epp/framework/plugins/datalayer/source/zmqmetrics/datasource.go`)
- Implements `StreamingDispatcher`, connecting ZMQ SUB sockets to endpoint TCP addresses (`tcp://<ip>:<port>`, default port 5555).
- Includes automatic exponential backoff reconnection logic (1s up to 30s max backoff) on stream interruptions, and per-extractor panic recovery to prevent extractor failures from disrupting the stream worker loop.

#### 3. Msgpack Metrics Extractor (`pkg/epp/framework/plugins/datalayer/extractor/zmqmetrics/extractor.go`)
- Decodes Msgpack payloads via unmarshaling into `ZmqMetricsStats`.
- Updates endpoint state atomically (`RunningRequestsSize`, `WaitingQueueSize`, `KVCacheUsagePercent`, `CacheBlockSize`, `CacheNumBlocks`, `KvCacheMaxTokenCapacity`).

#### 4. Plugin Registration & Default Ingestion (`runner.go` and `defaults.go`)
- Registered `zmq-metrics-data-source` and `zmq-state-extractor` into the in-tree plugin registry.
- Updated default configuration loader (`ensureDataLayer`) to bypass default HTTP polling metrics injection when `zmq-metrics-data-source` is present.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

vLLM side issue: https://github.com/vllm-project/vllm/issues/43643
vLLM side PR: https://github.com/vllm-project/vllm/pull/48969

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Add zmq-metrics-data-source and zmq-state-extractor plugins for push-based endpoint metrics (SGLang LoadStat)
```

