### PR TITLE
feat(epp): add model-affinity-filter for multi-cluster model-aware routing

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -111,6 +111,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/bylabel"
 	endpointattributefilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/endpointattribute"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/modelaffinity"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity"
 	sessionaffinityfilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier"
@@ -630,6 +631,7 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(burstprefix.PluginType, fwkplugin.StabilityAlpha, burstprefix.Factory)
 	fwkplugin.Register(p2psource.PluginType, fwkplugin.StabilityAlpha, p2psource.PluginFactory)
 	// multicluster variants
+	fwkplugin.Register(modelaffinity.PluginType, fwkplugin.StabilityAlpha, modelaffinity.Factory)
 	fwkplugin.Register(sessionaffinityfilter.MultiClusterFilterType, fwkplugin.StabilityAlpha, sessionaffinityfilter.MultiClusterFactory)
 	fwkplugin.Register(queuedepth.MultiClusterScorerType, fwkplugin.StabilityAlpha, queuedepth.MultiClusterScorerFactory)
 	fwkplugin.Register(kvcacheutilization.MultiClusterScorerType, fwkplugin.StabilityAlpha, kvcacheutilization.MultiClusterScorerFactory)

--- a/pkg/epp/framework/plugins/scheduling/filter/modelaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/modelaffinity/README.md
@@ -1,0 +1,102 @@
+# Model Affinity Filter
+
+**Type:** `model-affinity-filter`
+
+**Interface:** `scheduling.Filter`
+
+Retains only candidate endpoints whose configured label value matches the
+request's target model. Designed for multi-cluster hub deployments where
+endpoints are discovered via `multicluster-file-discovery` and each endpoint
+entry is labelled with the model it serves.
+
+---
+
+## What It Does
+
+In a hub EPP topology, the EPP routes inference requests to downstream clusters
+(spokes). Each spoke typically serves a specific model. By labelling
+`multicluster-file-discovery` entries with their served model, this filter
+ensures that only spokes serving the requested model are considered as
+candidates - enabling model-aware routing without requiring per-model scheduler
+profiles.
+
+## Inputs Consumed
+
+- **Request header** (configurable, default: `x-gateway-model-name`) - set by
+  IPP's `body-field-to-header` plugin in the ext_proc chain before EPP.
+- **Fallback: request body `model` field** - parsed by the EPP director from
+  the JSON body (e.g., `{"model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0", ...}`).
+- Endpoint label matching the configured `labelKey` (default: `model`).
+
+## Configuration
+
+### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `labelKey` | `string` | No | `model` | The endpoint label key whose value is compared against the resolved model name. |
+| `modelHeader` | `string` | No | `x-gateway-model-name` | The request header from which the target model name is read. Set by IPP's `body-field-to-header` plugin. When not present, falls back to the body's `model` field. Set to empty string (`""`) to always use the body. |
+
+### Example
+
+```yaml
+plugins:
+  - type: model-affinity-filter
+    name: model-filter
+    parameters:
+      labelKey: model
+      modelHeader: x-gateway-model-name
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: model-filter
+```
+
+### Endpoints File (multicluster-file-discovery)
+
+```yaml
+endpoints:
+  - name: spoke1
+    address: inference-gateway.apps.spoke1.example.com
+    port: "443"
+    labels:
+      model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+      metricsAddress: epp-metrics.apps.spoke1.example.com
+      metricsPort: "443"
+  - name: spoke2
+    address: inference-gateway.apps.spoke2.example.com
+    port: "443"
+    labels:
+      model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+      metricsAddress: epp-metrics.apps.spoke2.example.com
+      metricsPort: "443"
+  - name: spoke3
+    address: inference-gateway.apps.spoke3.example.com
+    port: "443"
+    labels:
+      model: Qwen/Qwen2.5-0.5B-Instruct
+      metricsAddress: epp-metrics.apps.spoke3.example.com
+      metricsPort: "443"
+```
+
+With the above configuration, a request targeting `TinyLlama/TinyLlama-1.1B-Chat-v1.0`
+is routed only to `spoke1` and `spoke2`; a request for `Qwen/Qwen2.5-0.5B-Instruct`
+is routed only to `spoke3`.
+
+## Behaviour Details
+
+- **Model resolution order**: Header (`modelHeader`) -> body `model` field.
+- **No model resolved** (nil request, empty header, empty body): All
+  endpoints pass through unfiltered.
+- **Endpoints without the label**: Filtered out (they cannot match any model).
+- **No matching endpoints**: Returns an empty list - the scheduler reports a
+  routing error rather than sending to the wrong model server.
+
+## Limitations
+
+- Only exact string equality is checked against the label value - no wildcards,
+  prefix matching, or regular expressions.
+- Each endpoint can only carry a single value per label key. Endpoints serving
+  multiple models require one entry per model (with different names but the same
+  address).
+

