### PR TITLE
Enable Envoy priorities for high availability for standalone mode

### DIFF
--- a/config/charts/llm-d-router-standalone/values.yaml
+++ b/config/charts/llm-d-router-standalone/values.yaml
@@ -26,6 +26,21 @@ router:
     # unreachable, for active/passive resiliency.
     failOpen: true
 
+    # Priority Routing configuration for Envoy ext_proc cluster (only supported in mode: service).
+    priorityRouting:
+      enabled: false
+      primaryReplicas: 1
+      standbyReplicas: 1
+      connectTimeout: "0.250s"
+      dnsRefreshRate: "5s"
+      healthyPanicThreshold: 10.0
+
+    # Active gRPC health check configuration for the ext_proc cluster.
+    healthCheckInterval: "5s"
+    healthCheckTimeout: "1s"
+    healthCheckUnhealthyThreshold: 2
+    healthCheckHealthyThreshold: 3
+
     resources:
       requests:
         cpu: "4"
@@ -43,6 +58,7 @@ router:
           name: envoy
           data:
             envoy.yaml: |
+              {{- $isPriorityRouting := eq (include "llm-d-router.priorityRouting.enabled" .) "true" -}}
               admin:
                 address:
                   socket_address:
@@ -208,8 +224,32 @@ router:
                       http_header_name: x-gateway-destination-endpoint
                   - name: ext_proc
                     type: {{ include "llm-d-router.proxy.extProcClusterType" . }}
+                    {{- if $isPriorityRouting }}
+                    # Short connection timeout allows Envoy to quickly detect unreachable primary pods and trigger failover.
+                    connect_timeout: {{ .Values.router.proxy.priorityRouting.connectTimeout }}
+                    lb_policy: {{ .Values.router.proxy.lbPolicy | default "LEAST_REQUEST" }}
+                    # Refresh DNS for headless Service endpoints regularly to discover newly scheduled EPP pods.
+                    dns_refresh_rate: {{ .Values.router.proxy.priorityRouting.dnsRefreshRate }}
+                    common_lb_config:
+                      # Avoid routing traffic to newly started hosts until their first health check passes.
+                      ignore_new_hosts_until_first_hc: true
+                      # Prevent Envoy from entering panic mode (broadcasting to all priorities) during primary ejection.
+                      healthy_panic_threshold:
+                        value: {{ .Values.router.proxy.priorityRouting.healthyPanicThreshold }}
+                    outlier_detection:
+                      # Treat local origin (connection/TCP) failures separately from HTTP errors for immediate failover.
+                      split_external_local_origin_errors: true
+                      # Eject primary endpoint immediately on the first local connection failure (e.g. pod killed).
+                      consecutive_local_origin_failure: 1
+                      enforcing_consecutive_local_origin_failure: 100
+                      # Max percentage of hosts that can be ejected via outlier detection.
+                      max_ejection_percent: 50
+                      # Hold ejection for 30s to allow replacement pod startup and avoid flapping.
+                      base_ejection_time: 30s
+                    {{- else }}
                     connect_timeout: 86400s
-                    lb_policy: LEAST_REQUEST
+                    lb_policy: {{ .Values.router.proxy.lbPolicy | default "LEAST_REQUEST" }}
+                    {{- end }}
                     circuit_breakers:
                       thresholds:
                         - max_connections: 40000
@@ -217,11 +257,12 @@ router:
                           max_requests: 40000
                           max_retries: 1024
                     health_checks:
-                      - timeout: 2s
-                        interval: 10s
-                        unhealthy_threshold: 3
-                        healthy_threshold: 2
-                        reuse_connection: true
+                      # Active gRPC health checking with fast failure detection and delayed failback.
+                      - timeout: {{ .Values.router.proxy.healthCheckTimeout }}
+                        interval: {{ .Values.router.proxy.healthCheckInterval }}
+                        unhealthy_threshold: {{ .Values.router.proxy.healthCheckUnhealthyThreshold }}
+                        healthy_threshold: {{ .Values.router.proxy.healthCheckHealthyThreshold }}
+                        reuse_connection: false
                         grpc_health_check:
                           service_name: "envoy.service.ext_proc.v3.ExternalProcessor"
               {{ include "llm-d-router.proxy.envoyExtProcTLSOptions" . | indent 10 }}
