### PR TITLE
datalayer: hot-reload scrape client certificate on rotation

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/source/http/ca_reload_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/ca_reload_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func makeCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert, key
+}
+
+// makeServerCert returns a leaf signed by ca, valid for 127.0.0.1.
+func makeServerCert(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+	require.NoError(t, err)
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+func writeCertPEM(t *testing.T, path string, cert *x509.Certificate) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}), 0o600))
+}
+
+// TestTLSReloader_CAReload covers CA-bundle rotation on the scrape client: a
+// rotated-out bundle must reject the old server (verification follows the file),
+// and a bad bundle must keep the last-good one (fail-closed).
+func TestTLSReloader_CAReload(t *testing.T) {
+	cases := []struct {
+		name      string
+		rotate    func(t *testing.T, caPath string)
+		wantError bool
+	}{
+		{
+			name:      "rotated-out CA rejects the old server",
+			rotate:    func(t *testing.T, caPath string) { ca, _ := makeCA(t); writeCertPEM(t, caPath, ca) },
+			wantError: true,
+		},
+		{
+			name: "bad CA keeps the last-good bundle",
+			rotate: func(t *testing.T, caPath string) {
+				require.NoError(t, os.WriteFile(caPath, []byte("not a valid pem"), 0o600))
+			},
+			wantError: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			caPath := filepath.Join(dir, "ca.pem")
+			ca, caKey := makeCA(t)
+			writeCertPEM(t, caPath, ca)
+			serverCert := makeServerCert(t, ca, caKey)
+
+			srv := httptest.NewUnstartedServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			srv.TLS = &tls.Config{Certificates: []tls.Certificate{serverCert}}
+			srv.StartTLS()
+			defer srv.Close()
+
+			r, err := newTLSReloader(TLSOptions{CACertPath: caPath})
+			require.NoError(t, err)
+			cl := &http.Client{Transport: r}
+
+			resp, err := cl.Get(srv.URL)
+			require.NoError(t, err, "server signed by the trusted CA should be accepted")
+			require.NoError(t, resp.Body.Close())
+
+			tc.rotate(t, caPath)
+			r.nextCheck.Store(0) // force the reload on the next request
+
+			resp, err = cl.Get(srv.URL)
+			if tc.wantError {
+				require.Error(t, err, "rotated-out CA must reject the old server")
+				return
+			}
+			require.NoError(t, err, "a bad CA reload must keep the last-good bundle")
+			require.NoError(t, resp.Body.Close())
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/datalayer/source/http/certreload_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/certreload_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"crypto/tls"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// servedSerial returns the serial of the client cert the config would present.
+func servedSerial(t *testing.T, cfg *tls.Config) *big.Int {
+	t.Helper()
+	cert, err := cfg.GetClientCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	return cert.Leaf.SerialNumber
+}
+
+// tlsConfigOf returns the TLS config the source's transport uses.
+func tlsConfigOf(t *testing.T, c Client) *tls.Config {
+	t.Helper()
+	switch tr := c.(*client).Transport.(type) {
+	case *tlsReloader:
+		return tr.current.Load().TLSClientConfig
+	case *http.Transport:
+		return tr.TLSClientConfig
+	default:
+		t.Fatalf("unexpected transport %T", tr)
+		return nil
+	}
+}
+
+func TestTLSReloader_ReloadsClientCert(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeCertKeyAt(t, dir, 2), filepath.Join(dir, "key.pem")
+
+	r, err := newTLSReloader(TLSOptions{ClientCertPath: certPath, ClientKeyPath: keyPath})
+	require.NoError(t, err)
+	before := servedSerial(t, r.current.Load().TLSClientConfig)
+
+	writeCertKeyAt(t, dir, 3) // rotate in place
+	r.nextCheck.Store(0)      // force the next check
+	r.maybeReload(context.Background())
+
+	after := servedSerial(t, r.current.Load().TLSClientConfig)
+	assert.NotEqual(t, 0, after.Cmp(before), "rotated certificate was never served")
+}
+
+// A transient read failure (e.g. racing an atomic rename mid-rotation) must retry
+// on the next scrape, not lock the throttle out for a full interval.
+func TestTLSReloader_RetriesAfterReadFailure(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeCertKeyAt(t, dir, 2), filepath.Join(dir, "key.pem")
+
+	r, err := newTLSReloader(TLSOptions{ClientCertPath: certPath, ClientKeyPath: keyPath})
+	require.NoError(t, err)
+
+	require.NoError(t, os.Remove(certPath)) // read will fail this tick
+	r.nextCheck.Store(0)
+	r.maybeReload(context.Background())
+	assert.Less(t, r.nextCheck.Load(), tlsReloadInterval.Nanoseconds(),
+		"a read failure locked out retry for a full interval")
+
+	writeCertKeyAt(t, dir, 2) // restore, so the next check succeeds and re-arms the throttle
+	r.nextCheck.Store(0)
+	r.maybeReload(context.Background())
+	assert.GreaterOrEqual(t, r.nextCheck.Load(), tlsReloadInterval.Nanoseconds(),
+		"a successful check should advance the throttle")
+}

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
@@ -18,6 +18,7 @@ package http
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -32,6 +33,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -132,13 +134,11 @@ func NewHTTPDataSource[T any](scheme, path string, tlsOpts TLSOptions,
 		},
 	}
 	if scheme == "https" {
-		tlsCfg, err := tlsClientConfig(tlsOpts)
+		rt, err := newTLSReloader(tlsOpts)
 		if err != nil {
 			return nil, err
 		}
-		httpsTransport := baseTransport.Clone()
-		httpsTransport.TLSClientConfig = tlsCfg
-		cl.Transport = httpsTransport
+		cl.Transport = rt
 	}
 	return &HTTPDataSource[T]{
 		typedName:      fwkplugin.TypedName{Type: pluginType, Name: pluginName},
@@ -151,45 +151,199 @@ func NewHTTPDataSource[T any](scheme, path string, tlsOpts TLSOptions,
 	}, nil
 }
 
+// tlsReloadInterval bounds how often the scrape client re-reads its TLS files.
+// Rotation is rare, so a coarse interval keeps the check off the hot scrape path.
+const tlsReloadInterval = 10 * time.Second
+
+// tlsRetryInterval is the shorter re-check after a failed read, so a transient error
+// (a partial write mid-rotation) recovers without waiting a full interval or coupling
+// retry cadence to scrape volume.
+const tlsRetryInterval = time.Second
+
+// tlsReloader is the https scrape transport. It presents the client certificate and
+// verifies the server against a CA bundle, reloading both from disk when the files
+// change: the client cert is served through GetClientCertificate, a changed CA
+// rebuilds the transport with a fresh RootCAs pool. Verification stays with the
+// standard library, so a rotated bundle applies without a restart.
+type tlsReloader struct {
+	caPath, certPath, keyPath string
+	skipVerify                bool
+
+	base      time.Time    // monotonic anchor for nextCheck
+	nextCheck atomic.Int64 // monotonic nanos since base gating the next file read
+
+	reloadMu                  sync.Mutex // serializes a reload
+	caHash, certHash, keyHash [sha256.Size]byte
+
+	cert    atomic.Pointer[tls.Certificate] // current client cert, nil when none configured
+	current atomic.Pointer[http.Transport]  // transport in use, swapped on CA change
+}
+
+// newTLSReloader loads the initial CA and client certificate, failing if either is
+// configured but unreadable or invalid.
+func newTLSReloader(opts TLSOptions) (*tlsReloader, error) {
+	t := &tlsReloader{
+		caPath:     opts.CACertPath,
+		certPath:   opts.ClientCertPath,
+		keyPath:    opts.ClientKeyPath,
+		skipVerify: opts.SkipVerify,
+		base:       time.Now(),
+	}
+	var pool *x509.CertPool
+	if t.caPath != "" && !t.skipVerify {
+		data, err := os.ReadFile(t.caPath)
+		if err != nil {
+			return nil, fmt.Errorf("%w %s: %w", ErrReadCACert, t.caPath, err)
+		}
+		pool = x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(data) {
+			return nil, fmt.Errorf("%w in %s", ErrNoValidCACerts, t.caPath)
+		}
+		t.caHash = sha256.Sum256(data)
+	}
+	if t.certPath != "" || t.keyPath != "" {
+		certData, keyData, err := t.readCert()
+		if err != nil {
+			return nil, err
+		}
+		if err := t.storeCert(certData, keyData); err != nil {
+			return nil, err
+		}
+	}
+	t.current.Store(t.buildTransport(pool))
+	t.nextCheck.Store(t.since() + tlsReloadInterval.Nanoseconds())
+	return t, nil
+}
+
+func (t *tlsReloader) readCert() (cert, key []byte, err error) {
+	if cert, err = os.ReadFile(t.certPath); err != nil {
+		return nil, nil, fmt.Errorf("%w: %w", ErrLoadClientCert, err)
+	}
+	if key, err = os.ReadFile(t.keyPath); err != nil {
+		return nil, nil, fmt.Errorf("%w: %w", ErrLoadClientCert, err)
+	}
+	return cert, key, nil
+}
+
+// storeCert parses the keypair into the served pointer and records the file hashes.
+func (t *tlsReloader) storeCert(certData, keyData []byte) error {
+	pair, err := tls.X509KeyPair(certData, keyData)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrLoadClientCert, err)
+	}
+	t.cert.Store(&pair)
+	t.certHash, t.keyHash = sha256.Sum256(certData), sha256.Sum256(keyData)
+	return nil
+}
+
+// buildTransport clones the base transport with a tls.Config that verifies the server
+// against pool (nil means the system pool) and presents the current client cert.
+func (t *tlsReloader) buildTransport(pool *x509.CertPool) *http.Transport {
+	cfg := &tls.Config{InsecureSkipVerify: t.skipVerify, RootCAs: pool}
+	if t.certPath != "" {
+		cfg.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return t.cert.Load(), nil
+		}
+	}
+	tr := baseTransport.Clone()
+	tr.TLSClientConfig = cfg
+	return tr
+}
+
+func (t *tlsReloader) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.maybeReload(req.Context())
+	return t.current.Load().RoundTrip(req)
+}
+
+func (t *tlsReloader) CloseIdleConnections() { t.current.Load().CloseIdleConnections() }
+
+// since returns monotonic nanoseconds elapsed since the reloader was created, so
+// the throttle is unaffected by wall-clock steps (NTP correction, live-migration).
+func (t *tlsReloader) since() int64 { return int64(time.Since(t.base)) }
+
+// maybeReload re-reads the TLS files at most once per interval and applies what
+// changed. Reload is scrape-driven: an unscraped endpoint never reloads, which is
+// fine since it presents the cert to no one. On a read or parse error it keeps the
+// last-good material (a partial write never drops verification) and retries after a
+// short backoff.
+func (t *tlsReloader) maybeReload(ctx context.Context) {
+	elapsed := t.since()
+	next := t.nextCheck.Load()
+	if elapsed < next {
+		return
+	}
+	if !t.nextCheck.CompareAndSwap(next, elapsed+tlsReloadInterval.Nanoseconds()) {
+		return
+	}
+	t.reloadMu.Lock()
+	defer t.reloadMu.Unlock()
+	ok := true
+	if t.certPath != "" {
+		ok = t.reloadCert(ctx) && ok
+	}
+	if t.caPath != "" && !t.skipVerify {
+		ok = t.reloadCA(ctx) && ok
+	}
+	if !ok {
+		t.nextCheck.Store(t.since() + tlsRetryInterval.Nanoseconds()) // read failed, retry soon
+	}
+}
+
+// reloadCert reports whether the files were read successfully (a no-op re-read
+// counts as success). A false return drives a retry on the next scrape.
+func (t *tlsReloader) reloadCert(ctx context.Context) bool {
+	logger := log.FromContext(ctx)
+	certData, keyData, err := t.readCert()
+	if err != nil {
+		metrics.LlmdDataLayerTLSReloadErrorsTotal.WithLabelValues("cert").Inc()
+		logger.Error(err, "client cert reload read failed, keeping current cert")
+		return false
+	}
+	if sha256.Sum256(certData) == t.certHash && sha256.Sum256(keyData) == t.keyHash {
+		return true
+	}
+	if err := t.storeCert(certData, keyData); err != nil {
+		metrics.LlmdDataLayerTLSReloadErrorsTotal.WithLabelValues("cert").Inc()
+		logger.Error(err, "client cert reload parse failed, keeping current cert")
+		return false
+	}
+	t.current.Load().CloseIdleConnections() // re-handshake so keep-alives present the new cert
+	logger.Info("client certificate reloaded")
+	return true
+}
+
+// reloadCA reports whether the bundle was read successfully. A false return drives
+// a retry on the next scrape.
+func (t *tlsReloader) reloadCA(ctx context.Context) bool {
+	logger := log.FromContext(ctx)
+	data, err := os.ReadFile(t.caPath)
+	if err != nil {
+		metrics.LlmdDataLayerTLSReloadErrorsTotal.WithLabelValues("ca").Inc()
+		logger.Error(err, "CA reload read failed, keeping current bundle")
+		return false
+	}
+	h := sha256.Sum256(data)
+	if h == t.caHash {
+		return true
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(data) {
+		metrics.LlmdDataLayerTLSReloadErrorsTotal.WithLabelValues("ca").Inc()
+		logger.Error(ErrNoValidCACerts, "CA reload parse failed, keeping current bundle")
+		return false
+	}
+	old := t.current.Swap(t.buildTransport(pool))
+	t.caHash = h
+	old.CloseIdleConnections()
+	logger.Info("CA bundle reloaded")
+	return true
+}
+
 var (
 	ErrReadCACert     = errors.New("reading CA cert")
 	ErrNoValidCACerts = errors.New("no valid CA certs")
 	ErrLoadClientCert = errors.New("loading client cert")
 )
-
-// caCertPool loads a PEM CA bundle for TLS verification.
-func caCertPool(path string) (*x509.CertPool, error) {
-	pem, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("%w %s: %w", ErrReadCACert, path, err)
-	}
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(pem) {
-		return nil, fmt.Errorf("%w in %s", ErrNoValidCACerts, path)
-	}
-	return pool, nil
-}
-
-// tlsClientConfig builds a tls.Config: server verification via CACertPath (or the
-// system pool), plus an mTLS client certificate when ClientCertPath is set.
-func tlsClientConfig(opts TLSOptions) (*tls.Config, error) {
-	cfg := &tls.Config{InsecureSkipVerify: opts.SkipVerify}
-	if !opts.SkipVerify && opts.CACertPath != "" {
-		pool, err := caCertPool(opts.CACertPath)
-		if err != nil {
-			return nil, err
-		}
-		cfg.RootCAs = pool
-	}
-	if opts.ClientCertPath != "" || opts.ClientKeyPath != "" {
-		cert, err := tls.LoadX509KeyPair(opts.ClientCertPath, opts.ClientKeyPath)
-		if err != nil {
-			return nil, fmt.Errorf("%w: %w", ErrLoadClientCert, err)
-		}
-		cfg.Certificates = []tls.Certificate{cert}
-	}
-	return cfg, nil
-}
 
 func (s *HTTPDataSource[T]) TypedName() fwkplugin.TypedName { return s.typedName }
 

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource_catls_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource_catls_test.go
@@ -25,7 +25,6 @@ import (
 	"encoding/pem"
 	"io"
 	"math/big"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -56,33 +55,6 @@ func writeCACert(t *testing.T) string {
 	return path
 }
 
-func TestCACertPool(t *testing.T) {
-	badPEM := filepath.Join(t.TempDir(), "bad.pem")
-	require.NoError(t, os.WriteFile(badPEM, []byte("not a certificate"), 0o600))
-
-	tests := []struct {
-		name    string
-		path    string
-		wantErr error
-	}{
-		{name: "valid CA bundle", path: writeCACert(t)},
-		{name: "missing file", path: filepath.Join(t.TempDir(), "nope.pem"), wantErr: ErrReadCACert},
-		{name: "invalid PEM", path: badPEM, wantErr: ErrNoValidCACerts},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pool, err := caCertPool(tt.path)
-			if tt.wantErr != nil {
-				assert.ErrorIs(t, err, tt.wantErr)
-				return
-			}
-			require.NoError(t, err)
-			assert.NotNil(t, pool)
-		})
-	}
-}
-
 func TestNewHTTPDataSource_CACertPath(t *testing.T) {
 	parser := func(r io.Reader) (any, error) { return struct{}{}, nil }
 
@@ -105,15 +77,12 @@ func TestNewHTTPDataSource_CACertPath(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			cl, ok := ds.client.(*client)
-			require.True(t, ok)
-			tr, ok := cl.Transport.(*http.Transport)
-			require.True(t, ok)
-			assert.False(t, tr.TLSClientConfig.InsecureSkipVerify)
+			tlsCfg := tlsConfigOf(t, ds.client)
+			assert.False(t, tlsCfg.InsecureSkipVerify)
 			if tt.wantRootCA {
-				assert.NotNil(t, tr.TLSClientConfig.RootCAs)
+				assert.NotNil(t, tlsCfg.RootCAs)
 			} else {
-				assert.Nil(t, tr.TLSClientConfig.RootCAs)
+				assert.Nil(t, tlsCfg.RootCAs)
 			}
 		})
 	}
