### PR TITLE
feat(scheduler): size approx-prefix-cache LRU to offload-extended KV cache capacity

### DIFF
--- a/docs/plugin-metric-protocol.md
+++ b/docs/plugin-metric-protocol.md
@@ -86,6 +86,40 @@ If absent, the value is taken from the `approximate-prefix` plugin's `LRUCapacit
 | Triton TensorRT-LLM | `nv_trt_llm_kv_cache_block_metrics{kv_cache_block_type=max}` | — |
 | trtllm-serve | `trtllm_kv_cache_max_blocks` | — |
 
+Note on trtllm-serve with host offloading (`kv_cache_config.host_cache_size`): under the default
+(legacy) KV cache manager, `trtllm_kv_cache_max_blocks` already counts GPU plus host blocks, so
+the auto-tuned capacity covers the offload-extended cache with no further configuration. Under
+the opt-in `use_kv_cache_manager_v2` (also the default for some hybrid-Mamba model families),
+the same gauge is GPU-only and the host tier is not observable via Prometheus; on such
+deployments disable the `approx-prefix-cache-producer`'s `autoTune` and set
+`lruCapacityPerServer` explicitly to avoid under-reporting prefix matches.
+
+### TotalKVCacheTokens (optional)
+
+The total effective KV cache capacity in tokens across all memory tiers (GPU HBM plus host/CPU
+offload). When reported, it takes precedence over NumGPUBlocks for auto-tuning the approximate
+prefix cache, so prefix-match estimates cover the offload-extended cache.
+
+- **Type:** Gauge (the maximum across the configured per-tier gauges is used)
+- **Required by:** `prefix-cache-scorer`, `prefix-cache-affinity-filter` (via `approximate-prefix` when `AutoTune` is enabled)
+
+| Model server | Metric | Notes |
+| --- | --- | --- |
+| SGLang | `sglang:hicache_host_total_tokens`, `sglang:max_total_num_tokens` | The hicache host pool (SGLang v0.5.10+, hierarchical cache enabled) is an inclusive superset of the device pool under the default `write_through` policy, so the effective total is the max of the two gauges, not their sum. On older SGLang versions only the device gauge exists; disable `autoTune` and set `lruCapacityPerServer` to `hicache-ratio x device tokens / page size` to account for the host tier. |
+| vLLM | — | Not reported. vLLM exposes no offload-tier capacity metric (`num_cpu_blocks` is always `None` on V1). See KVCacheOffloadDetection below. |
+| trtllm-serve | — | Not needed under the legacy KV cache manager (NumGPUBlocks already includes host blocks); not available under the V2 manager. |
+
+### KVCacheOffloadDetection (optional)
+
+Metrics whose presence indicates the model server offloads KV cache to a tier whose capacity is
+not reported. Detection does not change auto-tuned capacity by itself; it drives an operator
+warning that prefix matches will be under-reported unless `autoTune` is disabled and
+`lruCapacityPerServer` is set.
+
+| Model server | Signal |
+| --- | --- |
+| vLLM | Presence of any `vllm:kv_offload_*` OffloadingConnector series (registered at startup, before traffic), or a numeric `kv_offloading_size` label (GiB) on `vllm:cache_config_info` (only populated by the built-in `--kv-offloading-size` flag; hand-written `--kv-transfer-config` deployments leave it `None`). `vllm:external_prefix_cache_*` is deliberately not used: it is registered even without a connector. |
+
 ## LoRA Adapter Serving
 
 **Required by:** `lora-affinity-scorer`