@@ -235,7 +276,46 @@ router:
                             initial_connection_window_size: 1048576
                     load_assignment:
                       cluster_name: ext_proc
+                      {{- if $isPriorityRouting }}
+                      {{- $primaryReplicas := include "llm-d-router.priorityRouting.primaryReplicas" . | int }}
+                      # Overprovisioning factor scales traffic shifting between priority tiers.
+                      policy:
+                        overprovisioning_factor: {{ mul 100 $primaryReplicas }}
+                      {{- end }}
                       endpoints:
+                        {{- if $isPriorityRouting }}
+                        {{- $primaryReplicas := include "llm-d-router.priorityRouting.primaryReplicas" . | int }}
+                        {{- $standbyReplicas := include "llm-d-router.priorityRouting.standbyReplicas" . | int }}
+                        - locality:
+                            region: ext_proc/primary
+                          priority: 0
+                          load_balancing_weight:
+                            value: 1
+                          lb_endpoints:
+                            {{- range $i := untilStep 0 (int $primaryReplicas) 1 }}
+                            - endpoint:
+                                address:
+                                  socket_address:
+                                    address: {{ printf "%s-%d.%s-headless.%s.svc.%s" (include "llm-d-router.name" $) (int $i) (include "llm-d-router.name" $) $.Release.Namespace ($.Values.router.clusterDomain | default "cluster.local") }}
+                                    port_value: 9002
+                              load_balancing_weight: 1
+                            {{- end }}
+                        - locality:
+                            region: ext_proc/standby
+                          priority: 1
+                          load_balancing_weight:
+                            value: 1
+                          lb_endpoints:
+                            {{- range $j := untilStep 0 (int $standbyReplicas) 1 }}
+                            {{- $ord := add (int $primaryReplicas) (int $j) }}
+                            - endpoint:
+                                address:
+                                  socket_address:
+                                    address: {{ printf "%s-%d.%s-headless.%s.svc.%s" (include "llm-d-router.name" $) $ord (include "llm-d-router.name" $) $.Release.Namespace ($.Values.router.clusterDomain | default "cluster.local") }}
+                                    port_value: 9002
+                              load_balancing_weight: 1
+                            {{- end }}
+                        {{- else }}
                         - locality:
                             region: ext_proc/e2e/0
                           lb_endpoints:
@@ -245,6 +325,7 @@ router:
                                     address: {{ include "llm-d-router.proxy.extProcHost" . }}
                                     port_value: 9002
                               load_balancing_weight: 1
+                        {{- end }}
         name: envoy-proxy
         image: docker.io/envoyproxy/envoy:distroless-v1.33.2
         command: "envoy"
@@ -290,7 +371,7 @@ router:
         volumes:
           - name: config
             configMap:
-              name: envoy
+              name: '{{ .Values.router.proxy.presets.envoy.configMap.name }}'
               items:
                 - key: envoy.yaml
                   path: envoy.yaml

--- a/config/charts/llm-d-router-standalone/values.yaml
+++ b/config/charts/llm-d-router-standalone/values.yaml
@@ -36,10 +36,10 @@ router:
       healthyPanicThreshold: 10.0
 
     # Active gRPC health check configuration for the ext_proc cluster.
-    healthCheckInterval: "5s"
-    healthCheckTimeout: "1s"
-    healthCheckUnhealthyThreshold: 2
-    healthCheckHealthyThreshold: 3
+    healthCheckInterval: "10s"
+    healthCheckTimeout: "2s"
+    healthCheckUnhealthyThreshold: 3
+    healthCheckHealthyThreshold: 2
 
     resources:
       requests:
@@ -257,12 +257,12 @@ router:
                           max_requests: 40000
                           max_retries: 1024
                     health_checks:
-                      # Active gRPC health checking with fast failure detection and delayed failback.
+                      # Active gRPC health checking for the ext_proc cluster.
                       - timeout: {{ .Values.router.proxy.healthCheckTimeout }}
                         interval: {{ .Values.router.proxy.healthCheckInterval }}
                         unhealthy_threshold: {{ .Values.router.proxy.healthCheckUnhealthyThreshold }}
                         healthy_threshold: {{ .Values.router.proxy.healthCheckHealthyThreshold }}
