### PR TITLE
epp: add turn-priority strategy to program-aware fairness

### DIFF
--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/README.md
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/README.md
@@ -17,9 +17,33 @@ Choose this policy when:
 
 * **Identifies programs** via the fairness ID header carried on each request.
 * **Tracks per-program metrics** through the request lifecycle: queue wait time, dispatched count, in-flight count, last completion time, and (LAS) attained service in weighted tokens.
-* **Selects a queue to dispatch from** using the configured strategy. Currently `las` (Least Attained Service) is supported; programs with the lowest accumulated service score highest.
+* **Selects a queue to dispatch from** using the configured strategy: `las` (Least Attained Service), where programs with the lowest accumulated service score highest, or `turn-priority`, which favors deeper sessions.
 * **Decays attained service** in wall-clock time so a long-idle program is not penalized indefinitely. Decay is applied lazily whenever a program's service is read or accumulated, so it does not depend on the program being visited by the dispatch loop. The rate is set by an explicit half-life.
 * **Evicts idle program state** on a periodic sweep so per-program memory and Prometheus label series do not accumulate forever.
+
+## Strategies
+
+### `las`
+
+Orders programs by least attained service, so a program that has consumed fewer weighted tokens is dispatched first.
+
+### `turn-priority`
+
+Orders programs by how deep their session is. A session that has already taken many turns most likely still has its prefix in the KV cache, so serving it again costs less prefill and finishing it frees the slot sooner.
+
+Depth alone would starve shallow sessions, so head wait is scored alongside it under `turnPriorityTimeWeight`:
+
+```
+score = turnNumber + turnPriorityTimeWeight * headWaitSeconds
+```
+
+Head wait is unbounded, so a shallow program overtakes any deeper rival once it has waited long enough. The two terms are a raw count and raw seconds, so `turnPriorityTimeWeight` converts one second of waiting into a number of turns. A value tuned for one traffic profile does not carry over to a workload with a different depth or wait distribution.
+
+A program that has been idle beyond `turnPriorityInactivitySeconds` counts as turn one and re-earns depth, on the grounds that a session dormant that long has stopped competing for its own prefix. That threshold is separate from `evictionTtlSeconds`, which governs only when per-program bookkeeping is reclaimed.
+
+The default of `120` leaves a margin over the longest activity observed within a session, so a program still taking turns keeps its depth. On an agentic trace replay averaging 48 turns per session, mean think time between turns was about 2.5s and the slowest turn-to-turn cycle reached 96s under the heaviest load tested. A cycle includes service and queueing, so the post-completion gap this threshold measures is smaller. Workloads whose sessions pause for longer need a higher value.
+
+Under contention a prefix is evicted by capacity pressure while its program is still active, and ordering by turn depth is what keeps those prefixes resident. A low prefix-cache hit rate is therefore weak evidence for lowering this value.
 
 ## Unit of Fairness
 
@@ -51,10 +75,12 @@ flowControl:
 
 | Field | Default | Description |
 |---|---|---|
-| `strategy` | `las` | Scoring strategy. Only `las` is supported. |
+| `strategy` | `las` | Scoring strategy: `las` or `turn-priority`. |
 | `lasWeightService` | `0.8` | Weight on the inverted attained-service signal. Higher values prioritize underserved programs more aggressively. |
 | `lasWeightHeadWait` | `0.2` | Weight on the head-of-queue age. Acts as a tiebreaker on cold start when programs have equal attained service. |
 | `lasHalfLifeSeconds` | `60` | Wall-clock half-life of attained service. `0` disables decay, making attained service cumulative for the program's lifetime. |
+| `turnPriorityTimeWeight` | `0.05` | (`turn-priority`) Score contribution per second of head wait, against one point per turn of depth. `0` orders on depth alone. |
+| `turnPriorityInactivitySeconds` | `120` | (`turn-priority`) A program idle for longer than this counts as turn one. `0` disables the reset. |
 | `evictionTtlSeconds` | `3600` | A program with no completion in this window is evicted from the metrics map. |
 | `evictionSweepSeconds` | `300` | How often the eviction sweep runs. Must be `> 0`. |
 
@@ -79,6 +105,7 @@ mean the scheduler is scoring the program on stale service.
 
 * **Abandoned requests block eviction**: Requests abandoned after dispatch leave `inFlight` non-zero, and the eviction sweep skips any program with non-zero `inFlight`, so its `ProgramMetrics` entry and Prometheus series persist indefinitely.
 * **Memory and label-series growth**: A new program ID adds a `ProgramMetrics` entry plus per-program Prometheus label series. The eviction sweep bounds growth, but a workload with rapidly churning program IDs (e.g. a fresh ID per request) will see TTL-bounded accumulation. Choose a TTL that matches your churn rate.
+* **Turn-priority weighting is scale-dependent**: the score sums a turn count and a wait in seconds, so `turnPriorityTimeWeight` converts between the two rather than balancing them proportionally. A value tuned for one traffic profile does not carry over to another with a different depth or wait distribution.
 * **Decay accrues during generation**: Decay is continuous wall-clock time, including while a program's requests are in flight; the service consumed by an in-flight request is added back, post-decay, when it completes. With half-lives well above typical generation times this effect is negligible.
 
 ## Related Documentation

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/README.md
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/README.md
@@ -9,9 +9,17 @@ The program-aware fairness policy schedules per-program queues using aggregated 
 
 Choose this policy when:
 
