### PR TITLE
[ci]: Sign published container images with actions/attest

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -41,6 +41,10 @@ inputs:
     required: false
     description: Additional image tags to push
     default: ''
+outputs:
+  digest:
+    description: Digest of the pushed image index
+    value: ${{ steps.build.outputs.digest }}
 runs:
   using: "composite"
   steps:
@@ -56,6 +60,7 @@ runs:
         password: ${{ inputs.github-token }}
 
     - name: Build image
+      id: build
       uses: docker/build-push-action@v6
       with:
         file: ${{ inputs.docker-file }}

--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -43,6 +43,12 @@ permissions:
 jobs:
   build-epp:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
@@ -65,6 +71,7 @@ jobs:
 
       # Re-run the build with push enabled with: cache-to/cache-from type=gha
       - name: Push EPP image for both AMD64 and ARM64
+        id: push-epp
         uses: ./.github/actions/docker-build-and-push
         with:
           docker-file: Dockerfile.epp
@@ -77,8 +84,21 @@ jobs:
           push: 'true'
           additional-tags: ${{ inputs.epp-additional-tags }}
 
+      - name: Attest EPP image provenance
+        uses: actions/attest@v4
+        with:
+          subject-name: ghcr.io/llm-d/${{ inputs.epp-image-name }}
+          subject-digest: ${{ steps.push-epp.outputs.digest }}
+          push-to-registry: true
+
   build-sidecar:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
@@ -99,6 +119,7 @@ jobs:
           tarball: /tmp/sidecar-image.tar
 
       - name: Push sidecar image for both AMD64 and ARM64
+        id: push-sidecar
         uses: ./.github/actions/docker-build-and-push
         with:
           docker-file: Dockerfile.sidecar
@@ -110,6 +131,13 @@ jobs:
           commit-sha: ${{ github.sha }}
           push: 'true'
           additional-tags: ${{ inputs.sidecar-additional-tags }}
+
+      - name: Attest sidecar image provenance
+        uses: actions/attest@v4
+        with:
+          subject-name: ghcr.io/llm-d/${{ inputs.sidecar-image-name }}
+          subject-digest: ${{ steps.push-sidecar.outputs.digest }}
+          push-to-registry: true
 
   build-coordinator:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -141,6 +141,12 @@ jobs:
 
   build-coordinator:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
@@ -161,6 +167,7 @@ jobs:
           tarball: /tmp/coordinator-image.tar
 
       - name: Push coordinator image for both AMD64 and ARM64
+        id: push-coordinator
         uses: ./.github/actions/docker-build-and-push
         with:
           docker-file: Dockerfile.coordinator
@@ -172,6 +179,13 @@ jobs:
           commit-sha: ${{ github.sha }}
           push: 'true'
           additional-tags: ${{ inputs.coordinator-additional-tags }}
+
+      - name: Attest coordinator image provenance
+        uses: actions/attest@v4
+        with:
+          subject-name: ghcr.io/llm-d/${{ inputs.coordinator-image-name }}
+          subject-digest: ${{ steps.push-coordinator.outputs.digest }}
+          push-to-registry: true
 
   push-helm-charts:
     needs: [build-epp, build-sidecar, build-coordinator]

--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -11,8 +11,6 @@ permissions:
   contents: read
   packages: write
   security-events: write
-  id-token: write
-  attestations: write
 
 jobs:
   set-params:
@@ -46,6 +44,12 @@ jobs:
   build-and-push:
     if: github.event.repository.fork != true
     needs: set-params
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/ci-build-images.yaml
     with:
       epp-image-name: ${{ needs.set-params.outputs.epp_name }}

--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -11,6 +11,8 @@ permissions:
   contents: read
   packages: write
   security-events: write
+  id-token: write
+  attestations: write
 
 jobs:
   set-params:

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -11,6 +11,8 @@ permissions:
   contents: read
   packages: write
   security-events: write
+  id-token: write
+  attestations: write
 
 jobs:
   set-params:

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -11,8 +11,6 @@ permissions:
   contents: read
   packages: write
   security-events: write
-  id-token: write
-  attestations: write
 
 jobs:
   set-params:
@@ -48,6 +46,12 @@ jobs:
 
   build-and-push:
     needs: set-params
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/ci-build-images.yaml
     with:
       epp-image-name: ${{ needs.set-params.outputs.epp_name }}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Images already publish an SLSA v1 provenance predicate via buildx's default `mode=max`. It is not signed however and  so it's forgeable and proves nothing to a consumer. This commit adds GH attestations after each image push which signs the images keyed on the pushed index digest. The attestation covers both platforms and can't be swapped for a different build.

`id-token` and attestations permissions are scoped to the `build-epp` and `build-sidecar` jobs in `ci-build-images.yaml`. Permissions added to `ci-dev.yaml` and `ci-release.yaml` too since a reusable workflow's token can't exceed its caller's.

/cc @elevran 

**Which issue(s) this PR fixes**:
Partial https://github.com/llm-d/llm-d-router/issues/956 (Phase 3, Sign the published images)

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