-                        reuse_connection: false
+                        reuse_connection: true
                         grpc_health_check:
                           service_name: "envoy.service.ext_proc.v3.ExternalProcessor"
               {{ include "llm-d-router.proxy.envoyExtProcTLSOptions" . | indent 10 }}

--- a/config/charts/routerlib/templates/_config.yaml
+++ b/config/charts/routerlib/templates/_config.yaml
@@ -6,8 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   default-plugins.yaml: |
-    {{- $modelServerProtocol := .Values.router.modelServers.protocol | default "http" }}
-    {{- $modelServerType := .Values.router.modelServers.type | default "vllm" }}
+    {{- $modelServers := .Values.router.modelServers | default dict }}
+    {{- $modelServerProtocol := $modelServers.protocol | default "http" }}
+    {{- $modelServerType := $modelServers.type | default "vllm" }}
     {{- $parsers := list }}
     {{- if and (eq (lower $modelServerType) "vllm") (eq (lower $modelServerProtocol) "grpc") }}
       {{- $parsers = append $parsers "vllmgrpc-parser" }}
@@ -28,7 +29,6 @@ data:
         path: {{ .Values.router.epp.metricsDataSource.path | default "/metrics" | quote }}
         insecureSkipVerify: {{ .Values.router.epp.metricsDataSource.insecureSkipVerify | default true }}
     - type: core-metrics-extractor
-      {{- $modelServerType := .Values.router.modelServers.type | default "vllm" }}
       {{- if ne $modelServerType "vllm" }}
       parameters:
         defaultEngine: {{ $modelServerType | quote }}

--- a/config/charts/routerlib/templates/_deployment.yaml
+++ b/config/charts/routerlib/templates/_deployment.yaml
@@ -1,4 +1,5 @@
 {{- define "llm-d-epp.deployment-pod-spec" -}}
+      {{- $isPriorityRouting := eq (include "llm-d-router.priorityRouting.enabled" .) "true" -}}
       {{- $proxy := include "llm-d-router.proxy" . | fromYaml | default dict }}
       {{- $proxyType := include "llm-d-router.proxyType" . | trim }}
       {{- $proxyMode := include "llm-d-router.proxyMode" . | trim }}
@@ -11,7 +12,7 @@
       {{- end }}
       serviceAccountName: {{ include "llm-d-router.name" . }}
       # Conservatively, this timeout should mirror the longest grace period of the pods within the pool
-      terminationGracePeriodSeconds: 130
+      terminationGracePeriodSeconds: {{ .Values.router.epp.terminationGracePeriodSeconds | default 130 }}
       {{- if and .Values.router.tokenizer.enabled .Values.router.tokenizer.initContainers }}
       initContainers:
         {{- toYaml .Values.router.tokenizer.initContainers | nindent 8 }}
@@ -78,7 +79,8 @@
           {{- /* 1. Determine Mode Logic */ -}}
           {{- $useInferencePool := ne .Values.router.inferencePool.create false }}
           {{- /* 2. Determine Model Server Type */ -}}
-          {{- $modelServerType := .Values.router.modelServers.type | default "vllm" }}
+          {{- $modelServers := .Values.router.modelServers | default dict }}
+          {{- $modelServerType := $modelServers.type | default "vllm" }}
           {{- /* 3. Mode Specific Flags */ -}}
           {{- if not $useInferencePool }}
               - --endpoint-selector
@@ -107,12 +109,15 @@
               - --config-file
               - "/config/{{ .Values.router.epp.pluginsConfigFile }}"
           {{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict }}
-          {{- if and (gt (.Values.router.epp.replicas | int) 1) (not $gkePB.enabled) }}
+          {{- if and (gt (.Values.router.epp.replicas | int) 1) (not $gkePB.enabled) (not $isPriorityRouting) }}
               - --ha-enable-leader-election
           {{- end }}
           {{- $grpcHealthPort := .Values.router.epp.grpcHealthPort | default 9003 }}
               - --grpc-health-port
               - "{{ $grpcHealthPort }}"
+          {{- if $isPriorityRouting }}
+              - --health-checking=true
+          {{- end }}
               # Pass additional flags via the router.epp.flags field in values.yaml.
               # Render them as --flag=value so boolean values are parsed correctly.
           {{- range $key, $value := $eppFlags }}
@@ -163,6 +168,12 @@
               service: inference-extension
           {{- end }}
             periodSeconds: 2
