### PR TITLE
feat: add OpenTelemetry spans for tokenization and KV-cache event processing

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md
@@ -39,6 +39,13 @@ upstream. No-op otherwise.
 Set `kvEventsConfig.engineType` to `sglang` for SGLang KV-events. It defaults
 to `vllm` when omitted.
 
+Set `kvEventsConfig.tracing` to `true` to emit OpenTelemetry spans for the
+KV-event pipeline (`events_receive`, `events_process`, `events_decode`). It
+defaults to `false`: KV events arrive at many times the inference request rate,
+so with a shared head sampler always-on event spans crowd request traces out of
+the exported volume. The EPP `--tracing` flag gates tracing as a whole, so this
+field has no effect while that is off.
+
 See [llm-d-kv-cache/docs/configuration.md](https://github.com/llm-d/llm-d-kv-cache/blob/main/docs/configuration.md)
 for nested parameter details.
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -33,12 +33,18 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-router/pkg/kvcache/tokenization"
 	tokenizerTypes "github.com/llm-d/llm-d-router/pkg/kvcache/tokenization/types"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	mmobs "github.com/llm-d/llm-d-router/pkg/epp/framework/observability/multimodal"
+	rcplugins "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol"
 )
 
 type tokenizer interface {
@@ -77,6 +83,17 @@ const (
 	blockTypeToolUse          = "tool_use"
 	blockTypeToolResult       = "tool_result"
 )
+
+// Backend identifiers reported on the tokenize span.
+const (
+	backendUDS      = "uds"
+	backendVLLM     = "vllm"
+	backendEstimate = "estimate"
+)
+
+// resultSkippedNoTokens marks a tokenize span whose backend returned no tokens,
+// distinguishing it from a span missing attributes for any other reason.
+const resultSkippedNoTokens = "skipped_no_tokens"
 
 var TokenizedPromptDataKey = plugin.NewDataKey(tokenizedPromptKeyID, PluginType)
 
@@ -285,6 +302,7 @@ func LegacyPluginFactory(name string, rawParameters *json.Decoder, handle plugin
 // (the default when no backend is set).
 func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) (*Plugin, error) {
 	var backend tokenInputProducer
+	var backendName string
 	switch {
 	case config.TokenizerConfig.IsEnabled():
 		log.FromContext(ctx).Info(
@@ -296,6 +314,7 @@ func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) 
 			return nil, fmt.Errorf("failed to initialize UDS tokenizer for '%s' plugin - %w", PluginType, err)
 		}
 		backend = renderBackend{tk: uds}
+		backendName = backendUDS
 	case config.VLLM != nil || config.ModelName != "":
 		cfg := config.VLLM
 		if cfg == nil {
@@ -306,14 +325,17 @@ func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) 
 			return nil, fmt.Errorf("failed to initialize vLLM HTTP renderer for '%s' plugin - %w", PluginType, err)
 		}
 		backend = renderBackend{tk: renderer}
+		backendName = backendVLLM
 	default:
 		backend = estimateBackend{img: newImageEstimator(config.Estimate), vid: newVideoEstimator(config.Estimate)}
+		backendName = backendEstimate
 	}
 
 	p := &Plugin{
-		typedName: plugin.TypedName{Type: PluginType, Name: name},
-		backend:   backend,
-		dk:        TokenizedPromptDataKey.WithNonEmptyProducerName(name),
+		typedName:   plugin.TypedName{Type: PluginType, Name: name},
+		backend:     backend,
+		backendName: backendName,
+		dk:          TokenizedPromptDataKey.WithNonEmptyProducerName(name),
 	}
 	if w, ok := backend.(warmer); ok {
 		go w.warmup(ctx)
@@ -326,7 +348,9 @@ func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) 
 type Plugin struct {
 	typedName plugin.TypedName
 	backend   tokenInputProducer
-	dk        plugin.DataKey
+	// backendName identifies the configured backend on the tokenize span.
+	backendName string
+	dk          plugin.DataKey
 }
 
 // compile-time assertions.