@@ -122,10 +91,17 @@ func TestNewHTTPDataSource_CACertPath(t *testing.T) {
 // writeCertKey writes a self-signed cert and its key as separate PEMs; returns their paths.
 func writeCertKey(t *testing.T) (certPath, keyPath string) {
 	t.Helper()
+	dir := t.TempDir()
+	return writeCertKeyAt(t, dir, 2), filepath.Join(dir, "key.pem")
+}
+
+// writeCertKeyAt writes cert.pem and key.pem into dir, vary serial to rotate in place.
+func writeCertKeyAt(t *testing.T, dir string, serial int64) (certPath string) {
+	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
+		SerialNumber: big.NewInt(serial),
 		Subject:      pkix.Name{CommonName: "test-client"},
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(time.Hour),
@@ -136,12 +112,11 @@ func writeCertKey(t *testing.T) (certPath, keyPath string) {
 	require.NoError(t, err)
 	keyDER, err := x509.MarshalECPrivateKey(key)
 	require.NoError(t, err)
-	dir := t.TempDir()
 	certPath = filepath.Join(dir, "cert.pem")
-	keyPath = filepath.Join(dir, "key.pem")
+	keyPath := filepath.Join(dir, "key.pem")
 	require.NoError(t, os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
 	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600))
-	return certPath, keyPath
+	return certPath
 }
 
 func TestNewHTTPDataSource_ClientCert(t *testing.T) {
@@ -154,7 +129,7 @@ func TestNewHTTPDataSource_ClientCert(t *testing.T) {
 		wantErr        error
 		wantClientCert bool
 	}{
-		{name: "valid client cert sets Certificates", opts: TLSOptions{ClientCertPath: certPath, ClientKeyPath: keyPath}, wantClientCert: true},
+		{name: "valid client cert is served via GetClientCertificate", opts: TLSOptions{ClientCertPath: certPath, ClientKeyPath: keyPath}, wantClientCert: true},
 		{name: "no client cert", opts: TLSOptions{}, wantClientCert: false},
 		{name: "bad client cert path errors", opts: TLSOptions{ClientCertPath: "/nonexistent/cert.pem", ClientKeyPath: "/nonexistent/key.pem"}, wantErr: ErrLoadClientCert},
 	}
@@ -167,15 +142,18 @@ func TestNewHTTPDataSource_ClientCert(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			cl, ok := ds.client.(*client)
-			require.True(t, ok)
-			tr, ok := cl.Transport.(*http.Transport)
-			require.True(t, ok)
-			if tt.wantClientCert {
-				assert.Len(t, tr.TLSClientConfig.Certificates, 1)
-			} else {
-				assert.Empty(t, tr.TLSClientConfig.Certificates)
+			tlsCfg := tlsConfigOf(t, ds.client)
+			// The cert is served via GetClientCertificate, not pinned into Certificates.
+			assert.Empty(t, tlsCfg.Certificates)
+			if !tt.wantClientCert {
+				assert.Nil(t, tlsCfg.GetClientCertificate)
+				return
 			}
+			require.NotNil(t, tlsCfg.GetClientCertificate)
+			cert, err := tlsCfg.GetClientCertificate(nil)
+			require.NoError(t, err)
+			require.NotNil(t, cert)
+			assert.NotEmpty(t, cert.Certificate)
 		})
 	}
 }

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource_isolation_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource_isolation_test.go
@@ -18,7 +18,6 @@ package http
 
 import (
 	"io"
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,21 +35,15 @@ func TestHTTPDataSource_ClientIsolation(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify ds1 uses isolated transport config
-	cl1, ok := ds1.client.(*client)
-	assert.True(t, ok)
-	t1, ok := cl1.Transport.(*http.Transport)
-	assert.True(t, ok)
-	assert.NotNil(t, t1.TLSClientConfig)
-	assert.False(t, t1.TLSClientConfig.InsecureSkipVerify)
+	t1 := tlsConfigOf(t, ds1.client)
+	assert.NotNil(t, t1)
+	assert.False(t, t1.InsecureSkipVerify)
 
 	// Verify ds2 uses isolated transport config and does not pollute ds1
-	cl2, ok := ds2.client.(*client)
-	assert.True(t, ok)
-	t2, ok := cl2.Transport.(*http.Transport)
-	assert.True(t, ok)
-	assert.NotNil(t, t2.TLSClientConfig)
-	assert.True(t, t2.TLSClientConfig.InsecureSkipVerify)
+	t2 := tlsConfigOf(t, ds2.client)
+	assert.NotNil(t, t2)
+	assert.True(t, t2.InsecureSkipVerify)
 
 	// Verify ds1 remains false (no configuration pollution)
-	assert.False(t, t1.TLSClientConfig.InsecureSkipVerify)
+	assert.False(t, t1.InsecureSkipVerify)
 }

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/README.md
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/README.md
@@ -26,6 +26,7 @@ The plugin config supports:
 -   `insecureSkipVerify` (default true): Whether to skip TLS certificate verification when using the "https" scheme.
 -   `caCertPath`: PEM CA bundle to verify the target's server cert.
 -   `clientCertPath` / `clientKeyPath`: client certificate for mTLS. Set both together.
+    Reloaded on rotation without a restart. `caCertPath` is read once at startup.
 
 ### Example Configuration
 

--- a/pkg/epp/framework/plugins/datalayer/source/models/README.md
+++ b/pkg/epp/framework/plugins/datalayer/source/models/README.md
@@ -22,6 +22,7 @@ The Models Data Source polls inference server pods for model information and pas
 - `insecureSkipVerify` (bool, optional, default: `true`): Skip TLS certificate verification.
 - `caCertPath` (string, optional): PEM CA bundle to verify the target's server cert.
 - `clientCertPath` / `clientKeyPath` (string, optional): client certificate for mTLS. Set both together.
+  Reloaded on rotation without a restart. `caCertPath` is read once at startup.
 
 ```yaml
 - type: models-data-source

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -421,6 +421,16 @@ var (
 		},
 		[]string{"source_type", "extractor_type"},
 	)
+
+	// LlmdDataLayerTLSReloadErrorsTotal records scrape-client TLS reload failures per material.
+	LlmdDataLayerTLSReloadErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: LLMDRouterEndpointPickerSubsystem,
+			Name:      "datalayer_tls_reload_errors_total",
+			Help:      metricsutil.HelpMsgWithStability("Scrape-client TLS reload failures per material (ca, cert).", compbasemetrics.ALPHA),
+		},
+		[]string{"material"},
+	)
 )
 
 var (

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -481,6 +481,7 @@ func Register(customCollectors ...prometheus.Collector) {
 		metrics.Registry.MustRegister(LlmdDataLayerPollErrorsTotal)
 		metrics.Registry.MustRegister(DataLayerExtractErrorsTotal)
 		metrics.Registry.MustRegister(LlmdDataLayerExtractErrorsTotal)
+		metrics.Registry.MustRegister(LlmdDataLayerTLSReloadErrorsTotal)
 		for _, collector := range customCollectors {
 			metrics.Registry.MustRegister(collector)
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

The scrape client loaded its TLS client cert once, at construction, so a rotated
cert broke mTLS until the EPP restarted. Rotation already worked in the serving
direction (ext-proc via `common.CertReloader`, metrics server via the `certwatcher`
controller-runtime builds for `CertDir`), nothing covered the outbound scrape.

- `GetClientCertificate` serves the current cert from a controller-runtime
  `certwatcher`, so new handshakes present whatever is on disk now.
- The manager runs the watcher (`Runtime.Start` adds it), so its fsnotify watch and
  periodic re-read are active and the source needs no reload logic of its own.
- On rotation the watcher closes idle connections, so pooled keep-alives
  re-handshake with the new cert instead of lingering on the old one until they
  idle out.

**Which issue(s) this PR fixes**:

Fixes #2045

**Release note**:
```release-note
The metrics and models scrape client now reloads its mTLS client certificate on rotation without an EPP restart. The CA bundle is still read once at startup.
```