+          # Allow in-flight gRPC streams to drain and give Envoy health checks
+          # time to detect termination and shift traffic to standby endpoints before SIGTERM.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
           env:
             - name: NAMESPACE
               valueFrom:
@@ -293,10 +304,16 @@
 
 {{- define "llm-d-epp.deployment" -}}
 {{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict -}}
+{{- $isPriorityRouting := eq (include "llm-d-router.priorityRouting.enabled" .) "true" -}}
+{{- if or $gkePB.enabled $isPriorityRouting }}
+{{- $totalReplicas := 1 }}
 {{- if $gkePB.enabled }}
-{{- $preferredReplicas := $gkePB.preferredReplicas | default 1 | int }}
-{{- $defaultReplicas := $gkePB.defaultReplicas | default 1 | int }}
-{{- $totalReplicas := add $preferredReplicas $defaultReplicas }}
+  {{- $preferredReplicas := $gkePB.preferredReplicas | default 1 | int }}
+  {{- $defaultReplicas := $gkePB.defaultReplicas | default 1 | int }}
+  {{- $totalReplicas = add $preferredReplicas $defaultReplicas }}
+{{- else if $isPriorityRouting }}
+  {{- $totalReplicas = include "llm-d-router.priorityRouting.totalReplicas" . | int }}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -307,7 +324,7 @@ metadata:
     {{- include "llm-d-router.modeLabels" . | nindent 4 }}
 spec:
   replicas: {{ $totalReplicas }}
-  serviceName: {{ include "llm-d-router.name" . }}
+  serviceName: {{ if $isPriorityRouting }}{{ printf "%s-headless" (include "llm-d-router.name" .) }}{{ else }}{{ include "llm-d-router.name" . }}{{ end }}
   podManagementPolicy: Parallel
   selector:
     matchLabels:

--- a/config/charts/routerlib/templates/_helpers.tpl
+++ b/config/charts/routerlib/templates/_helpers.tpl
@@ -454,6 +454,39 @@ EPP generic validations
     {{- fail ".Values.provider.gke.preferredBackends.defaultReplicas must be at least 1 when preferredBackends.enabled is true" }}
   {{- end }}
 {{- end }}
+{{- end }}
+
+{{/*
+Helper to check if priorityRouting is enabled across chart contexts.
+*/}}
+{{- define "llm-d-router.priorityRouting.enabled" -}}
+{{- $router := .Values.router | default dict -}}
+{{- $proxy := index $router "proxy" | default dict -}}
+{{- if empty $proxy }}{{ $proxy = .Values.proxy | default dict }}{{ end -}}
+{{- $pr := index $proxy "priorityRouting" | default dict -}}
+{{- if index $pr "enabled" }}true{{ end -}}
+{{- end -}}
+
+{{- define "llm-d-router.priorityRouting.primaryReplicas" -}}
+{{- $router := .Values.router | default dict -}}
+{{- $proxy := index $router "proxy" | default dict -}}
+{{- if empty $proxy }}{{ $proxy = .Values.proxy | default dict }}{{ end -}}
+{{- $pr := index $proxy "priorityRouting" | default dict -}}
+{{- index $pr "primaryReplicas" | default 1 | int -}}
+{{- end -}}
+
+{{- define "llm-d-router.priorityRouting.standbyReplicas" -}}
+{{- $router := .Values.router | default dict -}}
+{{- $proxy := index $router "proxy" | default dict -}}
+{{- if empty $proxy }}{{ $proxy = .Values.proxy | default dict }}{{ end -}}
+{{- $pr := index $proxy "priorityRouting" | default dict -}}
+{{- index $pr "standbyReplicas" | default 1 | int -}}
+{{- end -}}
+
+{{- define "llm-d-router.priorityRouting.totalReplicas" -}}
+{{- $primary := include "llm-d-router.priorityRouting.primaryReplicas" . | int -}}
+{{- $standby := include "llm-d-router.priorityRouting.standbyReplicas" . | int -}}
+{{- add $primary $standby -}}
 {{- end -}}
 
 {{- define "llm-d-router.validations.epp" -}}
@@ -462,6 +495,14 @@ EPP generic validations
 {{- include "llm-d-router.validations.epp.inferenceObjectives" . }}
 {{- include "llm-d-router.validations.epp.tokenizer" . }}
 {{- include "llm-d-router.validations.epp.preferredBackends" . }}
