### PR TITLE
feat(epp): align prefix-cache tokens to UTF-8 character boundaries

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/cespare/xxhash/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -127,15 +128,14 @@ func (b estimateBackend) produce(ctx context.Context, body *fwkrh.InferenceReque
 	// Chat and Anthropic messages fold multimodal placeholders into the stream
 	// and report them as features.
 	if body.ChatCompletions != nil {
-		raw, features := b.chatCompletionsBytes(body.ChatCompletions, mmMetadataFromContext(ctx))
-		return &fwkrh.TokenizedPrompt{PerPromptTokens: [][]uint32{packBytes(raw)}, MultiModalFeatures: features}, nil
+		tokens, features := b.chatCompletionsTokens(body.ChatCompletions, mmMetadataFromContext(ctx))
+		return &fwkrh.TokenizedPrompt{PerPromptTokens: [][]uint32{tokens}, MultiModalFeatures: features}, nil
 	}
 	if body.Messages != nil {
-		raw, features := b.messagesBytes(body.Messages)
-		tokens := packBytes(raw)
+		tokens, features, rawBytes := b.messagesTokens(body.Messages)
 		log.FromContext(ctx).V(logutil.DEBUG).Info("Anthropic messages prefix-cache estimation",
 			"messageCount", len(body.Messages.Messages),
-			"rawBytes", len(raw),
+			"rawBytes", rawBytes,
 			"tokenCount", len(tokens),
 			"mmFeatureCount", len(features),
 			"mmFeatures", features,
@@ -189,114 +189,124 @@ func estimateBytes(body *fwkrh.InferenceRequestBody) ([]byte, error) {
 	}
 }
 
-// chatCompletionsBytes flattens roles + text into pseudo-token bytes, folding
-// multimodal assets in on aligned boundaries. Each asset occupies N placeholder
-// pseudo-tokens (its content hash repeated N times) so it carries weight in the
-// stream, and is reported as a MultiModalFeature with its token offset and span.
-func (b estimateBackend) chatCompletionsBytes(chat *fwkrh.ChatCompletionsRequest, meta mmMetadata) ([]byte, []fwkrh.MultiModalFeature) {
-	var out []byte
-	var features []fwkrh.MultiModalFeature
-	if len(chat.Tools) > 0 {
-		if raw, err := json.Marshal(chat.Tools); err == nil {
-			out = append(out, raw...)
-		}
-	}
-	for _, msg := range chat.Messages {
-		out, features = b.appendChatMessage(out, features, msg, meta)
-	}
-	return out, features
+// estimatedTokenStream keeps text packing and multimodal placeholder packing
+// separate so UTF-8 padding cannot shift feature offsets or reinterpret hash bytes.
+type estimatedTokenStream struct {
+	tokens   []uint32
+	text     []byte
+	features []fwkrh.MultiModalFeature
+	rawBytes int
 }
 
-// appendChatMessage flattens a single chat-completions message into the byte
-// stream, recording multimodal placeholders on aligned boundaries.
-func (b estimateBackend) appendChatMessage(out []byte, features []fwkrh.MultiModalFeature, msg fwkrh.Message, meta mmMetadata) ([]byte, []fwkrh.MultiModalFeature) {
-	if msg.Role != "" {
-		out = append(out, []byte(msg.Role)...)
-	}
-	if msg.Content.Raw != "" {
-		out = append(out, []byte(msg.Content.Raw)...)
-		return out, features
-	}
-	for _, block := range msg.Content.Structured {
-		switch block.Type {
-		case blockTypeText:
-			out = append(out, []byte(block.Text)...)
-		case "image_url":
-			out, features = appendMMAsset(out, features, fwkrh.ModalityImage, block.ImageURL.URL, b.img.placeholderCount(block.ImageURL.URL))
-		case "video_url":
-			out, features = appendMMAsset(out, features, fwkrh.ModalityVideo, block.VideoURL.URL, b.vid.placeholderCount(meta.video))
-		case "input_audio", "audio_url":
-			data := block.InputAudio.Data + block.InputAudio.Format
-			out, features = appendMMAsset(out, features, fwkrh.ModalityAudio, data, assetPlaceholderCount(len(data)))
-		}
-	}
-	return out, features
+func (s *estimatedTokenStream) appendText(raw []byte) {
+	s.text = append(s.text, raw...)
+	s.rawBytes += len(raw)
 }
 
-// messagesBytes flattens an Anthropic /v1/messages request into pseudo-token
-// bytes.
-func (b estimateBackend) messagesBytes(req *fwkrh.MessagesRequest) ([]byte, []fwkrh.MultiModalFeature) {
-	var out []byte
-	var features []fwkrh.MultiModalFeature
-	if len(req.Tools) > 0 {
-		if raw, err := json.Marshal(req.Tools); err == nil {
-			out = append(out, raw...)
-		}
-	}
-	// The system field accepts only text -- a string or an array of text blocks.
-	// See https://docs.anthropic.com/en/api/messages#body-system.
-	if req.System.Raw != "" {
-		out = append(out, []byte(req.System.Raw)...)
-	} else {
-		for _, block := range req.System.Structured {
-			if block.Type == blockTypeText {
-				out = append(out, []byte(block.Text)...)
-			}
-		}
-	}
-	for _, msg := range req.Messages {
-		if msg.Role != "" {
-			out = append(out, []byte(msg.Role)...)
-		}
-		if msg.Content.Raw != "" {
-			out = append(out, []byte(msg.Content.Raw)...)
-			continue
-		}
-		for _, block := range msg.Content.Structured {
-			switch block.Type {
-			case blockTypeText:
-				out = append(out, []byte(block.Text)...)
-			case "image":
-				if content, count := b.img.placeholderForAnthropicImage(block.Source); content != "" {
-					out, features = appendMMAsset(out, features, fwkrh.ModalityImage, content, count)
-				}
-			}
-		}
-	}
-	return out, features
+func (s *estimatedTokenStream) flushText() {
+	s.tokens = append(s.tokens, packBytes(s.text)...)
+	s.text = s.text[:0]
 }
 
-// appendMMAsset aligns out to a token boundary, appends count placeholder
-// pseudo-tokens derived from a stable content hash, and records the matching
-// feature under modality so labels agree with the vllm backend.
-func appendMMAsset(out []byte, features []fwkrh.MultiModalFeature, modality fwkrh.Modality, content string, count int) ([]byte, []fwkrh.MultiModalFeature) {
-	out = align(out)
-	offset := len(out) / bytesPerToken
-
+func (s *estimatedTokenStream) appendMMAsset(modality fwkrh.Modality, content string, count int) {
+	s.flushText()
+	offset := len(s.tokens)
 	sum := xxhash.Sum64String(content)
-	token := make([]byte, bytesPerToken)
-	binary.LittleEndian.PutUint32(token, uint32(sum))
 	for i := 0; i < count; i++ {
-		out = append(out, token...)
+		s.tokens = append(s.tokens, uint32(sum))
 	}
-
-	features = append(features, fwkrh.MultiModalFeature{
+	s.rawBytes += count * bytesPerToken
+	s.features = append(s.features, fwkrh.MultiModalFeature{
 		Modality: modality,
 		Hash:     strconv.FormatUint(sum, 16),
 		Offset:   offset,
 		Length:   count,
 	})
-	return out, features
+}
+
+func (s *estimatedTokenStream) finish() ([]uint32, []fwkrh.MultiModalFeature, int) {
+	s.flushText()
+	return s.tokens, s.features, s.rawBytes
+}
+
+// chatCompletionsTokens flattens roles + text into pseudo-tokens and inserts
+// multimodal placeholders on token boundaries.
+func (b estimateBackend) chatCompletionsTokens(chat *fwkrh.ChatCompletionsRequest, meta mmMetadata) ([]uint32, []fwkrh.MultiModalFeature) {
+	var stream estimatedTokenStream
+	if len(chat.Tools) > 0 {
+		if raw, err := json.Marshal(chat.Tools); err == nil {
+			stream.appendText(raw)
+		}
+	}
+	for _, msg := range chat.Messages {
+		b.appendChatMessage(&stream, msg, meta)
+	}
+	tokens, features, _ := stream.finish()
+	return tokens, features
+}
+
+func (b estimateBackend) appendChatMessage(stream *estimatedTokenStream, msg fwkrh.Message, meta mmMetadata) {
+	if msg.Role != "" {
+		stream.appendText([]byte(msg.Role))
+	}
+	if msg.Content.Raw != "" {
+		stream.appendText([]byte(msg.Content.Raw))
+		return
+	}
+	for _, block := range msg.Content.Structured {
+		switch block.Type {
+		case blockTypeText:
+			stream.appendText([]byte(block.Text))
+		case "image_url":
+			stream.appendMMAsset(fwkrh.ModalityImage, block.ImageURL.URL, b.img.placeholderCount(block.ImageURL.URL))
+		case "video_url":
+			stream.appendMMAsset(fwkrh.ModalityVideo, block.VideoURL.URL, b.vid.placeholderCount(meta.video))
+		case "input_audio", "audio_url":
+			data := block.InputAudio.Data + block.InputAudio.Format
+			stream.appendMMAsset(fwkrh.ModalityAudio, data, assetPlaceholderCount(len(data)))
+		}
+	}
+}
+
+// messagesTokens flattens an Anthropic /v1/messages request into pseudo-tokens.
+func (b estimateBackend) messagesTokens(req *fwkrh.MessagesRequest) ([]uint32, []fwkrh.MultiModalFeature, int) {
+	var stream estimatedTokenStream
+	if len(req.Tools) > 0 {
+		if raw, err := json.Marshal(req.Tools); err == nil {
+			stream.appendText(raw)
+		}
+	}
+	// The system field accepts only text -- a string or an array of text blocks.
+	// See https://docs.anthropic.com/en/api/messages#body-system.
+	if req.System.Raw != "" {
+		stream.appendText([]byte(req.System.Raw))
+	} else {
+		for _, block := range req.System.Structured {
+			if block.Type == blockTypeText {
+				stream.appendText([]byte(block.Text))
+			}
+		}
+	}
+	for _, msg := range req.Messages {
+		if msg.Role != "" {
+			stream.appendText([]byte(msg.Role))
+		}
+		if msg.Content.Raw != "" {
+			stream.appendText([]byte(msg.Content.Raw))
+			continue
+		}
+		for _, block := range msg.Content.Structured {
+			switch block.Type {
+			case blockTypeText:
+				stream.appendText([]byte(block.Text))
+			case "image":
+				if content, count := b.img.placeholderForAnthropicImage(block.Source); content != "" {
+					stream.appendMMAsset(fwkrh.ModalityImage, content, count)
+				}
+			}
+		}
+	}
+	return stream.finish()
 }
 
 // assetPlaceholderCount derives a deterministic placeholder count (>= 1) from an
@@ -308,16 +318,36 @@ func assetPlaceholderCount(dataLen int) int {
 	return 1
 }
 
-// packBytes packs bytes into little-endian uint32 tokens (zero-padded tail).
-// Reinterpreting them reproduces the input, so locality keys are unchanged.
+// utf8CharSize returns the next valid UTF-8 character's byte length. Invalid
+// and truncated encodings consume one byte so packing always makes progress.
+func utf8CharSize(raw []byte) int {
+	_, size := utf8.DecodeRune(raw)
+	return size
+}
+
+// packBytes packs bytes into little-endian uint32 pseudo-tokens respecting
+// UTF-8 character boundaries. Unfilled trailing bytes are naturally zero-padded.
 func packBytes(raw []byte) []uint32 {
 	if len(raw) == 0 {
 		return nil
 	}
-	raw = align(raw)
-	out := make([]uint32, len(raw)/bytesPerToken)
-	for i := range out {
-		out[i] = binary.LittleEndian.Uint32(raw[i*bytesPerToken:])
+	out := make([]uint32, 0, (len(raw)+bytesPerToken-1)/bytesPerToken)
+	var slot [bytesPerToken]byte
+	pos := 0
+
+	for len(raw) > 0 {
+		size := utf8CharSize(raw)
+		if pos+size > bytesPerToken {
+			out = append(out, binary.LittleEndian.Uint32(slot[:]))
+			slot = [bytesPerToken]byte{}
+			pos = 0
+		}
+		copy(slot[pos:], raw[:size])
+		pos += size
+		raw = raw[size:]
+	}
+	if pos > 0 {
+		out = append(out, binary.LittleEndian.Uint32(slot[:]))
 	}
 	return out
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
@@ -18,6 +18,7 @@ package tokenizer
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"strconv"
 	"testing"
@@ -721,6 +722,111 @@ func TestEstimateBackend_MultiStringCompletionsPopulatesPerPromptTokens(t *testi
 	if tp.TokenCount() != len(tp.PerPromptTokens[0])+len(tp.PerPromptTokens[1]) {
 		t.Errorf("flat TokenIDs length %d != sum of per-prompt lengths %d+%d",
 			tp.TokenCount(), len(tp.PerPromptTokens[0]), len(tp.PerPromptTokens[1]))
+	}
+}
+
+// TestPackBytes_ASCII_Unchanged asserts that ASCII-only input produces identical
+// packed tokens before and after the UTF-8-aware rewrite, preserving cache keys.
+func TestPackBytes_ASCII_Unchanged(t *testing.T) {
+	raw := []byte("hello, llm-d!")
+	tokens := packBytes(raw)
+	aligned := align(raw)
+	expected := make([]uint32, len(aligned)/bytesPerToken)
+	for i := range expected {
+		expected[i] = binary.LittleEndian.Uint32(aligned[i*bytesPerToken:])
+	}
+	assert.Equal(t, expected, tokens, "ASCII-only output must match legacy 4-byte-slicing")
+}
+
+// TestPackBytes_Chinese_CharBoundary asserts each CJK character resides entirely
+// within one slot and is not split across slot boundaries.
+func TestPackBytes_Chinese_CharBoundary(t *testing.T) {
+	raw := []byte("路由缓存永不漂移")
+	tokens := packBytes(raw)
+	assert.Len(t, tokens, 8, "each 3-byte character gets its own slot")
+	assert.Equal(t, raw[0], byte(tokens[0]&0xFF), "first character leading byte must sit at slot start")
+}
+
+// TestPackBytes_Mixed_CJK_Latin asserts that mixed CJK and Latin text produces
+// correct character-aligned slots without splitting any character.
+func TestPackBytes_Mixed_CJK_Latin(t *testing.T) {
+	raw := []byte("all your 缓存 are belong to us")
+	tokens := packBytes(raw)
+	assert.NotEmpty(t, tokens, "mixed-language text must produce tokens")
+	assertNoCharSplit(t, tokens)
+}
+
+// TestPackBytes_Emoji_FourByte asserts that 4-byte UTF-8 characters (emoji) stay
+// in a single slot and do not get broken up.
+func TestPackBytes_Emoji_FourByte(t *testing.T) {
+	raw := []byte("🐱 llm-d → 月 ✨")
+	tokens := packBytes(raw)
+	assert.NotEmpty(t, tokens, "emoji-bearing text must produce tokens")
+	assertNoCharSplit(t, tokens)
+}
+
+// TestPackBytes_Invalid_UTF8 tolerates malformed bytes without crashing.
+func TestPackBytes_Invalid_UTF8(t *testing.T) {
+	raw := []byte{0x48, 0x65, 0x6C, 0x6C, 0x6F, 0xFE, 0x80, 0xBF, 0x21} // "Hello" + junk + "!"
+	tokens := packBytes(raw)
+	assert.NotEmpty(t, tokens, "invalid UTF-8 must not crash and still produce tokens")
+}
+
+func TestPackBytes_InvalidUTF8PreservesBytePacking(t *testing.T) {
+	raw := []byte{'A', 'B', 'C', 0xE2, 'D', 'E'}
+	aligned := align(append([]byte(nil), raw...))
+	expected := make([]uint32, len(aligned)/bytesPerToken)
+	for i := range expected {
+		expected[i] = binary.LittleEndian.Uint32(aligned[i*bytesPerToken:])
+	}
+
+	assert.Equal(t, expected, packBytes(raw))
+}
+
+// TestPackBytes_Empty covers nil and zero-length inputs.
+func TestPackBytes_Empty(t *testing.T) {
+	assert.Nil(t, packBytes(nil), "nil input must return nil")
+	assert.Nil(t, packBytes([]byte{}), "empty input must return nil")
+}
+
+func TestEstimatedTokenStream_MultimodalOffsetAfterUTF8Text(t *testing.T) {
+	const content = "image payload"
+	var stream estimatedTokenStream
+	stream.appendText([]byte("ab路"))
+	stream.appendMMAsset(fwkrh.ModalityImage, content, 1)
+
+	tokens, features, _ := stream.finish()
+	require.Len(t, features, 1)
+	feature := features[0]
+	require.Less(t, feature.Offset, len(tokens))
+	assert.Equal(
+		t,
+		uint32(xxhash.Sum64String(content)),
+		tokens[feature.Offset],
+		"feature offset must point to its placeholder token",
+	)
+}
+
+// assertNoCharSplit verifies every multi-byte UTF-8 character is wholly contained
+// within one slot, without checking exact byte correspondence against raw input.
+func assertNoCharSplit(t *testing.T, tokens []uint32) {
+	t.Helper()
+	for _, tok := range tokens {
+		b := [4]byte{
+			byte(tok & 0xFF),
+			byte((tok >> 8) & 0xFF),
+			byte((tok >> 16) & 0xFF),
+			byte((tok >> 24) & 0xFF),
+		}
+		used := 0
+		for i := 0; i < bytesPerToken; {
+			size := utf8CharSize(b[i:])
+			if used+size > bytesPerToken && size < bytesPerToken {
+				t.Fatalf("character split across slot boundary (token=%08x, slot byte %d)", tok, i)
+			}
+			used += size
+			i += size
+		}
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Two things here:

First — replace the fixed 4-byte slicing in `packBytes` with UTF-8 character-aware
packing. Before, 3-byte CJK characters (or 4-byte emoji) could land across two
pseudo-token slots, so any small edit to a non-ASCII prompt shifted every downstream
block hash and trashed the prefix cache. Now `utf8.DecodeRune` reads the character
boundary from the bytes themselves and packs whole characters per slot.

The original issue suggested making `bytesPerToken` configurable or adding language
presets — doesn't really work. One number can't handle mixed-language prompts (set
it to 3 and English wastes slots; set it to 4 and CJK breaks). UTF-8 already encodes
width in the leading byte. Just read it. No knob needed.

Second — @hhk7734 spotted that the original code mixed text bytes and multimodal
placeholder hashes into a single `[]byte` before feeding it to `packBytes`. When
`packBytes` inserted UTF-8 boundary padding, it shifted the placeholder offsets so
feature records pointed at wrong tokens. Fixed by splitting them into separate paths
via `estimatedTokenStream`: text is buffered and flushed through `packBytes` first,
then placeholder hashes are inserted directly as `uint32`. Offsets stay accurate
regardless of padding.

Pure ASCII output is byte-identical to the legacy loop. All existing tests pass
unchanged. New tests cover CJK, emoji, invalid UTF-8 byte packing, and multimodal
offset consistency after UTF-8 text.

Credit to @hhk7734 for catching the offset-shift bug.

**Which issue(s) this PR fixes**:

Fixes #1711

**Release note** _(write `NONE` if no user-facing change)_:

```release-note
Prefix-cache pseudo-token packing now respects UTF-8 character boundaries instead of
a fixed 4-byte stride. Pure ASCII prompts are unchanged. Non-ASCII prompts produce
character-aligned slots that prevent wholesale cache invalidation on small edits.
Multimodal placeholder offsets no longer drift from UTF-8 boundary padding.
```