@@ -358,6 +382,9 @@ func (p *Plugin) ProduceTimeout() time.Duration {
 // Produce derives the request's TokenizedRequest via the configured backend and
 // stores it on the body. Skips when one is already present; errors propagate to
 // the Director, which logs and continues.
+//
+// The tokenize span covers the backend call only, so the skip path stays
+// untraced and the span always represents tokenization work.
 func (p *Plugin) Produce(ctx context.Context, request *scheduling.InferenceRequest, _ []scheduling.Endpoint) error {
 	if request.Body == nil {
 		return errors.New("request body is nil")
@@ -371,16 +398,46 @@ func (p *Plugin) Produce(ctx context.Context, request *scheduling.InferenceReque
 		return nil
 	}
 
+	ctx, span := tracing.Tracer(rcplugins.TracerScope).Start(ctx, "tokenize",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	defer span.End()
+	// On the default (tracing-disabled) path Start returns a non-recording span;
+	// skip attribute construction, which walks the request's multimodal features.
+	tracingActive := span.IsRecording()
+	if tracingActive {
+		attrs := []attribute.KeyValue{
+			attribute.String("llm_d.epp.token_producer.backend", p.backendName),
+		}
+		if request.TargetModel != "" {
+			attrs = append(attrs, attribute.String("gen_ai.request.model", request.TargetModel))
+		}
+		if request.RequestID != "" {
+			attrs = append(attrs, attribute.String("gen_ai.request.id", request.RequestID))
+		}
+		span.SetAttributes(attrs...)
+	}
+
 	ctx = withMMMetadata(ctx, parseMMMetadataHeaders(request.Headers))
 	tp, err := p.backend.produce(ctx, request.Body)
 	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 	if tp == nil || tp.TokenCount() == 0 {
+		if tracingActive {
+			span.SetAttributes(attribute.String("llm_d.epp.token_producer.result", resultSkippedNoTokens))
+		}
 		return nil
 	}
 	tp.CacheSalt = CacheSaltFromBody(request.Body)
 	request.Body.TokenizedRequest = tp
+
+	if tracingActive {
+		span.SetAttributes(append(mmobs.SpanAttributes(request),
+			attribute.Int("llm_d.epp.token_producer.token_count", tp.TokenCount()),
+		)...)
+	}
 	return nil
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -383,8 +383,8 @@ func (p *Plugin) ProduceTimeout() time.Duration {
 // stores it on the body. Skips when one is already present; errors propagate to
 // the Director, which logs and continues.
 //
-// The tokenize span covers the backend call only, so the skip path stays
-// untraced and the span always represents tokenization work.
+// The tokenize span opens below the already-tokenized skip path, so it is
+// emitted only when the backend is actually invoked.
 func (p *Plugin) Produce(ctx context.Context, request *scheduling.InferenceRequest, _ []scheduling.Endpoint) error {
 	if request.Body == nil {
 		return errors.New("request body is nil")
@@ -397,6 +397,8 @@ func (p *Plugin) Produce(ctx context.Context, request *scheduling.InferenceReque
 		}
 		return nil
 	}
+
+	ctx = withMMMetadata(ctx, parseMMMetadataHeaders(request.Headers))
 
 	ctx, span := tracing.Tracer(rcplugins.TracerScope).Start(ctx, "tokenize",
 		trace.WithSpanKind(trace.SpanKindInternal),
@@ -418,7 +420,6 @@ func (p *Plugin) Produce(ctx context.Context, request *scheduling.InferenceReque
 		span.SetAttributes(attrs...)
 	}
 
-	ctx = withMMMetadata(ctx, parseMMMetadataHeaders(request.Headers))
 	tp, err := p.backend.produce(ctx, request.Body)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -50,8 +50,9 @@ func (m *mockTokenizer) RenderChat(_ context.Context, payload fwkrh.RequestPaylo
 
 func newTestPlugin(tok tokenizer) *Plugin {
 	return &Plugin{
-		typedName: plugin.TypedName{Type: PluginType, Name: "test"},
-		backend:   renderBackend{tk: tok},
+		typedName:   plugin.TypedName{Type: PluginType, Name: "test"},
+		backend:     renderBackend{tk: tok},
+		backendName: backendVLLM,
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_tracing_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_tracing_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenizer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
+	"github.com/llm-d/llm-d-router/pkg/kvcache/tokenization"
+)
+
+// setupSpanRecorder installs an in-memory span recorder as the global tracer
+// provider and returns it, restoring the previous provider on cleanup.
+func setupSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	origTP := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(origTP) })
+	return recorder
+}
+
+func tokenizeSpan(t *testing.T, recorder *tracetest.SpanRecorder) sdktrace.ReadOnlySpan {
+	t.Helper()
+	for _, s := range recorder.Ended() {
+		if s.Name() == "tokenize" {
+			return s
+		}
+	}
+	t.Fatal("no tokenize span recorded")
+	return nil
+}
+
+func spanAttrs(span sdktrace.ReadOnlySpan) map[attribute.Key]attribute.Value {
+	attrs := make(map[attribute.Key]attribute.Value)
+	for _, kv := range span.Attributes() {
+		attrs[kv.Key] = kv.Value
+	}
+	return attrs
+}
+
+func chatRequest() *scheduling.InferenceRequest {
+	return &scheduling.InferenceRequest{
+		RequestID:   "req-1",
+		TargetModel: "model-a",
+		Body: &fwkrh.InferenceRequestBody{
+			ChatCompletions: &fwkrh.ChatCompletionsRequest{
+				Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Raw: "hi"}}},
+			},
+			Payload: fwkrh.PayloadMap{},
+		},
+	}
+}
+
+func TestProduce_EmitsTokenizeSpan(t *testing.T) {
+	recorder := setupSpanRecorder(t)
+	p := newTestPlugin(&mockTokenizer{
+		renderChatFunc: func(_ fwkrh.RequestPayload) ([]uint32, *tokenization.MultiModalFeatures, error) {
+			return []uint32{1, 2, 3}, nil, nil
+		},
+	})
+
+	require.NoError(t, p.Produce(context.Background(), chatRequest(), nil))
+
+	attrs := spanAttrs(tokenizeSpan(t, recorder))
+	assert.Equal(t, backendVLLM, attrs["llm_d.epp.token_producer.backend"].AsString())
+	assert.Equal(t, int64(3), attrs["llm_d.epp.token_producer.token_count"].AsInt64())
+	assert.Equal(t, "model-a", attrs["gen_ai.request.model"].AsString())
+	assert.Equal(t, "req-1", attrs["gen_ai.request.id"].AsString())
+	assert.Equal(t, "none", attrs["mm.modality"].AsString())
+	assert.Equal(t, int64(0), attrs["mm.hash_count"].AsInt64())
+}
+
+// The span must parent to the caller's span so tokenization appears under the
+// request trace rather than as a detached root.
+func TestProduce_TokenizeSpanParentedToCaller(t *testing.T) {
+	recorder := setupSpanRecorder(t)
+	p := newTestPlugin(&mockTokenizer{
+		renderChatFunc: func(_ fwkrh.RequestPayload) ([]uint32, *tokenization.MultiModalFeatures, error) {
+			return []uint32{1}, nil, nil
+		},
+	})
+
+	ctx, parent := otel.Tracer("test").Start(context.Background(), "parent")
+	require.NoError(t, p.Produce(ctx, chatRequest(), nil))
+	parent.End()
+
+	span := tokenizeSpan(t, recorder)
+	assert.Equal(t, parent.SpanContext().TraceID(), span.SpanContext().TraceID())
+	assert.Equal(t, parent.SpanContext().SpanID(), span.Parent().SpanID())
+}
+
+func TestProduce_TokenizeSpanRecordsMultiModal(t *testing.T) {
+	recorder := setupSpanRecorder(t)
+	p := newTestPlugin(&mockTokenizer{
+		renderChatFunc: func(_ fwkrh.RequestPayload) ([]uint32, *tokenization.MultiModalFeatures, error) {
+			return []uint32{1, 2}, &tokenization.MultiModalFeatures{
+				MMHashes:       map[string][]string{"image": {"h1"}},
+				MMPlaceholders: map[string][]kvblock.PlaceholderRange{"image": {{Offset: 0, Length: 2}}},
+			}, nil
+		},
+	})
+
+	require.NoError(t, p.Produce(context.Background(), chatRequest(), nil))
+
+	attrs := spanAttrs(tokenizeSpan(t, recorder))
+	assert.Equal(t, "image", attrs["mm.modality"].AsString())
+	assert.Equal(t, int64(1), attrs["mm.hash_count"].AsInt64())
+}
+
+func TestProduce_TokenizeSpanRecordsError(t *testing.T) {
+	recorder := setupSpanRecorder(t)
+	p := newTestPlugin(&mockTokenizer{
+		renderChatFunc: func(_ fwkrh.RequestPayload) ([]uint32, *tokenization.MultiModalFeatures, error) {
+			return nil, nil, errors.New("render failed")
+		},
+	})
+
+	require.Error(t, p.Produce(context.Background(), chatRequest(), nil))
+
+	span := tokenizeSpan(t, recorder)
+	assert.Equal(t, codes.Error, span.Status().Code)
+	assert.Contains(t, span.Status().Description, "render failed")
+}
+
+// The skip path does no tokenization work, so it must not emit a span.
+func TestProduce_NoSpanWhenAlreadyTokenized(t *testing.T) {
+	recorder := setupSpanRecorder(t)
+	p := newTestPlugin(&mockTokenizer{})
+
+	req := chatRequest()
+	req.Body.TokenizedRequest = &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{7}}}}
+	require.NoError(t, p.Produce(context.Background(), req, nil))
+
+	assert.Empty(t, recorder.Ended())
+}
+
+// A backend that returns no tokens still did work, so the span must say why it
+// carries no token count rather than looking like an unattributed span.
+func TestProduce_TokenizeSpanRecordsSkippedNoTokens(t *testing.T) {
+	recorder := setupSpanRecorder(t)
+	p := newTestPlugin(&mockTokenizer{
+		renderChatFunc: func(_ fwkrh.RequestPayload) ([]uint32, *tokenization.MultiModalFeatures, error) {
+			return nil, nil, nil
+		},
+	})
+
+	require.NoError(t, p.Produce(context.Background(), chatRequest(), nil))
+
+	attrs := spanAttrs(tokenizeSpan(t, recorder))
+	assert.Equal(t, resultSkippedNoTokens, attrs["llm_d.epp.token_producer.result"].AsString())
+	_, hasCount := attrs["llm_d.epp.token_producer.token_count"]
+	assert.False(t, hasCount, "no token count on the skipped path")
+}