+{{- $isPriorityRouting := eq (include "llm-d-router.priorityRouting.enabled" .) "true" -}}
+{{- if and $isPriorityRouting (ne (include "llm-d-router.proxyMode" .) "service") -}}
+{{- fail "priorityRouting is only supported when proxy mode is set to 'service' (router.proxy.mode=service)" -}}
+{{- end -}}
+{{- $eppFlags := .Values.router.epp.flags | default dict -}}
+{{- if and $isPriorityRouting (hasKey $eppFlags "health-checking") (not (index $eppFlags "health-checking")) -}}
+{{- fail "priorityRouting requires EPP's gRPC health service on port 9002 (router.epp.flags.health-checking cannot be false when priorityRouting.enabled=true)" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/config/charts/routerlib/templates/_inferencepool.yaml
+++ b/config/charts/routerlib/templates/_inferencepool.yaml
@@ -7,21 +7,22 @@ metadata:
   labels:
     {{- include "llm-d-router.labels" . | nindent 4 }}
 spec:
+  {{- $modelServers := .Values.router.modelServers | default dict }}
   targetPorts:
-  {{- range .Values.router.modelServers.targetPorts }}
+  {{- range $modelServers.targetPorts }}
   - number: {{ .number }}
   {{- end }}
-  {{- if .Values.router.modelServers.protocol }}
-  {{- if eq .Values.router.modelServers.protocol "grpc" }}
+  {{- if $modelServers.protocol }}
+  {{- if eq $modelServers.protocol "grpc" }}
   appProtocol: "kubernetes.io/h2c"
-  {{- else if eq .Values.router.modelServers.protocol "http" }}
+  {{- else if eq $modelServers.protocol "http" }}
   appProtocol: "http"
   {{- end }}
   {{- end }}
   selector:
     matchLabels:
-      {{- if .Values.router.modelServers.matchLabels }}
-      {{- range $key, $value := .Values.router.modelServers.matchLabels }}
+      {{- if $modelServers.matchLabels }}
+      {{- range $key, $value := $modelServers.matchLabels }}
       {{ $key }}: {{ quote $value }}
       {{- end }}
       {{- end }}

--- a/config/charts/routerlib/templates/_leader-election-rbac.yaml
+++ b/config/charts/routerlib/templates/_leader-election-rbac.yaml
@@ -1,5 +1,7 @@
 {{- define "llm-d-epp.leader-election-rbac" -}}
-{{- if gt (.Values.router.epp.replicas | int) 1 }}
+{{- $isPriorityRouting := eq (include "llm-d-router.priorityRouting.enabled" .) "true" -}}
+{{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict -}}
+{{- if and (gt (.Values.router.epp.replicas | int) 1) (not $gkePB.enabled) (not $isPriorityRouting) }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/charts/routerlib/templates/_proxy-deployment.yaml
+++ b/config/charts/routerlib/templates/_proxy-deployment.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         {{- include "llm-d-router.labels" . | nindent 8 }}
         {{- include "llm-d-router.proxySelectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include "llm-d-router.proxyConfigMapData" . | sha256sum }}
     spec:
       containers:
         - name: {{ $proxy.name }}

--- a/config/charts/routerlib/templates/_service.yaml
+++ b/config/charts/routerlib/templates/_service.yaml
@@ -1,4 +1,5 @@
 {{- define "llm-d-epp.service" -}}
+{{- $isPriorityRouting := eq (include "llm-d-router.priorityRouting.enabled" .) "true" -}}
 {{- $gkePB := include "llm-d-router.gkePreferredBackends" . | fromYaml | default dict -}}
 {{- if $gkePB.enabled }}
 {{- $preferredReplicas := $gkePB.preferredReplicas | default 1 | int }}
@@ -64,5 +65,29 @@ spec:
     {{- . | toYaml | nindent 4 }}
     {{- end }}
   type: ClusterIP
+{{- if $isPriorityRouting }}
+---
+# Headless Service is required for Priority Routing to provide deterministic, per-pod DNS records
+# (<pod-name>.<service-name>-headless.<namespace>.svc) for each StatefulSet replica.
+# publishNotReadyAddresses allows Envoy active gRPC health checking to probe newly created pods
+# before they are marked Ready by Kubernetes.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-headless" (include "llm-d-router.name" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "llm-d-router.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    {{- include "llm-d-router.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: grpc-ext-proc
+      protocol: TCP
+      port: {{ .Values.router.epp.extProcPort | default 9002 }}
+      appProtocol: kubernetes.io/h2c
+{{- end }}
 {{- end }}
 {{- end }}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -156,7 +156,7 @@ helm install optimize-baseline ./config/charts/llm-d-router-standalone -f resour
 
 The router supports multiple High Availability (HA) modes:
 
-1. **Fully Active-Active**: Multiple EPP replicas run concurrently and share load across all instances. Suitable when scheduling algorithms and plugins do not require unified state across pods.
+1. **Fully Active-Active**: Multiple EPP replicas run concurrently and share load across all instances. Suitable when scheduling algorithms and plugins do not require unified state across pods or there is a synchronization mechanism in place.
 2. **Active-Passive**: Traffic routes to a single primary replica set while standby replicas remain available for failover.
    - **Priority Routing**: Available only when proxy mode is set to service (`router.proxy.mode: service`). Uses Envoy Priority Routing and outlier detection to route traffic to Primary EPP replicas (Priority 0) and shift traffic to Standby EPP replicas (Priority 1) upon primary failure.
    - **Leader Election with Fail-Open**: Uses Kubernetes `coordination.k8s.io/Lease` coordination so only the elected leader serves inference extension requests. Standby pods remain idle until acquiring the lease. If the active leader fails, the proxy operates in fail-open mode, routing traffic directly to model servers until a standby acquires leadership.
@@ -173,7 +173,7 @@ Priority Routing is only available in standalone service mode (`router.proxy.mod
 2. **Active Health Probing**: Envoy actively probes EPP Port 9002 via gRPC health check (`grpc.health.v1.Health`).
 3. **Outlier Detection Failover**: When priority routing is enabled, if a primary pod fails or crashes, Envoy's Outlier Detection detects TCP connection failure and ejects the primary host, shifting traffic to Priority 1 standbys in sub-second time without lease expiration delays.
 4. **Graceful Pod Termination**: EPP pods include a `lifecycle.preStop` hook (`sleep 5`) during planned deletion or rollout. This gives Envoy active health checks time to detect pod shutdown and redirect new traffic to standby endpoints before SIGTERM, allowing in-flight gRPC streams to drain.
-5. **Safe Failback**: When a replacement primary pod is rescheduled, `healthy_threshold: 3` requires 3 consecutive passing health probes before Envoy restores traffic to Priority 0, ensuring the new EPP pod has finished syncing model server state and inference pools.
+5. **Safe Failback**: When a replacement primary pod is rescheduled, the health check `healthy_threshold` requires consecutive passing health probes before Envoy restores traffic to Priority 0, ensuring the new EPP pod has finished syncing model server state and inference pools.
 
 #### Helm Configuration
 
@@ -194,10 +194,10 @@ router:
 | `router.proxy.priorityRouting.healthyPanicThreshold` | `10.0` | Threshold percentage to prevent panic routing during primary ejection. |
 | `router.proxy.priorityRouting.dnsRefreshRate` | `5s` | DNS resolution refresh rate for headless EPP endpoints. |
 | `router.proxy.priorityRouting.connectTimeout` | `0.250s` | Connection timeout to detect unreachable primary pods. |
-| `router.proxy.healthCheckInterval` | `5s` | Active gRPC health check probe interval. |
-| `router.proxy.healthCheckTimeout` | `1s` | Health check probe timeout. |
-| `router.proxy.healthCheckUnhealthyThreshold` | `2` | Number of failed probes before marking an endpoint unhealthy. |
-| `router.proxy.healthCheckHealthyThreshold` | `3` | Number of passing probes required before admitting recreated pods. |
+| `router.proxy.healthCheckInterval` | `10s` | Active gRPC health check probe interval. |
+| `router.proxy.healthCheckTimeout` | `2s` | Health check probe timeout. |
+| `router.proxy.healthCheckUnhealthyThreshold` | `3` | Number of failed probes before marking an endpoint unhealthy. |
+| `router.proxy.healthCheckHealthyThreshold` | `2` | Number of passing probes required before admitting recreated pods. |
 | `router.epp.terminationGracePeriodSeconds` | `130` | Grace period (seconds) before SIGKILL on pod teardown. |
 
 ### Leader Election and Fail-Open

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -149,3 +149,71 @@ To apply these values during deployment, run the Helm install or upgrade command
 ```bash
 helm install optimize-baseline ./config/charts/llm-d-router-standalone -f resource_overrides.yaml
 ```
+
+---
+
+## 4. High Availability (HA)
+
+The router supports multiple High Availability (HA) modes:
+
+1. **Fully Active-Active**: Multiple EPP replicas run concurrently and share load across all instances. Suitable when scheduling algorithms and plugins do not require unified state across pods.
+2. **Active-Passive**: Traffic routes to a single primary replica set while standby replicas remain available for failover.
+   - **Priority Routing**: Available only when proxy mode is set to service (`router.proxy.mode: service`). Uses Envoy Priority Routing and outlier detection to route traffic to Primary EPP replicas (Priority 0) and shift traffic to Standby EPP replicas (Priority 1) upon primary failure.
+   - **Leader Election with Fail-Open**: Uses Kubernetes `coordination.k8s.io/Lease` coordination so only the elected leader serves inference extension requests. Standby pods remain idle until acquiring the lease. If the active leader fails, the proxy operates in fail-open mode, routing traffic directly to model servers until a standby acquires leadership.
+
+### Priority Routing
+
+Priority Routing is only available in standalone service mode (`router.proxy.mode: service`). When priority routing is enabled (`router.proxy.priorityRouting.enabled: true`), the router uses [Envoy Priority Routing](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/priority) to organize EPP endpoints into distinct priority tiers:
+* **Priority 0 (Primary / Active)**: Handles 100% of steady-state scheduling traffic.
+* **Priority 1 (Standby / Passive)**: Warm standby pods ready to accept failover traffic upon primary pod failure.
+
+#### Architecture and Failover Mechanics
+
+1. **Deterministic Endpoint Discovery**: EPP pods run as a StatefulSet with a headless Service (`publishNotReadyAddresses: true`). Envoy targets individual pod DNS entries (`<release>-epp-0`, `<release>-epp-1`, etc.) mapped to distinct priority levels.
+2. **Active Health Probing**: Envoy actively probes EPP Port 9002 via gRPC health check (`grpc.health.v1.Health`).
+3. **Outlier Detection Failover**: When priority routing is enabled, if a primary pod fails or crashes, Envoy's Outlier Detection detects TCP connection failure and ejects the primary host, shifting traffic to Priority 1 standbys in sub-second time without lease expiration delays.
+4. **Graceful Pod Termination**: EPP pods include a `lifecycle.preStop` hook (`sleep 5`) during planned deletion or rollout. This gives Envoy active health checks time to detect pod shutdown and redirect new traffic to standby endpoints before SIGTERM, allowing in-flight gRPC streams to drain.
+5. **Safe Failback**: When a replacement primary pod is rescheduled, `healthy_threshold: 3` requires 3 consecutive passing health probes before Envoy restores traffic to Priority 0, ensuring the new EPP pod has finished syncing model server state and inference pools.
+
+#### Helm Configuration
+
+```yaml
+router:
+  proxy:
+    mode: service
+    priorityRouting:
+      enabled: true
+      primaryReplicas: 1
+      standbyReplicas: 1
+```
+
+#### Tuning Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `router.proxy.priorityRouting.healthyPanicThreshold` | `10.0` | Threshold percentage to prevent panic routing during primary ejection. |
+| `router.proxy.priorityRouting.dnsRefreshRate` | `5s` | DNS resolution refresh rate for headless EPP endpoints. |
+| `router.proxy.priorityRouting.connectTimeout` | `0.250s` | Connection timeout to detect unreachable primary pods. |
+| `router.proxy.healthCheckInterval` | `5s` | Active gRPC health check probe interval. |
+| `router.proxy.healthCheckTimeout` | `1s` | Health check probe timeout. |
+| `router.proxy.healthCheckUnhealthyThreshold` | `2` | Number of failed probes before marking an endpoint unhealthy. |
+| `router.proxy.healthCheckHealthyThreshold` | `3` | Number of passing probes required before admitting recreated pods. |
+| `router.epp.terminationGracePeriodSeconds` | `130` | Grace period (seconds) before SIGKILL on pod teardown. |
+
+### Leader Election and Fail-Open
+
+In multi-replica deployments without priority routing (`router.epp.replicas > 1`), the router coordinates active-passive replicas using Kubernetes lease-based leader election:
+
+- **Leader Coordination**: EPP replicas contend for a `coordination.k8s.io/Lease`. The `--ha-enable-leader-election` flag enables leader election in EPP (automatically injected by Helm when `router.epp.replicas > 1`). The elected leader responds to active gRPC extension requests on Port 9002, while standby replicas run idle. (To run multi-replica in Fully Active-Active mode instead, set `router.epp.flags.ha-enable-leader-election: false`).
+- **Fail-Open Resiliency**: With `router.proxy.failOpen: true` (the default in standalone mode) or `router.inferencePool.failureMode: FailOpen`, if the active leader crashes or restarts, the proxy passes requests directly to backend model servers without dropping traffic during the lease transition period.
+
+```yaml
+router:
+  epp:
+    replicas: 2
+    flags:
+      ha-enable-leader-election: true
+  proxy:
+    failOpen: true
+```
+


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR introduces Envoy Priority Load Balancing (Priority 0 Primary vs. Priority 1 Standby), Outlier Detection, and TLS-secured gRPC health checking to standalone EPP deployments to achieve zero-drop high availability during pod restarts, failovers, and upgrades. 

[Link to design](https://docs.google.com/document/d/1A_HhZcNUELM3IaSVOGOyVqbhb04WqN7Hy7YNeIA27GM/edit?tab=t.0#heading=h.ccnjk6p9rovc)

### **Benchmarks**:
#### Metric Definitions
* **In-flight**: Requests open at kill time; severed at socket level.
* **Post-kill**: Requests sent after kill; what priority routing protects.
* **First Fail (s)**: Seconds from kill to first failure (when primary went down).
* **Fail Window (s)**: Duration between first and last failure.

| Topology | Shutdown Mode | Target QPS | Success Rate | Failed (Inflight / Post-kill) | Avg Latency | p95 Latency | Max Latency |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| Active-Passive (1P1S) | SIGTERM | 50 | 100.0% (9000/9000) | 0 / 0 | 123.78ms | 128.27ms | 295.30ms |
| Active-Passive (1P1S) | SIGTERM | 100 | 100.0% (18000/18000) | 0 / 0 | 130.60ms | 137.95ms | 342.10ms |
| Active-Passive (1P1S) | SIGTERM | 150 | 100.0% (26999/27000) | 0 / 1 | 148.02ms | 159.18ms | 384.72ms |
| Active-Passive (1P1S) | SIGKILL | 50 | 100.0% (9000/9000) | 0 / 0 | 123.79ms | 128.60ms | 288.87ms |
| Active-Passive (1P1S) | SIGKILL | 100 | 100.0% (17999/18000) | 0 / 1 | 125.80ms | 132.28ms | 331.30ms |
| Active-Passive (1P1S) | SIGKILL | 150 | 100.0% (26999/27000) | 0 / 1 | 136.38ms | 145.78ms | 379.31ms |
| Active-Active (2P2S) | SIGTERM | 50 | 99.4% (8950/9000) | 0 / 50 | 119.36ms | 125.80ms | 287.65ms |
| Active-Active (2P2S) | SIGTERM | 100 | 99.4% (17899/18000) | 0 / 101 | 122.14ms | 128.79ms | 334.70ms |
| Active-Active (2P2S) | SIGTERM | 150 | 99.4% (26849/27000) | 0 / 151 | 127.18ms | 136.79ms | 389.16ms |
| Active-Active (2P2S) | SIGKILL | 50 | 99.4% (8950/9000) | 0 / 50 | 119.40ms | 126.27ms | 288.78ms |
| Active-Active (2P2S) | SIGKILL | 100 | 99.4% (17899/18000) | 0 / 101 | 122.46ms | 130.56ms | 319.35ms |
| Active-Active (2P2S) | SIGKILL | 150 | 99.4% (26849/27000) | 0 / 151 | 127.48ms | 145.10ms | 373.06ms |

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Add native Envoy Priority Routing support in service mode, enabling automatic failover to standby Endpoint Pickers on pod failure.
```