### PR TITLE
test(coordinator): parallelize the e2e suite

### DIFF
--- a/Makefile.coord.mk
+++ b/Makefile.coord.mk
@@ -113,9 +113,13 @@ else
 BUILDER_E2E_KUBECONFIG_FLAGS =
 endif
 
-# Env vars forwarded into the e2e test container.
+E2E_NUM_PROCS ?= 5
+
+# Env vars forwarded into the e2e test container. E2E_NUM_PROCS reaches both
+# `ginkgo --procs` (via the runner script) and the suite's numProcesses; the
+# suite fails fast if the two disagree.
 E2E_ENV_VARS = COORDINATOR_IMAGE VLLM_IMAGE EPP_IMAGE VLLM_RENDER_IMAGE VLLM_RENDER_PORT \
-               E2E_GATEWAY_PORT E2E_KEEP_CLUSTER_ON_FAILURE \
+               E2E_GATEWAY_PORT E2E_KEEP_CLUSTER_ON_FAILURE E2E_NUM_PROCS \
                E2E_PRINT_LOGS K8S_CONTEXT READY_TIMEOUT MODEL_NAME E2E_EPP_TOPOLOGY
 BUILDER_E2E_ENV_FLAGS = $(foreach v,$(E2E_ENV_VARS),$(if $($(v)),-e '$(v)=$($(v))'))
 ifneq ($(filter command line environment,$(origin NAMESPACE)),)

--- a/README.coord.md
+++ b/README.coord.md
@@ -98,6 +98,28 @@ make -f Makefile.coord.mk test-e2e-coordinator-3epp   # 3-EPP
 - **single** (default): one EPP running a profile-per-phase, and one InferencePool spanning the encode, prefill, and decode workers.
 - **3epp**: one role-scoped EPP and InferencePool per phase (encode, prefill, decode), with Envoy dispatching each `EPP-Profile` request to that role's EPP.
 
+**Running the tests in parallel**
+
+By default the end to end tests are run in groups that are parallel to each other. The number of groups running in parallel at any time is controlled via the `E2E_NUM_PROCS` environment variable, which defaults to five. To run all of the tests in a serial fashion, use `E2E_NUM_PROCS=1`.
+
+```bash
+E2E_NUM_PROCS=1 make -f Makefile.coord.mk test-e2e-coordinator
+```
+
+Each parallel process gets its own namespace and its own gateway NodePort, so the groups do not interfere with each other. One vllm-render deployment is shared by every process and lives in the base namespace.
+
+**Setting the test namespace**
+
+The namespace(s) in which the tests run vary based on whether or not the tests are being run in parallel.
+
+If the tests are being run in parallel, the suite creates resources in namespaces of the form `<base>-N`, where `<base>` by default is `e2e-coordinator` and `N` is the process number of the process running the test. `<base>` can be changed by setting `NAMESPACE`.
+
+If the tests are not being run in parallel, then by default the suite creates resources in the `default` namespace. To change it, set the same variable:
+
+```bash
+export NAMESPACE=<MY_NS>
+```
+
 **Keeping the cluster on failure**
 
 Set `E2E_KEEP_CLUSTER_ON_FAILURE=true` to preserve the cluster when any test fails. This is useful for inspecting pod logs, events, or cluster state after a failure.
@@ -130,8 +152,9 @@ kubectl --context kind-e2e-coordinator-tests get pods
 
 | Variable | Default | Description |
 |---|---|---|
+| `E2E_NUM_PROCS` | `5` | Number of spec groups run in parallel. `1` runs the suite serially |
 | `E2E_KEEP_CLUSTER_ON_FAILURE` | `false` | Preserve the Kind cluster when the suite fails |
-| `E2E_GATEWAY_PORT` | `30080` | Host port mapped to the gateway NodePort |
+| `E2E_GATEWAY_PORT` | `30080` | Host port mapped to the gateway NodePort of the first process; each further process adds 100 |
 | `E2E_PRINT_LOGS` | `false` | Print all pod logs (coordinator, EPPs, Envoy, workers) for every spec, not just on failure |
 | `CONTAINER_RUNTIME` | `docker` | Container runtime used to load images into Kind (`docker` or `podman`) |
 | `EPP_IMAGE` | `ghcr.io/llm-d/llm-d-router-endpoint-picker:dev` | EPP image loaded into the Kind cluster |
@@ -140,7 +163,7 @@ kubectl --context kind-e2e-coordinator-tests get pods
 | `VLLM_RENDER_PORT` | `8082` | Port the vllm-render service listens on |
 | `COORDINATOR_IMAGE` | _(empty)_ | Coordinator image loaded into the Kind cluster |
 | `MODEL_NAME` | `Qwen/Qwen3-VL-2B-Instruct` | Model name used by the test pools |
-| `NAMESPACE` | `default` | Namespace to deploy test resources into |
+| `NAMESPACE` | `e2e-coordinator` in parallel, `default` when `E2E_NUM_PROCS=1` | Base namespace for test resources. In parallel runs each process uses `<base>-N` |
 | `K8S_CONTEXT` | _(empty)_ | Use an existing cluster context instead of creating a Kind cluster |
 | `READY_TIMEOUT` | `10m` | How long to wait for resources to become ready |
 | `E2E_EPP_TOPOLOGY` | `single` | EPP topology: `single` (one EPP + one pool) or `3epp` (per-role EPP + pool). `test-e2e-coordinator-3epp` sets `3epp` |

--- a/deploy/environments/dev/coordinator-e2e-infra/shared-envoy-resources.yaml
+++ b/deploy/environments/dev/coordinator-e2e-infra/shared-envoy-resources.yaml
@@ -5,7 +5,9 @@
 # named "envoy", mounted by this Deployment), which lives in envoy.yaml
 # (single EPP) or envoy-3-epp.yaml (per-role EPPs).
 #
-# Placeholder ${NAMESPACE} is substituted by the suite before apply.
+# Placeholders ${NAMESPACE} and ${ENVOY_NODE_PORT} are substituted by the suite
+# before apply. Each parallel process gets its own NodePort so the gateways do
+# not collide on one cluster.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -96,7 +98,7 @@ spec:
       port: 8081
       protocol: TCP
       targetPort: 8081
-      nodePort: 30080
+      nodePort: ${ENVOY_NODE_PORT}
   selector:
     app: envoy
   type: NodePort

--- a/test/coordinator/e2e/coordinator/configs_test.go
+++ b/test/coordinator/e2e/coordinator/configs_test.go
@@ -19,13 +19,14 @@ package coordinate2e
 import "strings"
 
 // coordinatorConfigNIXL is the coordinator pipeline config for the e-p-d-pools topology.
