### PR TITLE
feat(scheduling): add endpoint attribute weight scorer

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -68,6 +68,7 @@ import (
 	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
 	discoveryfile "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/discovery/file"
 	extdcgm "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/dcgm"
+	labelproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/label"
 	extractormetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	extmodels "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/models"
 	exttopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/topology"
@@ -120,6 +121,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/headerprofile"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/single"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/activerequest"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/attributeweight"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization"
@@ -562,8 +564,10 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(loadaware.LoadAwareType, loadaware.Factory)
 	fwkplugin.Register(sessionaffinity.SessionAffinityType, sessionaffinity.Factory)
 	fwkplugin.Register(contextlengthaware.ContextLengthAwareType, contextlengthaware.Factory)
+	fwkplugin.Register(attributeweight.EndpointAttributeWeightScorerType, attributeweight.Factory)
 
 	// data layer models source/extractor
+	fwkplugin.Register(labelproducer.LabelProducerType, labelproducer.Factory)
 	fwkplugin.Register(srcmodels.ModelsDataSourceType, srcmodels.ModelDataSourceFactory)
 	fwkplugin.Register(attrmodels.ModelsExtractorType, extmodels.ModelServerExtractorFactory)
 	fwkplugin.Register(attrtopology.TopologyExtractorType, exttopology.Factory)

--- a/pkg/epp/framework/plugins/datalayer/attribute/string/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/string/data_types.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package stringattribute declares string-valued endpoint attributes.
+package stringattribute
+
+import fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+
+// Value is a string-valued endpoint attribute.
+type Value string
+
+// Clone returns the value unchanged.
+func (v Value) Clone() fwkdl.Cloneable {
+	return v
+}
+
+// ReadValue retrieves a string value from an endpoint attribute map.
+func ReadValue(attrs fwkdl.AttributeMap, key string) (Value, bool) {
+	return fwkdl.ReadAttribute[Value](attrs, key)
+}

--- a/pkg/epp/framework/plugins/datalayer/extractor/label/producer.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/label/producer.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package label provides an endpoint extractor that copies a Pod label into
+// an endpoint attribute.
+package label
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+	attrstring "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/string"
+	sourcenotifications "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
+)
+
+const (
+	// LabelProducerType identifies the label producer plugin.
+	LabelProducerType = "label-producer"
+
+	valueTypeString = "string"
+	valueTypeNumber = "number"
+)
+
+var (
+	_ fwkplugin.Plugin        = (*Producer)(nil)
+	_ fwkdl.Registrant        = (*Producer)(nil)
+	_ fwkdl.EndpointExtractor = (*Producer)(nil)
+)
+
+type parameters struct {
+	// Label is the Pod label to copy.
+	Label string `json:"label"`
+	// AttributeKey is the endpoint attribute key to populate.
+	AttributeKey string `json:"attributeKey"`
+	// ValueType controls whether the value is stored as a string or number.
+	ValueType string `json:"valueType"`
+}
+
+// Factory creates a label producer.
+func Factory(name string, decoder *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	var params parameters
+	if decoder != nil {
+		if err := decoder.Decode(&params); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' plugin: %w", LabelProducerType, err)
+		}
+	}
+	return NewProducer(name, params)
+}
+
+// NewProducer validates parameters and creates a label producer.
+func NewProducer(name string, params parameters) (*Producer, error) {
+	if name == "" {
+		name = LabelProducerType
+	}
+	if params.Label == "" {
+		return nil, fmt.Errorf("'%s' requires a non-empty 'label'", LabelProducerType)
+	}
+	if params.AttributeKey == "" {
+		return nil, fmt.Errorf("'%s' requires a non-empty 'attributeKey'", LabelProducerType)
+	}
+	if params.ValueType == "" {
+		params.ValueType = valueTypeString
+	}
+	if params.ValueType != valueTypeString && params.ValueType != valueTypeNumber {
+		return nil, fmt.Errorf("'%s' valueType must be %q or %q, got %q", LabelProducerType, valueTypeString, valueTypeNumber, params.ValueType)
+	}
+
+	return &Producer{
+		typedName:    fwkplugin.TypedName{Type: LabelProducerType, Name: name},
+		label:        params.Label,
+		attributeKey: params.AttributeKey,
+		valueType:    params.ValueType,
+	}, nil
+}
+
+// Producer copies a Pod label into an endpoint attribute.
+type Producer struct {
+	typedName    fwkplugin.TypedName
+	label        string
+	attributeKey string
+	valueType    string
+}
+
+// TypedName returns the type and name of the producer.
+func (p *Producer) TypedName() fwkplugin.TypedName {
+	return p.typedName
+}
+
+// RegisterDependencies wires the producer to endpoint lifecycle events.
+func (p *Producer) RegisterDependencies(r fwkdl.Registrar) error {
+	return r.Register(fwkdl.PendingRegistration{
+		Owner:      p.typedName,
+		SourceType: sourcenotifications.EndpointNotificationSourceType,
+		Extractor:  p,
+		DefaultSource: sourcenotifications.NewEndpointDataSource(
+			sourcenotifications.EndpointNotificationSourceType,
+			sourcenotifications.EndpointNotificationSourceType,
+		),
+	})
+}
+
+// Extract copies the configured label into the endpoint attribute.
+func (p *Producer) Extract(_ context.Context, event fwkdl.EndpointEvent) error {
+	if event.Type == fwkdl.EventDelete || event.Endpoint == nil {
+		return nil
+	}
+
+	meta := event.Endpoint.GetMetadata()
+	if meta == nil {
+		return nil
+	}
+	value := meta.Labels[p.label]
+
+	if p.valueType == valueTypeString {
+		event.Endpoint.GetAttributes().Put(p.attributeKey, attrstring.Value(value))
+		return nil
+	}
+
+	if value == "" {
+		event.Endpoint.GetAttributes().Put(p.attributeKey, attrmetrics.ScalarMetricValue(0))
+		return nil
+	}
+	number, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		event.Endpoint.GetAttributes().Put(p.attributeKey, attrmetrics.ScalarMetricValue(0))
+		return fmt.Errorf("label %q on endpoint %s has non-numeric value %q: %w", p.label, meta.NamespacedName, value, err)
+	}
+	event.Endpoint.GetAttributes().Put(p.attributeKey, attrmetrics.ScalarMetricValue(number))
+	return nil
+}