-* **Workflow-level fairness matters**: Distinct agentic workflows or tenants share the same pool, and you want fair allocation between them rather than between individual requests.
+* **Workflow-level fairness matters**: Distinct agentic workflows or tenants share the same pool, and you want allocation decided between them rather than between individual requests.
+
+Under `las`:
+
 * **Token cost varies widely between flows**: A program issuing a few large requests should not dominate a program issuing many small ones, or vice versa.
 * **Programs may go idle and return**: Idle programs should not retain accumulated service indefinitely; on return they should compete on near-equal footing with persistently active ones.
+
+Under `turn-priority`:
+
+* **Sessions are long and prefix reuse dominates cost**: Multi-turn sessions share a growing prefix, and dispatching the deepest ones keeps that prefix resident instead of re-prefilling it.
+* **Fairness IDs identify sessions**: Traffic carries a session header, so one fairness ID is one session. This strategy is not the right choice for a pool whose requests share a single ID.
 
 ## What it does
 
@@ -31,29 +39,46 @@ Orders programs by least attained service, so a program that has consumed fewer 
 
 Orders programs by how deep their session is. A session that has already taken many turns most likely still has its prefix in the KV cache, so serving it again costs less prefill and finishing it frees the slot sooner.
 
-Depth alone would starve shallow sessions, so head wait is scored alongside it under `turnPriorityTimeWeight`:
+Head wait is scored alongside depth under `turnPriorityTimeWeight`, so a shallower flow ages up while it waits:
 
 ```
 score = turnNumber + turnPriorityTimeWeight * headWaitSeconds
 ```
 
-Head wait is unbounded, so a shallow program overtakes any deeper rival once it has waited long enough. The two terms are a raw count and raw seconds, so `turnPriorityTimeWeight` converts one second of waiting into a number of turns. A value tuned for one traffic profile does not carry over to a workload with a different depth or wait distribution.
+The two terms are a raw count and raw seconds, so `turnPriorityTimeWeight` converts one second of waiting into a number of turns. A value tuned for one traffic profile does not carry over to a workload with a different depth or wait distribution.
 
-A program that has been idle beyond `turnPriorityInactivitySeconds` counts as turn one and re-earns depth, on the grounds that a session dormant that long has stopped competing for its own prefix. That threshold is separate from `evictionTtlSeconds`, which governs only when per-program bookkeeping is reclaimed.
+Head wait is bounded by the flow controller's request TTL, which defaults to 60s and is measured from the same enqueue time this score reads. A waiting request therefore accrues at most
 
-The default of `120` leaves a margin over the longest activity observed within a session, so a program still taking turns keeps its depth. On an agentic trace replay averaging 48 turns per session, mean think time between turns was about 2.5s and the slowest turn-to-turn cycle reached 96s under the heaviest load tested. A cycle includes service and queueing, so the post-completion gap this threshold measures is smaller. Workloads whose sessions pause for longer need a higher value.
+```
+turnPriorityTimeWeight * requestTTL
+```
+
+turn-equivalents before it is shed, and that product is the maximum depth a newcomer can overcome. The default weight of `0.05` against a 60s TTL gives 3, so a turn-one request tops out at a score of 4 and never overtakes a session at turn 5 or deeper. Under sustained contention a new session is shed rather than dispatched ahead of established ones.
+
+That is the intended trade-off at the default: capacity goes to sessions whose prefix is already resident, and new sessions are admitted as the depth of completing ones frees up. It also means the wait term is not a general starvation guard at this weight. Raising the weight so that `turnPriorityTimeWeight * requestTTL` exceeds the depth of the workload lets a newcomer overtake inside the TTL, at the cost of prefix retention: covering 30 turns at a 60s TTL takes `0.5`. Only the product matters, so a deployment that changes `requestTTL` has to revisit the weight.
+
+A program that has been idle beyond `turnPriorityInactivitySeconds` has its next request scored as turn one, on the grounds that a session dormant that long has stopped competing for its own prefix. Once that request is dispatched it re-prefills the whole conversation, and the program competes at its full depth again. The idle gap is measured from the program's last completion to the head request's arrival, so a request that has since been queuing does not itself age the program into a reset.
+
+The default of `120` leaves a margin over the longest gap observed within an active session, so a program still taking turns keeps its depth. On an agentic trace replay averaging 48 turns per session, mean think time between turns was about 2.5s and the slowest turn-to-turn cycle reached 96s under the heaviest load tested. That cycle figure includes service and queueing, while the gap this threshold measures spans only last completion to next arrival, so the effective margin is wider than the 24s difference suggests. Workloads whose sessions pause for longer between turns need a higher value.
 
 Under contention a prefix is evicted by capacity pressure while its program is still active, and ordering by turn depth is what keeps those prefixes resident. A low prefix-cache hit rate is therefore weak evidence for lowering this value.
 
+This strategy requires one fairness ID per session. It reads a program's dispatched count as the depth of a single conversation, which holds only when the ID identifies one session: the fairness ID header, or the `agent-identity` attribute that the request-header plugin derives from a session header.
+
+Requests carrying neither share `default-flow`. Its dispatched count is the sum over unrelated clients, so it is not a session depth, it grows with total unlabeled traffic, and it rarely stays idle long enough for the inactivity reset to fire. Ordering it against real sessions by that count is not meaningful, and a pool that mixes labeled and unlabeled traffic gives `default-flow` a depth no single session can match. Route unlabeled traffic to a priority band on a different fairness policy.
+
 ## Unit of Fairness
 
