### PR TITLE
fix(epp): use exact cached blocks for in-flight load

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -510,12 +510,12 @@ func addedTokensKey(endpointID, profileName string) string {
 // excluding any prefix already cached on it.
 //
 // When the configured prefix producer (approximate or precise) has populated
-// PrefixCacheMatchInfo on the endpoint under prefixMatchInfoKey, the matched and
-// total block counts are in real (tokenized) units, so we use them directly:
-// uncached = (TotalBlocks - MatchBlocks) * BlockSizeTokens. For very long prompts
-// where the prefix index is capped (MaxPrefixTokensToMatch), any tail beyond the
-// cap is added back from the (estimated) inputTokens so the full prompt cost is
-// still reflected.
+// PrefixCacheMatchInfo on the endpoint under prefixMatchInfoKey, the literal
+// cached and total block counts are in real (tokenized) units, so we use them
+// directly: uncached = (TotalBlocks - CachedBlockCount) * BlockSizeTokens. For
+// very long prompts where the prefix index is capped (MaxPrefixTokensToMatch),
+// any tail beyond the cap is added back from the (estimated) inputTokens so the
+// full prompt cost is still reflected.
 //
 // When the attribute is missing, we fall back to the estimated inputTokens.
 func uncachedInputTokens(endpoint fwksched.Endpoint, inputTokens int64, prefixMatchInfoKey string) int64 {
@@ -532,10 +532,10 @@ func uncachedInputTokens(endpoint fwksched.Endpoint, inputTokens int64, prefixMa
 	}
 
 	blockSize := int64(info.BlockSizeTokens())
-	matched := int64(info.MatchBlocks()) * blockSize
+	cached := int64(info.CachedBlockCount()) * blockSize
 	indexed := int64(info.TotalBlocks()) * blockSize
 
-	uncachedIndexed := indexed - matched
+	uncachedIndexed := indexed - cached
 	if uncachedIndexed < 0 {
 		uncachedIndexed = 0
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -133,6 +133,33 @@ func TestInFlightLoadProducer_Produce(t *testing.T) {
 	require.False(t, ok, "InFlightLoad should not be populated by Produce")
 }
 
+func TestInFlightLoadProducer_ProduceUsesLiteralCachedBlocks(t *testing.T) {
+	t.Parallel()
+
+	// Initialize our load producer.
+	producer := newTestProducer(t)
+	// Disable output token estimation so we can test input tokens cleanly (output = 0).
+	producer.addEstimatedOutputTokens = false
+
+	// Create a stub endpoint representing our model-serving pod.
+	endpoint := newStubSchedulingEndpoint("precise-cache-endpoint")
+	// Inject mock prefix cache information onto this endpoint.
+	// matchBlocks = 1 (weighted), cachedBlockCount = 2 (literal), totalBlocks = 2, blockSizeTokens = 4.
+	endpoint.Put(
+		attrprefix.PrefixCacheMatchInfoDataKey.String(),
+		attrprefix.NewPrefixCacheMatchInfo(1, 2, 4).WithCachedBlockCount(2),
+	)
+
+	// Trigger the Produce logic with an 8-token request.
+	err := producer.Produce(context.Background(), makeTokenRequest("req-precise", 8), []fwksched.Endpoint{endpoint})
+	require.NoError(t, err)
+
+	// Assert the produced output is exactly 0 uncached tokens.
+	value, ok := endpoint.Get(producer.uncachedRequestTokensDk.String())
+	require.True(t, ok)
+	require.Equal(t, int64(0), value.(*attrconcurrency.UncachedRequestTokens).Tokens)
+}
+
 func TestInFlightLoadProducer_Extract(t *testing.T) {
 	t.Parallel()
 
@@ -648,23 +675,27 @@ func TestInFlightLoadProducer_ExcludeOutputTokens_SingleChunk(t *testing.T) {
 }
 
 // TestInFlightLoadProducer_PrefixCacheDiscount verifies that when PrefixCacheMatchInfo
-// is published on the endpoint, the matched prefix is excluded from the tracked input
-// tokens, and that release subtracts the same (discounted) amount.
+// is published on the endpoint, the literal cached prefix is excluded from the tracked
+// input tokens, and that release subtracts the same (discounted) amount.
 func TestInFlightLoadProducer_PrefixCacheDiscount(t *testing.T) {
 	t.Parallel()
 
+	// Setup the tracker database and context.
 	producer := newTestProducer(t)
 	ctx := context.Background()
 	endpointName := "prefix-cache-endpoint"
 	endpointID := fullEndpointName(endpointName)
 
 	// 8 input tokens. Output = 8 * 1.5 = 12.
-	// With block_size=4, total=2 blocks, matched=1 block (4 tokens cached):
-	//   uncached_input = (2-1)*4 + max(0, 8-2*4) = 4
-	//   total tokens = 4 + 12 = 16
+	// With block_size=4 and total=2 blocks, the tier-weighted match is 1 block,
+	// but both blocks are cached. The tracked total therefore contains only output.
 	endpoint := newStubSchedulingEndpoint(endpointName)
-	endpoint.Put(attrprefix.PrefixCacheMatchInfoDataKey.String(), attrprefix.NewPrefixCacheMatchInfo(1, 2, 4))
+	endpoint.Put(
+		attrprefix.PrefixCacheMatchInfoDataKey.String(),
+		attrprefix.NewPrefixCacheMatchInfo(1, 2, 4).WithCachedBlockCount(2),
+	)
 
+	// Create an 8-token input request (with 12 estimated output tokens).
 	req := makeTokenRequest("req-prefix", 8)
 	res := &fwksched.SchedulingResult{
 		PrimaryProfileName: "default",
@@ -673,10 +704,11 @@ func TestInFlightLoadProducer_PrefixCacheDiscount(t *testing.T) {
 		},
 	}
 
+	// Simulate dispatch (PreRequest Phase) adding request weight to trackers.
 	producer.PreRequest(ctx, req, res)
 	require.Equal(t, int64(1), producer.requestTracker.get(endpointID))
-	require.Equal(t, int64(16), producer.tokenTracker.get(endpointID),
-		"only uncached input (4) plus output (12) should be tracked")
+	require.Equal(t, int64(12), producer.tokenTracker.get(endpointID),
+		"only output tokens should be tracked for a fully cached input")
 
 	// Release uses the exact stored value, returning to zero.
 	req.SchedulingResult = res
@@ -915,23 +947,95 @@ func TestInFlightLoadProducer_AtomicTokenRelease_Concurrent(t *testing.T) {
 	require.Equal(t, int64(0), producer.requestTracker.get(endpointID))
 }
 
-func TestUncachedInputTokens_Overestimate(t *testing.T) {
-	// Setup:
-	// inputTokens (estimated) = 5
-	// PrefixCacheMatchInfo: matchBlocks=1, totalBlocks=2, blockSizeTokens=4
-	//   indexedTokens = 2 * 4 = 8
-	//   matchedTokens = 1 * 4 = 4
+func TestUncachedInputTokens(t *testing.T) {
+	t.Parallel()
 
-	endpoint := newStubSchedulingEndpoint("test-ep")
-	endpoint.Put(attrprefix.PrefixCacheMatchInfoDataKey.String(), attrprefix.NewPrefixCacheMatchInfo(1, 2, 4))
+	const key = "prefix-match-info"
+	tests := []struct {
+		name        string
+		inputTokens int64
+		info        datalayer.Cloneable
+		noEndpoint  bool
+		want        int64
+	}{
+		// Case: Missing/nil components should default back to treating the entire prompt as uncached.
+		{name: "nil endpoint", inputTokens: 8, noEndpoint: true, want: 8},
+		{name: "negative input without endpoint", inputTokens: -1, noEndpoint: true, want: 0},
+		{name: "missing prefix information", inputTokens: 8, want: 8},
+		{name: "wrong prefix information type", inputTokens: 8, info: &attrconcurrency.InFlightLoad{}, want: 8},
+		// Case: Literal count differs from weighted match (our big fix for offloaded caches).
+		{
+			name:        "literal count differs from weighted match",
+			inputTokens: 4096,
+			info: attrprefix.NewPrefixCacheMatchInfo(204, 256, 16).
+				WithCachedBlockCount(256),
+			want: 0,
+		},
+		// Case: Partially cached precise prefix.
+		{
+			name:        "partially cached precise prefix",
+			inputTokens: 4096,
+			info: attrprefix.NewPrefixCacheMatchInfo(128, 256, 16).
+				WithCachedBlockCount(192),
+			want: 1024,
+		},
+		// Case: Unindexed tail (prompt length exceeds maximum indexed range).
+		{
+			name:        "unindexed tail",
+			inputTokens: 4096,
+			info: attrprefix.NewPrefixCacheMatchInfo(128, 128, 16).
+				WithCachedBlockCount(128),
+			want: 2048,
+		},
+		{
+			name:        "partial final block",
+			inputTokens: 10,
+			info:        attrprefix.NewPrefixCacheMatchInfo(1, 2, 4),
+			want:        6,
+		},
+		// Case: Backward compatibility test (defaults cached count to match blocks).
+		{
+			name:        "approximate producer compatibility",
+			inputTokens: 4096,
+			info:        attrprefix.NewPrefixCacheMatchInfo(128, 256, 16),
+			want:        2048,
+		},
+		{
+			name:        "invalid block size",
+			inputTokens: 8,
+			info:        attrprefix.NewPrefixCacheMatchInfo(1, 2, 0),
+			want:        8,
+		},
+		// Case: Clamped bounds safety check.
+		{
+			name:        "cached count above total blocks",
+			inputTokens: 8,
+			info: attrprefix.NewPrefixCacheMatchInfo(2, 2, 4).
+				WithCachedBlockCount(3),
+			want: 0,
+		},
+		{
+			name:        "prefix count trusted over smaller estimate",
+			inputTokens: 5,
+			info:        attrprefix.NewPrefixCacheMatchInfo(1, 2, 4),
+			want:        4,
+		},
+	}
 
-	inputTokens := int64(5)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var endpoint fwksched.Endpoint
+			if !tt.noEndpoint {
+				stub := newStubSchedulingEndpoint("test-endpoint")
+				if tt.info != nil {
+					stub.Put(key, tt.info)
+				}
+				endpoint = stub
+			}
 
-	uncached := uncachedInputTokens(endpoint, inputTokens, attrprefix.PrefixCacheMatchInfoDataKey.String())
-
-	// When the prefix cache says 4 tokens are definitely uncached in the indexed portion (8-4),
-	// we trust that over the smaller (approximate) estimate of 5.
-	require.Equal(t, int64(4), uncached, "should trust the prefix cache's uncached count (indexed-matched) over the smaller estimate")
+			require.Equal(t, tt.want, uncachedInputTokens(endpoint, tt.inputTokens, key))
+		})
+	}
 }
 
 func TestInFlightLoadProducer_PanicSafety(t *testing.T) {


### PR DESCRIPTION
 # The Problem

The router represents prefix-cache matches with `PrefixCacheMatchInfo`. Two of
its fields describe different concepts:

| Field | Meaning | Intended usefix(epp): use exact cached blocks for in-flight load |
| --- | --- | --- |
| `MatchBlocks` | Tier-weighted cache-match score. A CPU-resident block may contribute less than one block. | Cache ranking and the existing predicted-latency `prefix_cache_score`. |
| `CachedBlockCount` | Literal number of contiguous cached blocks, independent of storage tier. | Converting cached blocks into cached or uncached token counts. |

The in-flight load producer currently uses `MatchBlocks` as though it were a
literal block count:

```text
uncached indexed tokens =
    (TotalBlocks - MatchBlocks) * BlockSizeTokens
```

That calculation is correct for the approximate prefix producer because its
constructor defaults `CachedBlockCount` to `MatchBlocks`. It is not correct for
the precise producer when tier weighting makes the two values different.

The narrow correction is:

```text
uncached indexed tokens =
    (TotalBlocks - CachedBlockCount) * BlockSizeTokens
```

The existing tail calculation remains unchanged so tokens beyond the indexed
prefix are still counted.

## Why We Need This Change (The Impact of the Bug)

Consider a 4,096-token request with 16-token cache blocks. The request contains
256 complete blocks. Assume the full prompt is cached on a pod in CPU cache,
whose default tier weight is `0.8`.

| Value | Result |
| --- | ---: |
| Raw weighted score | `256 * 0.8 = 204.8` |
| Published `MatchBlocks` | `204` |
| Published `CachedBlockCount` | `256` |
| Existing `prefix_cache_score` | `204 / 256 = 0.796875` |

The current in-flight calculation reports:

```text
(256 - 204) * 16 = 832 uncached input tokens
```

The literal cached-block calculation reports:

```text
(256 - 256) * 16 = 0 uncached input tokens
```

The current result incorrectly treats tier weighting as missing cache data. It
can inflate the current request's `UncachedRequestTokens`, inflate the load
committed after endpoint selection, and affect later scheduling decisions that
consume accumulated `InFlightLoad`.

This proposal does not claim that restoring CPU-resident cache has zero latency.
The existing tier-weighted `prefix_cache_score` continues to represent relative
cache benefit. The change only makes literal token accounting use the literal
cached-block field.

# Data Flow

A request contains 4,096 input tokens. Two candidate pods hold the complete
prefix:

- Pod A holds 256 blocks in GPU cache.
- Pod B holds 256 blocks in CPU cache.
- Pod A publishes `MatchBlocks=256` and `CachedBlockCount=256`.
- Pod B publishes `MatchBlocks=204` and `CachedBlockCount=256`.

The router is configured to use the precise prefix producer for both in-flight
load accounting and predicted-latency cache features.

## Step-by-Step Flow

```mermaid
sequenceDiagram
    autonumber

    actor Client
    participant Router
    participant Token as Token Producer
    participant Prefix as Precise Prefix Producer
    participant InFlight as In-Flight Load Producer
    participant Predict as Predicted Latency Producer
    participant Score as Scheduling Scorers
    participant Endpoint as Selected Endpoint

    Client->>Router: Send 4,096-token request
    Router->>Token: Produce engine-correlated token IDs
    Token-->>Router: TokenizedPrompt with 4,096 tokens

    Router->>Prefix: Look up candidate cache state
    Prefix-->>Router: Pod A MatchBlocks=256, CachedBlockCount=256
    Prefix-->>Router: Pod B MatchBlocks=204, CachedBlockCount=256

    Router->>InFlight: Produce current-request load projection
    Note over InFlight: Old Pod B result: 832 uncached tokens
    Note over InFlight: Correct Pod B result: 0 uncached tokens
    InFlight-->>Router: UncachedRequestTokens per endpoint

    Router->>Predict: Produce latency predictions
    Note over Predict: prefix_cache_score remains 204/256 for Pod B
    Note over Predict: Prediction reads accumulated InFlightLoad
    Predict-->>Router: LatencyPredictionInfo per endpoint

    Router->>Score: Score candidates and select endpoint
    Score-->>Router: Selected endpoint

    Router->>InFlight: PreRequest commits selected request load
    Router->>Endpoint: Forward request
    Endpoint-->>Router: Stream response
    Router->>InFlight: Release committed load
    Router-->>Client: Return response
```

# Proposed Changes

### [MODIFY] producer.go

Change the cached-token operand in `uncachedInputTokens`:

```diff
- matched := int64(info.MatchBlocks()) * blockSize
+ cached := int64(info.CachedBlockCount()) * blockSize
  indexed := int64(info.TotalBlocks()) * blockSize

- uncachedIndexed := indexed - matched
+ uncachedIndexed := indexed - cached
```

Update the function comment so it describes the literal cached-block contract.
Keep the current fallback, indexed-prefix, tail, and overestimate behavior.

## YAML Configuration Comparison

### Default (Approximate) Setup

```yaml
plugins:
  - type: token-producer

  - type: inflight-load-producer

  - type: predicted-latency-producer
```

With no explicit producer names, the dependency graph uses the default
approximate prefix-cache producer.

### Backward Compatibility: Why This Does Not Affect Existing (Approximate) Deployments

`NewPrefixCacheMatchInfo` initializes the literal count from the existing match
count:

```go
func NewPrefixCacheMatchInfo(matchBlocks int, totalBlocks int, blockSizeTokens int) *PrefixCacheMatchInfo {
 return &PrefixCacheMatchInfo{
  matchBlocks:      matchBlocks,
  totalBlocks:      totalBlocks,
  blockSizeTokens:  blockSizeTokens,
  cachedBlockCount: matchBlocks,
 }
}
```

The approximate prefix producer uses this default and does not replace
`CachedBlockCount`. Therefore, for valid approximate attributes:

```text
CachedBlockCount == MatchBlocks
```

Switching the token calculation to `CachedBlockCount` produces the same result
for existing approximate deployments. No configuration field is removed or
renamed, and approximate accounting remains the default.

### Opt-in Precise Setup (The Target Fix)

```yaml
plugins:
  - type: token-producer
    parameters:
      modelName: ${MODEL_NAME}
      vllm:
        url: http://localhost:8000

  - name: precise-prefix
    type: precise-prefix-cache-producer
    parameters:
      # Existing KV index and event-source settings belong here.

  - name: precise-inflight
    type: inflight-load-producer
    parameters:
      prefixMatchInfoProducerName: precise-prefix

  - name: predicted-latency
    type: predicted-latency-producer
    parameters:
      prefixMatchInfoProducerName: precise-prefix
      inFlightLoadProducerName: precise-inflight
```

In this setup:

- The in-flight producer uses precise `CachedBlockCount` for literal token
  accounting.
- The predicted-latency producer uses precise, tier-weighted `MatchBlocks` for
  `prefix_cache_score`.
- Later predictions observe the corrected accumulated `InFlightLoad` after a
  request is dispatched.

# Verification Plan

The focused test matrix should verify:

1. A nil endpoint returns the non-negative full input length.
2. Missing or incorrectly typed prefix information falls back to the full input.
3. A fully cached precise prefix returns zero uncached input when
   `MatchBlocks != CachedBlockCount`.
4. A partially cached precise prefix counts only the literal uncached blocks.
5. A prompt longer than the indexed range includes its unindexed tail.
6. A partial final block is included in the tail.
7. A prompt shorter than one cache block is treated as an unindexed tail.
8. Approximate-style attributes preserve their existing result.
9. An invalid block size falls back to the full input.
10. A cached count above the indexed total cannot produce a negative result.
11. Existing precedence between indexed block data and a shorter token estimate
    remains unchanged.
12. `Produce` publishes literal `UncachedRequestTokens` for every candidate.
13. `PreRequest` commits the literal uncached input plus any configured output
    estimate, and release removes the same stored amount.

The exact regression example is:

```text
inputTokens = 4096
MatchBlocks = 204
CachedBlockCount = 256
TotalBlocks = 256
BlockSizeTokens = 16
expected uncached input = 0
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
partially Fixes #1292 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