--- a/pkg/epp/framework/plugins/scheduling/filter/modelaffinity/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/modelaffinity/doc.go
@@ -1,0 +1,3 @@
+// Package modelaffinity provides the model-affinity-filter scheduling plugin
+// for the EPP.
+package modelaffinity

--- a/pkg/epp/framework/plugins/scheduling/filter/modelaffinity/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/modelaffinity/filter.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modelaffinity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+const (
+	// PluginType is the registered type name for the model-affinity filter.
+	PluginType = "model-affinity-filter"
+
+	// DefaultLabelKey is the default endpoint label key inspected by the filter.
+	DefaultLabelKey = "model"
+
+	// DefaultModelHeader is the default request header from which the target
+	// model name is read. This is the header set by IPP's body-field-to-header
+	// plugin (model extractor) in the ext_proc chain.
+	DefaultModelHeader = "x-gateway-model-name"
+)
+
+// parameters is the user-facing configuration for the filter.
+type parameters struct {
+	// LabelKey is the endpoint label key whose value is compared against the
+	// resolved model name. Defaults to "model".
+	LabelKey string `json:"labelKey"`
+	// ModelHeader is the request header from which the target model name is
+	// read. When empty, the filter falls back to InferenceRequest.TargetModel
+	// (populated from the body's "model" field or x-llm-d-model-name-rewrite
+	// header). Set to "x-gateway-model-name" (default) when IPP's
+	// body-field-to-header plugin runs before EPP in the ext_proc chain.
+	ModelHeader string `json:"modelHeader"`
+}
+
+// compile-time interface assertion
+var _ scheduling.Filter = &ModelAffinityFilter{}
+
+// Factory is the plugin factory registered with the EPP framework.
+func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
+	params := parameters{
+		LabelKey:    DefaultLabelKey,
+		ModelHeader: DefaultModelHeader,
+	}
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&params); err != nil {
+			return nil, fmt.Errorf("failed to parse parameters for '%s' filter: %w", PluginType, err)
+		}
+	}
+	return New(name, params)
+}
+
+// New validates the parameters and returns a new ModelAffinityFilter.
+func New(name string, params parameters) (*ModelAffinityFilter, error) {
+	if name == "" {
+		return nil, errors.New("model-affinity-filter: name cannot be empty")
+	}
+	if params.LabelKey == "" {
+		params.LabelKey = DefaultLabelKey
+	}
+	return &ModelAffinityFilter{
+		typedName:   plugin.TypedName{Type: PluginType, Name: name},
+		labelKey:    params.LabelKey,
+		modelHeader: params.ModelHeader,
+	}, nil
+}
+
+// ModelAffinityFilter retains only candidate endpoints whose configured label
+// value matches the model name extracted from the request. The model name is
+// resolved from a configurable request header (set by IPP's body-field-to-header
+// plugin), falling back to InferenceRequest.TargetModel. In a multi-cluster hub
+// topology where endpoints are discovered via file-discovery, this enables
+// model-aware routing by labelling each endpoint entry with the model it serves.
+type ModelAffinityFilter struct {
+	typedName   plugin.TypedName
+	labelKey    string
+	modelHeader string
+}
+
+// TypedName returns the typed name of the plugin.
+func (f *ModelAffinityFilter) TypedName() plugin.TypedName {
+	return f.typedName
+}
+
+// Filter retains endpoints whose label value for the configured key matches
+// the resolved model name. The model is resolved by reading the configured
+// request header (typically set by IPP), falling back to TargetModel from the
+// request body. If no endpoint matches, an empty slice is returned so the
+// scheduler reports a routing error rather than sending to the wrong model.
+func (f *ModelAffinityFilter) Filter(ctx context.Context, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) []scheduling.Endpoint {
+	targetModel := f.resolveModelName(request)
+	if targetModel == "" {
+		log.FromContext(ctx).V(4).Info("model-affinity-filter: no target model resolved, passing all endpoints through")
+		return endpoints
+	}
+
+	filtered := make([]scheduling.Endpoint, 0, len(endpoints))
+
+	for _, ep := range endpoints {
+		labels := ep.GetMetadata().Labels
+		if labels == nil {
+			continue
+		}
+		if labels[f.labelKey] == targetModel {
+			filtered = append(filtered, ep)
+		}
+	}
+
+	if len(filtered) == 0 {
+		log.FromContext(ctx).V(2).Info("model-affinity-filter: no endpoints matched target model",
+			"targetModel", targetModel, "labelKey", f.labelKey, "candidateCount", len(endpoints))
+	}
+
+	return filtered
+}
+
+// resolveModelName extracts the target model name from the request. It first
+// checks the configured header (set by IPP's body-field-to-header plugin in
+// the ext_proc chain), then falls back to InferenceRequest.TargetModel (parsed
+// from body or x-llm-d-model-name-rewrite header by the EPP director).
+func (f *ModelAffinityFilter) resolveModelName(request *scheduling.InferenceRequest) string {
+	if request == nil {
+		return ""
+	}
+	if f.modelHeader != "" && request.Headers != nil {
+		if headerValue := request.Headers[f.modelHeader]; headerValue != "" {
+			return headerValue
+		}
+	}
+	return request.TargetModel
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/modelaffinity/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/modelaffinity/filter_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modelaffinity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+type fakeEndpoint struct {
+	meta *fwkdl.EndpointMetadata
+}
+
+func (f *fakeEndpoint) GetMetadata() *fwkdl.EndpointMetadata { return f.meta }
+func (f *fakeEndpoint) GetMetrics() *fwkdl.Metrics           { return nil }
+func (f *fakeEndpoint) String() string                       { return f.meta.Name }
+func (f *fakeEndpoint) Get(string) (fwkdl.Cloneable, bool)   { return nil, false }
+func (f *fakeEndpoint) Put(string, fwkdl.Cloneable)          {}
+func (f *fakeEndpoint) Keys() []string                       { return nil }
+func (f *fakeEndpoint) Clone() fwkdl.AttributeMap            { return nil }
+
+func ep(name string, labels map[string]string) scheduling.Endpoint {
+	return &fakeEndpoint{meta: &fwkdl.EndpointMetadata{Name: name, Labels: labels}}
+}
+
+func TestFactory(t *testing.T) {
+	t.Run("nil parameters uses defaults", func(t *testing.T) {
+		p, err := Factory("test", nil, nil)
+		require.NoError(t, err)
+		f := p.(*ModelAffinityFilter)
+		assert.Equal(t, DefaultLabelKey, f.labelKey)
+		assert.Equal(t, DefaultModelHeader, f.modelHeader)
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		_, err := Factory("", nil, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestFilter(t *testing.T) {
+	endpoints := []scheduling.Endpoint{
+		ep("spoke1", map[string]string{"model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0"}),
+		ep("spoke2", map[string]string{"model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0"}),
+		ep("spoke3", map[string]string{"model": "Qwen/Qwen2.5-0.5B-Instruct"}),
+	}
+
+	tests := []struct {
+		name         string
+		request      *scheduling.InferenceRequest
+		expected     []string
+		labelKey     string
+		modelHeader  string
+	}{
+		{
+			name: "filters by header",
+			request: &scheduling.InferenceRequest{
+				Headers: map[string]string{"x-gateway-model-name": "TinyLlama/TinyLlama-1.1B-Chat-v1.0"},
+			},
+			expected: []string{"spoke1", "spoke2"},
+		},
+		{
+			name: "filters by TargetModel fallback",
+			request: &scheduling.InferenceRequest{
+				TargetModel: "Qwen/Qwen2.5-0.5B-Instruct",
+			},
+			expected: []string{"spoke3"},
+		},
+		{
+			name:     "nil request passes all through",
+			request:  nil,
+			expected: []string{"spoke1", "spoke2", "spoke3"},
+		},
+		{
+			name: "no matching model returns empty",
+			request: &scheduling.InferenceRequest{
+				TargetModel: "nonexistent-model",
+			},
+			expected: []string{},
+		},
+		{
+			name: "header takes priority over TargetModel",
+			request: &scheduling.InferenceRequest{
+				Headers:     map[string]string{"x-gateway-model-name": "Qwen/Qwen2.5-0.5B-Instruct"},
+				TargetModel: "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+			},
+			expected: []string{"spoke3"},
+		},
+		{
+			name: "custom label key",
+			request: &scheduling.InferenceRequest{
+				TargetModel: "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+			},
+			labelKey: "served-model",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labelKey := tt.labelKey
+			if labelKey == "" {
+				labelKey = DefaultLabelKey
+			}
+			modelHeader := tt.modelHeader
+			if modelHeader == "" {
+				modelHeader = DefaultModelHeader
+			}
+
+			f, err := New("test", parameters{LabelKey: labelKey, ModelHeader: modelHeader})
+			require.NoError(t, err)
+
+			result := f.Filter(context.Background(), tt.request, endpoints)
+
+			names := make([]string, 0, len(result))
+			for _, ep := range result {
+				names = append(names, ep.GetMetadata().Name)
+			}
+			assert.Equal(t, tt.expected, names)
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds a new `model-affinity-filter` scheduling plugin for multi-cluster hub EPP deployments.

In a hub topology, the Hub EPP routes inference requests to downstream spoke clusters discovered via `multicluster-file-discovery`. Each spoke serves a specific model. This filter reads the target model name from the request (via the `x-gateway-model-name` header set by IPP, or falling back to the `model` field from the request body) and retains only endpoints whose `model` label matches - enabling model-aware routing without requiring per-model scheduler profiles.

**Which issue(s) this PR fixes**:

**Fixes**
#2332 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Add model-affinity-filter scheduling plugin for multi-cluster hub EPP deployments that filters endpoints by model label.