--- a/pkg/kvevents/constants.go
+++ b/pkg/kvevents/constants.go
@@ -1,0 +1,19 @@
+// Copyright 2025 The llm-d Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvevents
+
+// TracerScope is the OTel instrumentation scope for spans emitted by the
+// kvevents event pipeline.
+const TracerScope = "llm-d-router/pkg/kvevents"

--- a/pkg/kvevents/events.go
+++ b/pkg/kvevents/events.go
@@ -76,7 +76,10 @@ type RawMessage struct {
 	// bridging the worker-queue boundary. Only the span identity crosses, never
 	// the subscriber's context: a subscriber reconnect cancels that context, and
 	// a queued task must not inherit the cancellation.
-	SpanContext trace.SpanContext
+	//
+	// A pointer keeps the 64-byte span context off messages the default
+	// configuration never traces. Nil when Config.Tracing is unset.
+	SpanContext *trace.SpanContext
 }
 
 // EngineAdapter defines the interface for engine-specific message parsers.

--- a/pkg/kvevents/events.go
+++ b/pkg/kvevents/events.go
@@ -14,6 +14,10 @@
 
 package kvevents
 
+import (
+	"go.opentelemetry.io/otel/trace"
+)
+
 // KVCacheSpecKind identifies vLLM KV cache group semantics.
 type KVCacheSpecKind string
 
@@ -68,6 +72,11 @@ type RawMessage struct {
 	SourceEndpoint string
 	// reset clears the message's pod before later messages on the same queue.
 	reset bool
+	// SpanContext links processing back to the span that received the message,
+	// bridging the worker-queue boundary. Only the span identity crosses, never
+	// the subscriber's context: a subscriber reconnect cancels that context, and
+	// a queued task must not inherit the cancellation.
+	SpanContext trace.SpanContext
 }
 
 // EngineAdapter defines the interface for engine-specific message parsers.

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -242,9 +242,9 @@ func newEventTracer(enabled bool) trace.Tracer {
 }
 
 // startSpan opens a pipeline span, or leaves ctx untouched and returns a span