--- a/pkg/epp/framework/interface/datalayer/metrics.go
+++ b/pkg/epp/framework/interface/datalayer/metrics.go
@@ -28,12 +28,20 @@ type Metrics struct {
 	ActiveModels  map[string]int
 	WaitingModels map[string]int
 	// MaxActiveModels is the maximum number of models that can be loaded to GPU.
-	MaxActiveModels         int
-	RunningRequestsSize     int
-	WaitingQueueSize        int
-	KVCacheUsagePercent     float64
+	MaxActiveModels     int
+	RunningRequestsSize int
+	WaitingQueueSize    int
+	KVCacheUsagePercent float64
+	// KvCacheMaxTokenCapacity is the total effective KV cache capacity of the
+	// model server in tokens, across all memory tiers (e.g. GPU HBM plus a
+	// host/CPU offload tier). Zero when the model server does not report it.
 	KvCacheMaxTokenCapacity int
-	CacheBlockSize          int
+	// KvCacheOffloadDetected is true when the model server reports KV cache
+	// offloading activity (e.g. vLLM's OffloadingConnector metrics) without
+	// reporting the offload tier's capacity. Consumers sizing caches from
+	// CacheNumBlocks alone are undercounting in that case.
+	KvCacheOffloadDetected bool
+	CacheBlockSize         int
 	// Number of GPU blocks in the model server for KV Cache.
 	CacheNumBlocks int
 
@@ -75,6 +83,7 @@ func (m *Metrics) Clone() *Metrics {
 		WaitingQueueSize:        m.WaitingQueueSize,
 		KVCacheUsagePercent:     m.KVCacheUsagePercent,
 		KvCacheMaxTokenCapacity: m.KvCacheMaxTokenCapacity,
+		KvCacheOffloadDetected:  m.KvCacheOffloadDetected,
 		CacheBlockSize:          m.CacheBlockSize,
 		CacheNumBlocks:          m.CacheNumBlocks,
 		UpdateTime:              m.UpdateTime,

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -172,6 +172,32 @@ func (ext *Extractor) Extract(ctx context.Context, in fwkdl.PollInput[sourcemetr
 		}
 	}
 
+	// Extract total KV cache capacity in tokens as the maximum across the
+	// configured tier gauges. Absent metrics are skipped, not errors: tier
+	// gauges (e.g. SGLang's hicache host pool) only exist when the feature is
+	// enabled and on engine versions that export them.
+	if len(mapping.TotalCacheTokens) > 0 {
+		maxTokens := 0
+		for _, spec := range mapping.TotalCacheTokens {
+			metric, err := spec.getLatestMetric(families)
+			if err != nil {
+				continue
+			}
+			if v := int(extractValue(metric)); v > maxTokens {
+				maxTokens = v
+			}
+		}
+		if maxTokens > 0 {
+			clone.KvCacheMaxTokenCapacity = maxTokens
+			updated = true
+		}
+	}
+
+	if detected, checked := detectOffload(mapping, families); checked && detected != clone.KvCacheOffloadDetected {
+		clone.KvCacheOffloadDetected = detected
+		updated = true
+	}
+
 	for _, custom := range mapping.CustomMetrics {
 		metric, err := custom.Spec.getLatestMetric(families)
 		if err != nil {
@@ -196,6 +222,34 @@ func (ext *Extractor) Extract(ctx context.Context, in fwkdl.PollInput[sourcemetr
 		return errors.Join(errs...)
 	}
 	return nil
+}
+
+// detectOffload reports whether the scrape indicates KV cache offloading with
+// unreported capacity: any OffloadDetection metric is present, or the
+// OffloadSizeLabel on the CacheInfo metric parses to a value greater than zero.
+// The second return value is false when the mapping has no detection configured.
+func detectOffload(mapping *Mapping, families sourcemetrics.PrometheusMetricMap) (bool, bool) {
+	if len(mapping.OffloadDetection) == 0 && mapping.OffloadSizeLabel == "" {
+		return false, false
+	}
+	for _, spec := range mapping.OffloadDetection {
+		if _, err := spec.getLatestMetric(families); err == nil {
+			return true, true
+		}
+	}
+	if mapping.OffloadSizeLabel != "" && mapping.CacheInfo != nil {
+		if metric, err := mapping.CacheInfo.getLatestMetric(families); err == nil {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() != mapping.OffloadSizeLabel {
+					continue
+				}
+				if v, err := strconv.ParseFloat(label.GetValue(), 64); err == nil && v > 0 {
+					return true, true
+				}
+			}
+		}
+	}
+	return false, true
 }
 
 // getEngineTypeFromEndpoint extracts the engine type from endpoint metadata labels.

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
@@ -60,6 +60,19 @@ type (
 		// CacheNumBlocksSpec defines the metric specification string for retrieving num GPU blocks directly
 		// as a gauge value (alternative to CacheInfoSpec labels). Used by engines like Triton TRT-LLM.
 		CacheNumBlocksSpec string `json:"cacheNumBlocksSpec,omitempty"`
+		// TotalCacheTokensSpecs lists gauge specifications reporting KV cache capacity in tokens.
+		// The maximum across the specs present in a scrape is used, allowing tiered engines to
+		// list per-tier capacity gauges (e.g. SGLang hicache host pool and device pool). Absent
+		// metrics are skipped, since tier gauges only exist when the feature is enabled.
+		TotalCacheTokensSpecs []string `json:"totalCacheTokensSpecs,omitempty"`
+		// OffloadDetectionSpecs lists metric specifications whose presence indicates the engine
+		// offloads KV cache to another tier without reporting that tier's capacity
+		// (e.g. vLLM OffloadingConnector runtime metrics).
+		OffloadDetectionSpecs []string `json:"offloadDetectionSpecs,omitempty"`
+		// OffloadSizeLabelName optionally names a label on the CacheInfoSpec metric whose numeric
+		// value, when greater than zero, indicates KV cache offloading (e.g. vLLM's
+		// kv_offloading_size, in GiB).
+		OffloadSizeLabelName string `json:"offloadSizeLabelName,omitempty"`
 		// CustomMetrics defines engine-specific scalar metrics to extract as endpoint attributes.
 		CustomMetrics []customMetricConfigParams `json:"customMetrics,omitempty"`
 	}
@@ -94,6 +107,22 @@ var defaultEngineConfigs = []engineConfigParams{
 		KVUsageSpec:         "vllm:kv_cache_usage_perc",
 		LoRASpec:            "vllm:lora_requests_info",
 		CacheInfoSpec:       "vllm:cache_config_info",
+		// vLLM does not report offload-tier capacity in any metric; these series
+		// exist only when the OffloadingConnector is active (registered at startup
+		// with zero values, before any offload traffic), so their presence flags
+		// deployments where CacheNumBlocks (HBM only) undercounts the real cache.
+		// Family names carry the exposition-format counter suffix; total_bytes is
+		// the deprecated pre-v0.26 name kept for older engines. The
+		// kv_offloading_size label (GiB) is only set via --kv-offloading-size.
+		// vllm:external_prefix_cache_* is deliberately excluded: it is registered
+		// unconditionally, connector or not.
+		OffloadDetectionSpecs: []string{
+			"vllm:kv_offload_cpu_cache_usage_perc",
+			"vllm:kv_offload_load_bytes_total",
+			"vllm:kv_offload_store_bytes_total",
+			"vllm:kv_offload_total_bytes_total",
+		},
+		OffloadSizeLabelName: "kv_offloading_size",
 	},
 	{
 		Name:                    "sglang",
@@ -104,6 +133,21 @@ var defaultEngineConfigs = []engineConfigParams{
 		CacheInfoSpec:           "sglang:cache_config_info",
 		CacheBlockSizeLabelName: "page_size",
 		CacheNumBlocksLabelName: "num_pages",
+		// Newer SGLang (verified on v0.5.16) does not export cache_config_info;
+		// it exposes page_size and num_pages as plain gauges instead. Direct
+		// gauge specs run after CacheInfo extraction, so whichever form the
+		// engine version provides wins.
+		CacheBlockSizeSpec: "sglang:page_size",
+		CacheNumBlocksSpec: "sglang:num_pages",
+		// With hicache enabled (default write_through policy) the host pool is
+		// an inclusive superset of the device pool, so total effective capacity
+		// is max(host, device), not their sum. hicache_host_total_tokens exists
+		// on SGLang v0.5.10+ when hierarchical cache is enabled; on older
+		// versions only the device gauge is present and capacity stays HBM-only.
+		TotalCacheTokensSpecs: []string{
+			"sglang:hicache_host_total_tokens",
+			"sglang:max_total_num_tokens",
+		},
 	},
 	{
 		Name:                "trtllm-serve",
@@ -221,6 +265,9 @@ func newCoreMetricsExtractorPlugin(ctx context.Context, name string, params *mod
 			CacheNumBlocksLabel: engineConfig.CacheNumBlocksLabelName,
 			CacheBlockSize:      engineConfig.CacheBlockSizeSpec,
 			CacheNumBlocks:      engineConfig.CacheNumBlocksSpec,
+			TotalCacheTokens:    engineConfig.TotalCacheTokensSpecs,
+			OffloadDetection:    engineConfig.OffloadDetectionSpecs,
+			OffloadSizeLabel:    engineConfig.OffloadSizeLabelName,
 			CustomMetrics:       customMetrics,
 		})
 		if err != nil {

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/fixture_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/fixture_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
+)
+
+// The .prom files under testdata are real /metrics scrapes captured from model
+// servers (families irrelevant to KV cache trimmed), so these tests exercise
+// the default engine mappings against actual exposition output:
+//   - vllm-none.prom: vLLM v0.26.0, no offloading configured.
+//   - vllm-flag.prom: vLLM v0.26.0 with --kv-offloading-size 4
+//     (kv_offloading_size label set, OffloadingConnector metrics present).
+//   - vllm-conn.prom: vLLM v0.26.0 with --kv-transfer-config naming
+//     OffloadingConnector directly (kv_offloading_size label is "None";
+//     only the connector runtime metrics reveal offloading).
+//   - sglang-new.prom: SGLang v0.5.16 with --enable-hierarchical-cache
+//     --hicache-ratio 2 --max-total-tokens 200000 (hicache_host_total_tokens
+//     gauge present; no cache_config_info, page_size/num_pages are plain gauges).
+//   - sglang-old.prom: SGLang v0.5.9, same flags (predates the host capacity
+//     gauge and the plain page gauges; cache_config_info carries the labels).
+//   - trtllm-legacy.prom: trtllm-serve v1.3.0rc23, default (legacy) KV cache
+//     manager with kv_cache_config.host_cache_size 4GiB: max_blocks counts
+//     GPU plus host blocks.
+//   - trtllm-nohost.prom: same, without host_cache_size (GPU-only baseline).
+//   - trtllm-v2.prom: same host_cache_size with use_kv_cache_manager_v2: true:
+//     max_blocks is GPU-only, the host tier is invisible on Prometheus.
+func loadFixture(t *testing.T, name string) sourcemetrics.PrometheusMetricMap {
+	t.Helper()
+	f, err := os.Open(filepath.Join("testdata", name))
+	if err != nil {
+		t.Skipf("fixture %s not available: %v", name, err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	parser := expfmt.NewTextParser(model.LegacyValidation)
+	families, err := parser.TextToMetricFamilies(f)
+	if err != nil {
+		t.Fatalf("failed to parse fixture %s: %v", name, err)
+	}
+	return families
+}
+
+func extractFixture(t *testing.T, engine, fixture string) *fwkdl.Metrics {
+	t.Helper()
+	extractor, err := newCoreMetricsExtractorPlugin(context.Background(), "fixture-test", nil)
+	if err != nil {
+		t.Fatalf("failed to build extractor with default engine configs: %v", err)
+	}
+	ep := fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+		Labels: map[string]string{DefaultEngineTypeLabelKey: engine},
+	}, nil)
+	// Absent optional families produce errors while present ones still extract.
+	_ = extractor.Extract(context.Background(), fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{
+		Payload:  loadFixture(t, fixture),
+		Endpoint: ep,
+	})
+	return ep.GetMetrics()
+}
+
+func TestVLLMFixtures(t *testing.T) {
+	tests := []struct {
+		fixture       string
+		wantDetected  bool
+		wantNumBlocks int
+	}{
+		{fixture: "vllm-none.prom", wantDetected: false, wantNumBlocks: 74272},
+		{fixture: "vllm-flag.prom", wantDetected: true, wantNumBlocks: 74272},
+		{fixture: "vllm-conn.prom", wantDetected: true, wantNumBlocks: 74272},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fixture, func(t *testing.T) {
+			m := extractFixture(t, "vllm", tt.fixture)
+			if m.KvCacheOffloadDetected != tt.wantDetected {
+				t.Errorf("KvCacheOffloadDetected = %v, want %v", m.KvCacheOffloadDetected, tt.wantDetected)
+			}
+			if m.CacheNumBlocks != tt.wantNumBlocks {
+				t.Errorf("CacheNumBlocks = %d, want %d", m.CacheNumBlocks, tt.wantNumBlocks)
+			}
+			if m.CacheBlockSize != 16 {
+				t.Errorf("CacheBlockSize = %d, want 16", m.CacheBlockSize)
+			}
+			// vLLM has no total-capacity metric; capacity must stay unset so the
+			// producer falls back to GPU blocks (plus multiplier if configured).
+			if m.KvCacheMaxTokenCapacity != 0 {
+				t.Errorf("KvCacheMaxTokenCapacity = %d, want 0", m.KvCacheMaxTokenCapacity)
+			}
+		})
+	}
+}
+
+func TestSGLangFixtures(t *testing.T) {
+	tests := []struct {
+		fixture           string
+		wantTokenCapacity int
+	}{
+		// v0.5.16 with hicache-ratio 2: host pool gauge = 2x device tokens and
+		// wins the max. v0.5.9 predates the gauge: device tokens only.
+		{fixture: "sglang-new.prom", wantTokenCapacity: -1}, // filled from device gauge at runtime; see body
+		{fixture: "sglang-old.prom", wantTokenCapacity: -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fixture, func(t *testing.T) {
+			m := extractFixture(t, "sglang", tt.fixture)
+			families := loadFixture(t, tt.fixture)
+
+			device := 0
+			if fam, ok := families["sglang:max_total_num_tokens"]; ok && len(fam.GetMetric()) > 0 {
+				device = int(fam.GetMetric()[0].GetGauge().GetValue())
+			}
+			host := 0
+			if fam, ok := families["sglang:hicache_host_total_tokens"]; ok && len(fam.GetMetric()) > 0 {
+				host = int(fam.GetMetric()[0].GetGauge().GetValue())
+			}
+			want := max(host, device)
+			if want == 0 {
+				t.Fatalf("fixture %s has no capacity gauges", tt.fixture)
+			}
+			if m.KvCacheMaxTokenCapacity != want {
+				t.Errorf("KvCacheMaxTokenCapacity = %d, want %d (host=%d device=%d)",
+					m.KvCacheMaxTokenCapacity, want, host, device)
+			}
+			if tt.fixture == "sglang-new.prom" {
+				if host == 0 {
+					t.Error("expected hicache_host_total_tokens gauge in v0.5.16 fixture")
+				}
+				if host <= device {
+					t.Errorf("expected host pool (%d) > device pool (%d) with hicache-ratio 2", host, device)
+				}
+			}
+			if tt.fixture == "sglang-old.prom" && host != 0 {
+				t.Error("v0.5.9 fixture unexpectedly has hicache_host_total_tokens; update version notes")
+			}
+			if m.KvCacheOffloadDetected {
+				t.Error("sglang mapping should not set KvCacheOffloadDetected")
+			}
+			// Both fixture versions were launched with a 200000-token pool and
+			// SGLang's default 1-token pages: v0.5.9 exposes them as
+			// cache_config_info labels, v0.5.16 as plain gauges.
+			if m.CacheNumBlocks != 200000 {
+				t.Errorf("CacheNumBlocks = %d, want 200000", m.CacheNumBlocks)
+			}
+			if m.CacheBlockSize != 1 {
+				t.Errorf("CacheBlockSize = %d, want 1", m.CacheBlockSize)
+			}
+		})
+	}
+}
+
+// TestTRTLLMFixtures documents the trtllm-serve tiering semantics the router
+// relies on: the legacy (default) KV cache manager folds host offload blocks
+// into trtllm_kv_cache_max_blocks, so auto-tuning from CacheNumBlocks already
+// covers the offload-extended cache; the V2 manager reports GPU only and needs
+// an explicit lruCapacityPerServer override when host offload is enabled.
+// Captured on trtllm-serve v1.3.0rc23 with Qwen3-0.6B: the 4GiB host cache is
+// ~1169 blocks at ~3.6MiB per 32-token block.
+func TestTRTLLMFixtures(t *testing.T) {
+	tests := []struct {
+		fixture       string
+		wantNumBlocks int
+	}{
+		{fixture: "trtllm-nohost.prom", wantNumBlocks: 19960}, // GPU-only baseline
+		{fixture: "trtllm-legacy.prom", wantNumBlocks: 21129}, // GPU + 4GiB host tier
+		{fixture: "trtllm-v2.prom", wantNumBlocks: 19958},     // host tier configured but not counted
+	}
+	for _, tt := range tests {
+		t.Run(tt.fixture, func(t *testing.T) {
+			m := extractFixture(t, "trtllm-serve", tt.fixture)
+			if m.CacheNumBlocks != tt.wantNumBlocks {
+				t.Errorf("CacheNumBlocks = %d, want %d", m.CacheNumBlocks, tt.wantNumBlocks)
+			}
+			if m.CacheBlockSize != 32 {
+				t.Errorf("CacheBlockSize = %d, want 32", m.CacheBlockSize)
+			}
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
@@ -42,7 +42,22 @@ type Mapping struct {
 	// (e.g. Triton TRT-LLM).
 	CacheBlockSize *Spec
 	CacheNumBlocks *Spec
-	CustomMetrics  []CustomMetric
+	// TotalCacheTokens lists gauges reporting KV cache capacity in tokens.
+	// The extractor takes the maximum across the specs present in a scrape,
+	// so tiered engines can list per-tier capacity gauges (e.g. SGLang's
+	// hicache host pool, which is an inclusive superset of the device pool).
+	// Specs whose metric is absent are skipped rather than treated as errors,
+	// since tier gauges only exist when the corresponding feature is enabled.
+	TotalCacheTokens []*Spec
+	// OffloadDetection lists metrics whose presence indicates that the engine
+	// offloads KV cache to another tier without reporting that tier's
+	// capacity (e.g. vLLM's OffloadingConnector runtime metrics).
+	OffloadDetection []*Spec
+	// OffloadSizeLabel optionally names a label on the CacheInfo metric whose
+	// numeric value, when greater than zero, likewise indicates KV cache
+	// offloading (e.g. vLLM's kv_offloading_size, in GiB).
+	OffloadSizeLabel string
+	CustomMetrics    []CustomMetric
 }
 
 // MappingConfig holds configuration used to build a Mapping.
@@ -56,6 +71,9 @@ type MappingConfig struct {
 	CacheNumBlocksLabel string
 	CacheBlockSize      string
 	CacheNumBlocks      string
+	TotalCacheTokens    []string
+	OffloadDetection    []string
+	OffloadSizeLabel    string
 	CustomMetrics       []CustomMetric
 }
 
@@ -75,7 +93,7 @@ func (m *Mapping) specs() []namedSpec {
 	if m.LoraRequestInfo != nil {
 		loraSpec = m.LoraRequestInfo.Spec
 	}
-	specs := make([]namedSpec, 0, 5+len(m.CustomMetrics))
+	specs := make([]namedSpec, 0, 5+len(m.TotalCacheTokens)+len(m.OffloadDetection)+len(m.CustomMetrics))
 	specs = append(specs,
 		namedSpec{"queue", m.TotalQueuedRequests, m.TotalQueuedRequests != nil},
 		namedSpec{"running", m.TotalRunningRequests, m.TotalRunningRequests != nil},
@@ -83,6 +101,12 @@ func (m *Mapping) specs() []namedSpec {
 		namedSpec{"lora", loraSpec, m.LoraRequestInfo != nil},
 		namedSpec{"cacheInfo", m.CacheInfo, m.CacheInfo != nil},
 	)
+	for _, spec := range m.TotalCacheTokens {
+		specs = append(specs, namedSpec{"totalCacheTokens", spec, spec != nil})
+	}
+	for _, spec := range m.OffloadDetection {
+		specs = append(specs, namedSpec{"offloadDetection", spec, spec != nil})
+	}
 	for _, custom := range m.CustomMetrics {
 		specs = append(specs, namedSpec{
 			name:    custom.AttributeKey,
@@ -161,6 +185,10 @@ func NewMappingFromConfig(cfg MappingConfig) (*Mapping, error) {
 	if err != nil {
 		errs = append(errs, err)
 	}
+	totalCacheTokensSpecs, specErrs := parseSpecList(cfg.TotalCacheTokens)
+	errs = append(errs, specErrs...)
+	offloadDetectionSpecs, specErrs := parseSpecList(cfg.OffloadDetection)
+	errs = append(errs, specErrs...)
 	customMetrics, customErrs := parseCustomMetrics(cfg.CustomMetrics)
 	errs = append(errs, customErrs...)
 
@@ -177,8 +205,28 @@ func NewMappingFromConfig(cfg MappingConfig) (*Mapping, error) {
 		CacheNumBlocksLabel:  cfg.CacheNumBlocksLabel,
 		CacheBlockSize:       cacheBlockSizeSpec,
 		CacheNumBlocks:       cacheNumBlocksSpec,
+		TotalCacheTokens:     totalCacheTokensSpecs,
+		OffloadDetection:     offloadDetectionSpecs,
+		OffloadSizeLabel:     cfg.OffloadSizeLabel,
 		CustomMetrics:        customMetrics,
 	}, nil
+}
+
+// parseSpecList parses a list of metric specification strings, dropping empties.
+func parseSpecList(specStrings []string) ([]*Spec, []error) {
+	specs := make([]*Spec, 0, len(specStrings))
+	var errs []error
+	for _, s := range specStrings {
+		spec, err := parseStringToSpec(s)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if spec != nil {
+			specs = append(specs, spec)
+		}
+	}
+	return specs, errs
 }
 
 func parseCustomMetrics(configs []CustomMetric) ([]CustomMetric, []error) {

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/offload_capacity_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/offload_capacity_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"k8s.io/utils/ptr"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
+)
+
+func gaugeFamily(value float64, labels map[string]string) *dto.MetricFamily {
+	metric := &dto.Metric{Gauge: &dto.Gauge{Value: ptr.To(value)}}
+	for name, val := range labels {
+		metric.Label = append(metric.Label, &dto.LabelPair{Name: ptr.To(name), Value: ptr.To(val)})
+	}
+	return &dto.MetricFamily{
+		Type:   dto.MetricType_GAUGE.Enum(),
+		Metric: []*dto.Metric{metric},
+	}
+}
+
+// sglangMapping builds a mapping mirroring the built-in sglang engine config.
+func sglangMapping(t *testing.T) *Mapping {
+	t.Helper()
+	mapping, err := NewMappingFromConfig(MappingConfig{
+		TotalCacheTokens: []string{
+			"sglang:hicache_host_total_tokens",
+			"sglang:max_total_num_tokens",
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create sglang mapping: %v", err)
+	}
+	return mapping
+}
+
+// vllmMapping builds a mapping mirroring the built-in vllm engine config.
+func vllmMapping(t *testing.T) *Mapping {
+	t.Helper()
+	mapping, err := NewMappingFromConfig(MappingConfig{
+		CacheInfo: "vllm:cache_config_info",
+		OffloadDetection: []string{
+			"vllm:kv_offload_cpu_cache_usage_perc",
+			"vllm:kv_offload_load_bytes",
+			"vllm:kv_offload_store_bytes",
+			"vllm:kv_offload_total_bytes",
+		},
+		OffloadSizeLabel: "kv_offloading_size",
+	})
+	if err != nil {
+		t.Fatalf("failed to create vllm mapping: %v", err)
+	}
+	return mapping
+}
+
+func extractWith(t *testing.T, mapping *Mapping, data sourcemetrics.PrometheusMetricMap) *fwkdl.Metrics {
+	t.Helper()
+	registry := NewMappingRegistry()
+	if err := registry.Register(DefaultEngineType, mapping); err != nil {
+		t.Fatalf("failed to register mapping: %v", err)
+	}
+	extractor, err := NewCoreMetricsExtractor(registry, "")
+	if err != nil {
+		t.Fatalf("failed to create extractor: %v", err)
+	}
+	ep := fwkdl.NewEndpoint(nil, nil)
+	// Errors are expected for specs whose metrics are absent from the scrape;
+	// extraction of present metrics still proceeds (matches Extract semantics).
+	_ = extractor.Extract(context.Background(), fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: ep})
+	return ep.GetMetrics()
+}
+
+func TestExtractTotalCacheTokens(t *testing.T) {
+	tests := []struct {
+		name              string
+		data              sourcemetrics.PrometheusMetricMap
+		wantTokenCapacity int
+	}{
+		{
+			name: "hicache host gauge present, host larger than device (inclusive tiers)",
+			data: sourcemetrics.PrometheusMetricMap{
+				"sglang:hicache_host_total_tokens": gaugeFamily(800000, nil),
+				"sglang:max_total_num_tokens":      gaugeFamily(400000, nil),
+			},
+			wantTokenCapacity: 800000,
+		},
+		{
+			name: "host smaller than device keeps device capacity (max semantics)",
+			data: sourcemetrics.PrometheusMetricMap{
+				"sglang:hicache_host_total_tokens": gaugeFamily(300000, nil),
+				"sglang:max_total_num_tokens":      gaugeFamily(400000, nil),
+			},
+			wantTokenCapacity: 400000,
+		},
+		{
+			name: "old engine version without hicache gauge falls back to device gauge",
+			data: sourcemetrics.PrometheusMetricMap{
+				"sglang:max_total_num_tokens": gaugeFamily(400000, nil),
+			},
+			wantTokenCapacity: 400000,
+		},
+		{
+			name:              "no capacity gauges leaves token capacity unset",
+			data:              sourcemetrics.PrometheusMetricMap{},
+			wantTokenCapacity: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := extractWith(t, sglangMapping(t), tt.data)
+			if metrics.KvCacheMaxTokenCapacity != tt.wantTokenCapacity {
+				t.Errorf("KvCacheMaxTokenCapacity = %d, want %d", metrics.KvCacheMaxTokenCapacity, tt.wantTokenCapacity)
+			}
+		})
+	}
+}
+
+func TestDetectOffload(t *testing.T) {
+	cacheInfoLabels := func(offloadSize string) map[string]string {
+		return map[string]string{
+			"num_gpu_blocks":     "1570",
+			"block_size":         "256",
+			"kv_offloading_size": offloadSize,
+		}
+	}
+
+	tests := []struct {
+		name         string
+		data         sourcemetrics.PrometheusMetricMap
+		wantDetected bool
+	}{
+		{
+			name: "offload connector runtime metric present",
+			data: sourcemetrics.PrometheusMetricMap{
+				"vllm:cache_config_info":     gaugeFamily(1, cacheInfoLabels("None")),
+				"vllm:kv_offload_load_bytes": gaugeFamily(0, nil),
+			},
+			wantDetected: true,
+		},
+		{
+			name: "kv_offloading_size label set via built-in flag",
+			data: sourcemetrics.PrometheusMetricMap{
+				"vllm:cache_config_info": gaugeFamily(1, cacheInfoLabels("4.0")),
+			},
+			wantDetected: true,
+		},
+		{
+			name: "no offload: label None and no connector metrics",
+			data: sourcemetrics.PrometheusMetricMap{
+				"vllm:cache_config_info": gaugeFamily(1, cacheInfoLabels("None")),
+			},
+			wantDetected: false,
+		},
+		{
+			name:         "no offload: empty scrape",
+			data:         sourcemetrics.PrometheusMetricMap{},
+			wantDetected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := extractWith(t, vllmMapping(t), tt.data)
+			if metrics.KvCacheOffloadDetected != tt.wantDetected {
+				t.Errorf("KvCacheOffloadDetected = %v, want %v", metrics.KvCacheOffloadDetected, tt.wantDetected)
+			}
+		})
+	}
+}
+
+// TestDefaultEngineConfigsIncludeOffloadSpecs guards the built-in engine
+// mappings: sglang carries the tier capacity gauges and vllm carries offload
+// detection, so offload-extended capacity flows without operator config.
+func TestDefaultEngineConfigsIncludeOffloadSpecs(t *testing.T) {
+	extractor, err := newCoreMetricsExtractorPlugin(context.Background(), "test", nil)
+	if err != nil {
+		t.Fatalf("failed to build extractor from default configs: %v", err)
+	}
+	sglang, ok := extractor.registry.Get("sglang")
+	if !ok {
+		t.Fatal("no sglang mapping registered")
+	}
+	if len(sglang.TotalCacheTokens) != 2 {
+		t.Errorf("sglang TotalCacheTokens specs = %d, want 2", len(sglang.TotalCacheTokens))
+	}
+	vllm, ok := extractor.registry.Get("vllm")
+	if !ok {
+		t.Fatal("no vllm mapping registered")
+	}
+	if len(vllm.OffloadDetection) == 0 {
+		t.Error("vllm mapping has no offload detection specs")
+	}
+	if vllm.OffloadSizeLabel != "kv_offloading_size" {
+		t.Errorf("vllm OffloadSizeLabel = %q, want kv_offloading_size", vllm.OffloadSizeLabel)
+	}
+}

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/sglang-new.prom
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/sglang-new.prom
@@ -1,0 +1,30 @@
+# HELP sglang:max_total_num_tokens Maximum total number of tokens in the KV cache pool.
+# TYPE sglang:max_total_num_tokens gauge
+sglang:max_total_num_tokens{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 200000.0
+# HELP sglang:page_size KV cache page size in tokens.
+# TYPE sglang:page_size gauge
+sglang:page_size{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 1.0
+# HELP sglang:num_pages Number of KV cache pages.
+# TYPE sglang:num_pages gauge
+sglang:num_pages{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 200000.0
+# HELP sglang:num_queue_reqs The number of requests in the waiting queue.
+# TYPE sglang:num_queue_reqs gauge
+sglang:num_queue_reqs{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 0.0
+# HELP sglang:token_usage The token usage.
+# TYPE sglang:token_usage gauge
+sglang:token_usage{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 0.0
+# HELP sglang:full_token_usage The token usage for full attention layers.
+# TYPE sglang:full_token_usage gauge
+sglang:full_token_usage{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 0.0
+# HELP sglang:swa_token_usage The token usage for SWA layers.
+# TYPE sglang:swa_token_usage gauge
+sglang:swa_token_usage{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 0.0
+# HELP sglang:pending_prealloc_token_usage The token usage for pending preallocated tokens (not preallocated yet).
+# TYPE sglang:pending_prealloc_token_usage gauge
+sglang:pending_prealloc_token_usage{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 0.0
+# HELP sglang:hicache_host_used_tokens Number of tokens currently used in the host KV cache.
+# TYPE sglang:hicache_host_used_tokens gauge
+sglang:hicache_host_used_tokens{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 6.0
+# HELP sglang:hicache_host_total_tokens Total capacity of the host KV cache in tokens.
+# TYPE sglang:hicache_host_total_tokens gauge
+sglang:hicache_host_total_tokens{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 400001.0

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/sglang-old.prom
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/sglang-old.prom
@@ -1,0 +1,18 @@
+# HELP sglang:cache_config_info Cache configuration information.
+# TYPE sglang:cache_config_info gauge
+sglang:cache_config_info{num_pages="200000",page_size="1"} 1.0
+# HELP sglang:token_usage The token usage.
+# TYPE sglang:token_usage gauge
+sglang:token_usage{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 0.0
+# HELP sglang:pending_prealloc_token_usage The token usage for pending preallocated tokens (not preallocated yet).
+# TYPE sglang:pending_prealloc_token_usage gauge
+sglang:pending_prealloc_token_usage{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 0.0
+# HELP sglang:swa_token_usage The token usage for SWA layers.
+# TYPE sglang:swa_token_usage gauge
+sglang:swa_token_usage{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 0.0
+# HELP sglang:num_queue_reqs The number of requests in the waiting queue.
+# TYPE sglang:num_queue_reqs gauge
+sglang:num_queue_reqs{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 0.0
+# HELP sglang:max_total_num_tokens Maximum total number of tokens in the KV cache pool.
+# TYPE sglang:max_total_num_tokens gauge
+sglang:max_total_num_tokens{engine_type="unified",model_name="Qwen/Qwen3-0.6B",moe_ep_rank="0",pp_rank="0",tp_rank="0"} 200000.0

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/trtllm-legacy.prom
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/trtllm-legacy.prom
@@ -1,0 +1,12 @@
+# HELP trtllm_kv_cache_utilization KV cache utilization
+# TYPE trtllm_kv_cache_utilization gauge
+trtllm_kv_cache_utilization{engine_type="pytorch",model_name="Qwen/Qwen3-0.6B",pid="1"} 0.055374130342183726
+# HELP trtllm_kv_cache_max_blocks Maximum number of KV cache blocks
+# TYPE trtllm_kv_cache_max_blocks gauge
+trtllm_kv_cache_max_blocks{engine_type="pytorch",model_name="Qwen/Qwen3-0.6B",pid="1"} 21129.0
+# HELP trtllm_kv_cache_free_blocks Number of free KV cache blocks
+# TYPE trtllm_kv_cache_free_blocks gauge
+trtllm_kv_cache_free_blocks{engine_type="pytorch",model_name="Qwen/Qwen3-0.6B",pid="1"} 19959.0
+# HELP trtllm_kv_cache_tokens_per_block Number of tokens per KV cache block
+# TYPE trtllm_kv_cache_tokens_per_block gauge
+trtllm_kv_cache_tokens_per_block{engine_type="pytorch",model_name="Qwen/Qwen3-0.6B",pid="1"} 32.0

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/trtllm-nohost.prom
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/trtllm-nohost.prom
@@ -1,0 +1,12 @@
+# HELP trtllm_kv_cache_utilization KV cache utilization
+# TYPE trtllm_kv_cache_utilization gauge
+trtllm_kv_cache_utilization{engine_type="pytorch",model_name="Qwen/Qwen3-0.6B",pid="1"} 0.0
+# HELP trtllm_kv_cache_max_blocks Maximum number of KV cache blocks
+# TYPE trtllm_kv_cache_max_blocks gauge
+trtllm_kv_cache_max_blocks{engine_type="pytorch",model_name="Qwen/Qwen3-0.6B",pid="1"} 19960.0
+# HELP trtllm_kv_cache_free_blocks Number of free KV cache blocks
+# TYPE trtllm_kv_cache_free_blocks gauge
+trtllm_kv_cache_free_blocks{engine_type="pytorch",model_name="Qwen/Qwen3-0.6B",pid="1"} 19960.0
+# HELP trtllm_kv_cache_tokens_per_block Number of tokens per KV cache block
+# TYPE trtllm_kv_cache_tokens_per_block gauge
+trtllm_kv_cache_tokens_per_block{engine_type="pytorch",model_name="Qwen/Qwen3-0.6B",pid="1"} 32.0

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/trtllm-v2.prom
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/trtllm-v2.prom
@@ -1,0 +1,12 @@
+# HELP trtllm_kv_cache_utilization KV cache utilization
+# TYPE trtllm_kv_cache_utilization gauge
+trtllm_kv_cache_utilization{engine_type="pytorch",model_name="Qwen/Qwen3-0.6B",pid="1"} 0.0
+# HELP trtllm_kv_cache_max_blocks Maximum number of KV cache blocks
+# TYPE trtllm_kv_cache_max_blocks gauge
+trtllm_kv_cache_max_blocks{engine_type="pytorch",model_name="Qwen/Qwen3-0.6B",pid="1"} 19958.0
+# HELP trtllm_kv_cache_free_blocks Number of free KV cache blocks
+# TYPE trtllm_kv_cache_free_blocks gauge
+trtllm_kv_cache_free_blocks{engine_type="pytorch",model_name="Qwen/Qwen3-0.6B",pid="1"} 19958.0
+# HELP trtllm_kv_cache_tokens_per_block Number of tokens per KV cache block
+# TYPE trtllm_kv_cache_tokens_per_block gauge
+trtllm_kv_cache_tokens_per_block{engine_type="pytorch",model_name="Qwen/Qwen3-0.6B",pid="1"} 32.0

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/vllm-conn.prom
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/vllm-conn.prom
@@ -1,0 +1,99 @@
+# HELP vllm:kv_offload_total_bytes_total Number of bytes offloaded by KV connector
+# TYPE vllm:kv_offload_total_bytes_total counter
+vllm:kv_offload_total_bytes_total{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_total_bytes_total{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+# HELP vllm:kv_offload_total_bytes_created Number of bytes offloaded by KV connector
+# TYPE vllm:kv_offload_total_bytes_created gauge
+vllm:kv_offload_total_bytes_created{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 1.785966956844271e+09
+vllm:kv_offload_total_bytes_created{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 1.785966956844314e+09
+# HELP vllm:kv_offload_total_time_total Total time measured by all KV offloading operations
+# TYPE vllm:kv_offload_total_time_total counter
+vllm:kv_offload_total_time_total{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_total_time_total{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+# HELP vllm:kv_offload_total_time_created Total time measured by all KV offloading operations
+# TYPE vllm:kv_offload_total_time_created gauge
+vllm:kv_offload_total_time_created{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 1.7859669568442802e+09
+vllm:kv_offload_total_time_created{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 1.7859669568443193e+09
+# HELP vllm:kv_offload_size Histogram of KV offload transfer size, in bytes.
+# TYPE vllm:kv_offload_size histogram
+vllm:kv_offload_size_bucket{engine="0",le="1e+06",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="5e+06",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="1e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="2e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="4e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="6e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="8e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="1e+08",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="1.5e+08",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="2e+08",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="+Inf",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_count{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_sum{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="1e+06",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="5e+06",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="1e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="2e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="4e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="6e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="8e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="1e+08",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="1.5e+08",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="2e+08",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="+Inf",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_count{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_sum{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+# HELP vllm:kv_offload_size_created Histogram of KV offload transfer size, in bytes.
+# TYPE vllm:kv_offload_size_created gauge
+vllm:kv_offload_size_created{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 1.7859669568442175e+09
+vllm:kv_offload_size_created{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 1.7859669568442905e+09
+# HELP vllm:kv_offload_cpu_cache_usage_perc Fraction of CPU KV-cache space currently pinned by active transfers (0.0 = idle, 1.0 = saturated). Sustained high values indicate transfers (stores or promotions) may be dropped due to insufficient capacity.
+# TYPE vllm:kv_offload_cpu_cache_usage_perc gauge
+# HELP vllm:kv_offload_cpu_cache_write_usage_perc Fraction of CPU KV-cache space currently pinned by in-flight stores that have not yet completed (0.0 = idle, 1.0 = saturated).
+# TYPE vllm:kv_offload_cpu_cache_write_usage_perc gauge
+# HELP vllm:kv_offload_cpu_cache_read_usage_perc Fraction of CPU KV-cache space currently pinned by in-flight loads that have not yet completed (0.0 = idle, 1.0 = saturated).
+# TYPE vllm:kv_offload_cpu_cache_read_usage_perc gauge
+# HELP vllm:kv_offload_cpu_allocation_size Histogram of the number of CPU blocks requested by each KV offload prepare_store call.
+# TYPE vllm:kv_offload_cpu_allocation_size histogram
+# HELP vllm:kv_offload_load_bytes_total Total bytes loaded from offload storage to GPU.
+# TYPE vllm:kv_offload_load_bytes_total counter
+# HELP vllm:kv_offload_load_time_total Total load time from offload storage to GPU, in seconds.
+# TYPE vllm:kv_offload_load_time_total counter
+# HELP vllm:kv_offload_load_size Histogram of KV offload load operation size, in bytes.
+# TYPE vllm:kv_offload_load_size histogram
+# HELP vllm:kv_offload_store_bytes_total Total bytes stored from GPU to offload storage.
+# TYPE vllm:kv_offload_store_bytes_total counter
+# HELP vllm:kv_offload_store_time_total Total store time from GPU to offload storage, in seconds.
+# TYPE vllm:kv_offload_store_time_total counter
+# HELP vllm:kv_offload_store_size Histogram of KV offload store operation size, in bytes.
+# TYPE vllm:kv_offload_store_size histogram
+# HELP vllm:kv_offload_lookup_sync_delay_seconds Histogram of the time spent in a single offload lookup call, in seconds.
+# TYPE vllm:kv_offload_lookup_sync_delay_seconds histogram
+# HELP vllm:kv_offload_lookup_async_delay_seconds Histogram of time between a request's offload lookup first deferring and the following lookup resolving, or request finish, in seconds.
+# TYPE vllm:kv_offload_lookup_async_delay_seconds histogram
+# HELP vllm:kv_offload_allocation_failure_total Number of KV offload store allocation attempts that failed.
+# TYPE vllm:kv_offload_allocation_failure_total counter
+# HELP vllm:num_requests_waiting Number of requests waiting to be processed.
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+# HELP vllm:num_requests_waiting_by_reason Number of waiting requests by reason. Reason labels: 'capacity' = waiting for scheduling capacity; 'deferred' = deferred by transient constraints (LoRA budget, KV transfer, blocked status). Sum of all reasons equals vllm:num_requests_waiting.
+# TYPE vllm:num_requests_waiting_by_reason gauge
+vllm:num_requests_waiting_by_reason{engine="0",model_name="Qwen/Qwen3-0.6B",reason="capacity"} 0.0
+vllm:num_requests_waiting_by_reason{engine="0",model_name="Qwen/Qwen3-0.6B",reason="deferred"} 0.0
+# HELP vllm:kv_cache_usage_perc KV-cache usage. 1 means 100 percent usage.
+# TYPE vllm:kv_cache_usage_perc gauge
+vllm:kv_cache_usage_perc{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+# HELP vllm:external_prefix_cache_queries_total External prefix cache queries from KV connector cross-instance cache sharing, in terms of number of queried tokens.
+# TYPE vllm:external_prefix_cache_queries_total counter
+vllm:external_prefix_cache_queries_total{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+# HELP vllm:external_prefix_cache_queries_created External prefix cache queries from KV connector cross-instance cache sharing, in terms of number of queried tokens.
+# TYPE vllm:external_prefix_cache_queries_created gauge
+vllm:external_prefix_cache_queries_created{engine="0",model_name="Qwen/Qwen3-0.6B"} 1.7859669568446817e+09
+# HELP vllm:external_prefix_cache_hits_total External prefix cache hits from KV connector cross-instance cache sharing, in terms of number of cached tokens.
+# TYPE vllm:external_prefix_cache_hits_total counter
+vllm:external_prefix_cache_hits_total{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+# HELP vllm:external_prefix_cache_hits_created External prefix cache hits from KV connector cross-instance cache sharing, in terms of number of cached tokens.
+# TYPE vllm:external_prefix_cache_hits_created gauge
+vllm:external_prefix_cache_hits_created{engine="0",model_name="Qwen/Qwen3-0.6B"} 1.7859669568446922e+09
+# HELP vllm:cache_config_info Information of the LLMEngine CacheConfig
+# TYPE vllm:cache_config_info gauge
+vllm:cache_config_info{_block_size_resolved="True",block_size="16",cache_dtype="auto",calculate_kv_scales="False",enable_prefix_caching="True",engine="0",gpu_memory_utilization="0.92",is_attention_free="False",kv_cache_dtype_skip_layers="[]",kv_cache_max_concurrency="145.0625",kv_cache_memory_bytes="None",kv_cache_size_tokens="1188352",kv_offloading_backend="native",kv_offloading_size="None",kv_sharing_fast_prefill="False",mamba_block_size="None",mamba_cache_dtype="auto",mamba_cache_mode="none",mamba_page_size_padded="None",mamba_ssm_cache_dtype="auto",num_cpu_blocks="None",num_gpu_blocks="74272",num_gpu_blocks_override="None",prefix_caching_hash_algo="sha256",prefix_match_unit="None",skip_page_size_padded="None",sliding_window="None",user_specified_block_size="False",user_specified_mamba_block_size="False"} 1.0

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/vllm-flag.prom
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/vllm-flag.prom
@@ -1,0 +1,99 @@
+# HELP vllm:kv_offload_total_bytes_total Number of bytes offloaded by KV connector
+# TYPE vllm:kv_offload_total_bytes_total counter
+vllm:kv_offload_total_bytes_total{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_total_bytes_total{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+# HELP vllm:kv_offload_total_bytes_created Number of bytes offloaded by KV connector
+# TYPE vllm:kv_offload_total_bytes_created gauge
+vllm:kv_offload_total_bytes_created{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 1.785966958566208e+09
+vllm:kv_offload_total_bytes_created{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 1.785966958566252e+09
+# HELP vllm:kv_offload_total_time_total Total time measured by all KV offloading operations
+# TYPE vllm:kv_offload_total_time_total counter
+vllm:kv_offload_total_time_total{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_total_time_total{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+# HELP vllm:kv_offload_total_time_created Total time measured by all KV offloading operations
+# TYPE vllm:kv_offload_total_time_created gauge
+vllm:kv_offload_total_time_created{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 1.785966958566217e+09
+vllm:kv_offload_total_time_created{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 1.7859669585662577e+09
+# HELP vllm:kv_offload_size Histogram of KV offload transfer size, in bytes.
+# TYPE vllm:kv_offload_size histogram
+vllm:kv_offload_size_bucket{engine="0",le="1e+06",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="5e+06",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="1e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="2e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="4e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="6e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="8e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="1e+08",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="1.5e+08",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="2e+08",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="+Inf",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_count{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_sum{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="1e+06",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="5e+06",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="1e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="2e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="4e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="6e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="8e+07",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="1e+08",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="1.5e+08",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="2e+08",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_bucket{engine="0",le="+Inf",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_count{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+vllm:kv_offload_size_sum{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 0.0
+# HELP vllm:kv_offload_size_created Histogram of KV offload transfer size, in bytes.
+# TYPE vllm:kv_offload_size_created gauge
+vllm:kv_offload_size_created{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="CPU_to_GPU"} 1.7859669585661597e+09
+vllm:kv_offload_size_created{engine="0",model_name="Qwen/Qwen3-0.6B",transfer_type="GPU_to_CPU"} 1.7859669585662274e+09
+# HELP vllm:kv_offload_cpu_cache_usage_perc Fraction of CPU KV-cache space currently pinned by active transfers (0.0 = idle, 1.0 = saturated). Sustained high values indicate transfers (stores or promotions) may be dropped due to insufficient capacity.
+# TYPE vllm:kv_offload_cpu_cache_usage_perc gauge
+# HELP vllm:kv_offload_cpu_cache_write_usage_perc Fraction of CPU KV-cache space currently pinned by in-flight stores that have not yet completed (0.0 = idle, 1.0 = saturated).
+# TYPE vllm:kv_offload_cpu_cache_write_usage_perc gauge
+# HELP vllm:kv_offload_cpu_cache_read_usage_perc Fraction of CPU KV-cache space currently pinned by in-flight loads that have not yet completed (0.0 = idle, 1.0 = saturated).
+# TYPE vllm:kv_offload_cpu_cache_read_usage_perc gauge
+# HELP vllm:kv_offload_cpu_allocation_size Histogram of the number of CPU blocks requested by each KV offload prepare_store call.
+# TYPE vllm:kv_offload_cpu_allocation_size histogram
+# HELP vllm:kv_offload_load_bytes_total Total bytes loaded from offload storage to GPU.
+# TYPE vllm:kv_offload_load_bytes_total counter
+# HELP vllm:kv_offload_load_time_total Total load time from offload storage to GPU, in seconds.
+# TYPE vllm:kv_offload_load_time_total counter
+# HELP vllm:kv_offload_load_size Histogram of KV offload load operation size, in bytes.
+# TYPE vllm:kv_offload_load_size histogram
+# HELP vllm:kv_offload_store_bytes_total Total bytes stored from GPU to offload storage.
+# TYPE vllm:kv_offload_store_bytes_total counter
+# HELP vllm:kv_offload_store_time_total Total store time from GPU to offload storage, in seconds.
+# TYPE vllm:kv_offload_store_time_total counter
+# HELP vllm:kv_offload_store_size Histogram of KV offload store operation size, in bytes.
+# TYPE vllm:kv_offload_store_size histogram
+# HELP vllm:kv_offload_lookup_sync_delay_seconds Histogram of the time spent in a single offload lookup call, in seconds.
+# TYPE vllm:kv_offload_lookup_sync_delay_seconds histogram
+# HELP vllm:kv_offload_lookup_async_delay_seconds Histogram of time between a request's offload lookup first deferring and the following lookup resolving, or request finish, in seconds.
+# TYPE vllm:kv_offload_lookup_async_delay_seconds histogram
+# HELP vllm:kv_offload_allocation_failure_total Number of KV offload store allocation attempts that failed.
+# TYPE vllm:kv_offload_allocation_failure_total counter
+# HELP vllm:num_requests_waiting Number of requests waiting to be processed.
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+# HELP vllm:num_requests_waiting_by_reason Number of waiting requests by reason. Reason labels: 'capacity' = waiting for scheduling capacity; 'deferred' = deferred by transient constraints (LoRA budget, KV transfer, blocked status). Sum of all reasons equals vllm:num_requests_waiting.
+# TYPE vllm:num_requests_waiting_by_reason gauge
+vllm:num_requests_waiting_by_reason{engine="0",model_name="Qwen/Qwen3-0.6B",reason="capacity"} 0.0
+vllm:num_requests_waiting_by_reason{engine="0",model_name="Qwen/Qwen3-0.6B",reason="deferred"} 0.0
+# HELP vllm:kv_cache_usage_perc KV-cache usage. 1 means 100 percent usage.
+# TYPE vllm:kv_cache_usage_perc gauge
+vllm:kv_cache_usage_perc{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+# HELP vllm:external_prefix_cache_queries_total External prefix cache queries from KV connector cross-instance cache sharing, in terms of number of queried tokens.
+# TYPE vllm:external_prefix_cache_queries_total counter
+vllm:external_prefix_cache_queries_total{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+# HELP vllm:external_prefix_cache_queries_created External prefix cache queries from KV connector cross-instance cache sharing, in terms of number of queried tokens.
+# TYPE vllm:external_prefix_cache_queries_created gauge
+vllm:external_prefix_cache_queries_created{engine="0",model_name="Qwen/Qwen3-0.6B"} 1.7859669585666087e+09
+# HELP vllm:external_prefix_cache_hits_total External prefix cache hits from KV connector cross-instance cache sharing, in terms of number of cached tokens.
+# TYPE vllm:external_prefix_cache_hits_total counter
+vllm:external_prefix_cache_hits_total{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+# HELP vllm:external_prefix_cache_hits_created External prefix cache hits from KV connector cross-instance cache sharing, in terms of number of cached tokens.
+# TYPE vllm:external_prefix_cache_hits_created gauge
+vllm:external_prefix_cache_hits_created{engine="0",model_name="Qwen/Qwen3-0.6B"} 1.7859669585666184e+09
+# HELP vllm:cache_config_info Information of the LLMEngine CacheConfig
+# TYPE vllm:cache_config_info gauge
+vllm:cache_config_info{_block_size_resolved="True",block_size="16",cache_dtype="auto",calculate_kv_scales="False",enable_prefix_caching="True",engine="0",gpu_memory_utilization="0.92",is_attention_free="False",kv_cache_dtype_skip_layers="[]",kv_cache_max_concurrency="145.0625",kv_cache_memory_bytes="None",kv_cache_size_tokens="1188352",kv_offloading_backend="native",kv_offloading_size="4.0",kv_sharing_fast_prefill="False",mamba_block_size="None",mamba_cache_dtype="auto",mamba_cache_mode="none",mamba_page_size_padded="None",mamba_ssm_cache_dtype="auto",num_cpu_blocks="None",num_gpu_blocks="74272",num_gpu_blocks_override="None",prefix_caching_hash_algo="sha256",prefix_match_unit="None",skip_page_size_padded="None",sliding_window="None",user_specified_block_size="False",user_specified_mamba_block_size="False"} 1.0

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/vllm-none.prom
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/testdata/vllm-none.prom
@@ -1,0 +1,25 @@
+# HELP vllm:num_requests_waiting Number of requests waiting to be processed.
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+# HELP vllm:num_requests_waiting_by_reason Number of waiting requests by reason. Reason labels: 'capacity' = waiting for scheduling capacity; 'deferred' = deferred by transient constraints (LoRA budget, KV transfer, blocked status). Sum of all reasons equals vllm:num_requests_waiting.
+# TYPE vllm:num_requests_waiting_by_reason gauge
+vllm:num_requests_waiting_by_reason{engine="0",model_name="Qwen/Qwen3-0.6B",reason="capacity"} 0.0
+vllm:num_requests_waiting_by_reason{engine="0",model_name="Qwen/Qwen3-0.6B",reason="deferred"} 0.0
+# HELP vllm:kv_cache_usage_perc KV-cache usage. 1 means 100 percent usage.
+# TYPE vllm:kv_cache_usage_perc gauge
+vllm:kv_cache_usage_perc{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+# HELP vllm:external_prefix_cache_queries_total External prefix cache queries from KV connector cross-instance cache sharing, in terms of number of queried tokens.
+# TYPE vllm:external_prefix_cache_queries_total counter
+vllm:external_prefix_cache_queries_total{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+# HELP vllm:external_prefix_cache_queries_created External prefix cache queries from KV connector cross-instance cache sharing, in terms of number of queried tokens.
+# TYPE vllm:external_prefix_cache_queries_created gauge
+vllm:external_prefix_cache_queries_created{engine="0",model_name="Qwen/Qwen3-0.6B"} 1.7859669528940387e+09
+# HELP vllm:external_prefix_cache_hits_total External prefix cache hits from KV connector cross-instance cache sharing, in terms of number of cached tokens.
+# TYPE vllm:external_prefix_cache_hits_total counter
+vllm:external_prefix_cache_hits_total{engine="0",model_name="Qwen/Qwen3-0.6B"} 0.0
+# HELP vllm:external_prefix_cache_hits_created External prefix cache hits from KV connector cross-instance cache sharing, in terms of number of cached tokens.
+# TYPE vllm:external_prefix_cache_hits_created gauge
+vllm:external_prefix_cache_hits_created{engine="0",model_name="Qwen/Qwen3-0.6B"} 1.7859669528940508e+09
+# HELP vllm:cache_config_info Information of the LLMEngine CacheConfig
+# TYPE vllm:cache_config_info gauge
+vllm:cache_config_info{_block_size_resolved="True",block_size="16",cache_dtype="auto",calculate_kv_scales="False",enable_prefix_caching="True",engine="0",gpu_memory_utilization="0.92",is_attention_free="False",kv_cache_dtype_skip_layers="[]",kv_cache_max_concurrency="145.0625",kv_cache_memory_bytes="None",kv_cache_size_tokens="1188352",kv_offloading_backend="native",kv_offloading_size="None",kv_sharing_fast_prefill="False",mamba_block_size="None",mamba_cache_dtype="auto",mamba_cache_mode="none",mamba_page_size_padded="None",mamba_ssm_cache_dtype="auto",num_cpu_blocks="None",num_gpu_blocks="74272",num_gpu_blocks_override="None",prefix_caching_hash_algo="sha256",prefix_match_unit="None",skip_page_size_padded="None",sliding_window="None",user_specified_block_size="False",user_specified_mamba_block_size="False"} 1.0

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/README.md
@@ -16,8 +16,10 @@ For each request, the plugin consumes `request.Body.TokenizedPrompt` (token IDs)
 - `maxPrefixTokensToMatch` (int, optional, default: `131072`): Cap expressed in tokens instead of blocks (`maxBlocks = maxPrefixTokensToMatch / blockSizeTokens`). Not auto-tuned. Takes precedence over `maxPrefixBlocksToMatch` when set (> 0); set to `0` to fall back to the block-based cap. The `131072` default (128K, the context window of large production models such as gpt-oss 120b) is a reasonable upper bound that covers the long-prompt use cases seen in production.
 
 Setting both caps to `0` matches the whole prompt. Prompt length is bounded by the model server's context window, so this caps matching at one context window without needing to name a token count. It raises EPP CPU on long prompts (see [operations](../../../../../../../docs/operations.md)); to turn prefix matching off, remove this producer from the configuration rather than zeroing the caps.
-- `lruCapacityPerServer` (int, optional, default: `31250`): Per-pod LRU index capacity. Used when `autoTune` is false or endpoint metrics are unavailable; ignored when auto-tuned from metrics.
+- `lruCapacityPerServer` (int, optional, default: `31250`): Per-pod LRU index capacity. Used when `autoTune` is false or endpoint metrics are unavailable; ignored when auto-tuned from metrics. Also the escape hatch for deployments with KV cache offloading whose model servers report only GPU capacity (e.g. vLLM with an offload connector, SGLang older than v0.5.10 with hicache, trtllm-serve's V2 KV cache manager): disable `autoTune` and size this to the offload-extended cache. A warning is logged when offloading is detected but unaccounted for (vLLM OffloadingConnector metrics) so the undercount is not silent.
 - `blockSize` (int, optional): Deprecated — character-based block size. Use `blockSizeTokens` instead.
+
+**Auto-tuned capacity resolution order** (per pod, when `autoTune` is true): total token capacity metric across tiers divided by the server block size (e.g. SGLang `max(hicache_host_total_tokens, max_total_num_tokens)`), then GPU blocks, then `lruCapacityPerServer`, then the built-in default. The chosen capacity and its source are logged when a pod's LRU is created or resized.
 
 **Configuration Examples:**
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/capacity_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/capacity_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package approximateprefix
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+func TestMakeServerCapacity(t *testing.T) {
+	tests := []struct {
+		name         string
+		config       config
+		metrics      *fwkdl.Metrics
+		wantCapacity int
+		wantSource   capacitySource
+	}{
+		{
+			name:   "total token capacity metric wins and converts at server block size",
+			config: config{AutoTune: true, LRUCapacityPerServer: 5000},
+			metrics: &fwkdl.Metrics{
+				KvCacheMaxTokenCapacity: 800000,
+				CacheBlockSize:          64,
+				CacheNumBlocks:          1570,
+			},
+			wantCapacity: 12500,
+			wantSource:   capacitySourceTotalTokens,
+		},
+		{
+			name:   "token capacity converts using configured block size when metric absent",
+			config: config{AutoTune: true, BlockSizeTokens: 128},
+			metrics: &fwkdl.Metrics{
+				KvCacheMaxTokenCapacity: 800000,
+			},
+			wantCapacity: 6250,
+			wantSource:   capacitySourceTotalTokens,
+		},
+		{
+			name:   "GPU blocks only, no offload",
+			config: config{AutoTune: true},
+			metrics: &fwkdl.Metrics{
+				CacheNumBlocks: 1570,
+			},
+			wantCapacity: 1570,
+			wantSource:   capacitySourceGPUBlocks,
+		},
+		{
+			name:   "GPU blocks with offload detected flags undercount",
+			config: config{AutoTune: true},
+			metrics: &fwkdl.Metrics{
+				CacheNumBlocks:         1570,
+				KvCacheOffloadDetected: true,
+			},
+			wantCapacity: 1570,
+			wantSource:   capacitySourceGPUBlocksUndercount,
+		},
+		{
+			name:         "autotune without usable metrics falls back to configured capacity",
+			config:       config{AutoTune: true, LRUCapacityPerServer: 5000},
+			metrics:      &fwkdl.Metrics{},
+			wantCapacity: 5000,
+			wantSource:   capacitySourceConfigured,
+		},
+		{
+			name:         "autotune disabled uses configured capacity",
+			config:       config{AutoTune: false, LRUCapacityPerServer: 5000},
+			metrics:      &fwkdl.Metrics{CacheNumBlocks: 1570},
+			wantCapacity: 5000,
+			wantSource:   capacitySourceConfigured,
+		},
+		{
+			name:         "no metrics and no configured capacity uses default",
+			config:       config{AutoTune: true},
+			metrics:      &fwkdl.Metrics{},
+			wantCapacity: defaultLRUCapacityPerServer,
+			wantSource:   capacitySourceDefault,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &dataProducer{config: tt.config}
+			endpoint := fwksched.NewEndpoint(
+				&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Namespace: "default", Name: "pod1"}},
+				tt.metrics,
+				fwkdl.NewAttributes(),
+			)
+			s := p.makeserver(endpoint)
+			assert.Equal(t, tt.wantCapacity, s.LRUCapacityBlocks)
+			assert.Equal(t, tt.wantSource, s.CapacitySource)
+		})
+	}
+}
+
+// TestIndexerResizeOnCapacityChange verifies that a pod's LRU grows when a
+// later Add carries a larger capacity, e.g. after tier capacity gauges appear
+// in a subsequent metrics scrape.
+func TestIndexerResizeOnCapacityChange(t *testing.T) {
+	i := newIndexer(context.Background(), 10, "test-name", "test-type").(*indexer)
+	pod := server{
+		ServerID:          ServerID{Namespace: "default", Name: "server1"},
+		LRUCapacityBlocks: 2,
+	}
+
+	i.Add([]blockHash{blockHash(1), blockHash(2)}, pod)
+	assert.Equal(t, 2, i.podToLRU[pod.ServerID].Len())
+
+	// Capacity 2 without resize would evict on the third insert.
+	pod.LRUCapacityBlocks = 3
+	i.Add([]blockHash{blockHash(3)}, pod)
+	assert.Equal(t, 3, i.podToLRU[pod.ServerID].Len(), "LRU should have been resized to 3")
+	assert.Equal(t, 3, i.podToCapacity[pod.ServerID])
+
+	// Shrinking evicts down to the new capacity.
+	pod.LRUCapacityBlocks = 2
+	i.Add([]blockHash{blockHash(4)}, pod)
+	assert.Equal(t, 2, i.podToLRU[pod.ServerID].Len(), "LRU should have been resized down to 2")
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-logr/logr"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -32,9 +33,11 @@ type indexer struct {
 	mu             sync.RWMutex
 	hashToPods     map[blockHash]podSet                         // the lookup data structure to find pods that have the blockHash cached
 	podToLRU       map[ServerID]*lru.Cache[blockHash, struct{}] // key is pod namespacedName, value is an LRU cache
+	podToCapacity  map[ServerID]int                             // current LRU capacity per pod, for resize-on-change
 	defaultLRUSize int
 	pluginName     string
 	pluginType     string
+	logger         logr.Logger
 }
 
 // newIndexer initializes an indexer with size limits and starts cache size reporting.
@@ -42,9 +45,11 @@ func newIndexer(ctx context.Context, defaultLRUSize int, pluginName, pluginType 
 	i := &indexer{
 		hashToPods:     make(map[blockHash]podSet),
 		podToLRU:       make(map[ServerID]*lru.Cache[blockHash, struct{}]),
+		podToCapacity:  make(map[ServerID]int),
 		defaultLRUSize: defaultLRUSize,
 		pluginName:     pluginName,
 		pluginType:     pluginType,
+		logger:         log.FromContext(ctx).WithName(pluginName),
 	}
 
 	go i.reportLRUSize(ctx, time.Second)
@@ -56,17 +61,27 @@ func (i *indexer) Add(hashes []blockHash, pod server) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
+	lruSize := pod.LRUCapacityBlocks
+	if lruSize <= 0 {
+		lruSize = i.defaultLRUSize
+	}
+
 	// Check if the LRU pod exist
 	lruForPod, exists := i.podToLRU[pod.ServerID]
 	if !exists {
-		lruSize := pod.NumOfGPUBlocks
-		if lruSize <= 0 {
-			lruSize = i.defaultLRUSize
-		}
 		// We ignore the error since the only possible error is if size <= 0.
 		newLRU, _ := lru.NewWithEvict(lruSize, i.makeEvictionFn(pod.ServerID))
 		i.podToLRU[pod.ServerID] = newLRU
+		i.podToCapacity[pod.ServerID] = lruSize
 		lruForPod = newLRU
+		i.logCapacity("Created prefix cache LRU for pod", pod, lruSize)
+	} else if current := i.podToCapacity[pod.ServerID]; current != lruSize {
+		// Capacity can legitimately change after creation: metrics may not have
+		// been scraped before the pod's first request, and tier capacity gauges
+		// (e.g. SGLang hicache) can appear later than the device gauge.
+		lruForPod.Resize(lruSize)
+		i.podToCapacity[pod.ServerID] = lruSize
+		i.logCapacity("Resized prefix cache LRU for pod", pod, lruSize)
 	}
 
 	// Add to LRU (may evict)
@@ -102,6 +117,20 @@ func (i *indexer) Get(hash blockHash) podSet {
 	}
 
 	return res
+}
+
+// logCapacity emits one line per LRU creation or capacity change so operators
+// can see the effective per-pod capacity and where it came from. It warns when
+// KV cache offload was detected but the offload tier's capacity is unknown,
+// since prefix matches will then be under-reported.
+func (i *indexer) logCapacity(msg string, pod server, lruSize int) {
+	i.logger.Info(msg, "pod", pod.ServerID, "capacityBlocks", lruSize, "capacitySource", pod.CapacitySource)
+	if pod.CapacitySource == capacitySourceGPUBlocksUndercount {
+		i.logger.Info("WARNING: KV cache offload detected but the offload tier capacity is not reported by the model server; "+
+			"the prefix cache LRU is sized to GPU blocks only and prefix matches will be under-reported. "+
+			"Disable autoTune and set lruCapacityPerServer to size it to the offload-extended cache.",
+			"pod", pod.ServerID, "capacityBlocks", lruSize)
+	}
 }
 
 // makeEvictionFn returns a per-pod LRU eviction callback that removes the pod from hashToPods on eviction.
@@ -182,6 +211,7 @@ func (i *indexer) RemovePod(pod ServerID) {
 	}
 
 	delete(i.podToLRU, pod)
+	delete(i.podToCapacity, pod)
 }
 
 // Pods returns the list of all pods currently tracked in the indexer.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer_test.go
@@ -26,8 +26,8 @@ import (
 
 func TestIndexer_AddAndGet(t *testing.T) {
 	pod := server{
-		ServerID:       ServerID{Namespace: "default", Name: "server1"},
-		NumOfGPUBlocks: 2,
+		ServerID:          ServerID{Namespace: "default", Name: "server1"},
+		LRUCapacityBlocks: 2,
 	}
 	i := newIndexer(context.Background(), 3, "test-name", "test-type").(*indexer) // Initialize with an lruSize greater than server.numOfGPUBlocks to verify server-defined limits take precedence.
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -298,16 +298,46 @@ func (p *dataProducer) PreRequest(ctx context.Context, request *fwksched.Inferen
 	recordPrefixCacheMatch(p.typedName.Name, p.typedName.Type, matchLen*blockSize*averageCharactersPerToken, total*blockSize*averageCharactersPerToken)
 }
 
+// makeserver resolves the per-pod LRU capacity, preferring (in order) the
+// model server's total token capacity across KV cache tiers, the GPU block
+// count, the configured lruCapacityPerServer, and finally the built-in
+// default. The chosen capacity and its source are logged by the indexer when
+// the pod's LRU is created or resized.
 func (p *dataProducer) makeserver(targetEndpoint fwksched.Endpoint) server {
-	gpuBlocks := defaultLRUCapacityPerServer
-	if p.config.AutoTune && targetEndpoint.GetMetrics() != nil && targetEndpoint.GetMetrics().CacheNumBlocks > 0 {
-		gpuBlocks = targetEndpoint.GetMetrics().CacheNumBlocks
-	} else if p.config.LRUCapacityPerServer > 0 {
-		gpuBlocks = p.config.LRUCapacityPerServer
+	capacity := defaultLRUCapacityPerServer
+	source := capacitySourceDefault
+
+	autoTuned := false
+	if m := targetEndpoint.GetMetrics(); p.config.AutoTune && m != nil {
+		switch {
+		case m.KvCacheMaxTokenCapacity > 0:
+			// Convert tokens to model-server-native blocks, matching the units
+			// of CacheNumBlocks used by the paths below.
+			blockSize := m.CacheBlockSize
+			if blockSize <= 0 {
+				blockSize = p.config.BlockSizeTokens
+			}
+			if blockSize <= 0 {
+				blockSize = defaultBlockSizeTokens
+			}
+			if blocks := m.KvCacheMaxTokenCapacity / blockSize; blocks > 0 {
+				capacity, source, autoTuned = blocks, capacitySourceTotalTokens, true
+			}
+		case m.CacheNumBlocks > 0:
+			capacity, source, autoTuned = m.CacheNumBlocks, capacitySourceGPUBlocks, true
+			if m.KvCacheOffloadDetected {
+				source = capacitySourceGPUBlocksUndercount
+			}
+		}
 	}
+	if !autoTuned && p.config.LRUCapacityPerServer > 0 {
+		capacity, source = p.config.LRUCapacityPerServer, capacitySourceConfigured
+	}
+
 	return server{
-		ServerID:       ServerID(targetEndpoint.GetMetadata().ID),
-		NumOfGPUBlocks: gpuBlocks,
+		ServerID:          ServerID(targetEndpoint.GetMetadata().ID),
+		LRUCapacityBlocks: capacity,
+		CapacitySource:    source,
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
@@ -46,8 +46,30 @@ type blockHash = prefixhash.BlockHash
 // server contains information about a specific server/pod and its cache capacity.
 type server struct {
 	ServerID
-	NumOfGPUBlocks int
+	// LRUCapacityBlocks is the routing-side LRU capacity for this pod in
+	// model-server-native blocks, covering all KV cache tiers when the model
+	// server reports total capacity (GPU HBM only otherwise).
+	LRUCapacityBlocks int
+	// CapacitySource records how LRUCapacityBlocks was derived, for logging.
+	CapacitySource capacitySource
 }
+
+// capacitySource identifies how a server's LRU capacity was derived.
+type capacitySource string
+
+const (
+	// capacitySourceTotalTokens: total token capacity metric across tiers, divided by block size.
+	capacitySourceTotalTokens capacitySource = "total-token-capacity-metric"
+	// capacitySourceGPUBlocks: GPU block count from metrics (no offload tier).
+	capacitySourceGPUBlocks capacitySource = "gpu-blocks"
+	// capacitySourceGPUBlocksUndercount: GPU block count although offload was
+	// detected; the real cache is larger and matches will be under-reported.
+	capacitySourceGPUBlocksUndercount capacitySource = "gpu-blocks-offload-unaccounted"
+	// capacitySourceConfigured: the lruCapacityPerServer configuration value.
+	capacitySourceConfigured capacitySource = "configured-lru-capacity"
+	// capacitySourceDefault: the built-in defaultLRUCapacityPerServer.
+	capacitySourceDefault capacitySource = "default-lru-capacity"
+)
 
 // ServerID is a unique identifier for a server, based on its NamespacedName.
 type ServerID k8stypes.NamespacedName


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The `approx-prefix-cache-producer` autotune sizes its per-endpoint LRU from `num_gpu_blocks` (HBM only). With KV cache offloading the actual cache is HBM plus a host tier, so the LRU evicts prefixes the server still holds and consumers (`prefix-cache-scorer`, `prefix-cache-affinity-filter`) get under-counted matches. See the issue for root cause and benchmarks.

Approach: when the model server reports its total cache size (GPU plus CPU), we size each pod's LRU to that total. When it reports only the GPU cache size but we can see offloading is enabled, we keep the GPU-only size and log a warning to set `lruCapacityPerServer` manually. If a pod's reported size changes later, its LRU is resized in place to match.

Per-engine behavior:

- **SGLang**: v0.5.10 and later report the CPU cache size as `sglang:hicache_host_total_tokens`, so we size to `max(hicache_host_total_tokens, max_total_num_tokens)`. Max rather than sum, because the CPU cache also holds a copy of everything in the GPU cache. Earlier versions only report the GPU cache size (`sglang:max_total_num_tokens`), so we size to that, and `lruCapacityPerServer` covers the rest.
- **vLLM**: no version reports the CPU cache size. We can see that offloading is enabled (the connector's `vllm:kv_offload_*` metrics appear at startup) but not how big it is, so we size to the GPU cache (`num_gpu_blocks`) and log the warning. Exact sizing needs a new `OffloadingConnector` metric: vllm-project/vllm#29605 tried populating the legacy `num_cpu_blocks` field and was rejected because offloading is now a connector concern, the maintainer wants the offload connector to export its own capacity metric instead.
- **trtllm-serve**: `trtllm_kv_cache_max_blocks` already counts GPU and CPU cache blocks together, so sizing was already correct and nothing changes. The exception is the experimental V2 cache manager, where this metric is GPU-only, so those deployments need `lruCapacityPerServer`.

Unrelated fix picked up along the way: newer SGLang (v0.5.16) renamed its block size and block count metrics, so the default SGLang mapping now reads both the old and new names.

**Which issue(s) this PR fixes**:
Fixes #1650

**Testing**:

- [x] Unit tests: extractor (max semantics, detection via series and label) and producer (capacity order, LRU resize)
- [x] Fixture tests: default engine mappings run against real `/metrics` scrapes, checked in as `testdata/*.prom`
- [x] Live verification on 8 deployments (2x8xH200), summarized below

All vLLM rows are v0.26.0 (latest release at time of testing). SGLang versions tested were v0.5.16 and v0.5.9 respectively. Both trtllm rows are v1.3.0rc23.

| Deployment | Observed | Outcome |
| --- | --- | --- |
| vLLM, no offload | no `kv_offload_*` series, label `None` | correct |
| vLLM, offload enabled | `kv_offload_*` series present via both `--kv-offloading-size` and `--kv-transfer-config`, label set or `None` respectively | undercounts + warning |
| SGLang v0.5.10+, hicache on | `hicache_host_total_tokens = 400001`, matching `--hicache-ratio 2` x 200000 GPU tokens | correct |
| SGLang pre-v0.5.10, hicache on | CPU metric absent, only `max_total_num_tokens = 200000` | undercounts |
| trtllm legacy manager, 4GiB host cache | `max_blocks = 21129`, host blocks included | correct |
| trtllm V2 manager, 4GiB host cache | `max_blocks = 19958`, GPU blocks only | undercounts |

The 4GiB host cache is ~1170 blocks at ~3.6MiB per 32-token block, matching the 21129 vs 19958 gap between the two managers.

In the undercount cases, user must turn `autotune: false` and manually set `lruCapacityPerServer` to override the metric manually. There is unfortunately no Prometheus visibility into the SGLang and trtllm undercounts so we can't log a warning.

**PR size breakdown** (most of the diff is tests):

- ~295 lines of code and docs (extractor specs, producer sizing, LRU resize, README and metric protocol docs)
- ~557 lines of test code (unit tables plus fixture tests)
- ~307 lines of `testdata/*.prom`, real `/metrics` scrapes from the deployments above, so the default engine mappings stay verified against actual engine output

**Release note**:
```release-note
The approx-prefix-cache-producer now sizes its per-endpoint LRU to the offload-extended KV cache capacity: SGLang `hicache_host_total_tokens` is used when present (v0.5.10+), vLLM KV uses GPU blocks + undercount warning, trtllm is already the combined amount unless v2 kv-cache manager is used which undercounts.
```


