### PR TITLE
docs: add coordinator metrics specification

### DIFF
--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -23,7 +23,7 @@ translate between the two components. Where a name matches an EPP metric, the
 Every metric on this page is exposed on a single `/metrics` endpoint served by the coordinator
 process, alongside the inference paths and `/healthz` and `/readyz` on the coordinator's chi router
 (`pkg/coordinator/server/server.go`). The registry it serves, the port or flag that selects it, and
-whether it is authenticated are settled by the phase 1 implementation. EPP's Prometheus wiring is
+whether it is authenticated are open. EPP's Prometheus wiring is
 separate: it lives in `cmd/epp/runner` and serves the controller-runtime registry rather than the
 default one.
 
@@ -65,7 +65,7 @@ A step may issue zero or many backend calls and includes local work; a phase is 
 `conditional-decode` issues a decode-phase call: `steps/decode_proxy.go` `newDecodeProxyRequest`
 stamps `EPPProfileHeader=PhaseDecode` unconditionally, and both the probe and the decode step go
 through it, so a cache-miss request sends two decode-phase calls. See the
-[open decision](#upstream-phase-family-phase-2) on the phase family.
+[open decision](#upstream-phase-family) on the phase family.
 
 ## Error classes
 
@@ -91,7 +91,7 @@ failure on the decode leg reaches the client but is absent from both error metri
 
 ## Metrics catalog
 
-### Request family (phase 1)
+### Request family
 
 Recorded in `server/handlers.go` `handleInference`. Requests that exit early because they are
 malformed (body-read error, 413, invalid JSON) count as `bad_request` with `model_name=unknown`.
@@ -110,7 +110,7 @@ Unless otherwise noted, metrics in this family share the label `{model_name}`.
 dashboard panel that groups the family by model has no series for it. EPP's
 `llm_d_epp_request_running` is labelled by model, fairness ID, and priority.
 
-### Pipeline step family (phase 1)
+### Pipeline step family
 
 Recorded in `pipeline.go` `Execute`, one observation per step per request. This family measures each
 stage's whole wall time, local work plus orchestration plus any backend calls the stage makes, not
@@ -151,7 +151,7 @@ histogram_quantile(0.95, sum by (le) (rate(
   llm_d_coordinator_pipeline_step_duration_seconds_bucket{step="decode"}[5m])))
 ```
 
-### Upstream phase family (phase 2)
+### Upstream phase family
 
 Recorded in `steps/encode.go`, `prefill.go` and `decode_proxy.go`. This family counts and times the
 outbound sub-requests the coordinator sends to the gateway carrying the epp-profile header. Only
@@ -201,7 +201,7 @@ upstream_request_total{phase="prefill"} += 1
 upstream_request_total{phase="decode"}  += 1
 ```
 
-### Disaggregation decision and decode cache (phase 3)
+### Disaggregation decision and decode cache
 
 #### `disagg_decision_total`
 

--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -173,12 +173,13 @@ This is reachable by any client, and it is a mitigation the implementation has t
 
 Capping the distinct values is the approach that fits: `model_name` is capped at 1000 over the
 process lifetime and further values are reported as `other`. The bounded-label helper lives in
-`pkg/common/observability/metrics/cardinality.go` (`BoundedLabel`, `OverflowValue = "other"`) and is
-instantiated with the same cap by both `pkg/coordinator/metrics/cardinality.go` and
-`pkg/epp/metrics/cardinality.go`, so the two components share one guard. An allowlist has no source
-of truth here, since the coordinator's config carries no model list and the coordinator is otherwise
-model-agnostic. The overflow value must not be `unknown`, which already means the request carried no
-model at all.
+[`pkg/common/observability/metrics/cardinality.go`](../pkg/common/observability/metrics/cardinality.go)
+(`BoundedLabel`, `OverflowValue = "other"`) and is instantiated with the same cap by both
+[`pkg/coordinator/metrics/cardinality.go`](../pkg/coordinator/metrics/cardinality.go) and
+[`pkg/epp/metrics/cardinality.go`](../pkg/epp/metrics/cardinality.go), so the two components share
+one guard. An allowlist has no source of truth here, since the coordinator's config carries no model
+list and the coordinator is otherwise model-agnostic. The overflow value must not be `unknown`,
+which already means the request carried no model at all.
 
 ## Related documentation
 

--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -90,9 +90,13 @@ probe has its own metric,
 the EPP side, as `request_error_total{error_code="PreconditionFailed"}`.
 
 `upstream_4xx` and `upstream_5xx` therefore describe the render, prefill, and encode steps, the only
-ones that turn a non-2xx response into an error. The conditional-decode and decode steps
-proxy the upstream response straight to the client without constructing an error, so an upstream
-failure on the decode leg reaches the client but is absent from both error metrics.
+ones that turn a non-2xx response into an error. The conditional-decode and decode steps proxy the
+upstream response straight to the client without constructing an error, so an upstream failure on the
+decode leg reaches the client but is absent from both error metrics. This covers the worst case: a
+worker that dies mid-generation truncates the client's response while the request still counts as a
+success. Both failure modes are already detected by the decode proxy, which writes 502 when the call
+fails before the response starts and logs a truncation when the copy fails after it, so closing the
+gap is a matter of recording those two points rather than adding detection.
 
 ## Metrics catalog
 
@@ -214,10 +218,13 @@ decode one step is one gateway call:
   one concurrent call per image, so `pipeline_step_duration_seconds{step="encode"}` observes the
   whole stage once per request (the fan-out envelope: slowest call plus the EC merge) and hides what
   a single image cost. A step p95 well above the call p95 means the width of the fan-out, not any one
-  image, is the expense. For prefill and decode the call latency already equals the step duration. Two loose ends remain: the `phase` label then carries exactly one value, which
-  invites empty `phase="prefill"` queries, and `generalLatencyBuckets` runs to 1h, far past any
-  single encode call. Either drop the label and name the metric for what it measures, or keep it
-  explicitly for forward compatibility, and consider `stepLatencyBuckets`.
+  image, is the expense. For prefill and decode the call latency already equals the step duration. Two
+  loose ends remain. The `phase` label carries exactly one value, which invites empty
+  `phase="prefill"` queries: either drop it and name the metric for what it measures, or keep it
+  explicitly for forward compatibility. And `generalLatencyBuckets` runs to 1h, far past any single
+  encode call, so `stepLatencyBuckets` fits the range better; note that `generalLatencyBuckets` is
+  EPP's own set, so switching gives up bucket-for-bucket comparison with
+  `llm_d_epp_request_duration_seconds`.
 - There is no `upstream_request_error_total`. A phase-call failure aborts its step and is already
   counted by `pipeline_step_errors_total` under the same `error_code`. Per-call encode fan-out
   failure granularity is the one gap, but the errgroup context cancels sibling calls on the first
@@ -320,11 +327,16 @@ transport-independent measure of image size, and are already computed in render 
 ## Cardinality
 
 `model_name` labels every request-family metric, three of them histograms, and the handler takes it
-straight from the request body without validation. An arbitrary set of client-supplied strings
-multiplied by the latency buckets is
-a cardinality-explosion vector against the coordinator's own memory, reachable by any client. The
-mitigation has to be chosen before implementing: allowlist against configured models, cap the
-distinct values as EPP does, or accept the risk explicitly.
+straight from the request body without validation. Each distinct value creates its own set of series,
+and a histogram multiplies that by its bucket count, so a client looping over invented model names
+grows the coordinator's memory without bound. This is reachable by any client, and it is a mitigation
+the implementation has to carry.
+
+Capping the distinct values is the approach that fits: EPP caps `model_name` at 1000 over the process
+lifetime and reports further values as `other`, and matching that keeps the two components
+consistent. An allowlist has no source of truth here, since the coordinator's config carries no model
+list and the coordinator is otherwise model-agnostic. The overflow value must not be `unknown`, which
+already means the request carried no model at all.
 
 ## Related documentation
 

--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -46,7 +46,9 @@ three to follow a request end to end.
 
 ## Labels
 
-Two labels use the words `encode`, `prefill`, and `decode`. They are not interchangeable.
+The `step` and `phase` labels share the values `encode`, `prefill`, `decode`, and
+`conditional-decode`, but are not interchangeable: a step is a pipeline stage, a phase is a single
+backend call.
 
 The **`step` label** names a stage of the coordinator's internal pipeline, observed once per request
 per stage. A step covers local work, orchestration, and any backend calls that stage makes. The
@@ -71,6 +73,10 @@ A step may issue zero or many backend calls and includes local work; a phase is 
 The first three values match the epp-profile header the coordinator sends. `conditional-decode` does
 not: the probe carries the decode profile header, like the decode step, and is distinguished by the
 `Prefer: if-available` header it adds. See the [Upstream phase family](#upstream-phase-family).
+
+The **`decision_type` label** names which phases a request ended up running, one value per request
+rather than per stage or per call: `decode-only`, `prefill-decode`, or `encode-prefill-decode`. See
+[`disagg_decision_total`](#disagg_decision_total).
 
 ## Error classes
 

--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -5,12 +5,15 @@ runs to serve them (see [Coordinator Architecture](coordinator_architecture.md))
 from the Endpoint Picker (EPP) metrics documented in [Metrics](metrics.md): the two components
 measure different points in the same request path.
 
-## Subsystems and naming
+## Subsystem and naming
 
-Every series carries the subsystem prefix `llm_d_coordinator_`, so a metric's full Prometheus name is
-`llm_d_coordinator_<name>`. Names below omit the prefix. All metrics are ALPHA stage.
+A metric's full Prometheus name is `<subsystem>_<name>`. The coordinator uses a single subsystem:
 
-Naming mirrors the EPP request family (`pkg/epp/metrics`) so PromQL expressions and dashboard panels
+| Prefix | Scope |
+|---|---|
+| `llm_d_coordinator_` | Every coordinator metric: request, pipeline step, upstream phase, disaggregation decision, and decode cache. |
+
+Naming mirrors the EPP request family so PromQL expressions and dashboard panels
 translate between the two components. Where a name matches an EPP metric, the
 [Relationship to EPP metrics](#relationship-to-epp-metrics) section states what differs.
 
@@ -21,13 +24,14 @@ translate between the two components. Where a name matches an EPP metric, the
 ### Coordinator metrics endpoint
 
 Every metric on this page is exposed on a single `/metrics` endpoint served by the coordinator
-process, alongside the inference paths and `/healthz` and `/readyz` on the coordinator's chi router
-(`pkg/coordinator/server/server.go`). The registry it serves, the port or flag that selects it, and
-whether it is authenticated are open. EPP's Prometheus wiring is
-separate: it lives in `cmd/epp/runner` and serves the controller-runtime registry rather than the
-default one.
+process, alongside the inference paths and `/healthz` and `/readyz`. EPP's metrics endpoint is
+separate, served from its own process on the controller-runtime registry.
 
-### Metrics served elsewhere
+TBD: the registry the endpoint serves, its address, and whether it is authenticated. EPP authenticates
+its endpoint by default (`--metrics-endpoint-auth`), which requires RBAC for TokenReview and
+SubjectAccessReview; matching that would extend the coordinator's ServiceAccount permissions.
+
+### Other scrape targets
 
 All coordinator metrics are self-instrumented: the coordinator counts and times its own work
 in-process, and scrapes nothing. Two series record a signal that originates upstream but is still
@@ -40,14 +44,16 @@ the other two endpoints: per-request token counts and pool aggregates such as KV
 and queue depth on EPP's (see [Metrics](metrics.md)), multimodal cache counters on vLLM's. Scrape all
 three to follow a request end to end.
 
-## Label vocabularies
+## Labels
 
-Two vocabularies use the words `encode`, `prefill`, and `decode`. They are not interchangeable.
+Two labels use the words `encode`, `prefill`, and `decode`. They are not interchangeable.
 
-**`step`** is a stage of the coordinator's internal pipeline, observed once per request per stage. A
-step covers local work, orchestration, and any backend calls that stage makes.
+The **`step` label** names a stage of the coordinator's internal pipeline, observed once per request
+per stage. A step covers local work, orchestration, and any backend calls that stage makes. The
+values are the built-in step names; [Coordinator Architecture](coordinator_architecture.md) describes
+what each one does and how a pipeline is assembled from them.
 
-| Value | Stage |
+| `step` value | Stage |
 |---|---|
 | `render` | Call the render service to tokenize and apply the chat template. |
 | `replace-media-urls` | Rewrite media URLs in the request body (local work only). |
@@ -56,82 +62,85 @@ step covers local work, orchestration, and any backend calls that stage makes.
 | `conditional-decode` | Probe the decode cache for the 412 fast path. |
 | `decode` | Decode and generation, streamed back to the client. |
 
-**`phase`** is a single outbound backend call, counted once per call. Its values are `encode`,
-`prefill`, and `decode`, matching `gateway.EPPProfileHeader`.
+The **`phase` label** names a single outbound backend call, counted once per call. Its values are
+`encode`, `prefill`, `decode`, and `conditional-decode`.
 
-A step may issue zero or many backend calls and includes local work; a phase is one call. Only
-`render` and `replace-media-urls` have no phase counterpart.
+A step may issue zero or many backend calls and includes local work; a phase is one call. Only the
+`render` and `replace-media-urls` steps have no phase counterpart.
 
-`conditional-decode` issues a decode-phase call: `steps/decode_proxy.go` `newDecodeProxyRequest`
-stamps `EPPProfileHeader=PhaseDecode` unconditionally, and both the probe and the decode step go
-through it, so a cache-miss request sends two decode-phase calls. See the
-[open decision](#upstream-phase-family) on the phase family.
+The first three values match the epp-profile header the coordinator sends. `conditional-decode` does
+not: the probe carries the decode profile header, like the decode step, and is distinguished by the
+`Prefer: if-available` header it adds. See the [Upstream phase family](#upstream-phase-family).
 
 ## Error classes
 
-`error_code` on `request_error_total` and `pipeline_step_errors_total` uses one coarse set of values:
+`error_code` on `request_error_total` and `pipeline_step_errors_total` uses one set of four values:
 `bad_request`, `upstream_4xx`, `upstream_5xx`, `internal`.
 
-This classification is finer than `server/handlers.go` `classifyPipelineError`, which collapses
-upstream 5xx faults and internal faults into HTTP 502. The metrics helper inspects the error type
-directly: an `UpstreamError` carrying a 5xx `StatusCode` is `upstream_5xx`, and any other
-non-`ErrBadRequest` error is `internal`.
+This classification is finer than the handler's client-facing status mapping, which collapses upstream
+5xx faults and internal faults into HTTP 502. Classification inspects the error type directly: an
+upstream error carrying a 5xx status is `upstream_5xx`, and any other error that is not a bad request
+is `internal`.
 
-The conditional-decode probe's 412 is not an error in any class. `steps/conditional_decode.go`
-intercepts that status in `ModifyResponse` and converts it to a cache miss, so the step returns
-`nil` and the pipeline continues; a hit returns `ErrPipelineDone`, a successful early exit. Neither
-outcome reaches the classifier, which is why the probe has its own metric,
+The conditional-decode probe's 412 is not an error in any class. The step intercepts that status and
+converts it to a cache miss, so it returns no error and the pipeline continues; a hit ends the
+pipeline early, which is also not an error. Neither outcome reaches the classifier, which is why the
+probe has its own metric,
 [`decode_cache_lookups_total`](#decode_cache_lookups_total). The same 412 does count as an error on
 the EPP side, as `request_error_total{error_code="PreconditionFailed"}`.
 
 `upstream_4xx` and `upstream_5xx` therefore describe the render, prefill, and encode steps, the only
-ones that build an `UpstreamError` from a non-2xx response. The conditional-decode and decode steps
+ones that turn a non-2xx response into an error. The conditional-decode and decode steps
 proxy the upstream response straight to the client without constructing an error, so an upstream
 failure on the decode leg reaches the client but is absent from both error metrics.
 
 ## Metrics catalog
 
+Names below omit the subsystem prefix, which is `llm_d_coordinator_` throughout, and every metric is
+ALPHA stage. Each family states the label set its metrics share; a metric that carries an extra label
+says so in its own row.
+
 ### Request family
 
-Recorded in `server/handlers.go` `handleInference`. Requests that exit early because they are
-malformed (body-read error, 413, invalid JSON) count as `bad_request` with `model_name=unknown`.
-Unless otherwise noted, metrics in this family share the label `{model_name}`.
+Label set `{model_name}` (the request's model).
+
+Recorded by the request handler. Requests that exit early because they are malformed (body-read
+error, 413, invalid JSON) count as `bad_request` with `model_name=unknown`.
 
 | Name | Type | Notes |
 |---|---|---|
 | `request_total` | Counter | Every inbound client request, including malformed ones. |
-| `request_error_total` | Counter | Failed requests by coarse class; adds label `error_code`. |
+| `request_error_total` | Counter | Failed requests; adds label `error_code`. |
 | `request_duration_seconds` | Histogram | End-to-end request latency; `generalLatencyBuckets` (5ms to 1h). |
 | `request_size_bytes` | Histogram | Request body length; powers-of-2 buckets. |
 | `response_size_bytes` | Histogram | Bytes streamed to the client, measured by a counting `ResponseWriter` wrapper in the handler rather than by parsing the body. |
-| `request_running` | Gauge | Requests in flight; unlabelled. |
+| `request_running` | Gauge | Requests in flight. |
 
-`request_running` is fleet-wide while the rest of the family is labelled by `model_name`, so a
-dashboard panel that groups the family by model has no series for it. EPP's
-`llm_d_epp_request_running` is labelled by model, fairness ID, and priority.
+EPP's `llm_d_epp_request_running` adds `fairness_id` and `priority`. Both come from flow control,
+which the coordinator does not implement, so neither has a coordinator counterpart.
 
 ### Pipeline step family
 
-Recorded in `pipeline.go` `Execute`, one observation per step per request. This family measures each
+Label set `{step}` (a stage of the coordinator's internal pipeline, see [Labels](#labels)).
+
+Recorded by the pipeline executor, one observation per step per request. This family measures each
 stage's whole wall time, local work plus orchestration plus any backend calls the stage makes, not
 the individual outbound calls. It answers where time goes inside the coordinator and which internal
-stage failed. Metrics in this family share the label `{step}`.
+stage failed.
 
 | Name | Type | Notes |
 |---|---|---|
 | `pipeline_step_duration_seconds` | Histogram | Per-step latency, from the timings the pipeline already computes. |
-| `pipeline_step_errors_total` | Counter | Step failures by class; adds label `error_code`. |
+| `pipeline_step_errors_total` | Counter | Step failures; adds label `error_code`. |
 
 `pipeline_step_duration_seconds` uses a dedicated bucket set, not `generalLatencyBuckets`: steps span
 microseconds (render, a skipped encode) to seconds (upstream-bound decode), and a 5ms floor collapses
 every fast step into one bucket. `stepLatencyBuckets` is 100us, 250us, 500us, 1ms, 2.5ms, 5ms, 10ms,
 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s, 30s, 60s.
 
-`pipeline.Execute` pre-sizes its timings slice for all steps (`make([]stepTiming, len(p.steps))`). On
-an early exit (`ErrPipelineDone`, which every conditional-decode hit takes) or a step failure, the
-trailing entries stay zero-valued, so iterating the slice emits a `step=""` series with a 0s
-observation for every step that never ran. Record inside the loop, or skip entries with an empty
-name.
+Only steps that ran are observed. The executor pre-sizes its timings for the full step list, so on an
+early exit (every conditional-decode hit) or a step failure the trailing entries are unset; recording
+them would emit a `step=""` series with a 0s observation for every step that never ran.
 
 Each step that ran expands to its own histogram block. For three decode steps taking 1.9s, 2.1s and
 1.7s:
@@ -153,53 +162,73 @@ histogram_quantile(0.95, sum by (le) (rate(
 
 ### Upstream phase family
 
-Recorded in `steps/encode.go`, `prefill.go` and `decode_proxy.go`. This family counts and times the
-outbound sub-requests the coordinator sends to the gateway carrying the epp-profile header. Only
-gateway phase calls count: the render-service call and media-URL fetches are outbound too but carry
-no phase header, and their latency appears in
-`pipeline_step_duration_seconds{step="render"|"replace-media-urls"}`. Metrics in this family share the label `{phase}`.
+Label set `{phase}` (one outbound backend call, not a pipeline stage, see [Labels](#labels)).
+
+Recorded by the encode, prefill, and decode steps. This family counts and times the outbound
+sub-requests the coordinator sends to the gateway carrying the epp-profile header. Only gateway phase
+calls count: the render-service call and media-URL fetches are outbound too but carry no phase
+header, and their latency appears in
+`pipeline_step_duration_seconds{step="render"|"replace-media-urls"}`.
 
 | Name | Type | Notes |
 |---|---|---|
 | `upstream_request_total` | Counter | Gateway sub-requests, one per call; encode contributes one per image. |
-| `upstream_request_duration_seconds` | Histogram | Per-call encode latency (encode only). |
+| `upstream_request_duration_seconds` | Histogram | Latency of one encode call, so one observation per image (encode only). |
+
+One multimodal chat request with two images, in a pipeline whose conditional-decode probe misses,
+counts once inbound and five times outbound:
+
+```
+request_total{model_name="llama"}                  += 1
+upstream_request_total{phase="conditional-decode"} += 1
+upstream_request_total{phase="encode"}             += 2
+upstream_request_total{phase="prefill"}            += 1
+upstream_request_total{phase="decode"}             += 1
+```
+
+Had the probe hit, it would be the only outbound call: the pipeline stops there and the encode,
+prefill, and decode series do not move.
+
+Dividing outbound calls by inbound requests gives the fan-out. Over a live window both sides are
+rates, so the per-second units cancel and the result reads as calls per request:
+
+```promql
+# mean backend calls per client request, all phases: 5 if every request matched the example
+sum(rate(llm_d_coordinator_upstream_request_total[5m]))
+  / sum(rate(llm_d_coordinator_request_total[5m]))
+
+# mean encode calls per client request, so mean images per request: 2 for the example
+sum(rate(llm_d_coordinator_upstream_request_total{phase="encode"}[5m]))
+  / sum(rate(llm_d_coordinator_request_total[5m]))
+```
+
+`sum` is needed on both sides because the two counters carry different labels (`phase` against
+`model_name`), so they have no label pairs to divide against directly.
 
 The family is deliberately narrower than the step family it sits beside, because for prefill and
 decode one step is one gateway call:
 
-- `upstream_request_total` covers all three phases: the backend fan-out ratio
-  (`upstream_request_total / request_total`) is not derivable from the step family, and it costs
-  three series.
-- `upstream_request_duration_seconds` is encode-only: encode fans out N concurrent calls, so
-  `pipeline_step_duration_seconds{step="encode"}` is the fan-out envelope (slowest call plus the EC
-  merge) and hides per-image call latency. For prefill and decode the call latency already equals the
-  step duration. Two loose ends remain: the `phase` label then carries exactly one value, which
+- `upstream_request_total` covers all three phases: the fan-out ratios above are not derivable from
+  the step family, and it costs three series.
+- `upstream_request_duration_seconds` is encode-only, and is the per-image latency: encode fans out
+  one concurrent call per image, so `pipeline_step_duration_seconds{step="encode"}` observes the
+  whole stage once per request (the fan-out envelope: slowest call plus the EC merge) and hides what
+  a single image cost. A step p95 well above the call p95 means the width of the fan-out, not any one
+  image, is the expense. For prefill and decode the call latency already equals the step duration. Two loose ends remain: the `phase` label then carries exactly one value, which
   invites empty `phase="prefill"` queries, and `generalLatencyBuckets` runs to 1h, far past any
   single encode call. Either drop the label and name the metric for what it measures, or keep it
   explicitly for forward compatibility, and consider `stepLatencyBuckets`.
 - There is no `upstream_request_error_total`. A phase-call failure aborts its step and is already
-  counted by `pipeline_step_errors_total` under the same coarse class. Per-call encode fan-out
+  counted by `pipeline_step_errors_total` under the same `error_code`. Per-call encode fan-out
   failure granularity is the one gap, but the errgroup context cancels sibling calls on the first
   error, so a clean per-call failure count is not reliably available. This is a limitation, not a
   metric.
 
-**Open decision:** `phase="decode"` counts two different calls. The conditional-decode probe carries
-the same `PhaseDecode` header as the decode step, so a cache miss produces two `phase="decode"`
-increments for one client request, which makes the fan-out reading wrong. Pick one before
-implementing: add a `conditional-decode` value to the `phase` label (diverges from the header
-vocabulary, but each call type stays countable, and this is the recommended option); skip the probe
-in `upstream_request_total` (loses probe-call visibility, though `decode_cache_lookups_total` still
-counts probes); or accept the double count and document it.
-
-Inbound against outbound, for one multimodal chat request with two images in a pipeline without a
-conditional-decode step:
-
-```
-request_total{model_name="llama"}       += 1
-upstream_request_total{phase="encode"}  += 2
-upstream_request_total{phase="prefill"} += 1
-upstream_request_total{phase="decode"}  += 1
-```
+`phase="conditional-decode"` counts the probe, which is a real call to the decode worker and on a hit
+is the only backend call the request makes. It gets its own value rather than counting under
+`decode`: without it, the miss above would report two decode calls for one client request. Its volume
+matches `decode_cache_lookups_total`, which breaks the same probes down by outcome; carrying the
+probe here keeps the fan-out ratio complete and every outbound call attributable to one phase.
 
 ### Disaggregation decision and decode cache
 
@@ -239,8 +268,7 @@ then went `prefill-decode` or `encode-prefill-decode`, which is what `disagg_dec
 
 | Coordinator metric | EPP counterpart | Difference |
 |---|---|---|
-| `request_total`, `request_error_total`, `request_duration_seconds`, `request_size_bytes`, `response_size_bytes` | `llm_d_epp_*`, same names | The coordinator counts client requests at its own entry point; EPP counts what reaches the gateway, which for one client request includes each phase sub-request. |
-| `request_running` | `llm_d_epp_request_running` | The coordinator series is unlabelled; EPP labels by model, fairness ID and priority. |
+| `request_total`, `request_error_total`, `request_duration_seconds`, `request_size_bytes`, `response_size_bytes`, `request_running` | `llm_d_epp_*`, same names | The coordinator counts client requests at its own entry point; EPP counts what reaches the gateway, which for one client request includes each phase sub-request. EPP also labels by `fairness_id` and `priority`, which have no coordinator counterpart. |
 | `disagg_decision_total` | `llm_d_epp_disagg_decision_total` | Same name and same `model_name`/`decision_type` labels, and EPP adds plugin identity labels. EPP counts the routing decision its profile handler makes; the coordinator counts the phases it actually executed. |
 | `pipeline_step_*`, `upstream_request_*`, `decode_cache_lookups_total` | none | Coordinator-only. |
 
@@ -256,11 +284,11 @@ observation, ext_proc streaming).
 The coordinator emits no token-count metrics. EPP owns per-request token accounting and the
 coordinator does not duplicate it.
 
-Input and prompt tokens are available cheaply in-process as `len(reqCtx.TokenIDs)` after the render
-step (`steps/render.go` sets `TokenIDs` from the render service or from client-supplied token IDs).
-Output and cached tokens are not: the decode step is a pure byte proxy (`steps/decode.go` streams
-`proxy.ServeHTTP` straight to the client), so extracting them means intercepting and parsing the
-streamed SSE, exactly the invasiveness `response_size_bytes` avoids by counting bytes.
+Input and prompt tokens are available cheaply in-process after the render step, which holds the token
+IDs from the render service or from client-supplied token IDs. Output and cached tokens are not: the
+decode step is a pure byte proxy that streams the response straight to the client, so extracting them
+means intercepting and parsing the streamed SSE, exactly the invasiveness `response_size_bytes` avoids
+by counting bytes.
 
 There is no coverage gap in coordinator-deployment mode. The decode phase call goes out through the
 gateway, where EPP parses the vLLM `usage` block and emits `request_input_tokens`,
@@ -270,7 +298,7 @@ per-step latency without a cross-component join. That is a candidate, not a comm
 
 | Candidate | Type | Source |
 |---|---|---|
-| `request_prompt_tokens` | Histogram | `len(reqCtx.TokenIDs)` after render; token-count buckets. Label: `model_name`. |
+| `request_prompt_tokens` | Histogram | Token count after render; token-count buckets. Label: `model_name`. |
 
 ### Per-request image visibility
 
@@ -279,8 +307,8 @@ the gap is documented:
 
 | Candidate | Type | Source |
 |---|---|---|
-| `request_images` | Histogram | `len(reqCtx.MultimodalEntries)`; small-integer buckets. Label: `model_name`. |
-| `image_placeholder_tokens` | Histogram | `MultimodalEntry.Placeholder.Length`; token-count buckets. Label: `model_name`. |
+| `request_images` | Histogram | Multimodal entries per request; small-integer buckets. Label: `model_name`. |
+| `image_placeholder_tokens` | Histogram | Placeholder length per entry; token-count buckets. Label: `model_name`. |
 
 Image count is visible only indirectly, as `upstream_request_total{phase="encode"}`, which is
 aggregate rather than per-request. Image byte size is not reliably available at all: inline base64
@@ -291,9 +319,9 @@ transport-independent measure of image size, and are already computed in render 
 
 ## Cardinality
 
-`model_name` labels five of the six request-family metrics, three of them histograms, and
-`server/handlers.go` takes it straight from the request body (`model, _ := parsed["model"].(string)`)
-without validation. An arbitrary set of client-supplied strings multiplied by the latency buckets is
+`model_name` labels every request-family metric, three of them histograms, and the handler takes it
+straight from the request body without validation. An arbitrary set of client-supplied strings
+multiplied by the latency buckets is
 a cardinality-explosion vector against the coordinator's own memory, reachable by any client. The
 mitigation has to be chosen before implementing: allowlist against configured models, cap the
 distinct values as EPP does, or accept the risk explicitly.

--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -46,63 +46,24 @@ three to follow a request end to end.
 
 ## Labels
 
-The `step` and `phase` labels share the values `encode`, `prefill`, `decode`, and
-`conditional-decode`, but are not interchangeable: a step is a pipeline stage, a phase is a single
-backend call.
+The `step` and `phase` labels share most of their values, but measure different boundaries: a step is a pipeline stage (which may make multiple calls), while a phase is a single backend call.
 
-The **`step` label** names a stage of the coordinator's internal pipeline, observed once per request
-per stage. A step covers local work, orchestration, and any backend calls that stage makes. The
-values are the built-in step names; [Coordinator Architecture](coordinator_architecture.md) describes
-what each one does and how a pipeline is assembled from them.
-
-| `step` value | Stage |
-|---|---|
-| `render` | Call the render service to tokenize and apply the chat template. |
-| `replace-media-urls` | Rewrite media URLs in the request body (local work only). |
-| `encode` | Encode multimodal inputs; fans out one call per image. |
-| `prefill` | Prefill sub-request, producing KV transfer parameters. |
-| `conditional-decode` | Probe the decode cache for the 412 fast path. |
-| `decode` | Decode and generation, streamed back to the client. |
-
-The **`phase` label** names a single outbound backend call, counted once per call. Its values are
-`encode`, `prefill`, `decode`, and `conditional-decode`.
-
-A step may issue zero or many backend calls and includes local work; a phase is one call. Only the
-`render` and `replace-media-urls` steps have no phase counterpart.
-
-The first three values match the epp-profile header the coordinator sends. `conditional-decode` does
-not: the probe carries the decode profile header, like the decode step, and is distinguished by the
-`Prefer: if-available` header it adds. See the [Upstream phase family](#upstream-phase-family).
-
-The **`decision_type` label** names which phases a request ended up running, one value per request
-rather than per stage or per call: `decode-only`, `prefill-decode`, or `encode-prefill-decode`. See
-[`disagg_decision_total`](#disagg_decision_total).
+- **`step`**: A stage of the internal pipeline, observed once per request per stage. Covers local work and all backend calls made by that stage. Values: `render`, `replace-media-urls`, `encode`, `prefill`, `conditional-decode`, `decode`. See [Coordinator Architecture](coordinator_architecture.md).
+- **`phase`**: A single outbound backend call. Values: `encode`, `prefill`, `decode`, `conditional-decode`.
+- **`decision_type`**: The sequence of phases a request actually executed. Values: `decode-only`, `prefill-decode`, `encode-prefill-decode`.
 
 ## Error classes
 
-`error_code` on `request_error_total` and `pipeline_step_errors_total` uses one set of four values:
-`bad_request`, `upstream_4xx`, `upstream_5xx`, `internal`.
+The `error_code` label on `request_error_total` and `pipeline_step_errors_total` uses four values:
 
-This classification is finer than the handler's client-facing status mapping, which collapses upstream
-5xx faults and internal faults into HTTP 502. Classification inspects the error type directly: an
-upstream error carrying a 5xx status is `upstream_5xx`, and any other error that is not a bad request
-is `internal`.
+- **`bad_request`**: Client-side errors (e.g., malformed body).
+- **`upstream_4xx`**: 4xx errors from upstream (e.g., render, prefill, encode).
+- **`upstream_5xx`**: 5xx errors from upstream.
+- **`internal`**: All other coordinator-internal faults.
 
-The conditional-decode probe's 412 is not an error in any class. The step intercepts that status and
-converts it to a cache miss, so it returns no error and the pipeline continues; a hit ends the
-pipeline early, which is also not an error. Neither outcome reaches the classifier, which is why the
-probe has its own metric,
-[`decode_cache_lookups_total`](#decode_cache_lookups_total). The same 412 does count as an error on
-the EPP side, as `request_error_total{error_code="PreconditionFailed"}`.
-
-`upstream_4xx` and `upstream_5xx` therefore describe the render, prefill, and encode steps, the only
-ones that turn a non-2xx response into an error. The conditional-decode and decode steps proxy the
-upstream response straight to the client without constructing an error, so an upstream failure on the
-decode leg reaches the client but is absent from both error metrics. This covers the worst case: a
-worker that dies mid-generation truncates the client's response while the request still counts as a
-success. Both failure modes are already detected by the decode proxy, which writes 502 when the call
-fails before the response starts and logs a truncation when the copy fails after it, so closing the
-gap is a matter of recording those two points rather than adding detection.
+**Key behaviors:**
+- The conditional-decode probe's HTTP 412 (cache miss) is handled internally and is **not** an error. It is tracked separately by [`decode_cache_lookups_total`](#decode_cache_lookups_total).
+- `upstream_4xx` and `upstream_5xx` only apply to the `render`, `prefill`, and `encode` steps. The `decode` and `conditional-decode` steps proxy responses directly to the client, so upstream failures during decode currently reach the client without incrementing these error metrics.
 
 ## Metrics catalog
 
@@ -133,149 +94,46 @@ which the coordinator does not implement, so neither has a coordinator counterpa
 
 Label set `{step}` (a stage of the coordinator's internal pipeline, see [Labels](#labels)).
 
-Recorded by the pipeline executor, one observation per step per request. This family measures each
-stage's whole wall time, local work plus orchestration plus any backend calls the stage makes, not
-the individual outbound calls. It answers where time goes inside the coordinator and which internal
-stage failed.
+Recorded by the pipeline executor, one observation per step per request. This family measures each stage's total wall time (local work, orchestration, and all backend calls made by the stage). It answers where time goes inside the coordinator and which internal stage failed.
 
 | Name | Type | Notes |
 |---|---|---|
-| `pipeline_step_duration_seconds` | Histogram | Per-step latency, from the timings the pipeline already computes. |
+| `pipeline_step_duration_seconds` | Histogram | Per-step latency. Uses fine-grained `stepLatencyBuckets` (100us to 60s) to capture both microsecond steps (render) and seconds-long steps (decode). |
 | `pipeline_step_errors_total` | Counter | Step failures; adds label `error_code`. |
 
-`pipeline_step_duration_seconds` uses a dedicated bucket set, not `generalLatencyBuckets`: steps span
-microseconds (render, a skipped encode) to seconds (upstream-bound decode), and a 5ms floor collapses
-every fast step into one bucket. `stepLatencyBuckets` is 100us, 250us, 500us, 1ms, 2.5ms, 5ms, 10ms,
-25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s, 30s, 60s.
-
-Only steps that ran are observed. The executor pre-sizes its timings for the full step list, so on an
-early exit (every conditional-decode hit) or a step failure the trailing entries are unset; recording
-them would emit a `step=""` series with a 0s observation for every step that never ran.
-
-Each step that ran expands to its own histogram block. For three decode steps taking 1.9s, 2.1s and
-1.7s:
-
-```
-..._bucket{step="decode",le="1"}    0
-..._bucket{step="decode",le="2.5"}  3
-..._bucket{step="decode",le="+Inf"} 3
-..._sum{step="decode"}   5.7
-..._count{step="decode"} 3
-```
-
-p95 of the decode step:
-
-```promql
-histogram_quantile(0.95, sum by (le) (rate(
-  llm_d_coordinator_pipeline_step_duration_seconds_bucket{step="decode"}[5m])))
-```
+**Key details:**
+*   Only steps that actually executed are recorded. Trailing steps from early exits (e.g., conditional-decode hit) or failures are not emitted.
 
 ### Upstream phase family
 
 Label set `{phase}` (one outbound backend call, not a pipeline stage, see [Labels](#labels)).
 
-Recorded by the encode, prefill, and decode steps. This family counts and times the outbound
-sub-requests the coordinator sends to the gateway carrying the epp-profile header. Only gateway phase
-calls count: the render-service call and media-URL fetches are outbound too but carry no phase
-header, and their latency appears in
-`pipeline_step_duration_seconds{step="render"|"replace-media-urls"}`.
+Recorded by the encode, prefill, and decode steps. This family counts and times the outbound sub-requests to the gateway. (Render and media fetches are not included, their latency is tracked in `pipeline_step_duration_seconds`).
 
 | Name | Type | Notes |
 |---|---|---|
-| `upstream_request_total` | Counter | Gateway sub-requests, one per call; encode contributes one per image. |
-| `upstream_request_duration_seconds` | Histogram | Latency of one encode call, so one observation per image (encode only). |
+| `upstream_request_total` | Counter | Gateway sub-requests, one per call. (e.g. encode contributes one per image). |
+| `upstream_request_duration_seconds` | Histogram | Latency of one encode call (encode only). |
 
-One multimodal chat request with two images, in a pipeline whose conditional-decode probe misses,
-counts once inbound and five times outbound:
-
-```
-request_total{model_name="llama"}                  += 1
-upstream_request_total{phase="conditional-decode"} += 1
-upstream_request_total{phase="encode"}             += 2
-upstream_request_total{phase="prefill"}            += 1
-upstream_request_total{phase="decode"}             += 1
-```
-
-Had the probe hit, it would be the only outbound call: the pipeline stops there and the encode,
-prefill, and decode series do not move.
-
-Dividing outbound calls by inbound requests gives the fan-out. Over a live window both sides are
-rates, so the per-second units cancel and the result reads as calls per request:
-
-```promql
-# mean backend calls per client request, all phases: 5 if every request matched the example
-sum(rate(llm_d_coordinator_upstream_request_total[5m]))
-  / sum(rate(llm_d_coordinator_request_total[5m]))
-
-# mean encode calls per client request, so mean images per request: 2 for the example
-sum(rate(llm_d_coordinator_upstream_request_total{phase="encode"}[5m]))
-  / sum(rate(llm_d_coordinator_request_total[5m]))
-```
-
-`sum` is needed on both sides because the two counters carry different labels (`phase` against
-`model_name`), so they have no label pairs to divide against directly.
-
-The family is deliberately narrower than the step family it sits beside, because for prefill and
-decode one step is one gateway call:
-
-- `upstream_request_total` covers all three phases: the fan-out ratios above are not derivable from
-  the step family, and it costs three series.
-- `upstream_request_duration_seconds` is encode-only, and is the per-image latency: encode fans out
-  one concurrent call per image, so `pipeline_step_duration_seconds{step="encode"}` observes the
-  whole stage once per request (the fan-out envelope: slowest call plus the EC merge) and hides what
-  a single image cost. A step p95 well above the call p95 means the width of the fan-out, not any one
-  image, is the expense. For prefill and decode the call latency already equals the step duration. Two
-  loose ends remain. The `phase` label carries exactly one value, which invites empty
-  `phase="prefill"` queries: either drop it and name the metric for what it measures, or keep it
-  explicitly for forward compatibility. And `generalLatencyBuckets` runs to 1h, far past any single
-  encode call, so `stepLatencyBuckets` fits the range better; note that `generalLatencyBuckets` is
-  EPP's own set, so switching gives up bucket-for-bucket comparison with
-  `llm_d_epp_request_duration_seconds`.
-- There is no `upstream_request_error_total`. A phase-call failure aborts its step and is already
-  counted by `pipeline_step_errors_total` under the same `error_code`. Per-call encode fan-out
-  failure granularity is the one gap, but the errgroup context cancels sibling calls on the first
-  error, so a clean per-call failure count is not reliably available. This is a limitation, not a
-  metric.
-
-`phase="conditional-decode"` counts the probe, which is a real call to the decode worker and on a hit
-is the only backend call the request makes. It gets its own value rather than counting under
-`decode`: without it, the miss above would report two decode calls for one client request. Its volume
-matches `decode_cache_lookups_total`, which breaks the same probes down by outcome; carrying the
-probe here keeps the fan-out ratio complete and every outbound call attributable to one phase.
+**Key details:**
+*   **Fan-out:** A single client request can result in multiple backend calls (e.g., one conditional-decode probe, two encode calls for two images, one prefill, one decode).
+*   **Narrower scope than steps:** 
+    *   `upstream_request_duration_seconds` is encode-only because it tracks per-image latency. Prefill and decode already have a 1:1 mapping between call latency and step duration, so their timings are tracked solely in `pipeline_step_duration_seconds`.
+    *   There is no `upstream_request_error_total`. A phase-call failure aborts its step and is already counted by `pipeline_step_errors_total`.
+*   **Conditional-decode:** The `phase="conditional-decode"` counts the cache probe. It gets its own phase to distinguish it from the actual `decode` phase, maintaining accurate fan-out ratios.
 
 ### Disaggregation decision and decode cache
 
-#### `disagg_decision_total`
-
-*   **Type:** Counter
+#### `disagg_decision_total` (Counter)
 *   **Labels:** `model_name`, `decision_type` (`decode-only`, `prefill-decode`, `encode-prefill-decode`)
-*   **Description:** Which phases actually ran.
+*   **Description:** Records which phases actually ran for a request. Unlike EPP, it lacks `encode-decode` because encode always implies prefill in the coordinator.
 
-`disagg_decision_total`'s value set is narrower than EPP's, which also has `encode-decode`. In the
-coordinator encode always implies prefill, because encode produces the EC transfer parameters prefill
-consumes, so encode without prefill is not a reachable path.
-
-#### `decode_cache_lookups_total`
-
-*   **Type:** Counter
+#### `decode_cache_lookups_total` (Counter)
 *   **Labels:** `result` (`hit` or `miss`)
-*   **Description:** Conditional-decode probe outcome.
-
-`decode_cache_lookups_total` is emitted by exactly one place, the conditional-decode step, once per
-request that runs it. The step optimistically sends the request to the decode worker with
-`Prefer: if-available`. On a `hit` the worker already held the prompt in its KV cache and streamed
-the response directly, so the pipeline stops early and the request's disaggregation path is
-decode-only. On a `miss` the worker returns 412 and the pipeline continues through the full
-encode/prefill/decode path. If the pipeline is configured without a conditional-decode step, the
-metric never moves.
-
-`hit / (hit + miss)` is the fraction of probed requests served straight from the decode worker's
-cache; `hit / request_total` is the share of all client requests. The name follows the
-`*_cache_*_total{result}` convention used by EPP's `encoder_cache_queries_total` and vLLM's
-`mm_cache_queries` rather than repeating the step name.
-
-The two are not redundant: on a miss, `decode_cache_lookups_total` cannot tell whether the request
-then went `prefill-decode` or `encode-prefill-decode`, which is what `disagg_decision_total` records.
+*   **Description:** Records the outcome of the conditional-decode probe. 
+    *   `hit`: The decode worker already had the prompt in its KV cache and served the response directly. The pipeline stops early (`decode-only`).
+    *   `miss`: The worker returned HTTP 412. The pipeline continues to encode/prefill/decode.
+*   **Note:** Not redundant with `disagg_decision_total` since a cache miss does not indicate whether the subsequent path was `prefill-decode` or `encode-prefill-decode`.
 
 ## Relationship to EPP metrics
 

--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -46,9 +46,9 @@ three: what this page does not list is on EPP's endpoint (see [Metrics](metrics.
 
 The `step` and `upstream` labels share most of their values, but measure different boundaries: a step is a pipeline stage, while an upstream is a single outbound call. They diverge where a stage is not one call: the `encode` step fans out one concurrent sub-request per multimodal entry, so a request with six images records one `step="encode"` observation and six `upstream="encode"` observations.
 
-- **`step`**: A stage of the internal pipeline, observed once per request per stage. Covers local work and all outbound calls made by that stage. Values: `render`, `replace-media-urls`, `encode`, `prefill`, `conditional-decode`, `decode`. See [Coordinator Architecture](coordinator_architecture.md).
+- **`step`**: A stage of the internal pipeline, observed once per request per stage. Covers local work and all outbound calls made by that stage. The label value is the step's registered `Name()` (see `pipeline.Register`), so its cardinality is bounded by the set of registered pipeline steps. Values in the built-in registry: `render`, `replace-media-urls`, `encode`, `prefill`, `conditional-decode`, `decode`. See [Coordinator Architecture](coordinator_architecture.md).
 - **`upstream`**: A single outbound call, whatever its destination. Values: `render`, `media-fetch`, `encode`, `prefill`, `conditional-decode`, `decode`. A step that gains an outbound call gains a value here.
-- **`decision_type`**: The sequence of disaggregation phases a request actually executed. Values: `decode-only`, `prefill-decode`, `encode-prefill-decode`.
+- **`path`**: The sequence of disaggregation phases a request actually executed. Values: `decode-only`, `prefill-decode`, `encode-prefill-decode`. `encode-decode` is intentionally unreachable because encode implies prefill.
 
 ## Error classes
 
@@ -61,7 +61,7 @@ The `error_code` label on `request_error_total` and `step_errors_total` uses fou
 
 **Key behaviors:**
 - The conditional-decode probe's HTTP 412 (the worker declined to serve it) is handled internally and is **not** an error. It is tracked separately by [`conditional_decode_probes_total`](#conditional_decode_probes_total-counter).
-- `upstream_4xx` and `upstream_5xx` are recorded for the `render`, `prefill`, and `encode` steps, which read the upstream status before continuing. The `decode` and `conditional-decode` steps stream the upstream response straight to the client, and today only the conditional-decode probe inspects its status (to detect the 412 miss), so a decode-phase status error reaches the client uncounted. The status is available to both: it can be read in the reverse proxy's `ModifyResponse` hook before any bytes are forwarded. What stays uncountable is a failure that occurs after streaming has begun, since the 200 and a partial body are already on the wire.
+- `upstream_4xx` and `upstream_5xx` are recorded for every step that calls out, including `decode` and `conditional-decode`: their reverse proxy captures the upstream status in `ModifyResponse` and transport failures in `ErrorHandler`, and both steps translate a 4xx/5xx or transport error into an `UpstreamStreamedError` before any bytes are forwarded. What stays uncountable is a failure that surfaces after streaming has begun, since the 200 and a partial body are already on the wire.
 
 ## Metrics catalog
 
@@ -80,9 +80,9 @@ error, 413, invalid JSON) count as `bad_request` with `model_name=unknown`.
 |---|---|---|
 | `request_total` | Counter | Every inbound client request, including malformed ones. |
 | `request_error_total` | Counter | Failed requests; adds label `error_code`. |
-| `request_duration_seconds` | Histogram | End-to-end request latency. |
-| `request_size_bytes` | Histogram | Request body size. |
-| `response_size_bytes` | Histogram | Bytes streamed to the client, measured by a counting `ResponseWriter` wrapper in the handler rather than by parsing the body. |
+| `request_duration_seconds` | Histogram | End-to-end request latency; `GeneralLatencyBuckets` (5 ms to 1 h). |
+| `request_size_bytes` | Histogram | Request body size; `RequestSizeBuckets` (64 B to 1 GiB, powers of two). |
+| `request_input_tokens` | Histogram | Prompt token count, recorded after the render step; `TokenCountBuckets` (1 to ~1 M). |
 | `request_running` | Gauge | Requests in flight. |
 
 ### Pipeline step family
@@ -93,7 +93,7 @@ Recorded by the pipeline executor, which brackets every step it runs. This famil
 
 | Name | Type | Notes |
 |---|---|---|
-| `step_duration_seconds` | Histogram | Per-step latency. |
+| `step_duration_seconds` | Histogram | Per-step latency; `GeneralLatencyBuckets` (5 ms to 1 h). |
 | `step_errors_total` | Counter | Step failures; adds label `error_code`. |
 | `step_running` | Gauge | Requests currently executing the step. Saturation rather than latency: `decode` stays in flight for the whole stream, so its value is the number of active streams. |
 
@@ -109,45 +109,42 @@ Recorded by every step that calls out: render to the renderer service, replace-m
 | Name | Type | Notes |
 |---|---|---|
 | `upstream_request_total` | Counter | Outbound calls, one per call (encode contributes one per image, media-fetch one per URL). |
-| `upstream_request_duration_seconds` | Histogram | Latency of one call. |
+| `upstream_request_duration_seconds` | Histogram | Latency of one call; `GeneralLatencyBuckets` (5 ms to 1 h). |
 
 **Key details:**
 *   **Fan-out:** A single client request can result in multiple outbound calls (e.g., three image fetches, one conditional-decode probe, three encode calls, one prefill, one decode). For the fan-out upstreams this is the only per-call latency available, since the step duration covers the whole concurrent batch.
 *   **No `upstream_request_error_total`:** A failed call aborts its step and is already counted by `step_errors_total`.
 *   **Conditional-decode:** The probe gets its own value rather than counting as `decode`, keeping fan-out ratios accurate.
 
-### Disaggregation decision and conditional decode
+### Execution path and conditional decode
 
-#### `disagg_decision_total` (Counter)
-*   **Labels:** `model_name`, `decision_type` (`decode-only`, `prefill-decode`, `encode-prefill-decode`)
-*   **Description:** Records which phases actually ran for a request. Unlike EPP, it lacks `encode-decode` because encode always implies prefill in the coordinator.
+#### `execution_path_total` (Counter)
+*   **Labels:** `model_name`, `path` (`decode-only`, `prefill-decode`, `encode-prefill-decode`)
+*   **Description:** Records which set of disaggregation phases actually ran for a client request. `encode-decode` is intentionally unreachable because encode implies prefill in the coordinator.
 
 #### `conditional_decode_probes_total` (Counter)
-*   **Labels:** `result` (`served` or `deferred`)
+*   **Labels:** `result` (`served`, `deferred`, or `error`)
 *   **Description:** Counts conditional-decode probes by the worker's answer. The coordinator sees the status code, not the reason behind it.
     *   `served`: The worker handled the request itself, whether because the prompt was cached or too short to disaggregate. The pipeline stops early (`decode-only`).
     *   `deferred`: The worker returned HTTP 412. The pipeline continues to encode/prefill/decode.
-*   **Note:** Not redundant with `disagg_decision_total` since a deferred probe does not indicate whether the subsequent path was `prefill-decode` or `encode-prefill-decode`.
+    *   `error`: Any other 4xx/5xx status or a transport failure on the probe. The step then returns an `UpstreamStreamedError` and the request is classified in the `upstream_4xx`/`upstream_5xx`/`internal` error buckets.
+*   **Note:** Not redundant with `execution_path_total` since a deferred probe does not indicate whether the subsequent path was `prefill-decode` or `encode-prefill-decode`.
 
 ## Relationship to EPP metrics
 
 | Coordinator metric | EPP counterpart | Difference |
 |---|---|---|
 | Request family (`llm_d_coordinator_request_total`, etc.) | `llm_d_epp_*` (same names) | Coordinator counts single client requests at entry; EPP counts every sub-request reaching the gateway. EPP adds flow-control labels (`fairness_id`, `priority`). |
-| `llm_d_coordinator_disagg_decision_total` | `llm_d_epp_disagg_decision_total` | Coordinator counts phases *executed*; EPP counts routing decisions *made* and adds plugin labels. |
+| `llm_d_coordinator_execution_path_total` | `llm_d_epp_disagg_decision_total` | Coordinator observes the phases that actually ran on the client request; EPP records the routing decision that was made and adds plugin labels. |
 | `llm_d_coordinator_step_*`, `llm_d_coordinator_upstream_request_*`, `llm_d_coordinator_conditional_decode_probes_total` | None | Unique to coordinator. |
 
 **EPP-only metrics:** Scheduling, flow control, and pool aggregates have no coordinator counterpart. EPP's token counts and TTFT do, but they are per leg: the same prompt reaches EPP on more than one leg, and decode-leg TTFT starts after render, encode, and prefill have finished, so neither describes a client request. Only the coordinator sees a client request as one request. See [Deliberate omissions](#deliberate-omissions) for what it could report and why it does not today.
 
 ## Deliberate omissions
 
-### Token counts
+### Output and cached token counts
 
-The coordinator emits no token-count metrics. Output and cached counts live in the vLLM `usage` block, and reading it means parsing the streamed SSE response, which the decode step does not do: it proxies bytes straight to the client, and `response_size_bytes` is the byte-level stand-in.
-
-Input tokens are a different case. The renderer returns the token IDs, so the count is already in hand after render, with no response parsing and no dependency on EPP.
-
-*Future candidate:* `request_input_tokens` (Histogram, after render). It is the per-client-request prompt size, which EPP cannot report from its per-leg view, and it correlates prompt size with encode fan-out without a cross-component join.
+The coordinator emits no output or cached token-count metrics. Those values live in the vLLM `usage` block, and reading them means parsing the streamed SSE response, which the decode step does not do: it proxies bytes straight to the client. Input tokens are recorded (see [`request_input_tokens`](#request-family)): the renderer returns the token IDs, so the count is in hand after render, with no response parsing and no dependency on EPP.
 
 ### Time to first token
 
@@ -168,17 +165,20 @@ Neither the coordinator nor EPP tracks per-request image count or size. Image co
 
 ## Cardinality
 
-`model_name` labels every request-family metric, three of them histograms, and the handler takes it
-straight from the request body without validation. Each distinct value creates its own set of series,
-and a histogram multiplies that by its bucket count, so a client looping over invented model names
-grows the coordinator's memory without bound. This is reachable by any client, and it is a mitigation
-the implementation has to carry.
+`model_name` labels every request-family metric and `execution_path_total` — every metric that
+carries `model_name` — and the handler takes it straight from the request body without validation.
+Each distinct value creates its own set of series, and a histogram multiplies that by its bucket
+count, so a client looping over invented model names grows the coordinator's memory without bound.
+This is reachable by any client, and it is a mitigation the implementation has to carry.
 
-Capping the distinct values is the approach that fits: EPP caps `model_name` at 1000 over the process
-lifetime and reports further values as `other`, and matching that keeps the two components
-consistent. An allowlist has no source of truth here, since the coordinator's config carries no model
-list and the coordinator is otherwise model-agnostic. The overflow value must not be `unknown`, which
-already means the request carried no model at all.
+Capping the distinct values is the approach that fits: `model_name` is capped at 1000 over the
+process lifetime and further values are reported as `other`. The bounded-label helper lives in
+`pkg/common/observability/metrics/cardinality.go` (`BoundedLabel`, `OverflowValue = "other"`) and is
+instantiated with the same cap by both `pkg/coordinator/metrics/cardinality.go` and
+`pkg/epp/metrics/cardinality.go`, so the two components share one guard. An allowlist has no source
+of truth here, since the coordinator's config carries no model list and the coordinator is otherwise
+model-agnostic. The overflow value must not be `unknown`, which already means the request carried no
+model at all.
 
 ## Related documentation
 

--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -108,7 +108,7 @@ Recorded by the pipeline executor, one observation per step per request. This fa
 
 Label set `{phase}` (one outbound backend call, not a pipeline stage, see [Labels](#labels)).
 
-Recorded by the encode, prefill, and decode steps. This family counts and times the outbound sub-requests to the gateway. (Render and media fetches are not included, their latency is tracked in `pipeline_step_duration_seconds`).
+Recorded by the conditional-decode, encode, prefill, and decode steps. This family counts and times the outbound sub-requests to the gateway. (Render and media fetches are not included, their latency is tracked in `pipeline_step_duration_seconds`).
 
 | Name | Type | Notes |
 |---|---|---|
@@ -120,7 +120,7 @@ Recorded by the encode, prefill, and decode steps. This family counts and times 
 *   **Narrower scope than steps:** 
     *   `upstream_request_duration_seconds` is encode-only because it tracks per-image latency. Prefill and decode already have a 1:1 mapping between call latency and step duration, so their timings are tracked solely in `pipeline_step_duration_seconds`.
     *   There is no `upstream_request_error_total`. A phase-call failure aborts its step and is already counted by `pipeline_step_errors_total`.
-*   **Conditional-decode:** The `phase="conditional-decode"` counts the cache probe. It gets its own phase to distinguish it from the actual `decode` phase, maintaining accurate fan-out ratios.
+*   **Conditional-decode:** The probe gets its own phase rather than counting as `decode`, keeping fan-out ratios accurate.
 
 ### Disaggregation decision and decode cache
 
@@ -139,54 +139,27 @@ Recorded by the encode, prefill, and decode steps. This family counts and times 
 
 | Coordinator metric | EPP counterpart | Difference |
 |---|---|---|
-| `request_total`, `request_error_total`, `request_duration_seconds`, `request_size_bytes`, `response_size_bytes`, `request_running` | `llm_d_epp_*`, same names | The coordinator counts client requests at its own entry point; EPP counts what reaches the gateway, which for one client request includes each phase sub-request. EPP also labels by `fairness_id` and `priority`, which have no coordinator counterpart. |
-| `disagg_decision_total` | `llm_d_epp_disagg_decision_total` | Same name and same `model_name`/`decision_type` labels, and EPP adds plugin identity labels. EPP counts the routing decision its profile handler makes; the coordinator counts the phases it actually executed. |
-| `pipeline_step_*`, `upstream_request_*`, `decode_cache_lookups_total` | none | Coordinator-only. |
+| Request family (`request_total`, etc.) | `llm_d_epp_*` (same names) | Coordinator counts single client requests at entry; EPP counts every sub-request reaching the gateway. EPP adds flow-control labels (`fairness_id`, `priority`). |
+| `disagg_decision_total` | `llm_d_epp_disagg_decision_total` | Coordinator counts phases *executed*; EPP counts routing decisions *made* and adds plugin labels. |
+| `pipeline_step_*`, `upstream_request_*`, `decode_cache_lookups_total` | None | Unique to coordinator. |
 
-EPP exposes many metrics the coordinator does not: token counts, TTFT/TPOT/ITL, `scheduler_*`,
-`plugin_duration_seconds`, pool aggregates, `flow_control_*`, `extproc_*` and `datalayer_*`. These
-measure responsibilities the coordinator does not have (endpoint scheduling, flow control, pool
-observation, ext_proc streaming).
+**EPP-only metrics:** EPP exposes token counts, latencies (TTFT/TPOT/ITL), and metrics for scheduling, flow control, and pool aggregates. The coordinator does not measure these as they are outside its scope.
 
 ## Deliberate omissions
 
 ### Token counts
 
-The coordinator emits no token-count metrics. EPP owns per-request token accounting and the
-coordinator does not duplicate it.
+The coordinator emits no token-count metrics. EPP already parses the vLLM `usage` block to emit `request_input_tokens`, `request_output_tokens`, and `request_cached_tokens`, and the coordinator avoids duplicating this effort. Furthermore, extracting output tokens would require the coordinator to parse the streamed SSE response, defeating the purpose of a pure byte proxy (which is why we use `response_size_bytes`).
 
-Input and prompt tokens are available cheaply in-process after the render step, which holds the token
-IDs from the render service or from client-supplied token IDs. Output and cached tokens are not: the
-decode step is a pure byte proxy that streams the response straight to the client, so extracting them
-means intercepting and parsing the streamed SSE, exactly the invasiveness `response_size_bytes` avoids
-by counting bytes.
-
-There is no coverage gap in coordinator-deployment mode. The decode phase call goes out through the
-gateway, where EPP parses the vLLM `usage` block and emits `request_input_tokens`,
-`request_output_tokens` and `request_cached_tokens`. The one coordinator-native cheap signal, prompt
-tokens, overlaps EPP's; its only unique value is correlating prompt size with encode fan-out or
-per-step latency without a cross-component join. That is a candidate, not a commitment:
-
-| Candidate | Type | Source |
-|---|---|---|
-| `request_prompt_tokens` | Histogram | Token count after render; token-count buckets. Label: `model_name`. |
+*Future candidate:* `request_prompt_tokens` (Histogram, after render) could be added to correlate prompt size with encode fan-out without needing a cross-component join.
 
 ### Per-request image visibility
 
-Neither the coordinator nor EPP exposes per-request image count or image size. Candidates, listed so
-the gap is documented:
+Neither the coordinator nor EPP tracks per-request image count or size. Currently, image count is only visible in aggregate via `upstream_request_total{phase="encode"}`. Image byte size is unreliable because URL images are fetched by `replace-media-urls` and do not traverse the coordinator.
 
-| Candidate | Type | Source |
-|---|---|---|
-| `request_images` | Histogram | Multimodal entries per request; small-integer buckets. Label: `model_name`. |
-| `image_placeholder_tokens` | Histogram | Placeholder length per entry; token-count buckets. Label: `model_name`. |
-
-Image count is visible only indirectly, as `upstream_request_total{phase="encode"}`, which is
-aggregate rather than per-request. Image byte size is not reliably available at all: inline base64
-images fall under `request_size_bytes`, but URL images are fetched by `replace-media-urls` and never
-traverse the coordinator. Placeholder tokens are the coordinator's only uniform,
-transport-independent measure of image size, and are already computed in render for the
-`max_total_placeholder_tokens` check.
+*Future candidates:* 
+*   `request_images`: Histogram of multimodal entries per request.
+*   `image_placeholder_tokens`: Histogram of placeholder length per entry (the only uniform measure of image size).
 
 ## Cardinality
 

--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -35,8 +35,8 @@ for TokenReview and SubjectAccessReview on the coordinator's ServiceAccount.
 All coordinator metrics are self-instrumented: the coordinator counts and times its own work
 in-process and scrapes no other component. Two of them describe upstream behavior but are still
 measured locally, from the coordinator's side of the call: `upstream_request_duration_seconds` times
-each encode sub-request, and `conditional_decode_probes_total` records how the decode worker
-answered the conditional-decode probe.
+each outbound call, and `conditional_decode_probes_total` records how the decode worker answered the
+conditional-decode probe.
 
 One client request passes through the coordinator, the EPP behind the gateway, and the vLLM workers,
 and each of the three serves its own `/metrics`. Following a request end to end means scraping all
@@ -44,11 +44,11 @@ three: what this page does not list is on EPP's endpoint (see [Metrics](metrics.
 
 ## Labels
 
-The `step` and `phase` labels share most of their values, but measure different boundaries: a step is a pipeline stage, while a phase is a single backend call. They diverge where a stage is not one call: the `encode` step fans out one concurrent sub-request per multimodal entry, so a request with six images records one `step="encode"` observation and six `phase="encode"` observations. Steps that make no backend call at all (`render`, `replace-media-urls`) have no phase.
+The `step` and `upstream` labels share most of their values, but measure different boundaries: a step is a pipeline stage, while an upstream is a single outbound call. They diverge where a stage is not one call: the `encode` step fans out one concurrent sub-request per multimodal entry, so a request with six images records one `step="encode"` observation and six `upstream="encode"` observations.
 
-- **`step`**: A stage of the internal pipeline, observed once per request per stage. Covers local work and all backend calls made by that stage. Values: `render`, `replace-media-urls`, `encode`, `prefill`, `conditional-decode`, `decode`. See [Coordinator Architecture](coordinator_architecture.md).
-- **`phase`**: A single outbound backend call. Values: `encode`, `prefill`, `decode`, `conditional-decode`.
-- **`decision_type`**: The sequence of phases a request actually executed. Values: `decode-only`, `prefill-decode`, `encode-prefill-decode`.
+- **`step`**: A stage of the internal pipeline, observed once per request per stage. Covers local work and all outbound calls made by that stage. Values: `render`, `replace-media-urls`, `encode`, `prefill`, `conditional-decode`, `decode`. See [Coordinator Architecture](coordinator_architecture.md).
+- **`upstream`**: A single outbound call, whatever its destination. Values: `render`, `media-fetch`, `encode`, `prefill`, `conditional-decode`, `decode`. A step that gains an outbound call gains a value here.
+- **`decision_type`**: The sequence of disaggregation phases a request actually executed. Values: `decode-only`, `prefill-decode`, `encode-prefill-decode`.
 
 ## Error classes
 
@@ -100,23 +100,21 @@ Recorded by the pipeline executor, which brackets every step it runs. This famil
 **Key details:**
 *   Only steps that actually executed are recorded. Trailing steps from early exits (e.g., conditional-decode hit) or failures are not emitted.
 
-### Upstream phase family
+### Upstream call family
 
-Label set `{phase}` (one outbound backend call, not a pipeline stage, see [Labels](#labels)).
+Label set `{upstream}` (one outbound call, not a pipeline stage, see [Labels](#labels)).
 
-Recorded by the conditional-decode, encode, prefill, and decode steps. This family counts and times the outbound sub-requests to the gateway. (Render and media fetches are not included, their latency is tracked in `step_duration_seconds`).
+Recorded by every step that calls out: render to the renderer service, replace-media-urls to image URLs, and conditional-decode, encode, prefill, and decode to the gateway. The step family answers where time went in the pipeline; this family answers how many external calls a request made and how slow each one was.
 
 | Name | Type | Notes |
 |---|---|---|
-| `upstream_request_total` | Counter | Gateway sub-requests, one per call. (e.g. encode contributes one per image). |
-| `upstream_request_duration_seconds` | Histogram | Latency of one encode call (encode only). |
+| `upstream_request_total` | Counter | Outbound calls, one per call (encode contributes one per image, media-fetch one per URL). |
+| `upstream_request_duration_seconds` | Histogram | Latency of one call. |
 
 **Key details:**
-*   **Fan-out:** A single client request can result in multiple backend calls (e.g., one conditional-decode probe, two encode calls for two images, one prefill, one decode).
-*   **Narrower scope than steps:** 
-    *   `upstream_request_duration_seconds` is encode-only because it tracks per-image latency. Prefill and decode already have a 1:1 mapping between call latency and step duration, so their timings are tracked solely in `step_duration_seconds`.
-    *   There is no `upstream_request_error_total`. A phase-call failure aborts its step and is already counted by `step_errors_total`.
-*   **Conditional-decode:** The probe gets its own phase rather than counting as `decode`, keeping fan-out ratios accurate.
+*   **Fan-out:** A single client request can result in multiple outbound calls (e.g., three image fetches, one conditional-decode probe, three encode calls, one prefill, one decode). For the fan-out upstreams this is the only per-call latency available, since the step duration covers the whole concurrent batch.
+*   **No `upstream_request_error_total`:** A failed call aborts its step and is already counted by `step_errors_total`.
+*   **Conditional-decode:** The probe gets its own value rather than counting as `decode`, keeping fan-out ratios accurate.
 
 ### Disaggregation decision and conditional decode
 
@@ -161,7 +159,7 @@ component reports the client's full wait for output.
 
 ### Per-request image visibility
 
-Neither the coordinator nor EPP tracks per-request image count or size. Image count is only visible in aggregate via `upstream_request_total{phase="encode"}`. Size is available but unrecorded: `replace-media-urls` downloads each URL image and base64-encodes it, so every entry, inline or fetched, carries its payload through the coordinator.
+Neither the coordinator nor EPP tracks per-request image count or size. Image count is only visible in aggregate via `upstream_request_total{upstream="encode"}`. Size is available but unrecorded: `replace-media-urls` downloads each URL image and base64-encodes it, so every entry, inline or fetched, carries its payload through the coordinator.
 
 *Future candidates:* 
 *   `request_images`: Histogram of multimodal entries per request.

--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -1,0 +1,305 @@
+# Coordinator Metrics
+
+The coordinator exposes Prometheus metrics describing the requests it accepts and the pipeline it
+runs to serve them (see [Coordinator Architecture](coordinator_architecture.md)). They are separate
+from the Endpoint Picker (EPP) metrics documented in [Metrics](metrics.md): the two components
+measure different points in the same request path.
+
+## Subsystems and naming
+
+Every series carries the subsystem prefix `llm_d_coordinator_`, so a metric's full Prometheus name is
+`llm_d_coordinator_<name>`. Names below omit the prefix. All metrics are ALPHA stage.
+
+Naming mirrors the EPP request family (`pkg/epp/metrics`) so PromQL expressions and dashboard panels
+translate between the two components. Where a name matches an EPP metric, the
+[Relationship to EPP metrics](#relationship-to-epp-metrics) section states what differs.
+
+`model_name` is taken from the request body; an empty or absent model is recorded as `unknown`.
+
+## Scrape topology
+
+### Coordinator metrics endpoint
+
+Every metric on this page is exposed on a single `/metrics` endpoint served by the coordinator
+process, alongside the inference paths and `/healthz` and `/readyz` on the coordinator's chi router
+(`pkg/coordinator/server/server.go`). The registry it serves, the port or flag that selects it, and
+whether it is authenticated are settled by the phase 1 implementation. EPP's Prometheus wiring is
+separate: it lives in `cmd/epp/runner` and serves the controller-runtime registry rather than the
+default one.
+
+### Metrics served elsewhere
+
+All coordinator metrics are self-instrumented: the coordinator counts and times its own work
+in-process, and scrapes nothing. Two series record a signal that originates upstream but is still
+measured by the coordinator: `upstream_request_duration_seconds` times each encode sub-request, and
+`decode_cache_lookups_total` records the decode server's response to the conditional-decode probe.
+
+One client request passes through the coordinator, the EPP behind the gateway, and the vLLM workers,
+and each of the three serves its own `/metrics`. Measurements this page does not list are on one of
+the other two endpoints: per-request token counts and pool aggregates such as KV-cache utilization
+and queue depth on EPP's (see [Metrics](metrics.md)), multimodal cache counters on vLLM's. Scrape all
+three to follow a request end to end.
+
+## Label vocabularies
+
+Two vocabularies use the words `encode`, `prefill`, and `decode`. They are not interchangeable.
+
+**`step`** is a stage of the coordinator's internal pipeline, observed once per request per stage. A
+step covers local work, orchestration, and any backend calls that stage makes.
+
+| Value | Stage |
+|---|---|
+| `render` | Call the render service to tokenize and apply the chat template. |
+| `replace-media-urls` | Rewrite media URLs in the request body (local work only). |
+| `encode` | Encode multimodal inputs; fans out one call per image. |
+| `prefill` | Prefill sub-request, producing KV transfer parameters. |
+| `conditional-decode` | Probe the decode cache for the 412 fast path. |
+| `decode` | Decode and generation, streamed back to the client. |
+
+**`phase`** is a single outbound backend call, counted once per call. Its values are `encode`,
+`prefill`, and `decode`, matching `gateway.EPPProfileHeader`.
+
+A step may issue zero or many backend calls and includes local work; a phase is one call. Only
+`render` and `replace-media-urls` have no phase counterpart.
+
+`conditional-decode` issues a decode-phase call: `steps/decode_proxy.go` `newDecodeProxyRequest`
+stamps `EPPProfileHeader=PhaseDecode` unconditionally, and both the probe and the decode step go
+through it, so a cache-miss request sends two decode-phase calls. See the
+[open decision](#upstream-phase-family-phase-2) on the phase family.
+
+## Error classes
+
+`error_code` on `request_error_total` and `pipeline_step_errors_total` uses one coarse set of values:
+`bad_request`, `upstream_4xx`, `upstream_5xx`, `internal`.
+
+This classification is finer than `server/handlers.go` `classifyPipelineError`, which collapses
+upstream 5xx faults and internal faults into HTTP 502. The metrics helper inspects the error type
+directly: an `UpstreamError` carrying a 5xx `StatusCode` is `upstream_5xx`, and any other
+non-`ErrBadRequest` error is `internal`.
+
+The conditional-decode probe's 412 is not an error in any class. `steps/conditional_decode.go`
+intercepts that status in `ModifyResponse` and converts it to a cache miss, so the step returns
+`nil` and the pipeline continues; a hit returns `ErrPipelineDone`, a successful early exit. Neither
+outcome reaches the classifier, which is why the probe has its own metric,
+[`decode_cache_lookups_total`](#decode_cache_lookups_total). The same 412 does count as an error on
+the EPP side, as `request_error_total{error_code="PreconditionFailed"}`.
+
+`upstream_4xx` and `upstream_5xx` therefore describe the render, prefill, and encode steps, the only
+ones that build an `UpstreamError` from a non-2xx response. The conditional-decode and decode steps
+proxy the upstream response straight to the client without constructing an error, so an upstream
+failure on the decode leg reaches the client but is absent from both error metrics.
+
+## Metrics catalog
+
+### Request family (phase 1)
+
+Recorded in `server/handlers.go` `handleInference`. Requests that exit early because they are
+malformed (body-read error, 413, invalid JSON) count as `bad_request` with `model_name=unknown`.
+Unless otherwise noted, metrics in this family share the label `{model_name}`.
+
+| Name | Type | Notes |
+|---|---|---|
+| `request_total` | Counter | Every inbound client request, including malformed ones. |
+| `request_error_total` | Counter | Failed requests by coarse class; adds label `error_code`. |
+| `request_duration_seconds` | Histogram | End-to-end request latency; `generalLatencyBuckets` (5ms to 1h). |
+| `request_size_bytes` | Histogram | Request body length; powers-of-2 buckets. |
+| `response_size_bytes` | Histogram | Bytes streamed to the client, measured by a counting `ResponseWriter` wrapper in the handler rather than by parsing the body. |
+| `request_running` | Gauge | Requests in flight; unlabelled. |
+
+`request_running` is fleet-wide while the rest of the family is labelled by `model_name`, so a
+dashboard panel that groups the family by model has no series for it. EPP's
+`llm_d_epp_request_running` is labelled by model, fairness ID, and priority.
+
+### Pipeline step family (phase 1)
+
+Recorded in `pipeline.go` `Execute`, one observation per step per request. This family measures each
+stage's whole wall time, local work plus orchestration plus any backend calls the stage makes, not
+the individual outbound calls. It answers where time goes inside the coordinator and which internal
+stage failed. Metrics in this family share the label `{step}`.
+
+| Name | Type | Notes |
+|---|---|---|
+| `pipeline_step_duration_seconds` | Histogram | Per-step latency, from the timings the pipeline already computes. |
+| `pipeline_step_errors_total` | Counter | Step failures by class; adds label `error_code`. |
+
+`pipeline_step_duration_seconds` uses a dedicated bucket set, not `generalLatencyBuckets`: steps span
+microseconds (render, a skipped encode) to seconds (upstream-bound decode), and a 5ms floor collapses
+every fast step into one bucket. `stepLatencyBuckets` is 100us, 250us, 500us, 1ms, 2.5ms, 5ms, 10ms,
+25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s, 30s, 60s.
+
+`pipeline.Execute` pre-sizes its timings slice for all steps (`make([]stepTiming, len(p.steps))`). On
+an early exit (`ErrPipelineDone`, which every conditional-decode hit takes) or a step failure, the
+trailing entries stay zero-valued, so iterating the slice emits a `step=""` series with a 0s
+observation for every step that never ran. Record inside the loop, or skip entries with an empty
+name.
+
+Each step that ran expands to its own histogram block. For three decode steps taking 1.9s, 2.1s and
+1.7s:
+
+```
+..._bucket{step="decode",le="1"}    0
+..._bucket{step="decode",le="2.5"}  3
+..._bucket{step="decode",le="+Inf"} 3
+..._sum{step="decode"}   5.7
+..._count{step="decode"} 3
+```
+
+p95 of the decode step:
+
+```promql
+histogram_quantile(0.95, sum by (le) (rate(
+  llm_d_coordinator_pipeline_step_duration_seconds_bucket{step="decode"}[5m])))
+```
+
+### Upstream phase family (phase 2)
+
+Recorded in `steps/encode.go`, `prefill.go` and `decode_proxy.go`. This family counts and times the
+outbound sub-requests the coordinator sends to the gateway carrying the epp-profile header. Only
+gateway phase calls count: the render-service call and media-URL fetches are outbound too but carry
+no phase header, and their latency appears in
+`pipeline_step_duration_seconds{step="render"|"replace-media-urls"}`. Metrics in this family share the label `{phase}`.
+
+| Name | Type | Notes |
+|---|---|---|
+| `upstream_request_total` | Counter | Gateway sub-requests, one per call; encode contributes one per image. |
+| `upstream_request_duration_seconds` | Histogram | Per-call encode latency (encode only). |
+
+The family is deliberately narrower than the step family it sits beside, because for prefill and
+decode one step is one gateway call:
+
+- `upstream_request_total` covers all three phases: the backend fan-out ratio
+  (`upstream_request_total / request_total`) is not derivable from the step family, and it costs
+  three series.
+- `upstream_request_duration_seconds` is encode-only: encode fans out N concurrent calls, so
+  `pipeline_step_duration_seconds{step="encode"}` is the fan-out envelope (slowest call plus the EC
+  merge) and hides per-image call latency. For prefill and decode the call latency already equals the
+  step duration. Two loose ends remain: the `phase` label then carries exactly one value, which
+  invites empty `phase="prefill"` queries, and `generalLatencyBuckets` runs to 1h, far past any
+  single encode call. Either drop the label and name the metric for what it measures, or keep it
+  explicitly for forward compatibility, and consider `stepLatencyBuckets`.
+- There is no `upstream_request_error_total`. A phase-call failure aborts its step and is already
+  counted by `pipeline_step_errors_total` under the same coarse class. Per-call encode fan-out
+  failure granularity is the one gap, but the errgroup context cancels sibling calls on the first
+  error, so a clean per-call failure count is not reliably available. This is a limitation, not a
+  metric.
+
+**Open decision:** `phase="decode"` counts two different calls. The conditional-decode probe carries
+the same `PhaseDecode` header as the decode step, so a cache miss produces two `phase="decode"`
+increments for one client request, which makes the fan-out reading wrong. Pick one before
+implementing: add a `conditional-decode` value to the `phase` label (diverges from the header
+vocabulary, but each call type stays countable, and this is the recommended option); skip the probe
+in `upstream_request_total` (loses probe-call visibility, though `decode_cache_lookups_total` still
+counts probes); or accept the double count and document it.
+
+Inbound against outbound, for one multimodal chat request with two images in a pipeline without a
+conditional-decode step:
+
+```
+request_total{model_name="llama"}       += 1
+upstream_request_total{phase="encode"}  += 2
+upstream_request_total{phase="prefill"} += 1
+upstream_request_total{phase="decode"}  += 1
+```
+
+### Disaggregation decision and decode cache (phase 3)
+
+#### `disagg_decision_total`
+
+*   **Type:** Counter
+*   **Labels:** `model_name`, `decision_type` (`decode-only`, `prefill-decode`, `encode-prefill-decode`)
+*   **Description:** Which phases actually ran.
+
+`disagg_decision_total`'s value set is narrower than EPP's, which also has `encode-decode`. In the
+coordinator encode always implies prefill, because encode produces the EC transfer parameters prefill
+consumes, so encode without prefill is not a reachable path.
+
+#### `decode_cache_lookups_total`
+
+*   **Type:** Counter
+*   **Labels:** `result` (`hit` or `miss`)
+*   **Description:** Conditional-decode probe outcome.
+
+`decode_cache_lookups_total` is emitted by exactly one place, the conditional-decode step, once per
+request that runs it. The step optimistically sends the request to the decode worker with
+`Prefer: if-available`. On a `hit` the worker already held the prompt in its KV cache and streamed
+the response directly, so the pipeline stops early and the request's disaggregation path is
+decode-only. On a `miss` the worker returns 412 and the pipeline continues through the full
+encode/prefill/decode path. If the pipeline is configured without a conditional-decode step, the
+metric never moves.
+
+`hit / (hit + miss)` is the fraction of probed requests served straight from the decode worker's
+cache; `hit / request_total` is the share of all client requests. The name follows the
+`*_cache_*_total{result}` convention used by EPP's `encoder_cache_queries_total` and vLLM's
+`mm_cache_queries` rather than repeating the step name.
+
+The two are not redundant: on a miss, `decode_cache_lookups_total` cannot tell whether the request
+then went `prefill-decode` or `encode-prefill-decode`, which is what `disagg_decision_total` records.
+
+## Relationship to EPP metrics
+
+| Coordinator metric | EPP counterpart | Difference |
+|---|---|---|
+| `request_total`, `request_error_total`, `request_duration_seconds`, `request_size_bytes`, `response_size_bytes` | `llm_d_epp_*`, same names | The coordinator counts client requests at its own entry point; EPP counts what reaches the gateway, which for one client request includes each phase sub-request. |
+| `request_running` | `llm_d_epp_request_running` | The coordinator series is unlabelled; EPP labels by model, fairness ID and priority. |
+| `disagg_decision_total` | `llm_d_epp_disagg_decision_total` | Same name and same `model_name`/`decision_type` labels, and EPP adds plugin identity labels. EPP counts the routing decision its profile handler makes; the coordinator counts the phases it actually executed. |
+| `pipeline_step_*`, `upstream_request_*`, `decode_cache_lookups_total` | none | Coordinator-only. |
+
+EPP exposes many metrics the coordinator does not: token counts, TTFT/TPOT/ITL, `scheduler_*`,
+`plugin_duration_seconds`, pool aggregates, `flow_control_*`, `extproc_*` and `datalayer_*`. These
+measure responsibilities the coordinator does not have (endpoint scheduling, flow control, pool
+observation, ext_proc streaming).
+
+## Deliberate omissions
+
+### Token counts
+
+The coordinator emits no token-count metrics. EPP owns per-request token accounting and the
+coordinator does not duplicate it.
+
+Input and prompt tokens are available cheaply in-process as `len(reqCtx.TokenIDs)` after the render
+step (`steps/render.go` sets `TokenIDs` from the render service or from client-supplied token IDs).
+Output and cached tokens are not: the decode step is a pure byte proxy (`steps/decode.go` streams
+`proxy.ServeHTTP` straight to the client), so extracting them means intercepting and parsing the
+streamed SSE, exactly the invasiveness `response_size_bytes` avoids by counting bytes.
+
+There is no coverage gap in coordinator-deployment mode. The decode phase call goes out through the
+gateway, where EPP parses the vLLM `usage` block and emits `request_input_tokens`,
+`request_output_tokens` and `request_cached_tokens`. The one coordinator-native cheap signal, prompt
+tokens, overlaps EPP's; its only unique value is correlating prompt size with encode fan-out or
+per-step latency without a cross-component join. That is a candidate, not a commitment:
+
+| Candidate | Type | Source |
+|---|---|---|
+| `request_prompt_tokens` | Histogram | `len(reqCtx.TokenIDs)` after render; token-count buckets. Label: `model_name`. |
+
+### Per-request image visibility
+
+Neither the coordinator nor EPP exposes per-request image count or image size. Candidates, listed so
+the gap is documented:
+
+| Candidate | Type | Source |
+|---|---|---|
+| `request_images` | Histogram | `len(reqCtx.MultimodalEntries)`; small-integer buckets. Label: `model_name`. |
+| `image_placeholder_tokens` | Histogram | `MultimodalEntry.Placeholder.Length`; token-count buckets. Label: `model_name`. |
+
+Image count is visible only indirectly, as `upstream_request_total{phase="encode"}`, which is
+aggregate rather than per-request. Image byte size is not reliably available at all: inline base64
+images fall under `request_size_bytes`, but URL images are fetched by `replace-media-urls` and never
+traverse the coordinator. Placeholder tokens are the coordinator's only uniform,
+transport-independent measure of image size, and are already computed in render for the
+`max_total_placeholder_tokens` check.
+
+## Cardinality
+
+`model_name` labels five of the six request-family metrics, three of them histograms, and
+`server/handlers.go` takes it straight from the request body (`model, _ := parsed["model"].(string)`)
+without validation. An arbitrary set of client-supplied strings multiplied by the latency buckets is
+a cardinality-explosion vector against the coordinator's own memory, reachable by any client. The
+mitigation has to be chosen before implementing: allowlist against configured models, cap the
+distinct values as EPP does, or accept the risk explicitly.
+
+## Related documentation
+
+- [Coordinator Architecture](coordinator_architecture.md) - the pipeline and steps these metrics measure
+- [Metrics](metrics.md) - EPP metrics
+- [Disaggregation](disaggregation.md) - the encode, prefill and decode phases

--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -11,7 +11,7 @@ A metric's full Prometheus name is `<subsystem>_<name>`. The coordinator uses a 
 
 | Prefix | Scope |
 |---|---|
-| `llm_d_coordinator_` | Canonical, coordinator-wide: request, response, pipeline step and latency, and the remaining coordinator metrics. |
+| `llm_d_coordinator_` | Canonical, coordinator-wide: request, pipeline step and latency, and the remaining coordinator metrics. |
 
 Naming mirrors the EPP request family so PromQL expressions and dashboard panels
 translate between the two components. Where a name matches an EPP metric, the
@@ -25,10 +25,12 @@ translate between the two components. Where a name matches an EPP metric, the
 
 Every metric on this page is exposed on a single `/metrics` endpoint served by the coordinator
 process on the metrics port (default 9090, configurable with `--metrics-port`), separate from the listener
-carrying the inference paths and `/healthz` and `/readyz`.
+carrying the inference paths and `/healthz` and `/readyz`. A non-positive port disables the
+endpoint.
 
-TBD: the registry the endpoint serves and whether it is authenticated. Authenticating it costs RBAC
-for TokenReview and SubjectAccessReview on the coordinator's ServiceAccount.
+The endpoint serves the shared controller-runtime registry, so controller-runtime's process
+collectors appear alongside the coordinator metrics. It is unauthenticated. Authenticating it costs
+RBAC for TokenReview and SubjectAccessReview on the coordinator's ServiceAccount.
 
 ### Other scrape targets
 
@@ -44,24 +46,25 @@ three: what this page does not list is on EPP's endpoint (see [Metrics](metrics.
 
 ## Labels
 
-The `step` and `upstream` labels share most of their values, but measure different boundaries: a step is a pipeline stage, while an upstream is a single outbound call. They diverge where a stage is not one call: the `encode` step fans out one concurrent sub-request per multimodal entry, so a request with six images records one `step="encode"` observation and six `upstream="encode"` observations.
+The `step` and `upstream` labels carry the same values, but measure different boundaries: a step is a pipeline stage, while an upstream is a single outbound call. They diverge where a stage is not one call: the `encode` step fans out one concurrent sub-request per multimodal entry, so a request with six images records one `step="encode"` observation and six `upstream="encode"` observations.
 
 - **`step`**: A stage of the internal pipeline, observed once per request per stage. Covers local work and all outbound calls made by that stage. The label value is the step's registered `Name()` (see `pipeline.Register`), so its cardinality is bounded by the set of registered pipeline steps. Values in the built-in registry: `render`, `replace-media-urls`, `encode`, `prefill`, `conditional-decode`, `decode`. See [Coordinator Architecture](coordinator_architecture.md).
-- **`upstream`**: A single outbound call, whatever its destination. Values: `render`, `media-fetch`, `encode`, `prefill`, `conditional-decode`, `decode`. A step that gains an outbound call gains a value here.
+- **`upstream`**: A single outbound call, whatever its destination. Values: `render`, `replace-media-urls`, `encode`, `prefill`, `conditional-decode`, `decode`. A step that gains an outbound call gains a value here.
 - **`path`**: The sequence of disaggregation phases a request actually executed. Values: `decode-only`, `prefill-decode`, `encode-prefill-decode`. `encode-decode` is intentionally unreachable because encode implies prefill.
 
 ## Error classes
 
-The `error_code` label on `request_error_total` and `step_errors_total` uses four values:
+The `error_code` label on `request_error_total` and `step_errors_total` uses five values:
 
 - **`bad_request`**: Client-side errors (e.g., malformed body).
 - **`upstream_4xx`**: 4xx errors from upstream (e.g., render, prefill, encode).
 - **`upstream_5xx`**: 5xx errors from upstream.
-- **`internal`**: All other coordinator-internal faults.
+- **`upstream_transport`**: The round trip failed before a response arrived (connection refused, timeout, TCP reset), so no status code was received.
+- **`internal`**: All other coordinator-internal faults. Not used for reachability failures, which are `upstream_transport`.
 
 **Key behaviors:**
 - The conditional-decode probe's HTTP 412 (the worker declined to serve it) is handled internally and is **not** an error. It is tracked separately by [`conditional_decode_probes_total`](#conditional_decode_probes_total-counter).
-- `upstream_4xx` and `upstream_5xx` are recorded for every step that calls out, including `decode` and `conditional-decode`: their reverse proxy captures the upstream status in `ModifyResponse` and transport failures in `ErrorHandler`, and both steps translate a 4xx/5xx or transport error into an `UpstreamStreamedError` before any bytes are forwarded. What stays uncountable is a failure that surfaces after streaming has begun, since the 200 and a partial body are already on the wire.
+- `upstream_4xx`, `upstream_5xx` and `upstream_transport` are recorded for every step that calls out, including `decode` and `conditional-decode`: their reverse proxy captures the upstream status in `ModifyResponse` and transport failures in `ErrorHandler`, and both steps translate a 4xx/5xx or transport error into an `UpstreamStreamedError` before any bytes are forwarded. A transport failure carries no status code, so it classifies as `upstream_transport` instead of by status band. What stays uncountable is a failure that surfaces after streaming has begun, since the 200 and a partial body are already on the wire.
 
 ## Metrics catalog
 
@@ -108,7 +111,7 @@ Recorded by every step that calls out: render to the renderer service, replace-m
 
 | Name | Type | Notes |
 |---|---|---|
-| `upstream_request_total` | Counter | Outbound calls, one per call (encode contributes one per image, media-fetch one per URL). |
+| `upstream_request_total` | Counter | Outbound calls, one per call (encode contributes one per image, replace-media-urls one per URL). |
 | `upstream_request_duration_seconds` | Histogram | Latency of one call; `GeneralLatencyBuckets` (5 ms to 1 h). |
 
 **Key details:**
@@ -123,11 +126,12 @@ Recorded by every step that calls out: render to the renderer service, replace-m
 *   **Description:** Records which set of disaggregation phases actually ran for a client request. `encode-decode` is intentionally unreachable because encode implies prefill in the coordinator.
 
 #### `conditional_decode_probes_total` (Counter)
-*   **Labels:** `result` (`served`, `deferred`, or `error`)
+*   **Labels:** `result` (`served`, `deferred`, `error`, or `transport_error`)
 *   **Description:** Counts conditional-decode probes by the worker's answer. The coordinator sees the status code, not the reason behind it.
     *   `served`: The worker handled the request itself, whether because the prompt was cached or too short to disaggregate. The pipeline stops early (`decode-only`).
     *   `deferred`: The worker returned HTTP 412. The pipeline continues to encode/prefill/decode.
-    *   `error`: Any other 4xx/5xx status or a transport failure on the probe. The step then returns an `UpstreamStreamedError` and the request is classified in the `upstream_4xx`/`upstream_5xx`/`internal` error buckets.
+    *   `error`: Any other 4xx/5xx status. The step returns an `UpstreamStreamedError` carrying that status, and the request is classified as `upstream_4xx` or `upstream_5xx`.
+    *   `transport_error`: No response arrived (connection refused, timeout, TCP reset). The step returns an `UpstreamStreamedError` with no status code, and the request is classified as `upstream_transport`.
 *   **Note:** Not redundant with `execution_path_total` since a deferred probe does not indicate whether the subsequent path was `prefill-decode` or `encode-prefill-decode`.
 
 ## Relationship to EPP metrics
@@ -165,11 +169,12 @@ Neither the coordinator nor EPP tracks per-request image count or size. Image co
 
 ## Cardinality
 
-`model_name` labels every request-family metric and `execution_path_total` — every metric that
-carries `model_name` — and the handler takes it straight from the request body without validation.
-Each distinct value creates its own set of series, and a histogram multiplies that by its bucket
-count, so a client looping over invented model names grows the coordinator's memory without bound.
-This is reachable by any client, and it is a mitigation the implementation has to carry.
+`model_name` labels every request-family metric and `execution_path_total`, which together are
+every metric that carries it. The handler takes the value straight from the request body without
+validation. Each distinct value creates its own set of series, and a histogram multiplies that by
+its bucket count, so a client looping over invented model names grows the coordinator's memory
+without bound. This is reachable by any client, and it is a mitigation the implementation has to
+carry.
 
 Capping the distinct values is the approach that fits: `model_name` is capped at 1000 over the
 process lifetime and further values are reported as `other`. The bounded-label helper lives in

--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -82,8 +82,8 @@ error, 413, invalid JSON) count as `bad_request` with `model_name=unknown`.
 |---|---|---|
 | `request_total` | Counter | Every inbound client request, including malformed ones. |
 | `request_error_total` | Counter | Failed requests; adds label `error_code`. |
-| `request_duration_seconds` | Histogram | End-to-end request latency; `generalLatencyBuckets` (5ms to 1h). |
-| `request_size_bytes` | Histogram | Request body length; powers-of-2 buckets. |
+| `request_duration_seconds` | Histogram | End-to-end request latency. |
+| `request_size_bytes` | Histogram | Request body size. |
 | `response_size_bytes` | Histogram | Bytes streamed to the client, measured by a counting `ResponseWriter` wrapper in the handler rather than by parsing the body. |
 | `request_running` | Gauge | Requests in flight. |
 
@@ -98,7 +98,7 @@ Recorded by the pipeline executor, one observation per step per request. This fa
 
 | Name | Type | Notes |
 |---|---|---|
-| `pipeline_step_duration_seconds` | Histogram | Per-step latency. Uses fine-grained `stepLatencyBuckets` (100us to 60s) to capture both microsecond steps (render) and seconds-long steps (decode). |
+| `pipeline_step_duration_seconds` | Histogram | Per-step latency. |
 | `pipeline_step_errors_total` | Counter | Step failures; adds label `error_code`. |
 
 **Key details:**
@@ -139,9 +139,9 @@ Recorded by the conditional-decode, encode, prefill, and decode steps. This fami
 
 | Coordinator metric | EPP counterpart | Difference |
 |---|---|---|
-| Request family (`request_total`, etc.) | `llm_d_epp_*` (same names) | Coordinator counts single client requests at entry; EPP counts every sub-request reaching the gateway. EPP adds flow-control labels (`fairness_id`, `priority`). |
-| `disagg_decision_total` | `llm_d_epp_disagg_decision_total` | Coordinator counts phases *executed*; EPP counts routing decisions *made* and adds plugin labels. |
-| `pipeline_step_*`, `upstream_request_*`, `decode_cache_lookups_total` | None | Unique to coordinator. |
+| Request family (`llm_d_coordinator_request_total`, etc.) | `llm_d_epp_*` (same names) | Coordinator counts single client requests at entry; EPP counts every sub-request reaching the gateway. EPP adds flow-control labels (`fairness_id`, `priority`). |
+| `llm_d_coordinator_disagg_decision_total` | `llm_d_epp_disagg_decision_total` | Coordinator counts phases *executed*; EPP counts routing decisions *made* and adds plugin labels. |
+| `llm_d_coordinator_pipeline_step_*`, `llm_d_coordinator_upstream_request_*`, `llm_d_coordinator_decode_cache_lookups_total` | None | Unique to coordinator. |
 
 **EPP-only metrics:** EPP exposes token counts, latencies (TTFT/TPOT/ITL), and metrics for scheduling, flow control, and pool aggregates. The coordinator does not measure these as they are outside its scope.
 
@@ -152,6 +152,14 @@ Recorded by the conditional-decode, encode, prefill, and decode steps. This fami
 The coordinator emits no token-count metrics. EPP already parses the vLLM `usage` block to emit `request_input_tokens`, `request_output_tokens`, and `request_cached_tokens`, and the coordinator avoids duplicating this effort. Furthermore, extracting output tokens would require the coordinator to parse the streamed SSE response, defeating the purpose of a pure byte proxy (which is why we use `response_size_bytes`).
 
 *Future candidate:* `request_prompt_tokens` (Histogram, after render) could be added to correlate prompt size with encode fan-out without needing a cross-component join.
+
+### Time to first token
+
+The coordinator emits no TTFT metric. Identifying the first token requires parsing the streamed
+response, which the decode step does not do: it proxies bytes straight to the client. EPP measures
+TTFT, but only per leg, since each phase reaches it as a separate request, so its decode-leg
+`request_ttft_seconds` starts after render, encode, and prefill have already finished. Neither
+component reports the client's full wait for output.
 
 ### Per-request image visibility
 

--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -11,7 +11,7 @@ A metric's full Prometheus name is `<subsystem>_<name>`. The coordinator uses a 
 
 | Prefix | Scope |
 |---|---|
-| `llm_d_coordinator_` | Every coordinator metric: request, pipeline step, upstream phase, disaggregation decision, and decode cache. |
+| `llm_d_coordinator_` | Canonical, coordinator-wide: request, response, pipeline step and latency, and the remaining coordinator metrics. |
 
 Naming mirrors the EPP request family so PromQL expressions and dashboard panels
 translate between the two components. Where a name matches an EPP metric, the
@@ -24,29 +24,27 @@ translate between the two components. Where a name matches an EPP metric, the
 ### Coordinator metrics endpoint
 
 Every metric on this page is exposed on a single `/metrics` endpoint served by the coordinator
-process, alongside the inference paths and `/healthz` and `/readyz`. EPP's metrics endpoint is
-separate, served from its own process on the controller-runtime registry.
+process on the metrics port (default 9090, configurable with `--metrics-port`), separate from the listener
+carrying the inference paths and `/healthz` and `/readyz`.
 
-TBD: the registry the endpoint serves, its address, and whether it is authenticated. EPP authenticates
-its endpoint by default (`--metrics-endpoint-auth`), which requires RBAC for TokenReview and
-SubjectAccessReview; matching that would extend the coordinator's ServiceAccount permissions.
+TBD: the registry the endpoint serves and whether it is authenticated. Authenticating it costs RBAC
+for TokenReview and SubjectAccessReview on the coordinator's ServiceAccount.
 
 ### Other scrape targets
 
 All coordinator metrics are self-instrumented: the coordinator counts and times its own work
-in-process, and scrapes nothing. Two series record a signal that originates upstream but is still
-measured by the coordinator: `upstream_request_duration_seconds` times each encode sub-request, and
-`decode_cache_lookups_total` records the decode server's response to the conditional-decode probe.
+in-process and scrapes no other component. Two of them describe upstream behavior but are still
+measured locally, from the coordinator's side of the call: `upstream_request_duration_seconds` times
+each encode sub-request, and `conditional_decode_probes_total` records how the decode worker
+answered the conditional-decode probe.
 
 One client request passes through the coordinator, the EPP behind the gateway, and the vLLM workers,
-and each of the three serves its own `/metrics`. Measurements this page does not list are on one of
-the other two endpoints: per-request token counts and pool aggregates such as KV-cache utilization
-and queue depth on EPP's (see [Metrics](metrics.md)), multimodal cache counters on vLLM's. Scrape all
-three to follow a request end to end.
+and each of the three serves its own `/metrics`. Following a request end to end means scraping all
+three: what this page does not list is on EPP's endpoint (see [Metrics](metrics.md)) or vLLM's.
 
 ## Labels
 
-The `step` and `phase` labels share most of their values, but measure different boundaries: a step is a pipeline stage (which may make multiple calls), while a phase is a single backend call.
+The `step` and `phase` labels share most of their values, but measure different boundaries: a step is a pipeline stage, while a phase is a single backend call. They diverge where a stage is not one call: the `encode` step fans out one concurrent sub-request per multimodal entry, so a request with six images records one `step="encode"` observation and six `phase="encode"` observations. Steps that make no backend call at all (`render`, `replace-media-urls`) have no phase.
 
 - **`step`**: A stage of the internal pipeline, observed once per request per stage. Covers local work and all backend calls made by that stage. Values: `render`, `replace-media-urls`, `encode`, `prefill`, `conditional-decode`, `decode`. See [Coordinator Architecture](coordinator_architecture.md).
 - **`phase`**: A single outbound backend call. Values: `encode`, `prefill`, `decode`, `conditional-decode`.
@@ -54,7 +52,7 @@ The `step` and `phase` labels share most of their values, but measure different 
 
 ## Error classes
 
-The `error_code` label on `request_error_total` and `pipeline_step_errors_total` uses four values:
+The `error_code` label on `request_error_total` and `step_errors_total` uses four values:
 
 - **`bad_request`**: Client-side errors (e.g., malformed body).
 - **`upstream_4xx`**: 4xx errors from upstream (e.g., render, prefill, encode).
@@ -62,8 +60,8 @@ The `error_code` label on `request_error_total` and `pipeline_step_errors_total`
 - **`internal`**: All other coordinator-internal faults.
 
 **Key behaviors:**
-- The conditional-decode probe's HTTP 412 (cache miss) is handled internally and is **not** an error. It is tracked separately by [`decode_cache_lookups_total`](#decode_cache_lookups_total).
-- `upstream_4xx` and `upstream_5xx` only apply to the `render`, `prefill`, and `encode` steps. The `decode` and `conditional-decode` steps proxy responses directly to the client, so upstream failures during decode currently reach the client without incrementing these error metrics.
+- The conditional-decode probe's HTTP 412 (the worker declined to serve it) is handled internally and is **not** an error. It is tracked separately by [`conditional_decode_probes_total`](#conditional_decode_probes_total-counter).
+- `upstream_4xx` and `upstream_5xx` are recorded for the `render`, `prefill`, and `encode` steps, which read the upstream status before continuing. The `decode` and `conditional-decode` steps stream the upstream response straight to the client, and today only the conditional-decode probe inspects its status (to detect the 412 miss), so a decode-phase status error reaches the client uncounted. The status is available to both: it can be read in the reverse proxy's `ModifyResponse` hook before any bytes are forwarded. What stays uncountable is a failure that occurs after streaming has begun, since the 200 and a partial body are already on the wire.
 
 ## Metrics catalog
 
@@ -87,19 +85,17 @@ error, 413, invalid JSON) count as `bad_request` with `model_name=unknown`.
 | `response_size_bytes` | Histogram | Bytes streamed to the client, measured by a counting `ResponseWriter` wrapper in the handler rather than by parsing the body. |
 | `request_running` | Gauge | Requests in flight. |
 
-EPP's `llm_d_epp_request_running` adds `fairness_id` and `priority`. Both come from flow control,
-which the coordinator does not implement, so neither has a coordinator counterpart.
-
 ### Pipeline step family
 
 Label set `{step}` (a stage of the coordinator's internal pipeline, see [Labels](#labels)).
 
-Recorded by the pipeline executor, one observation per step per request. This family measures each stage's total wall time (local work, orchestration, and all backend calls made by the stage). It answers where time goes inside the coordinator and which internal stage failed.
+Recorded by the pipeline executor, which brackets every step it runs. This family measures each stage's total wall time (local work, orchestration, and all backend calls made by the stage). It answers where time goes inside the coordinator and which internal stage failed.
 
 | Name | Type | Notes |
 |---|---|---|
-| `pipeline_step_duration_seconds` | Histogram | Per-step latency. |
-| `pipeline_step_errors_total` | Counter | Step failures; adds label `error_code`. |
+| `step_duration_seconds` | Histogram | Per-step latency. |
+| `step_errors_total` | Counter | Step failures; adds label `error_code`. |
+| `step_running` | Gauge | Requests currently executing the step. Saturation rather than latency: `decode` stays in flight for the whole stream, so its value is the number of active streams. |
 
 **Key details:**
 *   Only steps that actually executed are recorded. Trailing steps from early exits (e.g., conditional-decode hit) or failures are not emitted.
@@ -108,7 +104,7 @@ Recorded by the pipeline executor, one observation per step per request. This fa
 
 Label set `{phase}` (one outbound backend call, not a pipeline stage, see [Labels](#labels)).
 
-Recorded by the conditional-decode, encode, prefill, and decode steps. This family counts and times the outbound sub-requests to the gateway. (Render and media fetches are not included, their latency is tracked in `pipeline_step_duration_seconds`).
+Recorded by the conditional-decode, encode, prefill, and decode steps. This family counts and times the outbound sub-requests to the gateway. (Render and media fetches are not included, their latency is tracked in `step_duration_seconds`).
 
 | Name | Type | Notes |
 |---|---|---|
@@ -118,22 +114,22 @@ Recorded by the conditional-decode, encode, prefill, and decode steps. This fami
 **Key details:**
 *   **Fan-out:** A single client request can result in multiple backend calls (e.g., one conditional-decode probe, two encode calls for two images, one prefill, one decode).
 *   **Narrower scope than steps:** 
-    *   `upstream_request_duration_seconds` is encode-only because it tracks per-image latency. Prefill and decode already have a 1:1 mapping between call latency and step duration, so their timings are tracked solely in `pipeline_step_duration_seconds`.
-    *   There is no `upstream_request_error_total`. A phase-call failure aborts its step and is already counted by `pipeline_step_errors_total`.
+    *   `upstream_request_duration_seconds` is encode-only because it tracks per-image latency. Prefill and decode already have a 1:1 mapping between call latency and step duration, so their timings are tracked solely in `step_duration_seconds`.
+    *   There is no `upstream_request_error_total`. A phase-call failure aborts its step and is already counted by `step_errors_total`.
 *   **Conditional-decode:** The probe gets its own phase rather than counting as `decode`, keeping fan-out ratios accurate.
 
-### Disaggregation decision and decode cache
+### Disaggregation decision and conditional decode
 
 #### `disagg_decision_total` (Counter)
 *   **Labels:** `model_name`, `decision_type` (`decode-only`, `prefill-decode`, `encode-prefill-decode`)
 *   **Description:** Records which phases actually ran for a request. Unlike EPP, it lacks `encode-decode` because encode always implies prefill in the coordinator.
 
-#### `decode_cache_lookups_total` (Counter)
-*   **Labels:** `result` (`hit` or `miss`)
-*   **Description:** Records the outcome of the conditional-decode probe. 
-    *   `hit`: The decode worker already had the prompt in its KV cache and served the response directly. The pipeline stops early (`decode-only`).
-    *   `miss`: The worker returned HTTP 412. The pipeline continues to encode/prefill/decode.
-*   **Note:** Not redundant with `disagg_decision_total` since a cache miss does not indicate whether the subsequent path was `prefill-decode` or `encode-prefill-decode`.
+#### `conditional_decode_probes_total` (Counter)
+*   **Labels:** `result` (`served` or `deferred`)
+*   **Description:** Counts conditional-decode probes by the worker's answer. The coordinator sees the status code, not the reason behind it.
+    *   `served`: The worker handled the request itself, whether because the prompt was cached or too short to disaggregate. The pipeline stops early (`decode-only`).
+    *   `deferred`: The worker returned HTTP 412. The pipeline continues to encode/prefill/decode.
+*   **Note:** Not redundant with `disagg_decision_total` since a deferred probe does not indicate whether the subsequent path was `prefill-decode` or `encode-prefill-decode`.
 
 ## Relationship to EPP metrics
 
@@ -141,17 +137,19 @@ Recorded by the conditional-decode, encode, prefill, and decode steps. This fami
 |---|---|---|
 | Request family (`llm_d_coordinator_request_total`, etc.) | `llm_d_epp_*` (same names) | Coordinator counts single client requests at entry; EPP counts every sub-request reaching the gateway. EPP adds flow-control labels (`fairness_id`, `priority`). |
 | `llm_d_coordinator_disagg_decision_total` | `llm_d_epp_disagg_decision_total` | Coordinator counts phases *executed*; EPP counts routing decisions *made* and adds plugin labels. |
-| `llm_d_coordinator_pipeline_step_*`, `llm_d_coordinator_upstream_request_*`, `llm_d_coordinator_decode_cache_lookups_total` | None | Unique to coordinator. |
+| `llm_d_coordinator_step_*`, `llm_d_coordinator_upstream_request_*`, `llm_d_coordinator_conditional_decode_probes_total` | None | Unique to coordinator. |
 
-**EPP-only metrics:** EPP exposes token counts, latencies (TTFT/TPOT/ITL), and metrics for scheduling, flow control, and pool aggregates. The coordinator does not measure these as they are outside its scope.
+**EPP-only metrics:** Scheduling, flow control, and pool aggregates have no coordinator counterpart. EPP's token counts and TTFT do, but they are per leg: the same prompt reaches EPP on more than one leg, and decode-leg TTFT starts after render, encode, and prefill have finished, so neither describes a client request. Only the coordinator sees a client request as one request. See [Deliberate omissions](#deliberate-omissions) for what it could report and why it does not today.
 
 ## Deliberate omissions
 
 ### Token counts
 
-The coordinator emits no token-count metrics. EPP already parses the vLLM `usage` block to emit `request_input_tokens`, `request_output_tokens`, and `request_cached_tokens`, and the coordinator avoids duplicating this effort. Furthermore, extracting output tokens would require the coordinator to parse the streamed SSE response, defeating the purpose of a pure byte proxy (which is why we use `response_size_bytes`).
+The coordinator emits no token-count metrics. Output and cached counts live in the vLLM `usage` block, and reading it means parsing the streamed SSE response, which the decode step does not do: it proxies bytes straight to the client, and `response_size_bytes` is the byte-level stand-in.
 
-*Future candidate:* `request_prompt_tokens` (Histogram, after render) could be added to correlate prompt size with encode fan-out without needing a cross-component join.
+Input tokens are a different case. The renderer returns the token IDs, so the count is already in hand after render, with no response parsing and no dependency on EPP.
+
+*Future candidate:* `request_input_tokens` (Histogram, after render). It is the per-client-request prompt size, which EPP cannot report from its per-leg view, and it correlates prompt size with encode fan-out without a cross-component join.
 
 ### Time to first token
 
@@ -163,11 +161,12 @@ component reports the client's full wait for output.
 
 ### Per-request image visibility
 
-Neither the coordinator nor EPP tracks per-request image count or size. Currently, image count is only visible in aggregate via `upstream_request_total{phase="encode"}`. Image byte size is unreliable because URL images are fetched by `replace-media-urls` and do not traverse the coordinator.
+Neither the coordinator nor EPP tracks per-request image count or size. Image count is only visible in aggregate via `upstream_request_total{phase="encode"}`. Size is available but unrecorded: `replace-media-urls` downloads each URL image and base64-encodes it, so every entry, inline or fetched, carries its payload through the coordinator.
 
 *Future candidates:* 
 *   `request_images`: Histogram of multimodal entries per request.
-*   `image_placeholder_tokens`: Histogram of placeholder length per entry (the only uniform measure of image size).
+*   `image_bytes`: Histogram of decoded payload size per entry.
+*   `image_placeholder_tokens`: Histogram of placeholder length per entry, the token-space counterpart to `image_bytes`.
 
 ## Cardinality
 

--- a/pkg/coordinator/metrics/classify.go
+++ b/pkg/coordinator/metrics/classify.go
@@ -39,7 +39,7 @@ type ClassifyOptions struct {
 // ClassifyErrorCode maps a pipeline error to the error_code label emitted on
 // request_error_total and step_errors_total. Both metric families use the
 // same label vocabulary, so the two call sites share this function to stay
-// consistent — a new bucket or a shifted status band is one edit, both
+// consistent. A new bucket or a shifted status band is one edit, and both
 // metrics pick it up.
 func ClassifyErrorCode(err error, opts ClassifyOptions) string {
 	if opts.BadRequest != nil && errors.Is(err, opts.BadRequest) {

--- a/pkg/coordinator/metrics/llm_d_coordinator_metrics.go
+++ b/pkg/coordinator/metrics/llm_d_coordinator_metrics.go
@@ -120,9 +120,9 @@ var (
 
 // Upstream call family. Recorded once per outbound HTTP call by the step
 // that makes it: encode contributes one observation per multimodal entry
-// and replace-media-urls one per URL, so the counter multiplies past step_total
-// by the fan-out factor. Failures roll up into step_errors_total, so there
-// is no upstream_request_error_total.
+// and replace-media-urls one per URL, so this counter exceeds the number of
+// step executions by the fan-out factor. Failures roll up into
+// step_errors_total, so there is no upstream_request_error_total.
 var (
 	upstreamRequestTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -164,7 +164,7 @@ var (
 		prometheus.CounterOpts{
 			Subsystem: LLMDRouterCoordinatorSubsystem,
 			Name:      "conditional_decode_probes_total",
-			Help:      metricsutil.HelpMsgWithStability("Total number of conditional-decode probes by the worker's answer: served inline (2xx/3xx), deferred (HTTP 412) to the full pipeline, or error (any other 4xx/5xx).", compbasemetrics.ALPHA),
+			Help:      metricsutil.HelpMsgWithStability("Total number of conditional-decode probes by the worker's answer: served inline (2xx/3xx), deferred (HTTP 412) to the full pipeline, error (any other 4xx/5xx), or transport_error (no response received).", compbasemetrics.ALPHA),
 		},
 		[]string{"result"},
 	)

--- a/pkg/coordinator/metrics/record.go
+++ b/pkg/coordinator/metrics/record.go
@@ -95,7 +95,7 @@ func IncExecutionPath(modelName, path string) {
 }
 
 // IncConditionalDecodeProbes increments conditional_decode_probes_total for
-// one probe outcome ("served", "deferred", or "error").
+// one probe outcome ("served", "deferred", "error", or "transport_error").
 func IncConditionalDecodeProbes(result string) {
 	conditionalDecodeProbesTotal.WithLabelValues(result).Inc()
 }


### PR DESCRIPTION
 **What type of PR is this?**
    /kind documentation
    /kind feature

### PR Description

**What this PR does / why we need it**:
    This PR adds `docs/metrics.coord.md` as the first step towards instrumenting the coordinator. It defines the metrics that the coordinator will expose, including request latency, pipeline step durations, and upstream sub-requests.

By establishing the metric naming conventions, label sets, and cardinality bounds up front, we can align the design with EPP's existing telemetry before opening implementation PRs.

**Which issue(s) this PR fixes**:
    <!-- If there's an issue for coordinator telemetry, link it here: Fixes #123 -->
    Part of #2276