-**Attained service**, measured as a weighted sum of input and output tokens consumed by the program. Output tokens are weighted twice as much as input tokens to reflect their relative compute cost.
+Under `turn-priority`, **session depth**: the count of requests already dispatched for the program, plus the waiting request.
+
+Under `las`, **attained service**, measured as a weighted sum of input and output tokens consumed by the program. Output tokens are weighted twice as much as input tokens to reflect their relative compute cost.
 
 ## Inputs consumed
 
 * **Program identity**: From the request's `FairnessID` field, which the framework populates from the fairness ID header.
 * **Queue state**: Reads queue length and the head item's enqueue time from the `FlowQueueAccessor`.
-* **Token usage**: From the `Response.Usage` field on stream completion.
+* **Token usage** (`las`): From the `Response.Usage` field on stream completion.
+* **Dispatched count, in-flight count, last completion time** (`turn-priority`): From the per-program metrics maintained across the request lifecycle.
 
 ## Configuration
 
@@ -79,8 +104,8 @@ flowControl:
 | `lasWeightService` | `0.8` | Weight on the inverted attained-service signal. Higher values prioritize underserved programs more aggressively. |
 | `lasWeightHeadWait` | `0.2` | Weight on the head-of-queue age. Acts as a tiebreaker on cold start when programs have equal attained service. |
 | `lasHalfLifeSeconds` | `60` | Wall-clock half-life of attained service. `0` disables decay, making attained service cumulative for the program's lifetime. |
-| `turnPriorityTimeWeight` | `0.05` | (`turn-priority`) Score contribution per second of head wait, against one point per turn of depth. `0` orders on depth alone. |
-| `turnPriorityInactivitySeconds` | `120` | (`turn-priority`) A program idle for longer than this counts as turn one. `0` disables the reset. |
+| `turnPriorityTimeWeight` | `0.05` | (`turn-priority`) Score contribution per second of head wait, against one point per turn of depth. `turnPriorityTimeWeight * requestTTL` bounds the depth a waiting request can overcome, which at the default is 3 turns. `0` orders on depth alone, with longer head wait breaking ties. |
+| `turnPriorityInactivitySeconds` | `120` | (`turn-priority`) A program idle for longer than this has its next request scored as turn one. `0` disables the inactivity reset. Depth is still lost when the program is evicted after `evictionTtlSeconds`. |
 | `evictionTtlSeconds` | `3600` | A program with no completion in this window is evicted from the metrics map. |
 | `evictionSweepSeconds` | `300` | How often the eviction sweep runs. Must be `> 0`. |
 
@@ -88,7 +113,7 @@ A complete sample is shipped at [`deploy/config/sim-program-aware-config.yaml`](
 
 ## Observability
 
-The plugin exports two shared collectors and one strategy-owned collector under the `llm_d_epp` Prometheus subsystem:
+The plugin exports two shared collectors under the `llm_d_epp` Prometheus subsystem, plus one owned by the `las` strategy. Under `turn-priority` the strategy registers no collectors, so `program_aware_attained_service_tokens` is absent:
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
@@ -106,6 +131,8 @@ mean the scheduler is scoring the program on stale service.
 * **Abandoned requests block eviction**: Requests abandoned after dispatch leave `inFlight` non-zero, and the eviction sweep skips any program with non-zero `inFlight`, so its `ProgramMetrics` entry and Prometheus series persist indefinitely.
 * **Memory and label-series growth**: A new program ID adds a `ProgramMetrics` entry plus per-program Prometheus label series. The eviction sweep bounds growth, but a workload with rapidly churning program IDs (e.g. a fresh ID per request) will see TTL-bounded accumulation. Choose a TTL that matches your churn rate.
 * **Turn-priority weighting is scale-dependent**: the score sums a turn count and a wait in seconds, so `turnPriorityTimeWeight` converts between the two rather than balancing them proportionally. A value tuned for one traffic profile does not carry over to another with a different depth or wait distribution.
+* **Turn-priority sheds new sessions under contention**: a waiting request accrues at most `turnPriorityTimeWeight * requestTTL` turn-equivalents before the flow controller sheds it, 3 at the defaults, so a session deeper than that is never overtaken by a newcomer. Raising the weight to cover the depth of the workload trades prefix retention for admission latency.
+* **Turn depth is read one dispatch behind**: the dispatched count is incremented after the pick, off the dispatch path, so consecutive picks for one program can score against a count that has not yet caught up.
 * **Decay accrues during generation**: Decay is continuous wall-clock time, including while a program's requests are in flight; the service consumed by an in-flight request is added back, post-decay, when it completes. With half-lives well above typical generation times this effect is negligible.
 
 ## Related Documentation

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin.go
@@ -31,6 +31,9 @@ type Config struct {
 	LASWeightService   float64 `json:"lasWeightService,omitempty"`
 	LASWeightHeadWait  float64 `json:"lasWeightHeadWait,omitempty"`
 	LASHalfLifeSeconds float64 `json:"lasHalfLifeSeconds,omitempty"`
+
+	TurnPriorityTimeWeight        float64 `json:"turnPriorityTimeWeight,omitempty"`
+	TurnPriorityInactivitySeconds float64 `json:"turnPriorityInactivitySeconds,omitempty"`
 }
 
 func DefaultConfig() Config {
@@ -41,6 +44,9 @@ func DefaultConfig() Config {
 		LASWeightService:     0.8,
 		LASWeightHeadWait:    0.2,
 		LASHalfLifeSeconds:   60,
+
+		TurnPriorityTimeWeight:        0.05,
+		TurnPriorityInactivitySeconds: 120,
 	}
 }
 
@@ -59,6 +65,12 @@ func (c Config) validate() error {
 	}
 	if c.LASHalfLifeSeconds < 0 {
 		return fmt.Errorf("lasHalfLifeSeconds must be >= 0, got %v", c.LASHalfLifeSeconds)
+	}
+	if c.TurnPriorityTimeWeight < 0 {
+		return fmt.Errorf("turnPriorityTimeWeight must be >= 0, got %v", c.TurnPriorityTimeWeight)
+	}
+	if c.TurnPriorityInactivitySeconds < 0 {
+		return fmt.Errorf("turnPriorityInactivitySeconds must be >= 0, got %v", c.TurnPriorityInactivitySeconds)
 	}
 	return nil
 }

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin_test.go
@@ -351,3 +351,54 @@ func TestDumpStateEmpty(t *testing.T) {
 	// With no programs the policy is trivially fair.
 	assert.Equal(t, 1.0, state.FairnessIndex)
 }