--- a/pkg/epp/framework/plugins/datalayer/extractor/label/producer_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/label/producer_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package label
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+	attrstring "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/string"
+)
+
+const testLabel = "nvidia.com/gpu.product"
+
+type captureRegistrar struct {
+	registration fwkdl.PendingRegistration
+}
+
+func (r *captureRegistrar) Register(reg fwkdl.PendingRegistration) error {
+	r.registration = reg
+	return nil
+}
+
+func newEndpoint(labels map[string]string) fwkdl.Endpoint {
+	return fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{Labels: labels}, nil)
+}
+
+func TestFactory(t *testing.T) {
+	producer, err := Factory("gpu-product", fwkplugin.StrictDecoder(json.RawMessage(`{
+		"label": "nvidia.com/gpu.product",
+		"attributeKey": "gpu.product",
+		"valueType": "string"
+	}`)), nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, LabelProducerType, producer.TypedName().Type)
+	assert.Equal(t, "gpu-product", producer.TypedName().Name)
+}
+
+func TestFactory_Validation(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters string
+		wantErr    string
+	}{
+		{name: "missing label", parameters: `{"attributeKey":"gpu.product"}`, wantErr: "label"},
+		{name: "missing attribute key", parameters: `{"label":"gpu"}`, wantErr: "attributeKey"},
+		{name: "invalid value type", parameters: `{"label":"gpu","attributeKey":"gpu.product","valueType":"bool"}`, wantErr: "valueType"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			producer, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(test.parameters)), nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantErr)
+			assert.Nil(t, producer)
+		})
+	}
+}
+
+func TestExtract_StringValue(t *testing.T) {
+	producer, err := NewProducer("gpu-product", parameters{
+		Label:        testLabel,
+		AttributeKey: "gpu.product",
+		ValueType:    valueTypeString,
+	})
+	require.NoError(t, err)
+
+	endpoint := newEndpoint(map[string]string{testLabel: "H100"})
+	require.NoError(t, producer.Extract(context.Background(), fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: endpoint,
+	}))
+
+	value, ok := attrstring.ReadValue(endpoint.GetAttributes(), "gpu.product")
+	require.True(t, ok)
+	assert.Equal(t, attrstring.Value("H100"), value)
+}
+
+func TestExtract_NumberValue(t *testing.T) {
+	producer, err := NewProducer("gpu-score", parameters{
+		Label:        "gpu.score",
+		AttributeKey: "gpu.score",
+		ValueType:    valueTypeNumber,
+	})
+	require.NoError(t, err)
+
+	endpoint := newEndpoint(map[string]string{"gpu.score": "2.5"})
+	require.NoError(t, producer.Extract(context.Background(), fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: endpoint,
+	}))
+
+	value, ok := attrmetrics.ReadScalarMetricValue(endpoint.GetAttributes(), "gpu.score")
+	require.True(t, ok)
+	assert.Equal(t, attrmetrics.ScalarMetricValue(2.5), value)
+}
+
+func TestExtract_MissingLabelWritesFallbackValue(t *testing.T) {
+	producer, err := NewProducer("gpu-product", parameters{
+		Label:        testLabel,
+		AttributeKey: "gpu.product",
+		ValueType:    valueTypeString,
+	})
+	require.NoError(t, err)
+
+	endpoint := newEndpoint(nil)
+	require.NoError(t, producer.Extract(context.Background(), fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: endpoint,
+	}))
+
+	value, ok := attrstring.ReadValue(endpoint.GetAttributes(), "gpu.product")
+	require.True(t, ok)
+	assert.Empty(t, value)
+}
+
+func TestRegisterDependencies(t *testing.T) {
+	producer, err := NewProducer("gpu-product", parameters{
+		Label:        testLabel,
+		AttributeKey: "gpu.product",
+	})
+	require.NoError(t, err)
+
+	var registrar captureRegistrar
+	require.NoError(t, producer.RegisterDependencies(&registrar))
+	assert.Equal(t, "endpoint-notification-source", registrar.registration.SourceType)
+	assert.Same(t, producer, registrar.registration.Extractor)
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/attributeweight/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/attributeweight/README.md
@@ -1,0 +1,87 @@
+# Endpoint Attribute Weight Scorer
+
+**Type:** `endpoint-attribute-weight-scorer`
+
+Scores candidate endpoints by mapping a configured string endpoint attribute to a static, configurable weight. The attribute can be populated from a Pod label by `label-producer` or by another data-layer producer.
+
+**Use Cases:**
+- Prefer faster GPU types (e.g. H100 over A100 over L40S) in a heterogeneous InferencePool.
+- Prefer endpoints in a given zone or rack.
+- Any other case where a discrete endpoint attribute should map to a routing preference.
+
+## Important: picker choice determines traffic concentration
+
+This scorer only expresses a static preference; it has no notion of current load. If a scheduling profile has no picker configured, the EPP auto-injects `max-score-picker` (see `ensureSchedulingLayer` in the config loader). With its default `maxNumOfEndpoints: 1`, the picker selects an endpoint with the highest aggregate score. When this is the only scorer, ties are randomized but lower-scoring attribute groups are not selected.
+
+If the profile explicitly configures another picker, the EPP does not inject `max-score-picker`, even when this is the only scorer. For traffic distribution, compose this scorer with a load-aware scorer such as `running-requests-size-scorer` or `queue-scorer`, and use a picker such as `weighted-random-picker`. See the configuration example below.
+
+## What it does
+
+Weights are normalized at configuration time: the highest configured weight scores `1.0`, and the rest scale proportionally (`weight / maxConfiguredWeight`). No configured value ever scores `0`.
+
+Endpoints missing the configured attribute, or carrying a value with no configured weight, fall back to the **lowest configured, normalized weight** — the same score as your worst configured tier. This keeps endpoints eligible during incremental attribute rollout without giving missing values an advantage over a known weaker tier.
+
+## Scheduling intent
+
+The scorer returns category `Affinity`, indicating a stable preference for endpoints with higher-weighted attribute values. The category is descriptive; the scheduler still combines each scorer's result using its profile weight. Use a load-aware scorer and an appropriate picker when the goal is to avoid concentrating traffic on one endpoint group.
+
+## Relationship to other plugins
+
+- **`label-producer`**: copies a Pod label into a string or numeric endpoint attribute. Use it when the source is a Pod label and the consumer should remain independent of Kubernetes metadata.
+- **`label-selector-filter`**: a hard filter (include/exclude by label value). Use it when an endpoint must never receive certain traffic. The legacy `by-label` and `by-label-selector` types are deprecated. This scorer never excludes — it only ranks.
+- **`accelerator-capability-aware`** (tracks [#1868](https://github.com/llm-d/llm-d-router/issues/1868)): matches a *numeric* request-size range encoded in a label value (e.g. `"0-2048"`) against the request's token count. This scorer maps a *discrete* label value (e.g. a GPU model string) to a fixed weight — there is no range matching and no dependency on request size.
+- **`endpoint-attribute-scorer`**: scores a custom numeric endpoint attribute via linear normalization. Use it when the attribute is produced by `core-metrics-extractor` through `customMetrics`; it does not read standard fields such as `RunningRequestsSize` or `WaitingQueueSize`. Use `running-requests-size-scorer` or `queue-scorer` for those standard metrics.
+
+## Configuration
+
+| Parameter | Required | Description                                                           |
+|-----------|----------|-----------------------------------------------------------------------|
+| `attributeKey` | yes      | String endpoint attribute to read, e.g. `gpu.product`.                 |
+| `weights`     | yes      | Map of attribute value to positive weight, e.g. `{"H100": 4, "A100": 2}`. |
+
+**Configuration Example (static label preference composed with standard load scoring):**
+```yaml
+plugins:
+- type: label-producer
+  name: gpu-product
+  parameters:
+    label: nvidia.com/gpu.product
+    attributeKey: gpu.product
+    valueType: string
+- type: endpoint-attribute-weight-scorer
+  name: accelerator-weight
+  parameters:
+    attributeKey: gpu.product
+    weights:
+      NVIDIA-H100: 4
+      NVIDIA-A100: 2
+      NVIDIA-L40S: 1
+- type: running-requests-size-scorer
+  name: running-requests
+- type: weighted-random-picker
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: accelerator-weight
+        weight: 3
+      - pluginRef: running-requests
+        weight: 5
+      - pluginRef: weighted-random-picker
+```
+
+**Example Pod Labels:**
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vllm-h100
+  labels:
+    nvidia.com/gpu.product: NVIDIA-H100
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vllm-l40s
+  labels:
+    nvidia.com/gpu.product: NVIDIA-L40S
+```

--- a/pkg/epp/framework/plugins/scheduling/scorer/attributeweight/attributeweight.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/attributeweight/attributeweight.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package attributeweight
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrstring "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/string"
+)
+
+// EndpointAttributeWeightScorerType is the type of the endpoint attribute weight scorer plugin.
+const EndpointAttributeWeightScorerType = "endpoint-attribute-weight-scorer"
+
+var _ fwksched.Scorer = &EndpointAttributeWeightScorer{}
+
+// parameters configures the endpoint attribute weight scorer.
+type parameters struct {
+	// AttributeKey identifies the string endpoint attribute whose value selects a score.
+	AttributeKey string `json:"attributeKey"`
+	// Weights maps attribute values to positive weights.
+	Weights map[string]float64 `json:"weights"`
+}
+
+func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	var params parameters
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&params); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' plugin: %w", EndpointAttributeWeightScorerType, err)
+		}
+	}
+	return NewEndpointAttributeWeightScorer(name, params)
+}
+
+func NewEndpointAttributeWeightScorer(name string, params parameters) (*EndpointAttributeWeightScorer, error) {
+	if name == "" {
+		name = EndpointAttributeWeightScorerType
+	}
+	if params.AttributeKey == "" {
+		return nil, fmt.Errorf("'%s' requires a non-empty 'attributeKey'", EndpointAttributeWeightScorerType)
+	}
+	if len(params.Weights) == 0 {
+		return nil, fmt.Errorf("'%s' requires a non-empty 'weights' map", EndpointAttributeWeightScorerType)
+	}
+
+	maxWeight := 0.0
+	for value, weight := range params.Weights {
+		if weight <= 0 {
+			return nil, fmt.Errorf("'%s' weight for value %q must be positive, got %v", EndpointAttributeWeightScorerType, value, weight)
+		}
+		if weight > maxWeight {
+			maxWeight = weight
+		}
+	}
+
+	scores := make(map[string]float64, len(params.Weights))
+	fallbackScore := 1.0
+	for value, weight := range params.Weights {
+		normalized := weight / maxWeight
+		scores[value] = normalized
+		if normalized < fallbackScore {
+			fallbackScore = normalized
+		}
+	}
+
+	return &EndpointAttributeWeightScorer{
+		typedName:     fwkplugin.TypedName{Type: EndpointAttributeWeightScorerType, Name: name},
+		attributeKey:  params.AttributeKey,
+		scores:        scores,
+		fallbackScore: fallbackScore,
+	}, nil
+}
+
+// EndpointAttributeWeightScorer maps string endpoint attribute values to normalized scores.
+type EndpointAttributeWeightScorer struct {
+	// typedName identifies this plugin instance.
+	typedName fwkplugin.TypedName
+	// attributeKey is the endpoint attribute to score.
+	attributeKey string
+	// scores contains normalized scores for configured attribute values.
+	scores map[string]float64
+	// fallbackScore is used for missing or unknown attribute values.
+	fallbackScore float64
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (s *EndpointAttributeWeightScorer) TypedName() fwkplugin.TypedName {
+	return s.typedName
+}
+
+// Category returns the scorer category.
+func (s *EndpointAttributeWeightScorer) Category() fwksched.ScorerCategory {
+	return fwksched.Affinity
+}
+
+// Score returns scores for the configured attribute values.
+func (s *EndpointAttributeWeightScorer) Score(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
+	for _, endpoint := range endpoints {
+		score := s.fallbackScore
+		if value, ok := attrstring.ReadValue(endpoint, s.attributeKey); ok {
+			if configuredScore, ok := s.scores[string(value)]; ok {
+				score = configuredScore
+			}
+		}
+		scores[endpoint] = score
+	}
+	return scores
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/attributeweight/attributeweight_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/attributeweight/attributeweight_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package attributeweight
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrstring "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/string"
+)
+
+const testAttributeKey = "gpu.product"
+
+func createEndpoint(name, value string) scheduling.Endpoint {
+	attrs := fwkdl.NewAttributes()
+	if value != "" {
+		attrs.Put(testAttributeKey, attrstring.Value(value))
+	}
+	return scheduling.NewEndpoint(
+		&fwkdl.EndpointMetadata{
+			NamespacedName: k8stypes.NamespacedName{Name: name},
+		},
+		nil,
+		attrs,
+	)
+}
+
+func TestFactory(t *testing.T) {
+	tests := []struct {
+		name       string
+		pluginName string
+		jsonParams string
+		wantErr    string
+	}{
+		{
+			name:       "valid configuration",
+			pluginName: "gpu-weight",
+			jsonParams: `{"attributeKey": "gpu.product", "weights": {"H100": 4, "A100": 2}}`,
+		},
+		{
+			name:       "missing attribute key",
+			pluginName: "gpu-weight",
+			jsonParams: `{"weights": {"H100": 4}}`,
+			wantErr:    "attributeKey",
+		},
+		{
+			name:       "empty weights",
+			pluginName: "gpu-weight",
+			jsonParams: `{"attributeKey": "gpu.product", "weights": {}}`,
+			wantErr:    "weights",
+		},
+		{
+			name:       "zero weight",
+			pluginName: "gpu-weight",
+			jsonParams: `{"attributeKey": "gpu.product", "weights": {"L40S": 0}}`,
+			wantErr:    "positive",
+		},
+		{
+			name:       "negative weight",
+			pluginName: "gpu-weight",
+			jsonParams: `{"attributeKey": "gpu.product", "weights": {"L40S": -1}}`,
+			wantErr:    "positive",
+		},
+		{
+			name:       "malformed JSON",
+			pluginName: "gpu-weight",
+			jsonParams: `{"attributeKey": "test"`,
+			wantErr:    "failed to parse",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin, err := Factory(tt.pluginName, fwkplugin.StrictDecoder(json.RawMessage(tt.jsonParams)), nil)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, plugin)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, plugin)
+			}
+		})
+	}
+}
+
+func TestFactory_DefaultsNameToType(t *testing.T) {
+	plugin, err := Factory("", fwkplugin.StrictDecoder(json.RawMessage(`{"attributeKey": "l", "weights": {"a": 1}}`)), nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, EndpointAttributeWeightScorerType, plugin.TypedName().Name)
+}
+
+func TestScore(t *testing.T) {
+	scorer, err := NewEndpointAttributeWeightScorer("gpu-weight", parameters{
+		AttributeKey: testAttributeKey,
+		Weights: map[string]float64{
+			"H100": 4,
+			"A100": 2,
+			"L40S": 1,
+		},
+	})
+	require.NoError(t, err)
+
+	endpoints := []scheduling.Endpoint{
+		createEndpoint("h100-pod", "H100"),
+		createEndpoint("a100-pod", "A100"),
+		createEndpoint("l40s-pod", "L40S"),
+		createEndpoint("unknown-value-pod", "V100"),
+		createEndpoint("no-attribute-pod", ""),
+	}
+
+	scores := scorer.Score(context.Background(), &scheduling.InferenceRequest{}, endpoints)
+
+	assert.Equal(t, 1.0, scores[endpoints[0]], "highest configured weight normalizes to 1.0")
+	assert.Equal(t, 0.5, scores[endpoints[1]], "half the max weight normalizes to 0.5")
+	assert.Equal(t, 0.25, scores[endpoints[2]], "quarter the max weight normalizes to 0.25")
+	assert.Equal(t, 0.25, scores[endpoints[3]], "unrecognized attribute value falls back to the lowest configured weight")
+	assert.Equal(t, 0.25, scores[endpoints[4]], "missing attribute falls back to the lowest configured weight")
+
+	assert.LessOrEqual(t, scores[endpoints[3]], scores[endpoints[2]],
+		"an unrecognized value must never outscore the configured lowest tier")
+	assert.LessOrEqual(t, scores[endpoints[4]], scores[endpoints[2]],
+		"a missing attribute must never outscore the configured lowest tier")
+	assert.Greater(t, scores[endpoints[2]], 0.0, "the lowest configured weight never scores 0")
+}
+
+func TestScore_SingleConfiguredValueNormalizesToOne(t *testing.T) {
+	scorer, err := NewEndpointAttributeWeightScorer("gpu-weight", parameters{
+		AttributeKey: testAttributeKey,
+		Weights:      map[string]float64{"H100": 4},
+	})
+	require.NoError(t, err)
+
+	endpoints := []scheduling.Endpoint{
+		createEndpoint("h100-pod", "H100"),
+		createEndpoint("no-attribute-pod", ""),
+	}
+
+	scores := scorer.Score(context.Background(), &scheduling.InferenceRequest{}, endpoints)
+
+	assert.Equal(t, 1.0, scores[endpoints[0]])
+	assert.Equal(t, 1.0, scores[endpoints[1]], "with a single configured value, the fallback equals it too")
+}
+
+func TestCategory(t *testing.T) {
+	scorer, err := NewEndpointAttributeWeightScorer("gpu-weight", parameters{
+		AttributeKey: testAttributeKey,
+		Weights:      map[string]float64{"H100": 4},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, scheduling.Affinity, scorer.Category())
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/attributeweight/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/attributeweight/doc.go
@@ -1,0 +1,3 @@
+// Package attributeweight provides a scorer that maps a configured string endpoint
+// attribute value to a static, configurable weight.
+package attributeweight

--- a/test/integration/epp/attributeweight_scenario_test.go
+++ b/test/integration/epp/attributeweight_scenario_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package epp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+	"k8s.io/apimachinery/pkg/types"
+
+	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	testutil "github.com/llm-d/llm-d-router/pkg/epp/util/testing"
+	integration "github.com/llm-d/llm-d-router/test/integration"
+)
+
+// Keep metrics neutral so attribute weight is the only scoring signal.
+const gpuWeightScorerConfig = `
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: label-producer
+  name: gpu-product
+  parameters:
+    label: nvidia.com/gpu.product
+    attributeKey: gpu.product
+    valueType: string
+- type: endpoint-attribute-weight-scorer
+  parameters:
+    attributeKey: gpu.product
+    weights:
+      NVIDIA-H100: 4
+      NVIDIA-L40S: 1
+- type: max-score-picker
+- type: passthrough-parser
+- type: mock-metrics-source
+requestHandler:
+  parsers:
+  - pluginRef: passthrough-parser
+dataLayer:
+  sources:
+  - pluginRef: mock-metrics-source
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: endpoint-attribute-weight-scorer
+  - pluginRef: max-score-picker
+`
+
+type gpuPod struct {
+	index int
+	label string
+}
+
+func withGPUPods(h *TestHarness, pods []gpuPod) *TestHarness {
+	h.t.Helper()
+
+	metricsMap := make(map[types.NamespacedName]*fwkdl.Metrics, len(pods))
+	for _, p := range pods {
+		metricsMap[types.NamespacedName{Namespace: h.Namespace, Name: fmt.Sprintf("pod-%d-rank-0", p.index)}] = &fwkdl.Metrics{
+			ActiveModels:  make(map[string]int),
+			WaitingModels: make(map[string]int),
+		}
+	}
+	h.metricsBackend.SetPodMetrics(metricsMap)
+
+	for _, p := range pods {
+		labels := map[string]string{"app": testPoolName}
+		if p.label != "" {
+			labels["nvidia.com/gpu.product"] = p.label
+		}
+
+		pod := testutil.MakePod(fmt.Sprintf("pod-%d", p.index)).
+			Namespace(h.Namespace).
+			ReadyCondition().
+			Labels(labels).
+			IP(fmt.Sprintf("192.168.1.%d", p.index+1)).
+			Complete().
+			ObjRef()
+
+		intendedStatus := pod.Status
+		require.NoError(h.t, k8sClient.Create(h.ctx, pod), "failed to create pod pod-%d", p.index)
+		pod.Status = intendedStatus
+		require.NoError(h.t, k8sClient.Status().Update(h.ctx, pod), "failed to update status for pod pod-%d", p.index)
+	}
+	return h
+}
+
+func TestAttributeWeightScorer_PrefersHigherWeightedGPU(t *testing.T) {
+	ctx := t.Context()
+	h := NewTestHarness(ctx, t, WithConfigText(gpuWeightScorerConfig), WithStandardMode())
+	h = h.WithBaseResources()
+
+	pods := []gpuPod{
+		{index: 0, label: "NVIDIA-L40S"},
+		{index: 1, label: "NVIDIA-H100"},
+	}
+	withGPUPods(h, pods).WaitForSync(len(pods), modelMyModel)
+	h.WaitForReadyPodsMetric(len(pods))
+
+	requests := integration.ReqRaw(
+		map[string]string{"hi": "mom", reqcommon.RequestIDHeaderKey: "test-request-id"},
+		"passthrough-body",
+	)
+	want := ExpectPassthroughRouteTo("192.168.1.2:8000", []byte("passthrough-body"))
+	responses, err := integration.StreamedRequest(t, h.Client, requests, len(want))
+	require.NoError(t, err)
+
+	if diff := cmp.Diff(want, responses, protocmp.Transform()); diff != "" {
+		t.Errorf("expected routing to the higher-weighted (H100) pod at 192.168.1.2:8000 (-want +got): %s", diff)
+	}
+}
+
+func TestAttributeWeightScorer_UnlabeledPodStaysEligible(t *testing.T) {
+	ctx := t.Context()
+	h := NewTestHarness(ctx, t, WithConfigText(gpuWeightScorerConfig), WithStandardMode())
+	h = h.WithBaseResources()
+
+	pods := []gpuPod{
+		{index: 0, label: ""},
+		{index: 1, label: "NVIDIA-A10"},
+	}
+	withGPUPods(h, pods).WaitForSync(len(pods), modelMyModel)
+	h.WaitForReadyPodsMetric(len(pods))
+
+	requests := integration.ReqRaw(
+		map[string]string{"hi": "mom", reqcommon.RequestIDHeaderKey: "test-request-id"},
+		"passthrough-body",
+	)
+	// Both endpoints receive the fallback score, so either may be selected.
+	responses, err := integration.StreamedRequest(t, h.Client, requests, 2)
+	require.NoError(t, err)
+	require.Len(t, responses, 2)
+}


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

/kind feature

**What this PR does / why we need it**:

Add `label-producer` and `endpoint-attribute-weight-scorer`.

The producer exposes Pod labels as endpoint attributes, and the scorer maps discrete attribute values to normalized routing scores. This supports static preferences for heterogeneous GPUs, zones, racks, and similar endpoint groups while keeping missing or unknown values eligible.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2201

**Test plan**:

- [x] Unit tests cover configuration validation, score normalization, fallback behavior, and scorer category.
- [x] Hermetic integration tests verify weighted GPU routing and eligibility of missing or unknown attributes.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Add endpoint attribute weight scoring for configurable static routing preferences.
```