-// that records nothing when event tracing is disabled. A no-op span is cheap
-// but not free, and KV events arrive at many times the request rate, so the
-// default path skips Start rather than relying on a no-op tracer.
+// that records nothing when event tracing is disabled. The default path skips
+// Start rather than relying on a no-op tracer, which still builds an option
+// slice and a context per call. See Config.Tracing.
 func (p *Pool) startSpan(ctx context.Context, name string, opts []trace.SpanStartOption) (context.Context, trace.Span) {
 	if p.tracer == nil {
 		return ctx, disabledSpan
@@ -368,14 +368,15 @@ func (p *Pool) processRawMessage(ctx context.Context, msg *RawMessage) {
 	// cancellation, so index operations below land in the message's trace.
 	// The queue handoff stays inside one process, so the parent is local: a
 	// remote parent selects a different ParentBased sampler branch.
-	if msg.SpanContext.IsValid() {
-		ctx = trace.ContextWithSpanContext(ctx, msg.SpanContext)
+	if msg.SpanContext != nil {
+		ctx = trace.ContextWithSpanContext(ctx, *msg.SpanContext)
 	}
 
 	ctx, span := p.startSpan(ctx, "events_process", consumerSpanOptions)
 	defer span.End()
-	// A span that tracing sampled out still reports IsRecording false; skip
-	// attribute construction so those messages cost nothing either.
+	// Guards every attribute block in this package: a span the sampler dropped
+	// reports IsRecording false, so those messages skip attribute construction
+	// too, not just the ones with tracing off.
 	tracingActive := span.IsRecording()
 	if tracingActive {
 		span.SetAttributes(

--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -22,10 +22,15 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
 	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-router/pkg/kvcache/metrics"
 )
@@ -92,6 +97,13 @@ type Config struct {
 	// EngineType selects the inference engine adapter ("vllm" or "sglang").
 	// Default: "vllm".
 	EngineType string `json:"engineType,omitempty"`
+	// Tracing enables the receive, process and decode spans this package emits.
+	// KV events arrive at many times the inference request rate, so those spans
+	// are opt-in: with a shared head sampler, always-on event spans would crowd
+	// request traces out of the exported volume. Index spans reached from the
+	// event path are emitted by the traced Index wrapper and are not gated
+	// here, so an exporter still receives those with this unset.
+	Tracing bool `json:"tracing,omitempty"`
 	// DiscoverPods enables the Kubernetes pod reconciler for automatic
 	// per-pod subscriber management. When enabled, the reconciler watches
 	// Kubernetes pods and creates/removes ZMQ subscribers dynamically.
@@ -161,7 +173,12 @@ type Pool struct {
 	// tier, KV-cache group, DP rank) and a store must be counted only after
 	// Index.Add succeeds — both of which only the Pool observes.
 	dedup *eventDedupFilter
-	wg    sync.WaitGroup
+	// tracer is resolved once: tracing.Tracer rebuilds its instrumentation
+	// options on every call, which is not free on the per-message event path.
+	// Nil when Config.Tracing is unset, which is what startSpan tests to skip
+	// span construction on the default path.
+	tracer trace.Tracer
+	wg     sync.WaitGroup
 	// queueDepth mirrors the number of tasks queued across all shards. It is
 	// tracked incrementally rather than by summing queue.Len() so that the
 	// depth gauge stays O(1) on the enqueue/dequeue hot path.
@@ -190,6 +207,7 @@ func NewPool(cfg *Config, index kvblock.Index, tokenProcessor kvblock.TokenProce
 		adapter:        adapter,
 		groupCatalog:   kvblock.NewGroupCatalog(),
 		dedup:          newEventDedupFilter(),
+		tracer:         newEventTracer(cfg.Tracing),
 	}
 
 	for i := 0; i < p.concurrency; i++ {
@@ -199,6 +217,39 @@ func NewPool(cfg *Config, index kvblock.Index, tokenProcessor kvblock.TokenProce
 	metrics.Register()
 
 	return p
+}
+
+// Span start options are built once. Passing them variadically at each call
+// site allocates a fresh slice per message.
+var (
+	consumerSpanOptions = []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindConsumer)}
+	internalSpanOptions = []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)}
+)
+
+// disabledSpan stands in for a real span when event tracing is off. A single
+// package-level value keeps the default path free of allocation while call
+// sites use the span unconditionally.
+var disabledSpan trace.Span = tracenoop.Span{}
+
+// newEventTracer returns the event-pipeline tracer, or nil when event tracing
+// is disabled. Resolving it once keeps the per-message path clear of
+// tracing.Tracer's per-call option building.
+func newEventTracer(enabled bool) trace.Tracer {
+	if !enabled {
+		return nil
+	}
+	return tracing.Tracer(TracerScope)
+}
+
+// startSpan opens a pipeline span, or leaves ctx untouched and returns a span
+// that records nothing when event tracing is disabled. A no-op span is cheap
+// but not free, and KV events arrive at many times the request rate, so the
+// default path skips Start rather than relying on a no-op tracer.
+func (p *Pool) startSpan(ctx context.Context, name string, opts []trace.SpanStartOption) (context.Context, trace.Span) {
+	if p.tracer == nil {
+		return ctx, disabledSpan
+	}
+	return p.tracer.Start(ctx, name, opts...)
 }
 
 // addQueueDepth adjusts the tracked queue depth by delta and publishes the new
@@ -313,16 +364,70 @@ func (p *Pool) processRawMessage(ctx context.Context, msg *RawMessage) {
 		return
 	}
 
-	podID, modelName, batch, err := p.adapter.ParseMessage(msg)
+	// Parent to the receive span while keeping the worker's context for
+	// cancellation, so index operations below land in the message's trace.
+	// The queue handoff stays inside one process, so the parent is local: a
+	// remote parent selects a different ParentBased sampler branch.
+	if msg.SpanContext.IsValid() {
+		ctx = trace.ContextWithSpanContext(ctx, msg.SpanContext)
+	}
+
+	ctx, span := p.startSpan(ctx, "events_process", consumerSpanOptions)
+	defer span.End()
+	// A span that tracing sampled out still reports IsRecording false; skip
+	// attribute construction so those messages cost nothing either.
+	tracingActive := span.IsRecording()
+	if tracingActive {
+		span.SetAttributes(
+			attribute.String("llm_d.kv_cache.events.topic", msg.Topic),
+			attribute.Int("llm_d.kv_cache.events.payload_size_bytes", len(msg.Payload)),
+		)
+	}
+
+	podID, modelName, batch, err := p.decode(ctx, msg)
 	if err != nil {
+		if tracingActive {
+			span.SetStatus(codes.Error, err.Error())
+		}
 		logger.Error(err, "Failed to parse message")
 		return
 	}
+
 	if msg.SourceEndpoint != "" {
 		podID = msg.SourceEndpoint
 	}
+	if tracingActive {
+		span.SetAttributes(
+			attribute.String("llm_d.kv_cache.events.pod_id", podID),
+			attribute.Int("llm_d.kv_cache.events.event_count", len(batch.Events)),
+		)
+	}
 
 	p.processEventBatch(ctx, &batch, podID, modelName)
+}
+
+// decode spans the adapter's payload decode. It wraps the call rather than the
+// EngineAdapter itself so out-of-tree adapters need no signature change.
+//
+//nolint:gocritic // unnamedResult: named returns conflict with nonamedreturns linter
+func (p *Pool) decode(ctx context.Context, msg *RawMessage) (string, string, EventBatch, error) {
+	_, span := p.startSpan(ctx, "events_decode", internalSpanOptions)
+	defer span.End()
+
+	podID, modelName, batch, err := p.adapter.ParseMessage(msg)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return podID, modelName, batch, err
+	}
+
+	// pod_id and event_count live on events_process, which holds the effective
+	// pod after the SourceEndpoint override. Repeating the pre-override pod
+	// under the same key would give one attribute two meanings in one trace.
+	if span.IsRecording() {
+		span.SetAttributes(attribute.String("gen_ai.request.model", modelName))
+	}
+
+	return podID, modelName, batch, nil
 }
 
 func (p *Pool) clearPod(ctx context.Context, podIdentifier string) {

--- a/pkg/kvevents/pool_tracing_test.go
+++ b/pkg/kvevents/pool_tracing_test.go
@@ -122,7 +122,7 @@ func TestProcessRawMessage_ParentsToReceiveSpan(t *testing.T) {
 	pool.processRawMessage(logging.NewTestLoggerIntoContext(context.Background()), &RawMessage{
 		Topic:       "kv@10.0.0.1:8000@test-model",
 		Payload:     []byte{1},
-		SpanContext: carried,
+		SpanContext: &carried,
 	})
 
 	process := findEventSpan(t, recorder, "events_process")
@@ -211,8 +211,7 @@ func TestProcessRawMessage_IndexSpansNestUnderProcess(t *testing.T) {
 	assert.Equal(t, process.SpanContext().SpanID(), add.Parent().SpanID())
 }
 
-// Event tracing is opt-in: with a shared head sampler, always-on event traces
-// would crowd request traces out of the exported volume.
+// Event tracing is opt-in; see Config.Tracing for why.
 func TestPool_NoEventSpansUnlessConfigured(t *testing.T) {
 	recorder := setupEventSpanRecorder(t)
 	ctx := logging.NewTestLoggerIntoContext(context.Background())
@@ -235,8 +234,7 @@ func TestPool_NoEventSpansUnlessConfigured(t *testing.T) {
 	assert.Empty(t, recorder.Ended(), "no event spans when Config.Tracing is false")
 }
 
-// The default path must not pay for spans it never records. A no-op Start is
-// cheap but not free, and KV events arrive at many times the request rate.
+// The default path must not pay for spans it never records.
 func TestStartSpan_DisabledPathAllocatesNothing(t *testing.T) {
 	pool := NewPool(DefaultConfig(), nil, nil, nil)
 	require.Nil(t, pool.tracer, "event tracing must default off")

--- a/pkg/kvevents/pool_tracing_test.go
+++ b/pkg/kvevents/pool_tracing_test.go
@@ -1,0 +1,275 @@
+package kvevents //nolint:testpackage // tests drive unexported processRawMessage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
+)
+
+// setupEventSpanRecorder installs an in-memory span recorder as the global
+// tracer provider and returns it, restoring the previous provider on cleanup.
+func setupEventSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	origTP := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(origTP) })
+	return recorder
+}
+
+func findEventSpan(t *testing.T, recorder *tracetest.SpanRecorder, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+	for _, s := range recorder.Ended() {
+		if s.Name() == name {
+			return s
+		}
+	}
+	t.Fatalf("no %s span recorded", name)
+	return nil
+}
+
+// newTracingPool builds a pool with event tracing turned on, which is what
+// every test in this file exercises. Config.Tracing is off by default.
+func newTracingPool(t *testing.T) *Pool {
+	t.Helper()
+
+	idx, err := kvblock.NewInMemoryIndex(kvblock.DefaultInMemoryIndexConfig())
+	require.NoError(t, err)
+	tp, err := kvblock.NewChunkedTokenDatabase(&kvblock.TokenProcessorConfig{
+		BlockSizeTokens: 16,
+		HashSeed:        "test",
+	})
+	require.NoError(t, err)
+
+	cfg := DefaultConfig()
+	cfg.Tracing = true
+	return NewPool(cfg, idx, tp, nil)
+}
+
+func eventSpanAttrs(span sdktrace.ReadOnlySpan) map[attribute.Key]attribute.Value {
+	attrs := make(map[attribute.Key]attribute.Value)
+	for _, kv := range span.Attributes() {
+		attrs[kv.Key] = kv.Value
+	}
+	return attrs
+}
+
+type failingAdapter struct{}
+
+func (a *failingAdapter) ParseMessage(*RawMessage) (string, string, EventBatch, error) {
+	return "", "", EventBatch{}, errors.New("decode boom")
+}
+
+func (a *failingAdapter) ShardingKey(*RawMessage) string { return "" }
+
+func TestProcessRawMessage_EmitsProcessAndDecodeSpans(t *testing.T) {
+	recorder := setupEventSpanRecorder(t)
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool := newTracingPool(t)
+	pool.adapter = &sourceEndpointAdapter{}
+
+	pool.processRawMessage(ctx, &RawMessage{
+		Topic:          "kv@10.0.0.1:8000@test-model",
+		Payload:        []byte{1},
+		SourceEndpoint: "10.0.0.1:8003",
+	})
+
+	process := findEventSpan(t, recorder, "events_process")
+	pAttrs := eventSpanAttrs(process)
+	assert.Equal(t, "kv@10.0.0.1:8000@test-model", pAttrs["llm_d.kv_cache.events.topic"].AsString())
+	assert.Equal(t, int64(1), pAttrs["llm_d.kv_cache.events.payload_size_bytes"].AsInt64())
+	assert.Equal(t, int64(1), pAttrs["llm_d.kv_cache.events.event_count"].AsInt64())
+	// The subscriber's endpoint wins over the adapter-parsed one.
+	assert.Equal(t, "10.0.0.1:8003", pAttrs["llm_d.kv_cache.events.pod_id"].AsString())
+
+	decode := findEventSpan(t, recorder, "events_decode")
+	dAttrs := eventSpanAttrs(decode)
+	assert.Equal(t, "test-model", dAttrs["gen_ai.request.model"].AsString())
+	// pod_id carries the effective pod and belongs on events_process alone, so
+	// a query on it cannot return the pre-override value.
+	assert.NotContains(t, dAttrs, attribute.Key("llm_d.kv_cache.events.pod_id"))
+	assert.NotContains(t, dAttrs, attribute.Key("llm_d.kv_cache.events.event_count"))
+
+	// decode nests under process
+	assert.Equal(t, process.SpanContext().SpanID(), decode.Parent().SpanID())
+}
+
+// The message carries the receive span's identity across the worker queue, so
+// processing must join that trace rather than start a detached one.
+func TestProcessRawMessage_ParentsToReceiveSpan(t *testing.T) {
+	recorder := setupEventSpanRecorder(t)
+	pool := newTracingPool(t)
+	pool.adapter = &sourceEndpointAdapter{}
+
+	recvCtx, recvSpan := otel.Tracer("test").Start(context.Background(), "events_receive")
+	carried := trace.SpanContextFromContext(recvCtx)
+	recvSpan.End()
+
+	// A fresh worker context, as the real worker uses.
+	pool.processRawMessage(logging.NewTestLoggerIntoContext(context.Background()), &RawMessage{
+		Topic:       "kv@10.0.0.1:8000@test-model",
+		Payload:     []byte{1},
+		SpanContext: carried,
+	})
+
+	process := findEventSpan(t, recorder, "events_process")
+	assert.Equal(t, carried.TraceID(), process.SpanContext().TraceID())
+	assert.Equal(t, carried.SpanID(), process.Parent().SpanID())
+	// The handoff crosses a worker queue, not a process boundary. A remote
+	// parent selects a different ParentBased sampler branch.
+	assert.False(t, process.Parent().IsRemote(), "queue handoff parent must be local")
+}
+
+// Without a carried span context the pipeline still traces, just as its own root.
+func TestProcessRawMessage_RootsWhenNoReceiveSpan(t *testing.T) {
+	recorder := setupEventSpanRecorder(t)
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool := newTracingPool(t)
+	pool.adapter = &sourceEndpointAdapter{}
+
+	pool.processRawMessage(ctx, &RawMessage{
+		Topic:   "kv@10.0.0.1:8000@test-model",
+		Payload: []byte{1},
+	})
+
+	process := findEventSpan(t, recorder, "events_process")
+	assert.False(t, process.Parent().IsValid())
+}
+
+func TestProcessRawMessage_DecodeErrorMarksBothSpans(t *testing.T) {
+	recorder := setupEventSpanRecorder(t)
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool := newTracingPool(t)
+	pool.adapter = &failingAdapter{}
+
+	pool.processRawMessage(ctx, &RawMessage{Topic: "kv@bad", Payload: []byte{1}})
+
+	decode := findEventSpan(t, recorder, "events_decode")
+	assert.Equal(t, codes.Error, decode.Status().Code)
+	assert.Contains(t, decode.Status().Description, "decode boom")
+
+	process := findEventSpan(t, recorder, "events_process")
+	assert.Equal(t, codes.Error, process.Status().Code)
+}
+
+// A pool built the production way must emit the decode span, otherwise the
+// deployed path decodes untraced however well the span works in isolation.
+func TestNewPool_EmitsDecodeSpan(t *testing.T) {
+	recorder := setupEventSpanRecorder(t)
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+
+	idx, err := kvblock.NewInMemoryIndex(kvblock.DefaultInMemoryIndexConfig())
+	require.NoError(t, err)
+	tokenProcessor, err := kvblock.NewChunkedTokenDatabase(&kvblock.TokenProcessorConfig{
+		BlockSizeTokens: 16,
+		HashSeed:        "test",
+	})
+	require.NoError(t, err)
+
+	cfg := DefaultConfig()
+	cfg.Tracing = true
+	pool := NewPool(cfg, idx, tokenProcessor, &sourceEndpointAdapter{})
+	pool.processRawMessage(ctx, &RawMessage{
+		Topic:   "kv@10.0.0.1:8000@test-model",
+		Payload: []byte{1},
+	})
+
+	// Fails the test if the decode span was not emitted.
+	findEventSpan(t, recorder, "events_decode")
+}
+
+// The index write is the payoff: it must land inside the message's trace
+// instead of appearing as an unattributable root span.
+func TestProcessRawMessage_IndexSpansNestUnderProcess(t *testing.T) {
+	recorder := setupEventSpanRecorder(t)
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool := newTracingPool(t)
+	pool.adapter = &sourceEndpointAdapter{}
+	pool.index = kvblock.NewTracedIndex(pool.index)
+
+	pool.processRawMessage(ctx, &RawMessage{
+		Topic:   "kv@10.0.0.1:8000@test-model",
+		Payload: []byte{1},
+	})
+
+	process := findEventSpan(t, recorder, "events_process")
+	add := findEventSpan(t, recorder, "index_add")
+	require.Equal(t, process.SpanContext().TraceID(), add.SpanContext().TraceID())
+	assert.Equal(t, process.SpanContext().SpanID(), add.Parent().SpanID())
+}
+
+// Event tracing is opt-in: with a shared head sampler, always-on event traces
+// would crowd request traces out of the exported volume.
+func TestPool_NoEventSpansUnlessConfigured(t *testing.T) {
+	recorder := setupEventSpanRecorder(t)
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+
+	idx, err := kvblock.NewInMemoryIndex(kvblock.DefaultInMemoryIndexConfig())
+	require.NoError(t, err)
+	tp, err := kvblock.NewChunkedTokenDatabase(&kvblock.TokenProcessorConfig{
+		BlockSizeTokens: 16, HashSeed: "test",
+	})
+	require.NoError(t, err)
+
+	require.False(t, DefaultConfig().Tracing, "event tracing must default off")
+
+	pool := NewPool(DefaultConfig(), idx, tp, &sourceEndpointAdapter{})
+	z := newZMQSubscriber(pool, "pod-1", "", "tcp://x", "", "kv@", false)
+
+	z.addTask(context.Background(), "kv@10.0.0.1:8000@test-model", 1, []byte{1})
+	pool.processRawMessage(ctx, drainOne(t, pool))
+
+	assert.Empty(t, recorder.Ended(), "no event spans when Config.Tracing is false")
+}
+
+// The default path must not pay for spans it never records. A no-op Start is
+// cheap but not free, and KV events arrive at many times the request rate.
+func TestStartSpan_DisabledPathAllocatesNothing(t *testing.T) {
+	pool := NewPool(DefaultConfig(), nil, nil, nil)
+	require.Nil(t, pool.tracer, "event tracing must default off")
+
+	ctx := context.Background()
+	ctxPreserved := true
+	allocs := testing.AllocsPerRun(1000, func() {
+		spanCtx, span := pool.startSpan(ctx, "events_process", consumerSpanOptions)
+		span.End()
+		if spanCtx != ctx {
+			ctxPreserved = false
+		}
+	})
+
+	assert.True(t, ctxPreserved, "disabled path must return ctx untouched")
+	assert.Zero(t, allocs, "disabled path must not allocate")
+}
+
+// BenchmarkPipelineSpans_Disabled measures the per-message span cost carried by
+// the default configuration: one receive, one process, one decode.
+func BenchmarkPipelineSpans_Disabled(b *testing.B) {
+	pool := NewPool(DefaultConfig(), nil, nil, nil)
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, receive := pool.startSpan(ctx, "events_receive", consumerSpanOptions)
+		_ = receive.SpanContext()
+		receive.End()
+
+		processCtx, process := pool.startSpan(ctx, "events_process", consumerSpanOptions)
+		_, decode := pool.startSpan(processCtx, "events_decode", internalSpanOptions)
+		decode.End()
+		process.End()
+	}
+}

--- a/pkg/kvevents/zmq_subscriber.go
+++ b/pkg/kvevents/zmq_subscriber.go
@@ -254,8 +254,6 @@ func (z *zmqSubscriber) addTask(ctx context.Context, topic string, seq uint64, p
 	// every stage of the pipeline.
 	_, span := z.pool.startSpan(ctx, "events_receive", consumerSpanOptions)
 	defer span.End()
-	// A span that tracing sampled out still reports IsRecording false; skip
-	// attribute construction so those messages cost nothing either.
 	if span.IsRecording() {
 		attrs := []attribute.KeyValue{
 			attribute.String("llm_d.kv_cache.events.topic", topic),
@@ -269,13 +267,20 @@ func (z *zmqSubscriber) addTask(ctx context.Context, topic string, seq uint64, p
 		span.SetAttributes(attrs...)
 	}
 
-	z.pool.AddTask(&RawMessage{
+	msg := &RawMessage{
 		Topic:          topic,
 		Sequence:       seq,
 		Payload:        payload,
 		SourceEndpoint: z.sourceEndpoint,
-		SpanContext:    span.SpanContext(),
-	})
+	}
+	// carried is bound inside the branch on purpose. Taking &sc directly makes
+	// sc escape, so it heap-allocates on every message including the ones the
+	// disabled path never traces.
+	if sc := span.SpanContext(); sc.IsValid() {
+		carried := sc
+		msg.SpanContext = &carried
+	}
+	z.pool.AddTask(msg)
 }
 
 func (z *zmqSubscriber) canAttemptReplay() bool {

--- a/pkg/kvevents/zmq_subscriber.go
+++ b/pkg/kvevents/zmq_subscriber.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	zmq4 "github.com/go-zeromq/zmq4"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/semaphore"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -175,7 +176,7 @@ func (z *zmqSubscriber) runSubscriber(ctx context.Context) {
 		}
 
 		if z.replayEndpoint == "" {
-			z.addTask(topic, seq, payload)
+			z.addTask(ctx, topic, seq, payload)
 			continue
 		}
 
@@ -238,18 +239,42 @@ func (z *zmqSubscriber) runSubscriber(ctx context.Context) {
 
 		debugLogger.V(logging.TRACE).Info("Received message from zmq subscriber",
 			"topic", topic, "seq", seq, "payloadSize", len(payload))
-		z.addTask(topic, seq, payload)
+		z.addTask(ctx, topic, seq, payload)
 		z.lastSeq = seq
 		z.hasLastSeq = true
 	}
 }
 
-func (z *zmqSubscriber) addTask(topic string, seq uint64, payload []byte) {
+// addTask hands a received message to the pool, carrying the receive span's
+// identity so processing rejoins this trace across the worker queue. The span
+// starts after Recv returns so it measures handoff work rather than the idle
+// wait for the next message.
+func (z *zmqSubscriber) addTask(ctx context.Context, topic string, seq uint64, payload []byte) {
+	// Spans route through the pool so a single Config.Tracing decision governs
+	// every stage of the pipeline.
+	_, span := z.pool.startSpan(ctx, "events_receive", consumerSpanOptions)
+	defer span.End()
+	// A span that tracing sampled out still reports IsRecording false; skip
+	// attribute construction so those messages cost nothing either.
+	if span.IsRecording() {
+		attrs := []attribute.KeyValue{
+			attribute.String("llm_d.kv_cache.events.topic", topic),
+			attribute.Int64("llm_d.kv_cache.events.sequence", int64(seq)), //nolint:gosec // vLLM sequence counter never approaches int64 overflow
+			attribute.Int("llm_d.kv_cache.events.payload_size_bytes", len(payload)),
+		}
+		// Empty unless the subscriber was created by pod discovery.
+		if z.sourceEndpoint != "" {
+			attrs = append(attrs, attribute.String("llm_d.kv_cache.events.source_endpoint", z.sourceEndpoint))
+		}
+		span.SetAttributes(attrs...)
+	}
+
 	z.pool.AddTask(&RawMessage{
 		Topic:          topic,
 		Sequence:       seq,
 		Payload:        payload,
 		SourceEndpoint: z.sourceEndpoint,
+		SpanContext:    span.SpanContext(),
 	})
 }
 
@@ -363,7 +388,7 @@ func (z *zmqSubscriber) requestReplay(ctx context.Context, startSeq uint64) bool
 				break
 			}
 
-			z.addTask(topic, seq, payload)
+			z.addTask(ctx, topic, seq, payload)
 			z.lastSeq = seq
 			z.hasLastSeq = true
 			replayed++

--- a/pkg/kvevents/zmq_subscriber_tracing_test.go
+++ b/pkg/kvevents/zmq_subscriber_tracing_test.go
@@ -1,0 +1,79 @@
+// Copyright 2025 The llm-d Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvevents //nolint:testpackage // tests drive unexported addTask
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// drainOne pulls the single queued message off whichever shard received it.
+func drainOne(t *testing.T, pool *Pool) *RawMessage {
+	t.Helper()
+	for _, q := range pool.queues {
+		if q.Len() == 0 {
+			continue
+		}
+		msg, shutdown := q.Get()
+		require.False(t, shutdown)
+		q.Done(msg)
+		return msg
+	}
+	t.Fatal("no message was enqueued")
+	return nil
+}
+
+// addTask is the producing half of the receive-to-process trace link: it must
+// both emit the span and stamp its identity onto the queued message.
+func TestAddTask_EmitsReceiveSpanAndCarriesItsContext(t *testing.T) {
+	recorder := setupEventSpanRecorder(t)
+	pool := newTracingPool(t)
+	z := newZMQSubscriber(pool, "pod-1", "10.0.0.1:8003", "tcp://10.0.0.1:5557", "", "kv@", false)
+
+	z.addTask(context.Background(), "kv@10.0.0.1:8000@test-model", 42, []byte{1, 2, 3})
+
+	span := findEventSpan(t, recorder, "events_receive")
+	attrs := eventSpanAttrs(span)
+	assert.Equal(t, "kv@10.0.0.1:8000@test-model", attrs["llm_d.kv_cache.events.topic"].AsString())
+	assert.Equal(t, int64(42), attrs["llm_d.kv_cache.events.sequence"].AsInt64())
+	assert.Equal(t, int64(3), attrs["llm_d.kv_cache.events.payload_size_bytes"].AsInt64())
+	assert.Equal(t, "10.0.0.1:8003", attrs["llm_d.kv_cache.events.source_endpoint"].AsString())
+
+	// The queued message must carry the span's identity, or processing starts a
+	// detached trace no matter how well the consuming side re-parents.
+	msg := drainOne(t, pool)
+	assert.Equal(t, span.SpanContext().TraceID(), msg.SpanContext.TraceID())
+	assert.Equal(t, span.SpanContext().SpanID(), msg.SpanContext.SpanID())
+}
+
+// End to end across the queue boundary: the span the subscriber created must be
+// the parent of the span the worker creates.
+func TestAddTask_ReceiveSpanParentsProcessSpan(t *testing.T) {
+	recorder := setupEventSpanRecorder(t)
+	pool := newTracingPool(t)
+	pool.adapter = &sourceEndpointAdapter{}
+	z := newZMQSubscriber(pool, "pod-1", "", "tcp://10.0.0.1:5557", "", "kv@", false)
+
+	z.addTask(context.Background(), "kv@10.0.0.1:8000@test-model", 7, []byte{1})
+	pool.processRawMessage(context.Background(), drainOne(t, pool))
+
+	receive := findEventSpan(t, recorder, "events_receive")
+	process := findEventSpan(t, recorder, "events_process")
+	require.Equal(t, receive.SpanContext().TraceID(), process.SpanContext().TraceID())
+	assert.Equal(t, receive.SpanContext().SpanID(), process.Parent().SpanID())
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Closes the two remaining OTel coverage gaps carried over from llm-d-kv-cache#644, whose subject code now lives in this repo:

1. **Tokenization**: a `tokenize` span in the token-producer plugin, attributed with backend (`uds`/`vllm`/`estimate`), token count, and the shared `mm.*` attributes. The span covers the backend call only, so the already-tokenized skip path stays untraced.

2. **KV-cache events**: `events_receive` -> `events_process` -> `events_decode` across the ZMQ pipeline. The receive span's identity is carried on `RawMessage` across the worker queue, so index writes nest under the event that caused them instead of appearing as detached root spans.

**Event tracing is opt-in** via `kvEventsConfig.tracing` (default `false`). This addresses the trace-volume concern raised in review: KV events arrive at many times the inference request rate, so with a shared head sampler, always-on event traces would crowd request traces out of the exported volume. When off, no event spans are created at all and request tracing is unaffected.

```yaml
- type: precise-prefix-cache-producer
  parameters:
    kvEventsConfig:
      zmqEndpoint: tcp://0.0.0.0:5557
      tracing: true
```

**Notes**

- *Context handoff.* llm-d-kv-cache#679 put a `context.Context` on the queued task. That is unsafe here: `runSubscriber` returns and retries on any recv error, so a queued message would carry a cancelled context into the worker and fail its index lookups. Only `trace.SpanContext` crosses the queue; the worker re-parents onto its own live context.

- *No interface change.* An earlier revision added `ctx` to `EngineAdapter.ParseMessage` so a decorator could open `events_decode`. Per review that breaking change is dropped: the span now wraps the adapter call in an unexported `Pool.decode` helper, and `EngineAdapter` is untouched, so out-of-tree adapters need no migration.

- *Local parent across the queue.* The receive span's identity crosses the worker queue in memory, so `processRawMessage` re-parents with `trace.ContextWithSpanContext` rather than `ContextWithRemoteSpanContext`. The remote form sets the span context's remote flag, which selects the `remoteParent*` branch of a `ParentBased` sampler and reports an in-process handoff as cross-process in exported spans.

- *Hot-path cost with tracing on.* The tracer is resolved once per `Pool` at construction rather than per message (`tracing.Tracer` rebuilds its instrumentation options on every call), span start options are package-level slices rather than variadic arguments rebuilt per call, and attribute construction sits behind `span.IsRecording()`. Measured on the ingest path: 953 ns/op and 14 allocs/op before, 750 ns/op and 8 allocs/op after.

- *No cost with tracing off.* `Pool.startSpan` returns the context untouched and a shared no-op span when `Config.Tracing` is unset, so `Start` is never reached on the default path. The pipeline's three spans cost 11.16 ns/op, 0 B/op and 0 allocs/op per message, against 100.6 ns/op, 144 B/op and 3 allocs/op when the same path ran through a no-op tracer. A no-op `Start` still builds its variadic option slice and a context per call, which at KV-event rates is not negligible.

**On #644's instrumentation constraints**

#644 asks to "instrument at the interface boundary following the existing tracedIndex wrapper pattern, do not inline spans into business logic. Reuse telemetry.InstrumentationName and the llm_d.kv_cache.* span-name prefix." None of the three is followed here; the reasoning for each:

1. **Interface boundary.** Superseded by review on this PR: "`processRawMessage` already holds a live ctx and a span at the call site, so `events_decode` could be opened inline there with no interface change and no migration cost for out-of-tree adapters." `events_receive` and `events_process` have no interface to wrap at all, and `tokenize` cannot be a decorator without losing `gen_ai.request.model` / `gen_ai.request.id`, which the backend interface never receives.

2. **`telemetry.InstrumentationName`.** No such identifier exists in llm-d-router; it belonged to llm-d-kv-cache's `pkg/telemetry`. The local equivalent is unexported (`tracing.instrumentationName`), reachable only as `tracing.Tracer()` with no scope. The pattern #644 points at does not use it either: `traced_index.go` passes a per-package scope. `main` carries those scopes as per-package `TracerScope` constants (`pkg/kvcache/constants.go`, `pkg/kvcache/kvblock/constants.go`, `pkg/epp/framework/plugins/requestcontrol/constants.go`) since #2164; the new `pkg/kvevents/constants.go` is the same pattern, and the `tokenize` span uses the existing requestcontrol constant.

3. **`llm_d.kv_cache.*` span-name prefix.** #2164 renamed exactly these five spans -- `llm_d.kv_cache.index.add` to `index_add`, `.index.evict` to `index_evict`, `.index` to `index_lookup`, `.score_tokens` to `score_tokens`, `.scorer.compute` to `compute_scores` -- and left the `llm_d.kv_cache.*` **attribute** keys in place. This PR matches `main` on both counts: bare `events_receive` / `events_process` / `events_decode` span names, `llm_d.kv_cache.events.*` attributes. No prefixed span names remain in the repo.

**Test plan**

Unit tests use an in-memory span recorder. Deployed behaviour was checked separately on a kind stack (vLLM simulator publishing KV events over ZMQ), with the exporter set to console at 100% sampling.

- [x] Tokenize span is emitted with backend, model, request id, token count and `mm.*`, and parents to the caller's span rather than rooting
- [x] Tokenize span records an error status when the backend fails, is absent entirely on the already-tokenized skip path, and reports `skipped_no_tokens` when the backend returns no tokens
- [x] `addTask` emits the receive span and stamps its identity onto the queued message
- [x] The receive span is the parent of the process span across the worker-queue boundary, and processing still traces as its own root when no identity was carried
- [x] Decode failure marks both the decode and process spans
- [x] A pool built the production way emits the decode span
- [x] Index writes nest under the process span instead of appearing as detached roots
- [x] No event spans at all when `kvEventsConfig.tracing` is unset, and the default is off
- [x] The process span records its parent as local, not remote, across the queue handoff
- [x] The disabled path allocates nothing, asserted with `testing.AllocsPerRun`
- [x] `make presubmit` and `go test ./pkg/kvevents/... ./pkg/epp/framework/plugins/requestcontrol/... ./pkg/kvcache/...`

On the kind stack with `tracing: true`, two traces, as intended, since KV events arrive asynchronously from vLLM and are not part of any router request:

```
request                        (root)    events_receive              (root)
  request_orchestration                    events_process
    tokenize                                 events_decode
    produce_precise_prefix_cache             index_add
    run_scheduler_profile
```

`events_process` records its parent as local (`Parent.Remote = false`) and `index_add` nests under it in the same trace.

With `tracing` unset (the default), no `events_*` spans are emitted, `index_add` returns to being a detached root exactly as before this PR, and the request trace is unchanged. KV events still flow through the pipeline in that configuration, so the disabled path is exercised rather than skipped.

**Which issue(s) this PR fixes**:

Fixes https://github.com/llm-d/llm-d-kv-cache/issues/644

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
EPP can now emit OpenTelemetry spans for prompt tokenization and for the KV-cache event pipeline (receive, decode, dispatch), linking KV-cache index operations to the event that triggered them. Tokenization spans are emitted whenever tracing is enabled; KV-cache event spans are opt-in via the new `tracing` field on `kvEventsConfig` and are off by default.
```