+
+func TestNewStrategy_TurnPriority(t *testing.T) {
+	strategy, err := newStrategy(Config{
+		Strategy:                      "turn-priority",
+		TurnPriorityTimeWeight:        0.25,
+		TurnPriorityInactivitySeconds: 120,
+	})
+	require.NoError(t, err)
+
+	tp, ok := strategy.(*turnPriorityStrategy)
+	require.True(t, ok)
+	assert.Equal(t, "turn-priority", tp.Name())
+	assert.Equal(t, 0.25, tp.timeWeight)
+	assert.Equal(t, 120.0, tp.inactivitySeconds)
+}
+
+func TestNewStrategy_UnknownRejected(t *testing.T) {
+	_, err := newStrategy(Config{Strategy: "nope"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "turn-priority")
+}
+
+func TestConfigValidate_TurnPriority(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{"defaults", func(*Config) {}, ""},
+		{"weight zero", func(c *Config) { c.TurnPriorityTimeWeight = 0 }, ""},
+		{"weight one", func(c *Config) { c.TurnPriorityTimeWeight = 1 }, ""},
+		{"weight negative", func(c *Config) { c.TurnPriorityTimeWeight = -0.1 }, "turnPriorityTimeWeight"},
+		{"weight above one", func(c *Config) { c.TurnPriorityTimeWeight = 1.5 }, ""},
+		{"inactivity zero", func(c *Config) { c.TurnPriorityInactivitySeconds = 0 }, ""},
+		{"inactivity negative", func(c *Config) { c.TurnPriorityInactivitySeconds = -1 }, "turnPriorityInactivitySeconds"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			tc.mutate(&cfg)
+			err := cfg.validate()
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy.go
@@ -35,8 +35,13 @@ func newStrategy(cfg Config) (Strategy, error) {
 			weightHeadWait:  cfg.LASWeightHeadWait,
 			halfLifeSeconds: cfg.LASHalfLifeSeconds,
 		}, nil
+	case turnPriorityStrategyName:
+		return &turnPriorityStrategy{
+			timeWeight:        cfg.TurnPriorityTimeWeight,
+			inactivitySeconds: cfg.TurnPriorityInactivitySeconds,
+		}, nil
 	default:
-		return nil, fmt.Errorf("unknown scoring strategy %q: only \"las\" is supported", cfg.Strategy)
+		return nil, fmt.Errorf("unknown scoring strategy %q: only \"las\" and \"turn-priority\" are supported", cfg.Strategy)
 	}
 }
 

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy_turnpriority.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy_turnpriority.go
@@ -1,0 +1,110 @@
+package programaware
+
+import (
+	"math"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
+	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+const turnPriorityStrategyName = "turn-priority"
+
+var _ Strategy = &turnPriorityStrategy{}
+
+// turnPriorityStrategy scores each flow by its head request's priority
+//
+//	score = turnNumber + timeWeight*headWait
+//
+// and picks the highest, favoring deeper sessions whose prefix is most likely
+// still resident in the KV cache. headWait is unbounded, so a flow with a lower
+// turn number is not starved: it overtakes any deeper rival once it has waited
+// long enough.
+//
+// A program's turn counter resets once it has been inactive for
+// inactivitySeconds, so a session that returns with a cold cache competes from
+// turn one. The strategy keeps no accumulated per-program state.
+type turnPriorityStrategy struct {
+	timeWeight        float64
+	inactivitySeconds float64
+}
+
+func (s *turnPriorityStrategy) Name() string { return turnPriorityStrategyName }
+
+func (s *turnPriorityStrategy) Pick(_ int, queues map[string]QueueInfo) flowcontrol.FlowQueueAccessor {
+	// Collect the flows with pending work: with no waiting flow there is nothing
+	// to dispatch, and with exactly one the choice is forced.
+	type candidate struct {
+		queue    flowcontrol.FlowQueueAccessor
+		metrics  *ProgramMetrics
+		headWait float64
+	}
+
+	waiting := make([]candidate, 0, len(queues))
+	for _, qi := range queues {
+		if qi.Len == 0 {
+			continue
+		}
+		head := qi.Queue.Peek()
+		if head == nil {
+			continue
+		}
+		headWait := time.Since(head.EnqueueTime()).Seconds()
+		if headWait < 0 {
+			headWait = 0
+		}
+		waiting = append(waiting, candidate{queue: qi.Queue, metrics: qi.Metrics, headWait: headWait})
+	}
+
+	switch len(waiting) {
+	case 0:
+		return nil
+	case 1:
+		return waiting[0].queue
+	}
+
+	var best flowcontrol.FlowQueueAccessor
+	bestScore := math.Inf(-1)
+
+	for _, c := range waiting {
+		score := float64(s.turnNumberFor(c.metrics)) + s.timeWeight*c.headWait
+		if score > bestScore {
+			bestScore = score
+			best = c.queue
+		}
+	}
+
+	return best
+}
+
+func (s *turnPriorityStrategy) OnPreRequest(_ *ProgramMetrics, _ *fwksched.InferenceRequest) {}
+
+func (s *turnPriorityStrategy) OnCompleted(_ *ProgramMetrics, _ *fwksched.InferenceRequest, _ *fwkrc.Response) {
+}
+
+func (s *turnPriorityStrategy) EvictProgram(_ string) {}
+
+func (s *turnPriorityStrategy) Collectors() []prometheus.Collector { return nil }
+
+// turnNumberFor returns the turn number of a program's head request: the count of
+// requests already dispatched for the program plus the waiting request itself.
+//
+// A program idle for longer than inactivitySeconds counts as turn one and
+// re-earns depth from a cold state: a session dormant that long has stopped
+// competing for its own prefix. The threshold is independent of the metrics
+// eviction TTL, which governs only when per-program bookkeeping is reclaimed.
+func (s *turnPriorityStrategy) turnNumberFor(metrics *ProgramMetrics) int64 {
+	if metrics == nil {
+		return 1
+	}
+	if s.inactivitySeconds > 0 && metrics.InFlight() == 0 {
+		last := metrics.LastCompletionTime()
+		if !last.IsZero() && time.Since(last).Seconds() > s.inactivitySeconds {
+			return 1
+		}
+	}
+	return metrics.DispatchedCount() + 1
+}

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy_turnpriority.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy_turnpriority.go
@@ -20,13 +20,22 @@ var _ Strategy = &turnPriorityStrategy{}
 //	score = turnNumber + timeWeight*headWait
 //
 // and picks the highest, favoring deeper sessions whose prefix is most likely
-// still resident in the KV cache. headWait is unbounded, so a flow with a lower
-// turn number is not starved: it overtakes any deeper rival once it has waited
-// long enough.
+// still resident in the KV cache. A shallower flow ages up as its head waits, but
+// only up to timeWeight*requestTTL turn-equivalents, since the flow controller
+// sheds the request once the TTL elapses. That product bounds the depth a newcomer
+// can overcome: 3 turns at the default weight, so under sustained contention a new
+// session is shed rather than dispatched ahead of deeper ones. Covering a deeper
+// workload means raising the weight, which trades prefix retention for admission
+// latency.
+//
+// The strategy requires one fairness ID per session, which holds for traffic
+// carrying a session header. Requests with no fairness ID share a single flow
+// whose dispatched count aggregates unrelated clients, so that count is not a
+// session depth and the ordering it produces is not meaningful. Such traffic
+// belongs in a priority band on a different fairness policy.
 //
 // A program's turn counter resets once it has been inactive for
-// inactivitySeconds, so a session that returns with a cold cache competes from
-// turn one. The strategy keeps no accumulated per-program state.
+// inactivitySeconds. The strategy keeps no accumulated per-program state.
 type turnPriorityStrategy struct {
 	timeWeight        float64
 	inactivitySeconds float64
@@ -35,15 +44,11 @@ type turnPriorityStrategy struct {
 func (s *turnPriorityStrategy) Name() string { return turnPriorityStrategyName }
 
 func (s *turnPriorityStrategy) Pick(_ int, queues map[string]QueueInfo) flowcontrol.FlowQueueAccessor {
-	// Collect the flows with pending work: with no waiting flow there is nothing
-	// to dispatch, and with exactly one the choice is forced.
-	type candidate struct {
-		queue    flowcontrol.FlowQueueAccessor
-		metrics  *ProgramMetrics
-		headWait float64
-	}
+	var best flowcontrol.FlowQueueAccessor
+	bestScore := math.Inf(-1)
+	bestWait := math.Inf(-1)
+	now := time.Now()
 
-	waiting := make([]candidate, 0, len(queues))
 	for _, qi := range queues {
 		if qi.Len == 0 {
 			continue
@@ -52,28 +57,20 @@ func (s *turnPriorityStrategy) Pick(_ int, queues map[string]QueueInfo) flowcont
 		if head == nil {
 			continue
 		}
-		headWait := time.Since(head.EnqueueTime()).Seconds()
+
+		headEnqueue := head.EnqueueTime()
+		headWait := now.Sub(headEnqueue).Seconds()
 		if headWait < 0 {
 			headWait = 0
 		}
-		waiting = append(waiting, candidate{queue: qi.Queue, metrics: qi.Metrics, headWait: headWait})
-	}
 
-	switch len(waiting) {
-	case 0:
-		return nil
-	case 1:
-		return waiting[0].queue
-	}
-
-	var best flowcontrol.FlowQueueAccessor
-	bestScore := math.Inf(-1)
-
-	for _, c := range waiting {
-		score := float64(s.turnNumberFor(c.metrics)) + s.timeWeight*c.headWait
-		if score > bestScore {
+		score := float64(s.turnNumberFor(qi.Metrics, headEnqueue)) + s.timeWeight*headWait
+		// Tie-break on the longer head wait so equal depth dispatches in arrival
+		// order rather than by map iteration order.
+		if score > bestScore || (score == bestScore && headWait > bestWait) {
 			bestScore = score
-			best = c.queue
+			bestWait = headWait
+			best = qi.Queue
 		}
 	}
 
@@ -91,18 +88,25 @@ func (s *turnPriorityStrategy) Collectors() []prometheus.Collector { return nil 
 
 // turnNumberFor returns the turn number of a program's head request: the count of
 // requests already dispatched for the program plus the waiting request itself.
+// headEnqueue is the head request's arrival instant, so the idle gap is measured
+// from the previous completion to that arrival and excludes the head's own queue
+// wait.
 //
-// A program idle for longer than inactivitySeconds counts as turn one and
-// re-earns depth from a cold state: a session dormant that long has stopped
-// competing for its own prefix. The threshold is independent of the metrics
-// eviction TTL, which governs only when per-program bookkeeping is reclaimed.
-func (s *turnPriorityStrategy) turnNumberFor(metrics *ProgramMetrics) int64 {
+// A program idle for longer than inactivitySeconds has its next request scored as
+// turn one, on the grounds that a session dormant that long has stopped competing
+// for its own prefix. Dispatching that request re-prefills the conversation, and
+// the program competes at its full dispatched count again.
+//
+// The count is read here but incremented in PreRequest, off the dispatch path, so
+// consecutive picks for one program can score against a count that lags by the
+// requests already dispatched from it.
+func (s *turnPriorityStrategy) turnNumberFor(metrics *ProgramMetrics, headEnqueue time.Time) int64 {
 	if metrics == nil {
 		return 1
 	}
 	if s.inactivitySeconds > 0 && metrics.InFlight() == 0 {
 		last := metrics.LastCompletionTime()
-		if !last.IsZero() && time.Since(last).Seconds() > s.inactivitySeconds {
+		if !last.IsZero() && headEnqueue.Sub(last).Seconds() > s.inactivitySeconds {
 			return 1
 		}
 	}

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy_turnpriority_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy_turnpriority_test.go
@@ -1,0 +1,167 @@
+package programaware
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedTurns advances a program to the given turn depth, leaving nothing in flight
+// and the last completion at completedAt.
+func seedTurns(turns int, completedAt time.Time) *ProgramMetrics {
+	m := &ProgramMetrics{}
+	for range turns {
+		m.RecordDispatched(time.Time{})
+		m.RecordCompletion(completedAt)
+	}
+	return m
+}
+
+func turnInfo(id string, metrics *ProgramMetrics, headEnqueue time.Time) (string, QueueInfo) {
+	return id, QueueInfo{
+		Queue:   makeQueue(id, 1, headEnqueue),
+		Metrics: metrics,
+		Len:     1,
+	}
+}
+
+func TestTurnPriority_Name(t *testing.T) {
+	assert.Equal(t, "turn-priority", (&turnPriorityStrategy{}).Name())
+}
+
+func TestTurnPriority_PrefersDeeperSession(t *testing.T) {
+	s := &turnPriorityStrategy{timeWeight: 0}
+	now := time.Now()
+
+	idA, qA := turnInfo("shallow", seedTurns(1, now), now)
+	idB, qB := turnInfo("deep", seedTurns(20, now), now)
+
+	got := s.Pick(0, map[string]QueueInfo{idA: qA, idB: qB})
+	require.NotNil(t, got)
+	assert.Equal(t, "deep", got.FlowKey().ID)
+}
+
+func TestTurnPriority_PrefersLongerWaitWhenTimeWeighted(t *testing.T) {
+	s := &turnPriorityStrategy{timeWeight: 1.0}
+	now := time.Now()
+
+	idA, qA := turnInfo("deep", seedTurns(20, now), now)
+	idB, qB := turnInfo("waiting", seedTurns(1, now), now.Add(-30*time.Second))
+
+	got := s.Pick(0, map[string]QueueInfo{idA: qA, idB: qB})
+	require.NotNil(t, got)
+	assert.Equal(t, "waiting", got.FlowKey().ID)
+}
+
+// A long enough wait must overcome depth at the default weighting, otherwise a
+// shallow session starves behind deep ones.
+func TestTurnPriority_WaitOvercomesDepthAtDefaultWeight(t *testing.T) {
+	cfg := DefaultConfig()
+	s := &turnPriorityStrategy{timeWeight: cfg.TurnPriorityTimeWeight}
+	now := time.Now()
+
+	// At timeWeight 0.05 a turn-50 lead needs ~1000s of wait to overcome.
+	idA, qA := turnInfo("deep", seedTurns(50, now), now)
+	idB, qB := turnInfo("starving", seedTurns(1, now), now.Add(-30*time.Minute))
+
+	got := s.Pick(0, map[string]QueueInfo{idA: qA, idB: qB})
+	require.NotNil(t, got)
+	assert.Equal(t, "starving", got.FlowKey().ID)
+}
+
+func TestTurnPriority_SingleWaitingFlowBypassesScoring(t *testing.T) {
+	s := &turnPriorityStrategy{timeWeight: 0.5}
+	now := time.Now()
+
+	id, qi := turnInfo("only", seedTurns(1, now), now)
+	empty := QueueInfo{Queue: makeQueue("idle", 0, time.Time{}), Metrics: &ProgramMetrics{}, Len: 0}
+
+	got := s.Pick(0, map[string]QueueInfo{id: qi, "idle": empty})
+	require.NotNil(t, got)
+	assert.Equal(t, "only", got.FlowKey().ID)
+}
+
+func TestTurnPriority_NoWaitingFlows(t *testing.T) {
+	s := &turnPriorityStrategy{timeWeight: 0.5}
+	queues := map[string]QueueInfo{
+		"idle": {Queue: makeQueue("idle", 0, time.Time{}), Metrics: &ProgramMetrics{}, Len: 0},
+	}
+	assert.Nil(t, s.Pick(0, queues))
+	assert.Nil(t, s.Pick(0, map[string]QueueInfo{}))
+}
+
+// A positive Len with a nil head can appear when a queue drains between
+// iteration and scoring.
+func TestTurnPriority_SkipsNilHead(t *testing.T) {
+	s := &turnPriorityStrategy{timeWeight: 0.5}
+	now := time.Now()
+
+	drained := makeQueue("drained", 1, now)
+	drained.PeekV = nil
+
+	idA, qA := turnInfo("live", seedTurns(1, now), now)
+	queues := map[string]QueueInfo{
+		idA:       qA,
+		"drained": {Queue: drained, Metrics: &ProgramMetrics{}, Len: 1},
+	}
+
+	got := s.Pick(0, queues)
+	require.NotNil(t, got)
+	assert.Equal(t, "live", got.FlowKey().ID)
+}
+
+func TestTurnPriority_NilMetricsCountsAsFirstTurn(t *testing.T) {
+	s := &turnPriorityStrategy{timeWeight: 0}
+	now := time.Now()
+
+	idA, qA := turnInfo("deep", seedTurns(5, now), now)
+	queues := map[string]QueueInfo{
+		idA:      qA,
+		"absent": {Queue: makeQueue("absent", 1, now), Metrics: nil, Len: 1},
+	}
+
+	got := s.Pick(0, queues)
+	require.NotNil(t, got)
+	assert.Equal(t, "deep", got.FlowKey().ID)
+}
+
+func TestTurnPriority_InactivityResetsTurnCount(t *testing.T) {
+	s := &turnPriorityStrategy{inactivitySeconds: 60}
+
+	idle := seedTurns(30, time.Now().Add(-10*time.Minute))
+	assert.Equal(t, int64(1), s.turnNumberFor(idle))
+
+	active := seedTurns(30, time.Now())
+	assert.Equal(t, int64(31), s.turnNumberFor(active))
+}
+
+// An in-flight request means the program is active regardless of how old its last
+// completion is.
+func TestTurnPriority_InFlightSuppressesReset(t *testing.T) {
+	s := &turnPriorityStrategy{inactivitySeconds: 60}
+
+	m := seedTurns(5, time.Now().Add(-10*time.Minute))
+	m.RecordDispatched(time.Time{})
+
+	assert.Equal(t, int64(7), s.turnNumberFor(m))
+}
+
+func TestTurnPriority_ZeroInactivityDisablesReset(t *testing.T) {
+	s := &turnPriorityStrategy{inactivitySeconds: 0}
+	m := seedTurns(9, time.Now().Add(-24*time.Hour))
+	assert.Equal(t, int64(10), s.turnNumberFor(m))
+}
+
+func TestTurnPriority_EqualCandidatesResolve(t *testing.T) {
+	s := &turnPriorityStrategy{timeWeight: 0.5}
+	now := time.Now()
+
+	idA, qA := turnInfo("alpha", seedTurns(3, now), now)
+	idB, qB := turnInfo("beta", seedTurns(3, now), now)
+
+	got := s.Pick(0, map[string]QueueInfo{idA: qA, idB: qB})
+	require.NotNil(t, got)
+	assert.Contains(t, []string{"alpha", "beta"}, got.FlowKey().ID)
+}

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy_turnpriority_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy_turnpriority_test.go
@@ -55,20 +55,35 @@ func TestTurnPriority_PrefersLongerWaitWhenTimeWeighted(t *testing.T) {
 	assert.Equal(t, "waiting", got.FlowKey().ID)
 }
 
-// A long enough wait must overcome depth at the default weighting, otherwise a
-// shallow session starves behind deep ones.
-func TestTurnPriority_WaitOvercomesDepthAtDefaultWeight(t *testing.T) {
+// Wait overcomes depth only inside timeWeight*requestTTL, since the flow
+// controller sheds the head once the TTL elapses. At the default weight that
+// bound is 0.05*60 = 3 turn-equivalents.
+func TestTurnPriority_WaitOvercomesShallowDepthWithinRequestTTL(t *testing.T) {
 	cfg := DefaultConfig()
 	s := &turnPriorityStrategy{timeWeight: cfg.TurnPriorityTimeWeight}
 	now := time.Now()
 
-	// At timeWeight 0.05 a turn-50 lead needs ~1000s of wait to overcome.
-	idA, qA := turnInfo("deep", seedTurns(50, now), now)
-	idB, qB := turnInfo("starving", seedTurns(1, now), now.Add(-30*time.Minute))
+	idA, qA := turnInfo("deep", seedTurns(2, now), now)
+	idB, qB := turnInfo("starving", seedTurns(1, now), now.Add(-50*time.Second))
 
 	got := s.Pick(0, map[string]QueueInfo{idA: qA, idB: qB})
 	require.NotNil(t, got)
 	assert.Equal(t, "starving", got.FlowKey().ID)
+}
+
+// Past that bound the deeper session keeps the slot for the whole TTL, so the
+// newcomer is shed rather than dispatched.
+func TestTurnPriority_DeepSessionHoldsSlotBeyondTTLBound(t *testing.T) {
+	cfg := DefaultConfig()
+	s := &turnPriorityStrategy{timeWeight: cfg.TurnPriorityTimeWeight}
+	now := time.Now()
+
+	idA, qA := turnInfo("deep", seedTurns(20, now), now)
+	idB, qB := turnInfo("newcomer", seedTurns(1, now), now.Add(-60*time.Second))
+
+	got := s.Pick(0, map[string]QueueInfo{idA: qA, idB: qB})
+	require.NotNil(t, got)
+	assert.Equal(t, "deep", got.FlowKey().ID)
 }
 
 func TestTurnPriority_SingleWaitingFlowBypassesScoring(t *testing.T) {
@@ -129,12 +144,25 @@ func TestTurnPriority_NilMetricsCountsAsFirstTurn(t *testing.T) {
 
 func TestTurnPriority_InactivityResetsTurnCount(t *testing.T) {
 	s := &turnPriorityStrategy{inactivitySeconds: 60}
+	now := time.Now()
 
-	idle := seedTurns(30, time.Now().Add(-10*time.Minute))
-	assert.Equal(t, int64(1), s.turnNumberFor(idle))
+	idle := seedTurns(30, now.Add(-10*time.Minute))
+	assert.Equal(t, int64(1), s.turnNumberFor(idle, now))
 
-	active := seedTurns(30, time.Now())
-	assert.Equal(t, int64(31), s.turnNumberFor(active))
+	active := seedTurns(30, now)
+	assert.Equal(t, int64(31), s.turnNumberFor(active, now))
+}
+
+// The idle gap runs from the previous completion to the head's arrival, so a head
+// that has since waited past the threshold keeps its depth.
+func TestTurnPriority_QueueWaitDoesNotTriggerReset(t *testing.T) {
+	s := &turnPriorityStrategy{inactivitySeconds: 120}
+	now := time.Now()
+
+	m := seedTurns(40, now.Add(-130*time.Second))
+	headEnqueue := now.Add(-129 * time.Second)
+
+	assert.Equal(t, int64(41), s.turnNumberFor(m, headEnqueue))
 }
 
 // An in-flight request means the program is active regardless of how old its last
@@ -145,23 +173,27 @@ func TestTurnPriority_InFlightSuppressesReset(t *testing.T) {
 	m := seedTurns(5, time.Now().Add(-10*time.Minute))
 	m.RecordDispatched(time.Time{})
 
-	assert.Equal(t, int64(7), s.turnNumberFor(m))
+	assert.Equal(t, int64(7), s.turnNumberFor(m, time.Now()))
 }
 
 func TestTurnPriority_ZeroInactivityDisablesReset(t *testing.T) {
 	s := &turnPriorityStrategy{inactivitySeconds: 0}
 	m := seedTurns(9, time.Now().Add(-24*time.Hour))
-	assert.Equal(t, int64(10), s.turnNumberFor(m))
+	assert.Equal(t, int64(10), s.turnNumberFor(m, time.Now()))
 }
 
-func TestTurnPriority_EqualCandidatesResolve(t *testing.T) {
-	s := &turnPriorityStrategy{timeWeight: 0.5}
+// With depth alone, equal-depth flows fall back to arrival order rather than map
+// iteration order.
+func TestTurnPriority_EqualDepthBreaksTieOnHeadWait(t *testing.T) {
+	s := &turnPriorityStrategy{timeWeight: 0}
 	now := time.Now()
 
-	idA, qA := turnInfo("alpha", seedTurns(3, now), now)
-	idB, qB := turnInfo("beta", seedTurns(3, now), now)
+	for range 20 {
+		idA, qA := turnInfo("earlier", seedTurns(3, now), now.Add(-10*time.Second))
+		idB, qB := turnInfo("later", seedTurns(3, now), now.Add(-2*time.Second))
 
-	got := s.Pick(0, map[string]QueueInfo{idA: qA, idB: qB})
-	require.NotNil(t, got)
-	assert.Contains(t, []string{"alpha", "beta"}, got.FlowKey().ID)
+		got := s.Pick(0, map[string]QueueInfo{idA: qA, idB: qB})
+		require.NotNil(t, got)
+		assert.Equal(t, "earlier", got.FlowKey().ID)
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds a second scoring strategy, `turn-priority`, to the `program-aware-fairness` flow-control policy, alongside the existing `las` strategy. It orders waiting flows by their head request's `prio = turn_number + turnPriorityTimeWeight * elapsed_seconds`, favoring deeper sessions while the elapsed term ages waiting flows up to avoid starvation. Scoring engages only under contention (a lone waiting flow dispatches directly). The per-program turn counter resets on eviction to match cold KV-cache state.

Adds one config field, `turnPriorityTimeWeight` (default `0.5`), with validation.

**Which issue(s) this PR fixes**:

Fixes #2088

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Add a `turn-priority` scoring strategy to the program-aware fairness policy, configurable via `strategy: turn-priority` with a new `turnPriorityTimeWeight` field (default 0.5).
```

**Test plan** _(new tests, all passing locally)_:
- [x] Turn-priority scoring prefers higher turn number and longer wait
- [x] Single waiting flow bypasses scoring; empty queues skipped; zero-weight ties resolve
- [x] Config factory accepts `turn-priority`; rejects negative `turnPriorityTimeWeight`
