### PR TITLE
feat(epp): add multicluster-topology-scorer for topology aware routing

### DIFF
--- a/cmd/epp/runner/multicluster_config_test.go
+++ b/cmd/epp/runner/multicluster_config_test.go
@@ -79,6 +79,7 @@ func TestMultiClusterConfigLoad(t *testing.T) {
 				"session-affinity":  "multicluster-session-affinity-filter",
 				"kv-cache":          "multicluster-kv-cache-utilization-scorer",
 				"queue":             "multicluster-queue-scorer",
+				"geo":               "multicluster-topology-scorer",
 			} {
 				p := r.PluginHandle.Plugin(name)
 				require.NotNil(t, p, "plugin %q must resolve", name)
@@ -113,6 +114,11 @@ plugins:
     name: kv-cache
   - type: multicluster-queue-scorer
     name: queue
+  - type: multicluster-topology-scorer
+    name: geo
+    parameters:
+      weights:
+        east: 1
   - type: max-score-picker
   - type: single-profile-handler
 dataLayer:

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -635,6 +635,7 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(kvcacheutilization.MultiClusterScorerType, fwkplugin.StabilityAlpha, kvcacheutilization.MultiClusterScorerFactory)
 	fwkplugin.Register(prefix.MultiClusterScorerType, fwkplugin.StabilityAlpha, prefix.MultiClusterScorerFactory)
 	fwkplugin.Register(reqdataprodprefix.MultiClusterPluginType, fwkplugin.StabilityAlpha, reqdataprodprefix.MultiClusterFactory)
+	fwkplugin.Register(topologyaffinityscorer.MultiClusterPluginType, fwkplugin.StabilityAlpha, topologyaffinityscorer.MultiClusterFactory)
 
 	// Flow Control plugins
 	// Beta

--- a/pkg/epp/framework/plugins/README.md
+++ b/pkg/epp/framework/plugins/README.md
@@ -27,7 +27,12 @@ If an Alpha plugin is configured while `--allow-experimental-plugins` is not set
 
 ## Multi-cluster variants
 
-A few plugins ship a multi-cluster variant beside the stock plugin, for a cluster-scoped EPP whose candidate endpoints are clusters. The scheduling variants are `multicluster-kv-cache-utilization-scorer`, `multicluster-queue-scorer`, `multicluster-session-affinity-filter`, and `multicluster-prefix-cache-scorer`. The `multicluster-approx-prefix-cache-producer` is the matching request-control data producer. They rely on three datalayer variants: `multicluster-file-discovery` discovers peer clusters as endpoints, and `multicluster-metrics-data-source` with `multicluster-metrics-extractor` scrape each cluster and write its pool-aggregate metrics into the attributes the scorers read.
+A few plugins ship a multi-cluster variant beside the stock plugin, for a cluster-scoped EPP whose candidate endpoints are clusters.
+
+- Scheduling variants: `multicluster-kv-cache-utilization-scorer`, `multicluster-queue-scorer`, `multicluster-topology-scorer`, `multicluster-session-affinity-filter`, `multicluster-prefix-cache-scorer`.
+- Request-control data producer: `multicluster-approx-prefix-cache-producer`.
+- Datalayer variants: `multicluster-file-discovery` discovers peer clusters as endpoints; `multicluster-metrics-data-source` and `multicluster-metrics-extractor` scrape each cluster and write its pool-aggregate metrics into the attributes the scorers read.
+- `multicluster-topology-scorer` is the exception: it needs only `multicluster-file-discovery` plus `topology-extractor`, scoring clusters from a static per-gateway weight over a topology label (region by default) on each discovery entry, not from scraped metrics.
 
 The pure-delegation variants (`multicluster-session-affinity-filter`, `multicluster-prefix-cache-scorer`, `multicluster-approx-prefix-cache-producer`) reuse the stock plugin's behavior and only rename the type, so their per-plugin Prometheus metrics report under the stock type label rather than the multicluster one.
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
@@ -92,3 +92,45 @@ schedulingProfiles:
 
 The `topology-affinity-filter` plugin drops candidates below a minimum affinity instead
 of scoring them, and is the filtering counterpart of this scorer.
+
+## Multi-cluster support
+
+`multicluster-topology-scorer` is the cluster-scoped variant: over whole-cluster endpoints
+from `multicluster-file-discovery`, it scores each cluster by a static per-gateway `weights`
+map on one `Topology` field (default `region`; also `zone`, `rack`, `host`) instead of by peer
+proximity. Weights normalize by their max (top 1.0, ratios kept), so any non-negative scale
+works (`10`/`5` or `1`/`0.5`); at least one must be positive, negatives are rejected, and an
+unlisted value or missing `Topology` scores 0. Give it a profile weight above the load scorers
+so region dominates and queue/kv only break ties within a region; spill falls out of a
+capacity filter dropping the preferred region. It reads the base scorer's `Topology` attribute,
+so it needs `topology-extractor` (region label configured), not the metrics scrape pipeline.
+
+| Parameter               | Required | Default          | Description                                                                 |
+|-------------------------|----------|------------------|-----------------------------------------------------------------------------|
+| `weights`               | yes      |                  | Map of topology-field value to a relative weight (normalized by the max at load). A value absent from the map scores 0. |
+| `field`                 | no       | `region`         | Topology field the weights key on: `region`, `zone`, `rack`, or `host`.     |
+| `topologyProducerName`  | no       | default producer | `topology-extractor` instance to read the `Topology` attribute from.        |
+
+**Configuration Example (EAST gateway):**
+```yaml
+plugins:
+  - type: multicluster-file-discovery
+    name: discovery
+    parameters:
+      path: /etc/epp/clusters.yaml
+  - type: topology-extractor
+    parameters:
+      region: region
+  - type: multicluster-topology-scorer
+    name: geo
+    parameters:
+      field: region
+      weights:            # WEST gateway flips these to { west: 10, east: 5 }
+        east: 10
+        west: 5
+schedulingProfiles:
+  - name: clusters
+    plugins:
+      - pluginRef: geo
+        weight: 10
+```

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/multicluster.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologyaffinity
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+	topoutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/util/topology"
+)
+
+// MultiClusterPluginType is the cross-cluster topology scorer. Unlike
+// topology-affinity-scorer, which scores proximity to a peer endpoint, this
+// scorer scores against a configured weight table and needs no peer.
+const MultiClusterPluginType = "multicluster-topology-scorer"
+
+type multiClusterParameters struct {
+	// Field selects which Topology field the weights key on: region (default),
+	// zone, rack, or host.
+	Field string `json:"field,omitempty"`
+	// Weights maps a field value to its score. A value absent from the map
+	// scores 0, so an unlisted or unlabeled cluster is deprioritized, not dropped.
+	Weights map[string]float64 `json:"weights"`
+	// TopologyProducerName selects the topology-extractor instance to read from.
+	TopologyProducerName string `json:"topologyProducerName,omitempty"`
+}
+
+var (
+	_ fwksched.Scorer          = &MultiClusterScorer{}
+	_ fwkplugin.ConsumerPlugin = &MultiClusterScorer{}
+)
+
+// MultiClusterFactory builds the cross-cluster topology scorer.
+func MultiClusterFactory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	if rawParameters == nil {
+		return nil, errors.New(MultiClusterPluginType + " requires parameters")
+	}
+	params := multiClusterParameters{}
+	if err := rawParameters.Decode(&params); err != nil {
+		return nil, fmt.Errorf("decode %s parameters: %w", MultiClusterPluginType, err)
+	}
+	if len(params.Weights) == 0 {
+		return nil, errors.New(MultiClusterPluginType + " requires a non-empty weights map")
+	}
+	// The scheduler clamps each scorer output to [0,1] before weighting, so
+	// normalize by the max to keep the ratio between regions on any scale.
+	weights, err := normalizeWeights(params.Weights)
+	if err != nil {
+		return nil, err
+	}
+	level, err := topoutil.ParseLevel(cmp.Or(params.Field, topoutil.LevelRegion.String()))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", MultiClusterPluginType, err)
+	}
+	if name == "" {
+		name = MultiClusterPluginType
+	}
+	return &MultiClusterScorer{
+		typedName: fwkplugin.TypedName{Type: MultiClusterPluginType, Name: name},
+		selector:  fieldSelector(level),
+		weights:   weights,
+		dataKey:   attrtopology.TopologyAttributeKey.WithNonEmptyProducerName(params.TopologyProducerName),
+	}, nil
+}
+
+// MultiClusterScorer scores cluster endpoints by a static weight table over a
+// Topology field, instead of by proximity to a peer.
+type MultiClusterScorer struct {
+	typedName fwkplugin.TypedName
+	selector  func(*attrtopology.Topology) string
+	weights   map[string]float64
+	dataKey   fwkplugin.DataKey
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (s *MultiClusterScorer) TypedName() fwkplugin.TypedName { return s.typedName }
+
+// Category reports that this scorer expresses an affinity preference.
+func (s *MultiClusterScorer) Category() fwksched.ScorerCategory { return fwksched.Affinity }
+
+// Consumes marks Topology optional: a missing producer scores every endpoint 0
+// rather than failing, matching the topology-affinity-scorer.
+func (s *MultiClusterScorer) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
+		Optional: map[fwkplugin.DataKey]any{s.dataKey: attrtopology.Topology{}},
+	}
+}
+
+// Score returns the configured weight for each endpoint's topology field value.
+// Endpoints with no Topology attribute score 0.
+func (s *MultiClusterScorer) Score(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
+	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
+	for _, endpoint := range endpoints {
+		topology, ok := fwkdl.ReadAttribute[*attrtopology.Topology](endpoint, s.dataKey.String())
+		if !ok {
+			scores[endpoint] = 0
+			continue
+		}
+		scores[endpoint] = s.weights[s.selector(topology)]
+	}
+	return scores
+}
+
+// normalizeWeights scales the table so its largest value is 1.0, keeping the
+// ratios between values. Weights must be non-negative with at least one positive.
+func normalizeWeights(weights map[string]float64) (map[string]float64, error) {
+	maxW := 0.0
+	for value, w := range weights {
+		if w < 0 {
+			return nil, fmt.Errorf("%s weight for %q must be non-negative, got %v", MultiClusterPluginType, value, w)
+		}
+		maxW = max(maxW, w)
+	}
+	if maxW == 0 {
+		return nil, errors.New(MultiClusterPluginType + " requires at least one positive weight")
+	}
+	normalized := make(map[string]float64, len(weights))
+	for value, w := range weights {
+		normalized[value] = w / maxW
+	}
+	return normalized, nil
+}
+
+// fieldSelector returns the accessor for a validated topology level. ParseLevel
+// has already rejected any other value, so the default reads region.
+func fieldSelector(level topoutil.Level) func(*attrtopology.Topology) string {
+	switch level {
+	case topoutil.LevelHost:
+		return func(t *attrtopology.Topology) string { return t.Hostname }
+	case topoutil.LevelRack:
+		return func(t *attrtopology.Topology) string { return t.Rack }
+	case topoutil.LevelZone:
+		return func(t *attrtopology.Topology) string { return t.Zone }
+	default:
+		return func(t *attrtopology.Topology) string { return t.Region }
+	}
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/multicluster_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/multicluster_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologyaffinity
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+)
+
+func newScorer(t *testing.T, params string) *MultiClusterScorer {
+	t.Helper()
+	p, err := MultiClusterFactory("test", json.NewDecoder(strings.NewReader(params)), nil)
+	require.NoError(t, err)
+	s, ok := p.(*MultiClusterScorer)
+	require.True(t, ok)
+	return s
+}
+
+func TestMultiClusterScorer_WeightByRegion(t *testing.T) {
+	s := newScorer(t, `{"weights":{"east":1.0,"west":0.5}}`)
+
+	east := makeEndpoint(t, "east", &attrtopology.Topology{Region: "east"})
+	west := makeEndpoint(t, "west", &attrtopology.Topology{Region: "west"})
+	unlisted := makeEndpoint(t, "unlisted", &attrtopology.Topology{Region: "central"})
+	noTopo := makeEndpoint(t, "no-topo", nil)
+
+	got := s.Score(context.Background(), &fwksched.InferenceRequest{},
+		[]fwksched.Endpoint{east, west, unlisted, noTopo})
+
+	assert.Equal(t, 1.0, got[east])
+	assert.Equal(t, 0.5, got[west])
+	assert.Equal(t, 0.0, got[unlisted], "a region absent from the weights table scores 0, not dropped")
+	assert.Equal(t, 0.0, got[noTopo], "an endpoint with no Topology attribute scores 0")
+}
+
+func TestMultiClusterScorer_NormalizesWeightsByMax(t *testing.T) {
+	// 10 and 5 must not both clamp to 1.0 in the scheduler; normalization by the
+	// max keeps the ratio so the preference survives.
+	s := newScorer(t, `{"weights":{"east":10,"west":5}}`)
+
+	east := makeEndpoint(t, "east", &attrtopology.Topology{Region: "east"})
+	west := makeEndpoint(t, "west", &attrtopology.Topology{Region: "west"})
+
+	got := s.Score(context.Background(), &fwksched.InferenceRequest{},
+		[]fwksched.Endpoint{east, west})
+
+	assert.Equal(t, 1.0, got[east])
+	assert.Equal(t, 0.5, got[west])
+}
+
+func TestMultiClusterScorer_ConfigurableField(t *testing.T) {
+	s := newScorer(t, `{"field":"zone","weights":{"z1":1.0}}`)
+
+	inZone := makeEndpoint(t, "in-zone", &attrtopology.Topology{Zone: "z1", Region: "east"})
+	otherZone := makeEndpoint(t, "other-zone", &attrtopology.Topology{Zone: "z2", Region: "east"})
+
+	got := s.Score(context.Background(), &fwksched.InferenceRequest{},
+		[]fwksched.Endpoint{inZone, otherZone})
+
+	assert.Equal(t, 1.0, got[inZone])
+	assert.Equal(t, 0.0, got[otherZone], "weights key on zone, not region, when field is zone")
+}
+
+func TestMultiClusterScorer_ProducerScopedKey(t *testing.T) {
+	s := newScorer(t, `{"weights":{"east":1.0},"topologyProducerName":"topo2"}`)
+
+	meta := &fwkdl.EndpointMetadata{ID: types.NamespacedName{Name: "east", Namespace: "default"}}
+	ep := fwksched.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
+	ep.Put(attrtopology.TopologyAttributeKey.WithNonEmptyProducerName("topo2").String(),
+		&attrtopology.Topology{Region: "east"})
+
+	got := s.Score(context.Background(), &fwksched.InferenceRequest{}, []fwksched.Endpoint{ep})
+	assert.Equal(t, 1.0, got[ep], "reads the Topology attribute under the configured producer name")
+}
+
+func TestMultiClusterScorer_Category(t *testing.T) {
+	s := newScorer(t, `{"weights":{"east":1.0}}`)
+	assert.Equal(t, fwksched.Affinity, s.Category())
+}
+
+func TestMultiClusterScorer_Consumes(t *testing.T) {
+	s := newScorer(t, `{"weights":{"east":1.0}}`)
+
+	consumes := s.Consumes()
+
+	assert.Empty(t, consumes.Required)
+	require.Len(t, consumes.Optional, 1)
+	assert.Equal(t, attrtopology.Topology{}, consumes.Optional[s.dataKey])
+}
+
+func TestMultiClusterFactory_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  *json.Decoder
+		wantErr string
+	}{
+		{name: "nil params", params: nil, wantErr: "requires parameters"},
+		{name: "empty weights", params: json.NewDecoder(strings.NewReader(`{"weights":{}}`)), wantErr: "non-empty weights"},
+		{name: "no weights key", params: json.NewDecoder(strings.NewReader(`{"field":"region"}`)), wantErr: "non-empty weights"},
+		{name: "negative weight", params: json.NewDecoder(strings.NewReader(`{"weights":{"east":-1}}`)), wantErr: "non-negative"},
+		{name: "all-zero weights", params: json.NewDecoder(strings.NewReader(`{"weights":{"east":0}}`)), wantErr: "at least one positive"},
+		{name: "bad field", params: json.NewDecoder(strings.NewReader(`{"field":"bogus","weights":{"east":1.0}}`)), wantErr: "must be one of"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := MultiClusterFactory("", tc.params, nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestMultiClusterFactory_DefaultFieldAndName(t *testing.T) {
+	p, err := MultiClusterFactory("", json.NewDecoder(strings.NewReader(`{"weights":{"east":1.0}}`)), nil)
+	require.NoError(t, err)
+	s, ok := p.(*MultiClusterScorer)
+	require.True(t, ok)
+	assert.Equal(t, MultiClusterPluginType, s.TypedName().Name, "name defaults to the type")
+
+	east := makeEndpoint(t, "east", &attrtopology.Topology{Region: "east"})
+	got := s.Score(context.Background(), &fwksched.InferenceRequest{}, []fwksched.Endpoint{east})
+	assert.Equal(t, 1.0, got[east], "field defaults to region")
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds `multicluster-topology-scorer`, a cluster-scoped scorer that grades whole-cluster
endpoints by a static per-gateway weight over a `Topology` field (region by default). A
gateway weights its own region highest, so it prefers local clusters and spills elsewhere
only when a capacity filter drops the preferred ones.

It reads the `Topology` attribute from `topology-extractor` (populated from
`multicluster-file-discovery` labels), so it needs no peer like `topology-affinity-scorer`
and no metrics scrape like the multicluster metric scorers. Registered as an alpha variant
in the `topologyaffinity` package; adds tests and README docs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