-// ${NAMESPACE} and ${VLLM_RENDER_PORT} are substituted by createCoordinator before the ConfigMap is built.
+// ${NAMESPACE}, ${RENDER_NAMESPACE}, and ${VLLM_RENDER_PORT} are substituted by
+// createCoordinator before the ConfigMap is built.
 const coordinatorConfigNIXL = `log_level: 5
 server:
   listen_addr: ":8080"
   read_timeout: 30s
   write_timeout: 120s
-  # Recreated per spec behind a suite-lived Envoy; drain fast so a deleted
+  # Recreated per spec behind a group-lived Envoy; drain fast so a deleted
   # coordinator stops serving immediately instead of lingering on a stale
   # endpoint the gateway may still route to. 0s is avoided: it makes the
   # server Shutdown context expire instantly and the process exit non-zero.
@@ -48,7 +49,7 @@ pipeline:
         max_concurrent_downloads: 10
     - type: render
       params:
-        address: "http://vllm-render.${NAMESPACE}.svc:${VLLM_RENDER_PORT}"
+        address: "http://vllm-render.${RENDER_NAMESPACE}.svc:${VLLM_RENDER_PORT}"
         timeout: 60s
     - type: encode
       params:

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -49,55 +49,68 @@ var (
 )
 
 var _ = ginkgo.Describe("Coordinator pipeline", func() {
-	ginkgo.It("routes a text only chat completion end-to-end", func() {
-		runCoordinatorPipeline(gateway.PathChatCompletions, []byte(fmt.Sprintf(
-			`{"model":%q,"messages":[{"role":"user","content":"hello"}]}`,
-			modelName,
-		)), textOnlySteps, 0, 0, 0)
-	})
+	ginkgo.When("the request is text only", ginkgo.Ordered, testWrapper(func() {
+		ginkgo.It("routes a text only chat completion end-to-end", func() {
+			runCoordinatorPipeline(gateway.PathChatCompletions, []byte(fmt.Sprintf(
+				`{"model":%q,"messages":[{"role":"user","content":"hello"}]}`,
+				modelName,
+			)), textOnlySteps, 0, 0, 0)
+		})
+	}))
 
-	ginkgo.It("forwards the client min_tokens/max_tokens to decode and caps them on prefill and encode", func() {
-		runCoordinatorPipeline(gateway.PathChatCompletions, []byte(fmt.Sprintf(
-			`{"model":%q,"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":%q},"uuid":"image-0"},{"type":"text","text":"Describe what you see."}]}],"min_tokens":3,"max_tokens":5}`,
-			modelName, inlineImageDataURI,
-		)), allSteps, 1, 3, 5)
-	})
+	ginkgo.When("the request carries token limits", ginkgo.Ordered, testWrapper(func() {
+		ginkgo.It("forwards the client min_tokens/max_tokens to decode and caps them on prefill and encode", func() {
+			runCoordinatorPipeline(gateway.PathChatCompletions, []byte(fmt.Sprintf(
+				`{"model":%q,"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":%q},"uuid":"image-0"},{"type":"text","text":"Describe what you see."}]}],"min_tokens":3,"max_tokens":5}`,
+				modelName, inlineImageDataURI,
+			)), allSteps, 1, 3, 5)
+		})
+	}))
 
-	ginkgo.It("forwards min_tokens/max_tokens to decode and caps them on prefill and encode with OpenAI passthrough disabled", func() {
-		runCoordinatorPipeline(gateway.PathChatCompletions, []byte(fmt.Sprintf(
-			`{"model":%q,"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":%q},"uuid":"image-0"},{"type":"text","text":"Describe what you see."}]}],"min_tokens":3,"max_tokens":5}`,
-			modelName, inlineImageDataURI,
-		)), allSteps, 1, 3, 5, coordinatorConfigNIXLGenerate)
-	})
+	ginkgo.When("the request carries token limits and OpenAI passthrough is disabled", ginkgo.Ordered, testWrapper(func() {
+		ginkgo.It("forwards min_tokens/max_tokens to decode and caps them on prefill and encode", func() {
+			runCoordinatorPipeline(gateway.PathChatCompletions, []byte(fmt.Sprintf(
+				`{"model":%q,"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":%q},"uuid":"image-0"},{"type":"text","text":"Describe what you see."}]}],"min_tokens":3,"max_tokens":5}`,
+				modelName, inlineImageDataURI,
+			)), allSteps, 1, 3, 5, coordinatorConfigNIXLGenerate)
+		})
+	}))
 
-	ginkgo.It("routes a multimodal image chat completion end-to-end", func() {
-		runCoordinatorPipeline(gateway.PathChatCompletions, []byte(fmt.Sprintf(
-			`{"model":%q,"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":%q},"uuid":"image-0"},{"type":"text","text":"Describe what you see."}]}],"max_tokens":150}`,
-			modelName, testImageURL,
-		)), allSteps, 1, 0, 0)
-	})
+	ginkgo.When("the request carries one remote image", ginkgo.Ordered, testWrapper(func() {
+		ginkgo.It("routes a multimodal image chat completion end-to-end", func() {
+			runCoordinatorPipeline(gateway.PathChatCompletions, []byte(fmt.Sprintf(
+				`{"model":%q,"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":%q},"uuid":"image-0"},{"type":"text","text":"Describe what you see."}]}],"max_tokens":150}`,
+				modelName, testImageURL,
+			)), allSteps, 1, 0, 0)
+		})
+	}))
 
-	ginkgo.It("routes a multimodal chat completion with two images end-to-end", func() {
-		runCoordinatorPipeline(gateway.PathChatCompletions, []byte(fmt.Sprintf(
-			`{"model":%q,"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":%q},"uuid":"image-0"},{"type":"image_url","image_url":{"url":%q},"uuid":"image-1"},{"type":"text","text":"What is in these two images?"}]}],"max_tokens":150}`,
-			modelName, testImageURL, testImageURL2,
-		)), allSteps, 2, 0, 0)
-	})
+	ginkgo.When("the request carries two remote images", ginkgo.Ordered, testWrapper(func() {
+		ginkgo.It("routes a multimodal chat completion with two images end-to-end", func() {
+			runCoordinatorPipeline(gateway.PathChatCompletions, []byte(fmt.Sprintf(
+				`{"model":%q,"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":%q},"uuid":"image-0"},{"type":"image_url","image_url":{"url":%q},"uuid":"image-1"},{"type":"text","text":"What is in these two images?"}]}],"max_tokens":150}`,
+				modelName, testImageURL, testImageURL2,
+			)), allSteps, 2, 0, 0)
+		})
+	}))
 
-	ginkgo.It("routes a multimodal chat completion with an inline base64 image end-to-end", func() {
-		runCoordinatorPipeline(gateway.PathChatCompletions, []byte(fmt.Sprintf(
-			`{"model":%q,"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":%q},"uuid":"image-0"},{"type":"text","text":"Describe what you see."}]}],"max_tokens":150}`,
-			modelName, inlineImageDataURI,
-		)), allSteps, 1, 0, 0)
-	})
+	ginkgo.When("the request carries one inline base64 image", ginkgo.Ordered, testWrapper(func() {
+		ginkgo.It("routes a multimodal chat completion with an inline base64 image end-to-end", func() {
+			runCoordinatorPipeline(gateway.PathChatCompletions, []byte(fmt.Sprintf(
+				`{"model":%q,"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":%q},"uuid":"image-0"},{"type":"text","text":"Describe what you see."}]}],"max_tokens":150}`,
+				modelName, inlineImageDataURI,
+			)), allSteps, 1, 0, 0)
+		})
+	}))
 
-	ginkgo.It("routes a multimodal chat completion with one inline and one remote image end-to-end", func() {
-		runCoordinatorPipeline(gateway.PathChatCompletions, []byte(fmt.Sprintf(
-			`{"model":%q,"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":%q},"uuid":"image-0"},{"type":"image_url","image_url":{"url":%q},"uuid":"image-1"},{"type":"text","text":"Describe what you see in both images."}]}],"max_tokens":150}`,
-			modelName, inlineImageDataURI, testImageURL,
-		)), allSteps, 2, 0, 0)
-	})
-
+	ginkgo.When("the request mixes an inline and a remote image", ginkgo.Ordered, testWrapper(func() {
+		ginkgo.It("routes a multimodal chat completion with one inline and one remote image end-to-end", func() {
+			runCoordinatorPipeline(gateway.PathChatCompletions, []byte(fmt.Sprintf(
+				`{"model":%q,"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":%q},"uuid":"image-0"},{"type":"image_url","image_url":{"url":%q},"uuid":"image-1"},{"type":"text","text":"Describe what you see in both images."}]}],"max_tokens":150}`,
+				modelName, inlineImageDataURI, testImageURL,
+			)), allSteps, 2, 0, 0)
+		})
+	}))
 })
 
 // inlineImageDataURI is a 64x64 solid-color PNG encoded as a base64 data URI.
@@ -116,44 +129,19 @@ const inlineImageDataURI = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAA
 // requests) cap max_tokens to 1 and strip min_tokens.
 // coordinatorConfig, when supplied, overrides the default coordinatorConfigNIXL
 // pipeline config for the coordinator deployment.
-func runCoordinatorPipeline(path string, body []byte, expectedSteps []string, expectedImages, wantMinTokens, wantMaxTokens int, coordinatorConfig ...string) {
+// It returns the coordinator logs it asserted against so callers can make further
+// assertions on them; the coordinator is gone by the time it returns.
+func runCoordinatorPipeline(path string, body []byte, expectedSteps []string, expectedImages, wantMinTokens, wantMaxTokens int, coordinatorConfig ...string) string {
 	nsName := getNamespace()
-	var (
-		coordinator  []string
-		modelServers []string
-		epp          []string
-		pool         []string
-	)
-
-	// Registered first → runs last (LIFO), after the log dump below.
-	ginkgo.DeferCleanup(func() {
-		if keepClusterOnFailure && ginkgo.CurrentSpecReport().Failed() {
-			return
-		}
-		testutils.DeleteObjects(testConfig, coordinator, nsName)
-		testutils.DeleteObjects(testConfig, modelServers, nsName)
-		testutils.DeleteObjects(testConfig, epp, nsName)
-		testutils.DeleteObjects(testConfig, pool, nsName)
-	})
-
-	// Dump all pod logs (coordinator, EPPs, Envoy, workers) on failure, or always
-	// when E2E_PRINT_LOGS is set. Registered second → runs first (LIFO), so the
-	// pods still exist.
-	ginkgo.DeferCleanup(func() {
-		if !ginkgo.CurrentSpecReport().Failed() && !printLogs {
-			return
-		}
-		testutils.DumpPodsAndLogs(testConfig, nsName, testutils.WithFullLogs())
-	})
 
 	// Pool first so the EPP can resolve its --pool-name.
-	pool = createInferencePool(true)
+	pool := createInferencePool(true)
 	expectPoolExists()
 
-	epp = createEndPointPickers()
+	epp := createEndPointPickers()
 
 	encodeReplicas, prefillReplicas, decodeReplicas := 1, 1, 1
-	modelServers = createModelServers(encodeReplicas, prefillReplicas, decodeReplicas)
+	modelServers := createModelServers(encodeReplicas, prefillReplicas, decodeReplicas)
 
 	encodePods := getPodNames(encodeSelector)
 	prefillPods := getPodNames(prefillSelector)
@@ -166,7 +154,7 @@ func runCoordinatorPipeline(path string, body []byte, expectedSteps []string, ex
 	if len(coordinatorConfig) > 0 {
 		cfg = coordinatorConfig[0]
 	}
-	coordinator = createCoordinator(cfg)
+	coordinator := createCoordinator(cfg)
 
 	req, err := http.NewRequest(http.MethodPost,
 		gatewayBaseURL()+path,
@@ -176,8 +164,9 @@ func runCoordinatorPipeline(path string, body []byte, expectedSteps []string, ex
 	// Envoy's pipeline listener preserves a client-supplied x-request-id
 	// (preserve_external_request_id) and the coordinator propagates it to every
 	// pipeline leg, so a unique id here scopes the per-role routing check to this
-	// one request. Envoy is shared infra whose access log accumulates across specs,
-	// so an unscoped parse would match earlier specs' legs on since-recycled IPs.
+	// one request. Envoy outlives the per-spec workload and its access log
+	// accumulates every leg and readiness probe the group sends, so an unscoped
+	// parse would match unrelated entries on since-recycled pod IPs.
 	reqID := uuid.NewString()
 	req.Header.Set("X-Request-Id", reqID)
 
@@ -207,6 +196,21 @@ func runCoordinatorPipeline(path string, body []byte, expectedSteps []string, ex
 		}
 		verifyTokenLimits(logs, wantMinTokens, wantMaxTokens, capLegs)
 	}
+
+	if printLogs {
+		testutils.DumpPodsAndLogs(testConfig, nsName, testutils.WithFullLogs())
+	}
+
+	// Torn down here rather than via ginkgo.DeferCleanup: Ginkgo runs DeferCleanup
+	// after the group's AfterAll, which has already deleted the namespace by then,
+	// so the objects would be gone. A failing assertion above aborts before these
+	// deletes, leaving the workload in place for testWrapper's AfterAll to dump.
+	testutils.DeleteObjects(testConfig, coordinator, nsName)
+	testutils.DeleteObjects(testConfig, modelServers, nsName)
+	testutils.DeleteObjects(testConfig, epp, nsName)
+	testutils.DeleteObjects(testConfig, pool, nsName)
+
+	return logs
 }
 
 // verifyCoordinatorSteps asserts that the coordinator logs show every expected
@@ -320,9 +324,9 @@ func verifyPerRoleRouting(nsName string, expectEncode bool, reqID string) {
 // parseEnvoyLegRoutes extracts the per-role pipeline legs from the Envoy access
 // log (format defined in envoy-3-epp.yaml). It returns, per EPP-Profile value in
 // roles, the upstream pod IPs Envoy routed those legs to. Only lines carrying
-// reqID are considered: Envoy is shared across specs and its access log
-// accumulates, so scoping by request id keeps earlier specs' legs (on
-// since-recycled pod IPs) out. Lines whose profile is not a known role (the
+// reqID are considered: Envoy outlives the per-spec workload and its access log
+// accumulates, so scoping by request id keeps unrelated legs (on since-recycled
+// pod IPs) out. Lines whose profile is not a known role (the
 // external client request and readiness probes take the default route) are ignored.
 func parseEnvoyLegRoutes(logs string, roles map[string]map[string]bool, reqID string) map[string][]string {
 	out := map[string][]string{}
@@ -405,10 +409,10 @@ func verifyTokenLimits(logs string, wantMin, wantMax int, capLegs []string) {
 // verifyEncodeSkipped asserts the coordinator skipped the encode fan-out on the
 // generate path. The skip marker is logged immediately before the step returns,
 // so its presence is dispositive: the prefill worker encodes inline from
-// kwargs_data and no encode sub-request is issued.
-func verifyEncodeSkipped(nsName string) {
-	logs := fetchCoordinatorLogs(nsName)
-
+// kwargs_data and no encode sub-request is issued. It takes the logs rather than
+// fetching them: runCoordinatorPipeline deletes the coordinator Deployment before
+// returning, so they are no longer retrievable from the cluster by then.
+func verifyEncodeSkipped(logs string) {
 	ginkgo.By("Verifying encode was skipped for the generate request")
 	gomega.Expect(logHasLine(logs, `"msg":"skipping encode for generate request"`)).To(gomega.BeTrue(),
 		"coordinator logs missing 'skipping encode for generate request'")

--- a/test/coordinator/e2e/coordinator/e2e_suite_test.go
+++ b/test/coordinator/e2e/coordinator/e2e_suite_test.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -35,7 +34,6 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	k8slog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -124,10 +122,8 @@ var (
 
 	readyTimeout = env.GetEnvDuration("READY_TIMEOUT", defaultReadyTimeout, ginkgo.GinkgoLogr)
 
-	portForwardSessions []*gexec.Session
-	rendererObjects     []string
-	stableInfraObjects  []string
-	createdNameSpace    bool
+	rendererObjects   []string
+	createdRendererNS bool
 )
 
 // roleEPP describes one EPP to create: its EPP/Service name, the InferencePool
@@ -169,7 +165,10 @@ func TestCoordinatorE2E(t *testing.T) {
 	ginkgo.RunSpecs(t, "Coordinator E2E Suite")
 }
 
-var _ = ginkgo.BeforeSuite(func() {
+// Process 1 provisions what every process shares: the cluster, the CRDs, and
+// the single renderer in baseNsName that each process's coordinator reaches
+// cross-namespace. Every other process only needs its own client.
+var _ = ginkgo.SynchronizedBeforeSuite(func() {
 	gomega.Expect(coordinatorImage).NotTo(gomega.BeEmpty(), "COORDINATOR_IMAGE must be set")
 
 	testutils.RequireParallelProcessesMatch(numProcesses)
@@ -179,52 +178,59 @@ var _ = ginkgo.BeforeSuite(func() {
 	}
 	testConfig = testutils.NewTestConfig(k8sContext)
 	setupK8sClient()
-	setupNameSpace()
-
-	// Base infra (CRDs, RBAC, Envoy) is created here on suite-owned kind clusters.
-	// With K8S_CONTEXT set, base infra is assumed pre-deployed; the per-test
-	// workload (EPPs, pools, vLLM workers, coordinator) is created in the test body.
+	// Only a suite-owned kind cluster gets CRDs installed. An existing cluster is
+	// assumed to have them already, and installing here would adopt them on
+	// AlreadyExists, so teardown would delete CRDs the suite does not own, taking
+	// every InferencePool in that cluster with them.
 	if k8sContext == "" {
-		setupInfra()
-	} else {
-		// Base infra (including Envoy) is pre-deployed; forward the gateway so
-		// the test can post to it. The kind nodePort mapping is unavailable here.
-		startPortForward("service/envoy", strconv.Itoa(getGatewayPort()), "8081")
+		createCRDs()
 	}
-
-	rendererObjects = createRenderer()
-
-	// Coordinator and EPP Services/RBAC are created once and kept stable across
-	// specs (see createStableInfra).
-	createStableInfra()
+	createdRendererNS = testutils.SetupNamespace(testConfig, baseNsName)
+	rendererObjects = createRenderer(baseNsName)
+}, func() {
+	if ginkgo.GinkgoParallelProcess() != 1 {
+		testConfig = testutils.NewTestConfig(k8sContext)
+		setupK8sClient()
+	}
 })
 
+// ReportAfterSuite receives the full suite report and uses report.SuiteSucceeded
+// to detect any failure, including failures in the suite setup nodes, which a
+// ReportAfterEach would miss. It tears down only what process 1 created; the
+// per-group namespace, Envoy, and Services are torn down by testWrapper.
 var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
 	if !report.SuiteSucceeded {
+		// baseNsName holds the shared renderer, and is the only namespace still
+		// alive when the suite fails in SynchronizedBeforeSuite before any group
+		// runs. The per-process namespaces are usually already gone by now: a
+		// group's AfterAll dumps its own namespace when its specs failed (which
+		// includes specs interrupted by --fail-fast) and then deletes it.
+		testutils.DumpPodsAndLogs(testConfig, baseNsName)
 		for idx := range numProcesses {
-			testutils.DumpPodsAndLogs(testConfig, testutils.NamespaceForProcess(baseNsName, numProcesses, idx+1))
+			if nsName := testutils.NamespaceForProcess(baseNsName, numProcesses, idx+1); nsName != baseNsName {
+				testutils.DumpPodsAndLogs(testConfig, nsName)
+			}
 		}
 	}
 
-	if k8sContext == "" && keepClusterOnFailure && !report.SuiteSucceeded {
-		ginkgo.By("Keeping kind cluster " + kindClusterName + " due to suite failure (E2E_KEEP_CLUSTER_ON_FAILURE=true)")
+	shouldKeep := keepClusterOnFailure && !report.SuiteSucceeded
+	if k8sContext != "" {
+		if shouldKeep {
+			ginkgo.By("Keeping created Kubernetes objects due to suite failure (E2E_KEEP_CLUSTER_ON_FAILURE=true)")
+			return
+		}
+		// CRDs are not deleted here: the suite installs them only on a kind cluster
+		// it owns, which this branch is not.
+		ginkgo.By("Deleting created Kubernetes objects")
+		testutils.DeleteObjects(testConfig, rendererObjects, baseNsName)
+		if createdRendererNS {
+			testutils.DeleteNamespace(testConfig, baseNsName)
+		}
 		return
 	}
-	nsName := getNamespace()
-	if len(rendererObjects) > 0 {
-		testutils.DeleteObjects(testConfig, rendererObjects, nsName)
-	}
-	if len(stableInfraObjects) > 0 {
-		testutils.DeleteObjects(testConfig, stableInfraObjects, nsName)
-	}
-	for _, session := range portForwardSessions {
-		session.Terminate()
-	}
-	if createdNameSpace {
-		err := testConfig.KubeCli.CoreV1().Namespaces().Delete(testConfig.Context, nsName, metav1.DeleteOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	}
-	if k8sContext != "" {
+
+	if shouldKeep {
+		ginkgo.By("Keeping kind cluster " + kindClusterName + " due to suite failure (E2E_KEEP_CLUSTER_ON_FAILURE=true)")
 		return
 	}
 	ginkgo.By("Deleting kind cluster " + kindClusterName)
@@ -236,19 +242,6 @@ var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
 	}
 	gomega.Eventually(session).WithTimeout(60 * time.Second).Should(gexec.Exit())
 })
-
-// startPortForward forwards a local port to the given target (e.g.
-// "deployment/llm-d-coordinator" or "service/envoy"). Used when running against
-// an existing cluster (K8S_CONTEXT set), where the kind nodePort mapping is not
-// available. Sessions are tracked for teardown in AfterSuite.
-func startPortForward(target, localPort, remotePort string) {
-	command := exec.Command("kubectl", "port-forward", target,
-		localPort+":"+remotePort,
-		"--context="+k8sContext, "--namespace="+getNamespace())
-	session, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-	portForwardSessions = append(portForwardSessions, session)
-}
 
 func setupK8sCluster() {
 	// extraPortMappings is substituted into `extraPortMappings: ${EXTRA_PORT_MAPPINGS}` in the Kind
@@ -320,9 +313,19 @@ func setupK8sClient() {
 	k8slog.SetLogger(ginkgo.GinkgoLogr)
 }
 
-// getGatewayPort returns the envoy gateway's NodePort for this process. See testutils.ProcessPort.
+// getGatewayPort returns the host port this process reaches the gateway on,
+// derived from E2E_GATEWAY_PORT. See testutils.ProcessPort.
 func getGatewayPort() int {
 	return testutils.ProcessPort(baseGatewayPort)
+}
+
+// getGatewayNodePort returns the envoy Service's NodePort for this process. It
+// derives from defaultGatewayHostPort rather than baseGatewayPort because it is
+// the cluster-side port: it must match the containerPort BuildExtraPortMappings
+// maps to the host, and stay inside the Kubernetes NodePort range whatever host
+// port E2E_GATEWAY_PORT asks for. See testutils.ProcessPort.
+func getGatewayNodePort() int {
+	return testutils.ProcessPort(defaultGatewayHostPort)
 }
 
 // getNamespace returns the namespace being used by the current process. Each

--- a/test/coordinator/e2e/coordinator/generate_endpoint_test.go
+++ b/test/coordinator/e2e/coordinator/generate_endpoint_test.go
@@ -45,19 +45,23 @@ const generateTestKwargs = "dGVuc29y"
 var generateSteps = []string{"render", "prefill", "decode"}
 
 var _ = ginkgo.Describe("Coordinator pipeline - generate endpoint", func() {
-	ginkgo.It("routes a text-only generate end-to-end", func() {
-		runCoordinatorPipeline(gateway.DefaultGeneratePath,
-			generateBody(modelName, nil), generateSteps, 0, 0, 0)
-	})
+	ginkgo.When("the generate request is text-only", ginkgo.Ordered, testWrapper(func() {
+		ginkgo.It("routes a text-only generate end-to-end", func() {
+			runCoordinatorPipeline(gateway.DefaultGeneratePath,
+				generateBody(modelName, nil), generateSteps, 0, 0, 0)
+		})
+	}))
 
-	ginkgo.It("routes a single-image generate end-to-end", func() {
-		images := []genImage{
-			{Hash: "e2e-gen-hash-0", Offset: 1, Length: 3},
-		}
-		runCoordinatorPipeline(gateway.DefaultGeneratePath,
-			generateBody(modelName, images), generateSteps, 0, 0, 0)
-		verifyEncodeSkipped(getNamespace())
-	})
+	ginkgo.When("the generate request carries one image", ginkgo.Ordered, testWrapper(func() {
+		ginkgo.It("routes a single-image generate end-to-end", func() {
+			images := []genImage{
+				{Hash: "e2e-gen-hash-0", Offset: 1, Length: 3},
+			}
+			logs := runCoordinatorPipeline(gateway.DefaultGeneratePath,
+				generateBody(modelName, images), generateSteps, 0, 0, 0)
+			verifyEncodeSkipped(logs)
+		})
+	}))
 })
 
 // generateBody builds a native /inference/v1/generate request body. With no

--- a/test/coordinator/e2e/coordinator/setup_test.go
+++ b/test/coordinator/e2e/coordinator/setup_test.go
@@ -19,12 +19,15 @@ package coordinate2e
 import (
 	"fmt"
 	"net/http"
+	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,57 +38,102 @@ import (
 	testutils "github.com/llm-d/llm-d-router/test/utils"
 )
 
-// setupNameSpace creates the test namespace if it does not already exist and
-// records whether it was created so AfterSuite can delete it on cleanup.
-func setupNameSpace() {
-	nsName := getNamespace()
-	_, err := testConfig.KubeCli.CoreV1().Namespaces().Get(testConfig.Context, nsName, metav1.GetOptions{})
-	if err == nil {
-		return
-	}
-	gomega.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
+// coordinatorComponentDocs renders the coordinator component once per process.
+// Its output depends only on the manifest tree, and both the per-group Services
+// and the per-spec Deployment are sliced out of the same render.
+var coordinatorComponentDocs = sync.OnceValue(func() []string {
+	return e2eutil.RunKustomize(coordinatorComponentDir)
+})
 
-	ginkgo.By("Creating namespace " + nsName)
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: nsName,
-		},
-	}
-	_, err = testConfig.KubeCli.CoreV1().Namespaces().Create(testConfig.Context, ns, metav1.CreateOptions{})
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	createdNameSpace = true
-}
-
-// setupInfra installs the base infra shared across tests: Gateway API + GIE
-// CRDs and Envoy. Runs only on suite-owned kind clusters; with K8S_CONTEXT set
-// the caller is responsible for having base infra in place. The per-test
-// workload (EPPs, InferencePools, vLLM workers, coordinator) is created in the
-// test body; the EPP's RBAC/ServiceAccount/Service come from createStableInfra.
-func setupInfra() {
-	nsName := getNamespace()
-	createCRDs()
-
-	manifest := envoyManifest
+// createEnvoy applies the active topology's Envoy routing ConfigMap plus the
+// shared Envoy Deployment and Service in nsName. Against an existing cluster
+// (K8S_CONTEXT set) the kind nodePort mapping is unavailable, so it also
+// forwards the gateway port and returns the session for the caller to terminate.
+// It appends to objects as it goes rather than returning them at the end, so a
+// failure partway through still leaves the already-created ids tracked for
+// teardown; the namespace delete does not cover this when the suite did not
+// create the namespace.
+func createEnvoy(nsName string, objects *[]string) *gexec.Session {
 	infraSubs := map[string]string{
-		"${NAMESPACE}": nsName,
-		"${EPP_NAME}":  eppName,
+		"${NAMESPACE}":       nsName,
+		"${ENVOY_NODE_PORT}": strconv.Itoa(getGatewayNodePort()),
 	}
+	manifest := envoyManifest
 	if threeEPP {
 		manifest = envoy3EPPManifest
-		infraSubs = map[string]string{
-			"${NAMESPACE}":        nsName,
-			"${EPP_NAME_ENCODE}":  eppNameEncode,
-			"${EPP_NAME_PREFILL}": eppNamePrefill,
-			"${EPP_NAME_DECODE}":  eppNameDecode,
-		}
+		infraSubs["${EPP_NAME_ENCODE}"] = eppNameEncode
+		infraSubs["${EPP_NAME_PREFILL}"] = eppNamePrefill
+		infraSubs["${EPP_NAME_DECODE}"] = eppNameDecode
+	} else {
+		infraSubs["${EPP_NAME}"] = eppName
 	}
+
 	ginkgo.By("Applying Envoy routing ConfigMap from " + manifest)
-	applyManifest(manifest, infraSubs)
+	*objects = append(*objects, applyManifest(nsName, manifest, infraSubs)...)
 	ginkgo.By("Applying shared Envoy Deployment and Service from " + sharedEnvoyManifest)
-	applyManifest(sharedEnvoyManifest, infraSubs)
+	*objects = append(*objects, applyManifest(nsName, sharedEnvoyManifest, infraSubs)...)
+
+	if k8sContext == "" {
+		return nil
+	}
+	command := exec.Command("kubectl", "port-forward", "service/envoy",
+		strconv.Itoa(getGatewayPort())+":8081",
+		"--context="+k8sContext, "--namespace="+nsName)
+	portForwardSession, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	return portForwardSession
 }
 
-// createCRDs installs the GIE CRDs used for testing.
+// testWrapper wraps a group of specs with the setup and teardown they share:
+// the namespace, Envoy, and the Services/ServiceAccounts/RBAC the per-spec
+// workload binds to. It is used as a wrapper of the function passed to
+// ginkgo.When calls. Ginkgo hands an Ordered group to a single process
+// start-to-finish, so the group must carry the ginkgo.Ordered decorator both to
+// keep it on the process that set its Envoy up and to enable BeforeAll/AfterAll.
+func testWrapper(test func()) func() {
+	var (
+		nsName           string
+		createdNameSpace bool
+
+		envoyObjects       []string
+		stableInfraObjects []string
+		portForwardSession *gexec.Session
+	)
+	return func() {
+		ginkgo.BeforeAll(func() {
+			nsName = getNamespace()
+			createdNameSpace = testutils.SetupNamespace(testConfig, nsName)
+			portForwardSession = createEnvoy(nsName, &envoyObjects)
+			createStableInfra(nsName, &stableInfraObjects)
+		})
+
+		ginkgo.AfterAll(func() {
+			if ginkgo.CurrentSpecReport().Failed() {
+				// A failing spec aborts before its inline teardown, so its workload
+				// is still up; dump it before the deletes below remove it.
+				testutils.DumpPodsAndLogs(testConfig, nsName, testutils.WithFullLogs())
+				if keepClusterOnFailure {
+					return
+				}
+			}
+			testutils.DeleteObjects(testConfig, stableInfraObjects, nsName)
+			if portForwardSession != nil {
+				portForwardSession.Terminate()
+			}
+			testutils.DeleteObjects(testConfig, envoyObjects, nsName)
+
+			if createdNameSpace {
+				testutils.DeleteNamespace(testConfig, nsName)
+			}
+		})
+
+		test()
+	}
+}
+
+// createCRDs installs the GIE CRDs used for testing. The ids are discarded: the
+// suite installs CRDs only on a kind cluster it owns, and deleting that cluster
+// reclaims them.
 func createCRDs() {
 	ginkgo.By("Installing GIE CRDs from " + crdGIEPath)
 	gieCRDs := e2eutil.RunKustomize(crdGIEPath)
@@ -96,7 +144,7 @@ func createCRDs() {
 // for the active topology and waits for the Deployments to become ready. The
 // single-EPP topology creates one EPP from eppConfig; the 3-EPP topology creates
 // one per role, each from its role config with a per-role ConfigMap. Each EPP's
-// ServiceAccount, RoleBinding, and Service are created once by createStableInfra.
+// ServiceAccount, RoleBinding, and Service come from createStableInfra.
 // Returns all created object ids for cleanup.
 func createEndPointPickers() []string {
 	epps := eppsToCreate()
@@ -121,14 +169,14 @@ func createOneEndPointPicker(e roleEPP) []string {
 	objects := make([]string, 1, 8)
 	objects[0] = "ConfigMap/" + cmName
 	// eppManifest is the EPP Deployment only; its Service, ServiceAccount, and
-	// RBAC are created once by createStableInfra.
+	// RBAC come from createStableInfra.
 	docs := testutils.ReadYaml(eppManifest)
 	docs = e2eutil.SubstituteMany(docs, eppSubstitutionsFor(e.eppName, e.poolName))
 	if threeEPP {
 		docs = renameEPPConfigVolume(docs, cmName)
 	}
 	objects = append(objects, testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())...)
-	podsInDeploymentsReady(objects)
+	podsInDeploymentsReady(getNamespace(), objects)
 	return objects
 }
 
@@ -214,17 +262,18 @@ func createModelServers(encodeReplicas, prefillReplicas, decodeReplicas int) []s
 	docs = e2eutil.RemoveEmptyArgs(docs)
 	docs = e2eutil.RemoveEmptyLabels(docs)
 	objects := testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())
-	podsInDeploymentsReady(objects)
+	podsInDeploymentsReady(getNamespace(), objects)
 	return objects
 }
 
 // createCoordinator builds the coordinator ConfigMap from the given pipeline
 // config, deploys the coordinator Deployment, and waits for readiness. Its
-// Service and ServiceAccount are created once by createStableInfra.
+// Service and ServiceAccount come from createStableInfra.
 func createCoordinator(config string) []string {
 	nsName := getNamespace()
 	coordinatorYAML := e2eutil.SubstituteMany([]string{config}, map[string]string{
 		"${NAMESPACE}":        nsName,
+		"${RENDER_NAMESPACE}": baseNsName,
 		"${VLLM_RENDER_PORT}": vllmRenderPort,
 	})[0]
 	cm := &corev1.ConfigMap{
@@ -241,25 +290,24 @@ func createCoordinator(config string) []string {
 	objects := make([]string, 1, 8)
 	objects[0] = "ConfigMap/llm-d-coordinator-config"
 
-	docs := e2eutil.RunKustomize(coordinatorComponentDir)
-	// Service and ServiceAccount are created once by createStableInfra; recreate
-	// only the Deployment per spec.
-	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Service", "ServiceAccount")
+	// Service and ServiceAccount come from createStableInfra; recreate only the
+	// Deployment per spec.
+	docs := e2eutil.FilterKinds(coordinatorComponentDocs(), "ConfigMap", "Service", "ServiceAccount")
 	docs = e2eutil.SubstituteMany(docs, coordinatorSubstitutions())
 	docs = e2eutil.RemoveEmptyArgs(docs)
 	objects = append(objects, testutils.CreateObjsFromYaml(testConfig, docs, nsName)...)
 
-	podsInDeploymentsReady(objects)
+	podsInDeploymentsReady(nsName, objects)
 	waitForCoordinatorReady()
 	return objects
 }
 
 // waitForCoordinatorReady polls /readyz through Envoy until it returns 200,
 // confirming the freshly recreated coordinator pod is reachable through the
-// gateway before the test sends its request. The gateway Service is stable
-// across specs (see createStableInfra), so this waits only for the new pod to
-// appear behind it. (podsInDeploymentsReady already confirms the coordinator
-// pod itself is ready.)
+// gateway before the test sends its request. The gateway Service outlives the
+// coordinator Deployment (see createStableInfra), so this waits only for the
+// new pod to appear behind it. (podsInDeploymentsReady already confirms the
+// coordinator pod itself is ready.)
 func waitForCoordinatorReady() {
 	ginkgo.By("Waiting for coordinator to be reachable via gateway")
 	gomega.Eventually(func() bool {
@@ -292,31 +340,30 @@ func createEPPConfigMap(name, content string) {
 	}
 }
 
-// applyManifest reads a manifest, substitutes vars, and creates the objects.
-// It does not strip empty args: the manifests it applies (Envoy, the EPP's
-// Deployment/RBAC/ServiceAccount/Service) carry no empty ${VLLM_EXTRA_ARGS_*}
-// placeholders, and rbac.yaml's core API group ("") is a legitimate `- ""` that
-// RemoveEmptyArgs would wrongly drop. The vLLM workers, which do need arg
-// stripping, go through createModelServers instead.
-func applyManifest(path string, subs map[string]string) []string {
+// applyManifest reads a manifest, substitutes vars, and creates the objects in
+// nsName. It does not strip empty args: the manifests it applies (Envoy, the
+// EPP's Deployment/RBAC/ServiceAccount/Service) carry no empty
+// ${VLLM_EXTRA_ARGS_*} placeholders, and rbac.yaml's core API group ("") is a
+// legitimate `- ""` that RemoveEmptyArgs would wrongly drop. The vLLM workers,
+// which do need arg stripping, go through createModelServers instead.
+func applyManifest(nsName, path string, subs map[string]string) []string {
 	docs := testutils.ReadYaml(path)
 	docs = e2eutil.SubstituteMany(docs, subs)
-	return testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())
+	return testutils.CreateObjsFromYaml(testConfig, docs, nsName)
 }
 
 // createStableInfra creates the coordinator and EPP Services, ServiceAccounts,
-// and RoleBindings once, up front. It appends each created id to
-// stableInfraObjects as it goes rather than returning them at the end, so a
-// partial failure still leaves the already-created objects tracked for suite
-// teardown. Envoy fronts the Services via STRICT_DNS clusters and outlives the
-// per-spec workload; recreating a Service each spec would rotate its ClusterIP and
-// force Envoy to re-resolve, so only the Deployments behind them churn per spec.
-func createStableInfra() {
-	docs := e2eutil.RunKustomize(coordinatorComponentDir)
-	docs = e2eutil.FilterKinds(docs, "ConfigMap", "Deployment")
+// and RoleBindings the group's specs bind to. Envoy fronts the Services via
+// STRICT_DNS clusters and outlives the per-spec workload; recreating a Service
+// each spec would rotate its ClusterIP and force Envoy to re-resolve, so only
+// the Deployments behind them churn per spec. Like createEnvoy it appends to
+// objects as it goes, so a failure partway through still leaves the
+// already-created ids tracked for teardown.
+func createStableInfra(nsName string, objects *[]string) {
+	docs := e2eutil.FilterKinds(coordinatorComponentDocs(), "ConfigMap", "Deployment")
 	docs = e2eutil.SubstituteMany(docs, coordinatorSubstitutions())
 	docs = e2eutil.RemoveEmptyArgs(docs)
-	stableInfraObjects = append(stableInfraObjects, testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())...)
+	*objects = append(*objects, testutils.CreateObjsFromYaml(testConfig, docs, nsName)...)
 
 	// Each EPP's RBAC, ServiceAccount, and Service come from the shared
 	// inference-gateway component's split files; the Deployment is recreated per
@@ -324,7 +371,7 @@ func createStableInfra() {
 	for _, e := range eppsToCreate() {
 		subs := eppSubstitutionsFor(e.eppName, e.poolName)
 		for _, manifest := range []string{eppRbacManifest, eppServiceAccountManifest, eppServicesManifest} {
-			stableInfraObjects = append(stableInfraObjects, applyManifest(manifest, subs)...)
+			*objects = append(*objects, applyManifest(nsName, manifest, subs)...)
 		}
 	}
 }
@@ -367,7 +414,7 @@ func allSubstitutions() map[string]string {
 		"${POOL_NAME}":               poolNameBase,
 		"${MODEL_NAME}":              modelName,
 		"${VLLM_IMAGE}":              vllmSimImage,
-		"${VLLM_RENDER_URL}":         fmt.Sprintf("http://vllm-render.%s.svc:%s", getNamespace(), vllmRenderPort),
+		"${VLLM_RENDER_URL}":         fmt.Sprintf("http://vllm-render.%s.svc:%s", baseNsName, vllmRenderPort),
 		"${VLLM_DATA_PARALLEL_SIZE}": "1",
 		"${VLLM_REPLICA_COUNT_E}":    "1",
 		"${VLLM_REPLICA_COUNT_P}":    "1",
@@ -405,13 +452,14 @@ func rendererSubstitutions() map[string]string {
 	}
 }
 
-// createRenderer deploys the vllm-render component and waits for readiness.
-func createRenderer() []string {
-	ginkgo.By("Deploying vllm-render")
+// createRenderer deploys the vllm-render component in nsName and waits for
+// readiness.
+func createRenderer(nsName string) []string {
+	ginkgo.By("Deploying vllm-render in " + nsName)
 	docs := testutils.ReadYaml(rendererManifest)
 	docs = e2eutil.SubstituteMany(docs, rendererSubstitutions())
 	docs = e2eutil.RemoveEmptyArgs(docs)
-	objects := testutils.CreateObjsFromYaml(testConfig, docs, getNamespace())
-	podsInDeploymentsReady(objects)
+	objects := testutils.CreateObjsFromYaml(testConfig, docs, nsName)
+	podsInDeploymentsReady(nsName, objects)
 	return objects
 }

--- a/test/coordinator/e2e/coordinator/utils_test.go
+++ b/test/coordinator/e2e/coordinator/utils_test.go
@@ -82,12 +82,12 @@ func podIPs(labels map[string]string) map[string]bool {
 }
 
 // podsInDeploymentsReady waits until every Deployment named in objects reports
-// all replicas ready. Non-Deployment entries are ignored.
-func podsInDeploymentsReady(objects []string) {
+// all replicas ready in nsName. Non-Deployment entries are ignored.
+func podsInDeploymentsReady(nsName string, objects []string) {
 	isDeploymentReady := func(deploymentName string) bool {
 		var deployment appsv1.Deployment
 		err := testConfig.K8sClient.Get(testConfig.Context,
-			types.NamespacedName{Namespace: getNamespace(), Name: deploymentName}, &deployment)
+			types.NamespacedName{Namespace: nsName, Name: deploymentName}, &deployment)
 		if err != nil || deployment.Spec.Replicas == nil {
 			return false
 		}

--- a/test/coordinator/scripts/run_e2e_coordinator.sh
+++ b/test/coordinator/scripts/run_e2e_coordinator.sh
@@ -1,21 +1,37 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -euo pipefail
 
-cleanup() {
-    echo "Interrupted!"
-    if [ "${E2E_KEEP_CLUSTER_ON_FAILURE:-false}" = "true" ]; then
-        echo "Keeping kind cluster 'e2e-coordinator-tests' (E2E_KEEP_CLUSTER_ON_FAILURE=true)"
-    else
-        echo "Deleting kind cluster 'e2e-coordinator-tests'"
-        kind delete cluster --name e2e-coordinator-tests 2>/dev/null || true
-    fi
-    exit 130
-}
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-trap cleanup INT TERM
+# shellcheck source=test/scripts/e2e-common.sh
+source "${DIR}/../../scripts/e2e-common.sh"
+
+# Set trap only for interruption signals.
+# Normally kind cluster cleanup is done by the suite's ReportAfterSuite; this
+# trap deletes the e2e-coordinator-tests cluster on Ctrl-C. The delete is
+# unconditional and only meaningful when the suite created that cluster
+# (K8S_CONTEXT unset); when running against an existing context it is a no-op
+# unless a cluster of that name happens to exist.
+trap 'e2e_handle_interrupt "e2e-coordinator-tests"' INT TERM
 
 echo "Running coordinator end-to-end tests"
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-NAMESPACE="${NAMESPACE:-default}" go test -v -timeout 120m ${DIR}/../e2e/coordinator/ -ginkgo.v -ginkgo.fail-fast
+# Every spec deploys its own encode/prefill/decode workers and coordinator, so
+# each parallel process carries several full workload cycles; 90m leaves the
+# slowest process headroom over the shared 45m default.
+run_ginkgo_suite "${DIR}/../e2e/coordinator/" 90m

--- a/test/coordinator/scripts/run_e2e_coordinator.sh
+++ b/test/coordinator/scripts/run_e2e_coordinator.sh
@@ -31,7 +31,4 @@ trap 'e2e_handle_interrupt "e2e-coordinator-tests"' INT TERM
 
 echo "Running coordinator end-to-end tests"
 
-# Every spec deploys its own encode/prefill/decode workers and coordinator, so
-# each parallel process carries several full workload cycles; 90m leaves the
-# slowest process headroom over the shared 45m default.
-run_ginkgo_suite "${DIR}/../e2e/coordinator/" 90m
+run_ginkgo_suite "${DIR}/../e2e/coordinator/"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -12,11 +12,8 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	k8slog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -119,7 +116,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() {
 	setupK8sClient()
 	createCRDs()
 	// If we are running tests in parallel, create the renderer in the "base namespace"
-	createdRendererNS = setupNameSpaceHelper(baseNsName)
+	createdRendererNS = testutils.SetupNamespace(testConfig, baseNsName)
 	renderObjects = createRender(baseNsName)
 }, func() {
 	if ginkgo.GinkgoParallelProcess() != 1 {
@@ -162,7 +159,7 @@ var _ = ginkgo.ReportAfterSuite("cleanup", func(report ginkgo.Report) {
 			ginkgo.By("Deleting created Kubernetes objects")
 			testutils.DeleteObjects(testConfig, renderObjects, baseNsName)
 			if createdRendererNS {
-				deleteNameSpace(baseNsName)
+				testutils.DeleteNamespace(testConfig, baseNsName)
 			}
 			testutils.DeleteObjects(testConfig, crdObjects, "")
 		}
@@ -249,47 +246,6 @@ func setupK8sClient() {
 	testConfig.CreateCli()
 
 	k8slog.SetLogger(ginkgo.GinkgoLogr)
-}
-
-// setupNameSpace sets up the specified namespace if it doesn't exist
-func setupNameSpace() bool {
-	return setupNameSpaceHelper(getNamespace())
-}
-
-func setupNameSpaceHelper(nsName string) bool {
-	ginkgo.By("Setup namespace " + nsName)
-	_, err := testConfig.KubeCli.CoreV1().Namespaces().Get(testConfig.Context, nsName, metav1.GetOptions{})
-	if err == nil {
-		return false
-	}
-	gomega.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
-
-	ginkgo.By("Creating namespace " + nsName)
-	namespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: nsName,
-		},
-	}
-	_, err = testConfig.KubeCli.CoreV1().Namespaces().Create(testConfig.Context, namespace, metav1.CreateOptions{})
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	ginkgo.By("Ensuring namespace exists: " + nsName)
-	testutils.EventuallyExists(testConfig, func() error {
-		return testConfig.K8sClient.Get(testConfig.Context,
-			types.NamespacedName{Name: nsName}, &corev1.Namespace{})
-	})
-
-	return true
-}
-
-func deleteNameSpace(nsName string) {
-	ginkgo.By("Deleting namespace " + nsName)
-	err := testConfig.KubeCli.CoreV1().Namespaces().Delete(testConfig.Context, nsName, metav1.DeleteOptions{})
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-	gomega.Eventually(func() bool {
-		_, err := testConfig.KubeCli.CoreV1().Namespaces().Get(testConfig.Context, nsName, metav1.GetOptions{})
-		return apierrors.IsNotFound(err)
-	}, testConfig.ExistsTimeout, testConfig.Interval).Should(gomega.BeTrue())
 }
 
 // createCRDs creates the Inference Extension CRDs used for testing.

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -242,7 +242,7 @@ func testWrapper(test func()) func() {
 	return func() {
 		ginkgo.BeforeAll(func() {
 			nsName = getNamespace()
-			createdNameSpace = setupNameSpace()
+			createdNameSpace = testutils.SetupNamespace(testConfig, nsName)
 
 			envoyObjects, portForwardSession = createEnvoy(nsName)
 
@@ -282,7 +282,7 @@ func testWrapper(test func()) func() {
 				testutils.DeleteObjects(testConfig, envoyObjects, nsName)
 
 				if createdNameSpace {
-					deleteNameSpace(nsName)
+					testutils.DeleteNamespace(testConfig, nsName)
 				}
 			}
 		})

--- a/test/scripts/e2e-common.sh
+++ b/test/scripts/e2e-common.sh
@@ -30,7 +30,10 @@ e2e_handle_interrupt() {
 }
 
 # run_ginkgo_suite runs the Ginkgo e2e suite in the given package directory.
+# The optional second argument overrides the 45m default timeout for suites
+# whose specs each stand up their own model servers.
 run_ginkgo_suite() {
   local pkg="$1"
-  ginkgo run --procs="${E2E_NUM_PROCS}" --timeout 45m -v --fail-fast "${pkg}"
+  local timeout="${2:-45m}"
+  ginkgo run --procs="${E2E_NUM_PROCS}" --timeout "${timeout}" -v --fail-fast "${pkg}"
 }

--- a/test/scripts/e2e-common.sh
+++ b/test/scripts/e2e-common.sh
@@ -30,10 +30,7 @@ e2e_handle_interrupt() {
 }
 
 # run_ginkgo_suite runs the Ginkgo e2e suite in the given package directory.
-# The optional second argument overrides the 45m default timeout for suites
-# whose specs each stand up their own model servers.
 run_ginkgo_suite() {
   local pkg="$1"
-  local timeout="${2:-45m}"
-  ginkgo run --procs="${E2E_NUM_PROCS}" --timeout "${timeout}" -v --fail-fast "${pkg}"
+  ginkgo run --procs="${E2E_NUM_PROCS}" --timeout 45m -v --fail-fast "${pkg}"
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -239,6 +239,49 @@ func EventuallyExists(testConfig *TestConfig, getResource func() error) {
 	}, testConfig.ExistsTimeout, testConfig.Interval).Should(gomega.Succeed())
 }
 
+// SetupNamespace creates nsName if it does not already exist and reports whether
+// it created it, so the caller knows whether to delete it on cleanup.
+func SetupNamespace(testConfig *TestConfig, nsName string) bool {
+	ginkgo.By("Setup namespace " + nsName)
+	_, err := testConfig.KubeCli.CoreV1().Namespaces().Get(testConfig.Context, nsName, metav1.GetOptions{})
+	if err == nil {
+		return false
+	}
+	gomega.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
+
+	ginkgo.By("Creating namespace " + nsName)
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsName,
+		},
+	}
+	_, err = testConfig.KubeCli.CoreV1().Namespaces().Create(testConfig.Context, namespace, metav1.CreateOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	EventuallyExists(testConfig, func() error {
+		return testConfig.K8sClient.Get(testConfig.Context,
+			types.NamespacedName{Name: nsName}, &corev1.Namespace{})
+	})
+
+	return true
+}
+
+// DeleteNamespace deletes nsName and waits until the API server reports it gone,
+// so a caller that recreates it does not race the terminating namespace. The
+// wait is ReadyTimeout, not ExistsTimeout: finalizing a namespace means reaping
+// every workload still in it, which under parallel runs sharing one node takes
+// far longer than an object needs to appear in the API server.
+func DeleteNamespace(testConfig *TestConfig, nsName string) {
+	ginkgo.By("Deleting namespace " + nsName)
+	err := testConfig.KubeCli.CoreV1().Namespaces().Delete(testConfig.Context, nsName, metav1.DeleteOptions{})
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	gomega.Eventually(func() bool {
+		_, err := testConfig.KubeCli.CoreV1().Namespaces().Get(testConfig.Context, nsName, metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, testConfig.ReadyTimeout, testConfig.Interval).Should(gomega.BeTrue(),
+		"namespace %s was not fully deleted", nsName)
+}
+
 func CreateAndVerifyObjs(testConfig *TestConfig, objs []*unstructured.Unstructured, nsName string) []string {
 	objNames := CreateObjsWithVerifier(testConfig, objs, nsName,
 		func(kind string, clientObj client.Object) {


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Parallelizes the coordinator e2e suite, applying the same mechanism the router
e2e already uses (#1931 / PR #2033): `ginkgo run --procs=N` over one Kind
cluster, with per-process namespaces and NodePorts.

Measured on a local dev machine (22 cores, 31 GB, WSL2), not CI:
`make -f Makefile.coord.mk test-e2e-coordinator-run` drops from 8m41s to 5m05s
at the default `E2E_NUM_PROCS=5`, a 1.7x speedup. CI runners are smaller, so
expect a different absolute number there

- **Suite lifecycle.** `SynchronizedBeforeSuite` provisions the cluster, CRDs,
  and a single `vllm-render` once on process 1; every other process only builds
  its own client. `ReportAfterSuite` tears down what process 1 created.

- **Per-group infra.** A `testWrapper` mirroring the router's creates the
  namespace, Envoy, and the Services/ServiceAccounts/RBAC each group binds to in
  `BeforeAll`, and removes them in `AfterAll`. Each of the 9 scenarios becomes
  its own `When(..., ginkgo.Ordered, testWrapper(...))` group so Ginkgo can
  distribute them; `Ordered` keeps a group on the process that built its Envoy.

- **Shared renderer.** One `vllm-render` in the base namespace serves every
  process. The pipeline config gains `${RENDER_NAMESPACE}` for the render step
  so it resolves cross-namespace while the gateway stays on `${NAMESPACE}`.

- **Per-process NodePort.** `shared-envoy-resources.yaml` takes
  `${ENVOY_NODE_PORT}` instead of a hardcoded `30080`, matching the router's
  `envoy.yaml`; without it processes 2..N collide on one port.

- **Shared helpers.** `SetupNamespace`/`DeleteNamespace` move to `test/utils`,
  replacing near-identical copies in both suites. `DeleteNamespace` waits
  `ReadyTimeout` rather than `ExistsTimeout`: finalizing a namespace means
  reaping every pod in it, and the EPP's drain alone exceeds 30s.

- **Runner.** `run_ginkgo_suite` takes an optional timeout; the coordinator
  passes 90m. `E2E_NUM_PROCS` (default 5) is forwarded through
  `Makefile.coord.mk` so `ginkgo --procs` and the suite's `numProcesses` agree.

  ### Behavior change: namespace delete wait

  The shared `testutils.DeleteNamespace` waits until the namespace is gone for up to `ReadyTimeout` (default 3m, set with `READY_TIMEOUT`). This changes both suites:

  | Suite | Before | After |
  |---|---|---|
  | Router | Waits up to `ExistsTimeout` (default 30s) | Waits up to `ReadyTimeout` (default 3m) |
  | Coordinator | Does not wait | Waits up to `ReadyTimeout` (default 3m) |

  Kubernetes deletes every pod in a namespace before it removes the namespace. The EPP pod alone takes more than 30s to stop, and parallel runs on one node take longer. A 30s limit can
  fail a delete that is still in progress.

  A longer timeout cannot cause a false failure. A stuck delete fails after 3m, not 30s.


Fixes #2932 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
