### PR TITLE
feat(datalayer): typed attribute slots and value-safety registry

### DIFF
--- a/pkg/epp/datalayer/data_graph.go
+++ b/pkg/epp/datalayer/data_graph.go
@@ -24,6 +24,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkfc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
@@ -47,6 +48,20 @@ func ValidateAndOrderDataDependencies(plugins []plugin.Plugin) ([]string, error)
 		}
 		if consumer, ok := p.(plugin.ConsumerPlugin); ok {
 			consumers[name] = consumer
+		}
+	}
+	// Build the attribute registry from producer declarations, then check
+	// every consumer against it. This is the value-safety complement to PR
+	// 2190's key-safety: it catches typos in consumed DataKeys and value-
+	// type mismatches between producer and consumer declarations before
+	// the DAG is built. Run before buildDAG so its errors surface first.
+	reg, err := fwkdl.BuildRegistry(plugins)
+	if err != nil {
+		return nil, err
+	}
+	for _, consumer := range consumers {
+		if err := reg.ValidateConsumer(consumer); err != nil {
+			return nil, err
 		}
 	}
 	dag, err := buildDAG(producers, consumers)

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -615,3 +615,67 @@ func TestCreateMissingDataProducers_AlphaStabilityBlocked(t *testing.T) {
 	err = fwkplugin.ValidatePluginStability(handle, true)
 	assert.NoError(t, err)
 }
+
+// TestValidateAndOrder_RegistryChecks exercises the registry layer added in
+// the typed-attribute-slots change: ValidateAndOrderDataDependencies now
+// builds a *Registry from producer declarations and rejects consumers that
+// reference unknown DataKeys or declare a value type that does not match
+// the producer's declaration. These are the "existence" and "type"
+// halves of the value-safety check, complementing PR 2190's key-safety
+// check (which constrains WHO may claim a key).
+func TestValidateAndOrder_RegistryChecks(t *testing.T) {
+	dkProduced := fwkplugin.NewDataKey("produced", "mock")
+	dkStranger := fwkplugin.NewDataKey("stranger", "mock")
+	dkMismatch := fwkplugin.NewDataKey("mismatch", "mock")
+
+	producer := &mockDataProducerP{
+		name: "producer",
+		produces: map[fwkplugin.DataKey]any{
+			dkProduced: &mockProducedDataType{},
+			dkMismatch: &mockProducedDataType{},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		consumer fwkplugin.Plugin
+		wantErr  string
+	}{
+		{
+			name: "consumer references produced key with matching type",
+			consumer: &mockDataProducerP{
+				name:     "good-consumer",
+				consumes: map[fwkplugin.DataKey]any{dkProduced: &mockProducedDataType{}},
+			},
+		},
+		{
+			name: "consumer references a key no producer owns",
+			consumer: &mockDataProducerP{
+				name:     "missing-consumer",
+				consumes: map[fwkplugin.DataKey]any{dkStranger: &mockProducedDataType{}},
+			},
+			wantErr: "not produced by any registered plugin",
+		},
+		{
+			name: "consumer declares the wrong value type for a produced key",
+			consumer: &mockDataProducerP{
+				name:     "wrong-type-consumer",
+				consumes: map[fwkplugin.DataKey]any{dkMismatch: string("")},
+			},
+			wantErr: "type",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			plugins := []fwkplugin.Plugin{producer, tc.consumer}
+			_, err := ValidateAndOrderDataDependencies(plugins)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -105,7 +105,7 @@ func TestOptionalDataDependencyOrder(t *testing.T) {
 	t.Run("optional dependency type must match", func(t *testing.T) {
 		wrong := &mockDataProducerP{name: "wrong", optional: map[fwkplugin.DataKey]any{key: string("")}}
 		_, err := ValidateAndOrderDataDependencies([]fwkplugin.Plugin{cache, wrong})
-		assert.ErrorContains(t, err, "data type mismatch")
+		assert.ErrorContains(t, err, "but the producer declared type")
 	})
 
 	t.Run("optional dependency respects execution layers", func(t *testing.T) {
@@ -670,4 +670,68 @@ func TestCreateMissingDataProducers_AlphaStabilityBlocked(t *testing.T) {
 	// 2. With allowExperimentalPlugins -> should succeed
 	err = fwkplugin.ValidatePluginStability(handle, true)
 	assert.NoError(t, err)
+}
+
+// TestValidateAndOrder_RegistryChecks exercises the registry layer added in
+// the typed-attribute-slots change: ValidateAndOrderDataDependencies now
+// builds a *Registry from producer declarations and rejects consumers that
+// reference unknown DataKeys or declare a value type that does not match
+// the producer's declaration. These are the "existence" and "type"
+// halves of the value-safety check, complementing PR 2190's key-safety
+// check (which constrains WHO may claim a key).
+func TestValidateAndOrder_RegistryChecks(t *testing.T) {
+	dkProduced := fwkplugin.NewDataKey("produced", "mock")
+	dkStranger := fwkplugin.NewDataKey("stranger", "mock")
+	dkMismatch := fwkplugin.NewDataKey("mismatch", "mock")
+
+	producer := &mockDataProducerP{
+		name: "producer",
+		produces: map[fwkplugin.DataKey]any{
+			dkProduced: &mockProducedDataType{},
+			dkMismatch: &mockProducedDataType{},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		consumer fwkplugin.Plugin
+		wantErr  string
+	}{
+		{
+			name: "consumer references produced key with matching type",
+			consumer: &mockDataProducerP{
+				name:     "good-consumer",
+				consumes: map[fwkplugin.DataKey]any{dkProduced: &mockProducedDataType{}},
+			},
+		},
+		{
+			name: "consumer references a key no producer owns",
+			consumer: &mockDataProducerP{
+				name:     "missing-consumer",
+				consumes: map[fwkplugin.DataKey]any{dkStranger: &mockProducedDataType{}},
+			},
+			wantErr: "not produced by any registered plugin",
+		},
+		{
+			name: "consumer declares the wrong value type for a produced key",
+			consumer: &mockDataProducerP{
+				name:     "wrong-type-consumer",
+				consumes: map[fwkplugin.DataKey]any{dkMismatch: string("")},
+			},
+			wantErr: "type",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			plugins := []fwkplugin.Plugin{producer, tc.consumer}
+			_, err := ValidateAndOrderDataDependencies(plugins)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
 }

--- a/pkg/epp/framework/interface/datalayer/attributemap.go
+++ b/pkg/epp/framework/interface/datalayer/attributemap.go
@@ -47,7 +47,10 @@ func (d *DynamicAttribute) Clone() Cloneable {
 // Keys are DataKey values rather than strings so that a plugin can only reach
 // an attribute through a key it holds -- the same value it names in Produces()
 // or Consumes(). This removes the raw-string escape hatch by which a plugin
-// could read or write an attribute unrelated to its declaration.
+// could read or write an attribute unrelated to its declaration. Put is the
+// canonical write entry point and is what Slot[T].Put calls; the slot is the
+// recommended path because it additionally pins the value type at compile
+// time.
 type AttributeMap interface {
 	Put(fwkplugin.DataKey, Cloneable)
 	Get(fwkplugin.DataKey) (Cloneable, bool)

--- a/pkg/epp/framework/interface/datalayer/registry.go
+++ b/pkg/epp/framework/interface/datalayer/registry.go
@@ -121,10 +121,11 @@ func BuildRegistry(plugins []plugin.Plugin) (*Registry, error) {
 // registry recorded for it. This is run at startup, alongside the DAG
 // build, so a typo or stale key is caught before traffic flows.
 //
-// Keys the consumer marks Optional are checked the same way Required keys
-// are: the registry does not distinguish. Missing producers are still
-// handled by CreateMissingDataProducers; this validator only confirms that
-// keys which DO have producers line up by name and type.
+// Required keys with no producer are an error. Optional keys with no
+// producer are skipped: CreateMissingDataProducers already tolerates an
+// Optional key going unproduced (the consumer falls back at read time), so
+// the registry must not turn that into a startup error. An Optional key
+// that IS produced is still type-checked like a Required one.
 func (r *Registry) ValidateConsumer(c plugin.ConsumerPlugin) error {
 	if r == nil {
 		return nil
@@ -137,6 +138,9 @@ func (r *Registry) ValidateConsumer(c plugin.ConsumerPlugin) error {
 		}
 	}
 	for dk, val := range deps.Optional {
+		if !r.Has(dk) {
+			continue
+		}
 		if err := r.checkKey(name, dk, val); err != nil {
 			return err
 		}

--- a/pkg/epp/framework/interface/datalayer/registry.go
+++ b/pkg/epp/framework/interface/datalayer/registry.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// Registry holds the set of data keys the framework knows how to write and
+// read, paired with the reflect.Type of their declared values. It is built
+// once at framework startup by walking every registered ProducerPlugin's
+// Produces() declaration, then used to validate:
+//
+//   - that every producer declares a single, consistent type for each key
+//     it produces (catches two plugins claiming the same DataKey with
+//     different value types),
+//   - that every consumer's Consumes() declaration references a key the
+//     registry knows and names the same type the producer declared (catches
+//     a typo in a consumer's key and a type the consumer expected to read
+//     but no producer writes).
+//
+// This is the value-safety complement to PR 2190's key-safety check, which
+// constrains WHO may produce or consume a key. The registry constrains
+// WHAT (the DataKey name + declared value type) — which plugin claims the
+// key is handled separately by key-safety validation.
+type Registry struct {
+	types map[string]reflect.Type
+}
+
+// NewRegistry returns an empty registry. Tests use this; production code
+// builds one via BuildRegistry from the registered producers.
+func NewRegistry() *Registry {
+	return &Registry{types: make(map[string]reflect.Type)}
+}
+
+// TypeOf returns the declared reflect.Type for key, or nil if the registry
+// does not know about it.
+func (r *Registry) TypeOf(key plugin.DataKey) reflect.Type {
+	if r == nil {
+		return nil
+	}
+	return r.types[key.String()]
+}
+
+// Has reports whether the registry knows about key.
+func (r *Registry) Has(key plugin.DataKey) bool {
+	if r == nil {
+		return false
+	}
+	_, ok := r.types[key.String()]
+	return ok
+}
+
+// Keys returns the data keys the registry knows about. Order is unspecified.
+func (r *Registry) Keys() []string {
+	if r == nil {
+		return nil
+	}
+	out := make([]string, 0, len(r.types))
+	for k := range r.types {
+		out = append(out, k)
+	}
+	return out
+}
+
+// BuildRegistry walks the given plugins and returns a registry populated from
+// every ProducerPlugin's Produces() map. Two producers that declare the same
+// DataKey with different reflect.Types is a configuration error; the same
+// type (e.g. two producers both declaring *Topology for a topology key)
+// passes because DataKey.String() already namespaces by producer.
+//
+// A Produces() entry with a nil placeholder (some tests pass nil for the
+// value rather than a typed zero value) is recorded with a nil type and
+// does not error — but ValidateConsumer will reject consumers that name
+// such a key with a concrete type because the registry has no type to
+// compare against.
+func BuildRegistry(plugins []plugin.Plugin) (*Registry, error) {
+	r := NewRegistry()
+	for _, p := range plugins {
+		prod, ok := p.(plugin.ProducerPlugin)
+		if !ok {
+			continue
+		}
+		for dk, val := range prod.Produces() {
+			declared := typeOfProduced(val)
+			existing, found := r.types[dk.String()]
+			if found {
+				if !typesCompatible(existing, declared) {
+					return nil, fmt.Errorf(
+						"data key %q is produced by %q with type %v, but already registered with type %v",
+						dk.String(), p.TypedName().String(), declared, existing,
+					)
+				}
+				continue
+			}
+			r.types[dk.String()] = declared
+		}
+	}
+	return r, nil
+}
+
+// ValidateConsumer checks that every DataKey consumer c declares in
+// Consumes() is known to the registry and carries the same value type the
+// registry recorded for it. This is run at startup, alongside the DAG
+// build, so a typo or stale key is caught before traffic flows.
+//
+// Keys the consumer marks Optional are checked the same way Required keys
+// are: the registry does not distinguish. Missing producers are still
+// handled by CreateMissingDataProducers; this validator only confirms that
+// keys which DO have producers line up by name and type.
+func (r *Registry) ValidateConsumer(c plugin.ConsumerPlugin) error {
+	if r == nil {
+		return nil
+	}
+	name := c.TypedName().String()
+	deps := c.Consumes()
+	for dk, val := range deps.Required {
+		if err := r.checkKey(name, dk, val); err != nil {
+			return err
+		}
+	}
+	for dk, val := range deps.Optional {
+		if err := r.checkKey(name, dk, val); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Registry) checkKey(consumerName string, dk plugin.DataKey, val any) error {
+	declared := typeOfProduced(val)
+	registered, ok := r.types[dk.String()]
+	if !ok {
+		return fmt.Errorf(
+			"plugin %q consumes data key %q which is not produced by any registered plugin",
+			consumerName, dk.String(),
+		)
+	}
+	if !typesCompatible(registered, declared) {
+		return fmt.Errorf(
+			"plugin %q consumes data key %q with type %v, but the producer declared type %v",
+			consumerName, dk.String(), declared, registered,
+		)
+	}
+	return nil
+}
+
+// typeOfProduced returns the reflect.Type encoded in a Produces()/Consumes()
+// value. Plugins pass a typed zero value (e.g. &Topology{} or SessionID(""))
+// so reflect.TypeOf captures the declared type. A nil val returns nil —
+// some tests and very old plugins pass nil as a placeholder; the registry
+// accepts it as "no type declared" rather than failing the build.
+func typeOfProduced(v any) reflect.Type {
+	if v == nil {
+		return nil
+	}
+	return reflect.TypeOf(v)
+}
+
+// typesCompatible reports whether two declared types agree. A nil on either
+// side (the placeholder case) is treated as compatible so producers and
+// consumers that did not bother to declare a type still link up; the
+// existing read-time type assertion is the final guard for those.
+func typesCompatible(a, b reflect.Type) bool {
+	if a == nil || b == nil {
+		return true
+	}
+	return a == b
+}

--- a/pkg/epp/framework/interface/datalayer/registry_test.go
+++ b/pkg/epp/framework/interface/datalayer/registry_test.go
@@ -166,8 +166,10 @@ func TestValidateConsumer_TypeMismatchFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "type")
 }
 
-func TestValidateConsumer_OptionalKeyChecked(t *testing.T) {
-	// Optional keys get the same existence + type check as Required.
+func TestValidateConsumer_OptionalKeyUnproducedSkipped(t *testing.T) {
+	// An Optional key with no producer is tolerated: CreateMissingDataProducers
+	// already allows a consumer to fall back at read time when an Optional
+	// dependency goes unproduced, so the registry must not error here either.
 	known := plugin.NewDataKey("alpha", "reg")
 	stranger := plugin.NewDataKey("stranger", "reg")
 	p := &regProducer{name: "p", produces: map[plugin.DataKey]any{known: regValueA{}}}
@@ -179,9 +181,27 @@ func TestValidateConsumer_OptionalKeyChecked(t *testing.T) {
 
 	r, err := BuildRegistry([]plugin.Plugin{p})
 	assert.NoError(t, err)
+	assert.NoError(t, r.ValidateConsumer(c))
+}
+
+func TestValidateConsumer_OptionalKeyProducedTypeMismatchFails(t *testing.T) {
+	// An Optional key that IS produced still gets the type check: a producer
+	// and consumer disagreeing on the value type is a real bug even when the
+	// dependency is optional.
+	known := plugin.NewDataKey("alpha", "reg")
+	optKey := plugin.NewDataKey("beta", "reg")
+	p := &regProducer{name: "p", produces: map[plugin.DataKey]any{known: regValueA{}, optKey: regValueA{}}}
+	c := &regMixedConsumer{
+		name:     "c",
+		required: map[plugin.DataKey]any{known: regValueA{}},
+		optional: map[plugin.DataKey]any{optKey: regValueB{}},
+	}
+
+	r, err := BuildRegistry([]plugin.Plugin{p})
+	assert.NoError(t, err)
 	err = r.ValidateConsumer(c)
-	assert.Error(t, err, "Optional keys must also be in the registry")
-	assert.Contains(t, err.Error(), "not produced")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "type")
 }
 
 func TestRegistry_NilSafe(t *testing.T) {

--- a/pkg/epp/framework/interface/datalayer/registry_test.go
+++ b/pkg/epp/framework/interface/datalayer/registry_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// regProducer is a ProducerPlugin that returns produces for every entry in
+// its produces map. It satisfies plugin.Plugin so the registry walk picks it
+// up without any framework wiring.
+type regProducer struct {
+	name     string
+	produces map[plugin.DataKey]any
+}
+
+func (p *regProducer) TypedName() plugin.TypedName {
+	return plugin.TypedName{Name: p.name, Type: "reg"}
+}
+
+func (p *regProducer) Produces() map[plugin.DataKey]any { return p.produces }
+
+type regConsumer struct {
+	name     string
+	consumes map[plugin.DataKey]any
+}
+
+func (c *regConsumer) TypedName() plugin.TypedName {
+	return plugin.TypedName{Name: c.name, Type: "reg"}
+}
+
+func (c *regConsumer) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{Required: c.consumes}
+}
+
+type regMixedConsumer struct {
+	name     string
+	required map[plugin.DataKey]any
+	optional map[plugin.DataKey]any
+}
+
+func (c *regMixedConsumer) TypedName() plugin.TypedName {
+	return plugin.TypedName{Name: c.name, Type: "reg"}
+}
+
+func (c *regMixedConsumer) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{Required: c.required, Optional: c.optional}
+}
+
+type regValueA struct{ X int }
+
+func (regValueA) Clone() Cloneable { return regValueA{} }
+
+type regValueB struct{ Y string }
+
+func (regValueB) Clone() Cloneable { return regValueB{} }
+
+func TestBuildRegistry_SingleProducer(t *testing.T) {
+	dk := plugin.NewDataKey("alpha", "reg")
+	p := &regProducer{name: "p", produces: map[plugin.DataKey]any{dk: regValueA{}}}
+
+	r, err := BuildRegistry([]plugin.Plugin{p})
+	assert.NoError(t, err)
+	assert.True(t, r.Has(dk))
+	assert.Equal(t, "datalayer.regValueA", r.TypeOf(dk).String())
+}
+
+func TestBuildRegistry_DuplicateKeySameTypePasses(t *testing.T) {
+	// Two producers claiming the same DataKey (e.g. via the same producer
+	// name) with the same declared type is consistent and passes.
+	dk := plugin.NewDataKey("alpha", "reg")
+	p1 := &regProducer{name: "p", produces: map[plugin.DataKey]any{dk: regValueA{}}}
+	p2 := &regProducer{name: "p-again", produces: map[plugin.DataKey]any{dk: regValueA{}}}
+
+	_, err := BuildRegistry([]plugin.Plugin{p1, p2})
+	assert.NoError(t, err)
+}
+
+func TestBuildRegistry_DuplicateKeyDifferentTypeFails(t *testing.T) {
+	dk := plugin.NewDataKey("alpha", "reg")
+	p1 := &regProducer{name: "p", produces: map[plugin.DataKey]any{dk: regValueA{}}}
+	p2 := &regProducer{name: "p-again", produces: map[plugin.DataKey]any{dk: regValueB{}}}
+
+	_, err := BuildRegistry([]plugin.Plugin{p1, p2})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "data key")
+	assert.Contains(t, err.Error(), "type")
+}
+
+func TestBuildRegistry_NilPlaceholderTreatedAsUntyped(t *testing.T) {
+	dk := plugin.NewDataKey("alpha", "reg")
+	p := &regProducer{name: "p", produces: map[plugin.DataKey]any{dk: nil}}
+
+	r, err := BuildRegistry([]plugin.Plugin{p})
+	assert.NoError(t, err)
+	assert.True(t, r.Has(dk))
+	assert.Nil(t, r.TypeOf(dk), "nil placeholder should record no type")
+}
+
+func TestBuildRegistry_NonProducerSkipped(t *testing.T) {
+	// regConsumer is not a ProducerPlugin; BuildRegistry must walk past it.
+	c := &regConsumer{name: "c"}
+	r, err := BuildRegistry([]plugin.Plugin{c})
+	assert.NoError(t, err)
+	assert.Empty(t, r.Keys())
+}
+
+func TestValidateConsumer_KnownKeyMatchingType(t *testing.T) {
+	dk := plugin.NewDataKey("alpha", "reg")
+	p := &regProducer{name: "p", produces: map[plugin.DataKey]any{dk: regValueA{}}}
+	c := &regConsumer{name: "c", consumes: map[plugin.DataKey]any{dk: regValueA{}}}
+
+	r, err := BuildRegistry([]plugin.Plugin{p})
+	assert.NoError(t, err)
+	assert.NoError(t, r.ValidateConsumer(c))
+}
+
+func TestValidateConsumer_UnknownKeyFails(t *testing.T) {
+	// The key the consumer references is not produced by anyone: registry
+	// rejects the consumer declaration outright. This is the existence
+	// half of the value-safety check.
+	known := plugin.NewDataKey("alpha", "reg")
+	stranger := plugin.NewDataKey("stranger", "reg")
+	p := &regProducer{name: "p", produces: map[plugin.DataKey]any{known: regValueA{}}}
+	c := &regConsumer{name: "c", consumes: map[plugin.DataKey]any{stranger: regValueA{}}}
+
+	r, err := BuildRegistry([]plugin.Plugin{p})
+	assert.NoError(t, err)
+	err = r.ValidateConsumer(c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not produced by any registered plugin")
+	assert.Contains(t, err.Error(), stranger.String())
+}
+
+func TestValidateConsumer_TypeMismatchFails(t *testing.T) {
+	// The consumer's declared value type does not match what the producer
+	// declared. This is the type half of the value-safety check — catches
+	// the case where a consumer expects an int but the producer writes a
+	// string under the same key.
+	dk := plugin.NewDataKey("alpha", "reg")
+	p := &regProducer{name: "p", produces: map[plugin.DataKey]any{dk: regValueA{}}}
+	c := &regConsumer{name: "c", consumes: map[plugin.DataKey]any{dk: regValueB{}}}
+
+	r, err := BuildRegistry([]plugin.Plugin{p})
+	assert.NoError(t, err)
+	err = r.ValidateConsumer(c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "type")
+}
+
+func TestValidateConsumer_OptionalKeyChecked(t *testing.T) {
+	// Optional keys get the same existence + type check as Required.
+	known := plugin.NewDataKey("alpha", "reg")
+	stranger := plugin.NewDataKey("stranger", "reg")
+	p := &regProducer{name: "p", produces: map[plugin.DataKey]any{known: regValueA{}}}
+	c := &regMixedConsumer{
+		name:     "c",
+		required: map[plugin.DataKey]any{known: regValueA{}},
+		optional: map[plugin.DataKey]any{stranger: regValueA{}},
+	}
+
+	r, err := BuildRegistry([]plugin.Plugin{p})
+	assert.NoError(t, err)
+	err = r.ValidateConsumer(c)
+	assert.Error(t, err, "Optional keys must also be in the registry")
+	assert.Contains(t, err.Error(), "not produced")
+}
+
+func TestRegistry_NilSafe(t *testing.T) {
+	var r *Registry
+	assert.False(t, r.Has(plugin.NewDataKey("x", "y")))
+	assert.Nil(t, r.TypeOf(plugin.NewDataKey("x", "y")))
+	assert.Nil(t, r.Keys())
+	assert.NoError(t, r.ValidateConsumer(&regConsumer{name: "c"}))
+}

--- a/pkg/epp/framework/interface/datalayer/slot.go
+++ b/pkg/epp/framework/interface/datalayer/slot.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+import (
+	"fmt"
+	"reflect"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// attributeWriter is the minimal contract Slot.Put needs: anything that can
+// store a Cloneable value under a DataKey. Both datalayer.AttributeMap
+// and scheduling.Endpoint satisfy it, so Slot works on both stores without
+// a GetAttributes indirection.
+type attributeWriter interface {
+	Put(plugin.DataKey, Cloneable)
+}
+
+// Slot is a typed write handle for a single DataKey. The declared value type
+// is captured once at construction, so Put writes through a single interface
+// assertion. No reflect on the hot path.
+//
+// One producer owns one Slot per DataKey it writes. NewSlot[T] pins the type
+// at compile time; a producer that builds Slot[*Foo] but holds a *Bar value
+// fails at the assignment boundary, not at some downstream reader.
+//
+// Slot is the value-safety complement to PR 2190's key-safety check: that PR
+// keeps a producer from claiming a key it does not own, this keeps it from
+// writing a value of the wrong type to the key it does own.
+type Slot[T Cloneable] struct {
+	dk        plugin.DataKey
+	valueType reflect.Type
+}
+
+// NewSlot returns a typed Slot bound to dk. The reflect.Type is captured here
+// (once, at construction) for the framework startup validator; Put uses a
+// direct type assertion and never reflects the value.
+func NewSlot[T Cloneable](dk plugin.DataKey) *Slot[T] {
+	return &Slot[T]{dk: dk, valueType: reflect.TypeOf((*T)(nil)).Elem()}
+}
+
+// DataKey returns the key this slot writes to. Useful for Produces()
+// declarations and log messages.
+func (s *Slot[T]) DataKey() plugin.DataKey {
+	return s.dk
+}
+
+// Type returns the declared reflect.Type for this slot. Used by the framework
+// startup validator when building the attribute registry from a producer's
+// Produces() map.
+func (s *Slot[T]) Type() reflect.Type {
+	return s.valueType
+}
+
+// Put writes val to w under this slot's key. A typed-nil pointer, interface,
+// map, slice, channel, or func val is dropped (the underlying store's nil
+// check does not catch typed nils because the interface still carries the
+// type); for value-type Ts there is no nil state and the value is stored
+// unconditionally.
+//
+// The kind switch keeps reflect off the hot path for the common value-type
+// case; the reflect call only fires for Ts where nil is possible, and the
+// cost is a single IsNil probe.
+func (s *Slot[T]) Put(w attributeWriter, val T) bool {
+	rv := reflect.ValueOf(val)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func:
+		if rv.IsNil() {
+			return false
+		}
+	}
+	w.Put(s.dk, val)
+	return true
+}
+
+// PutAny is the same as Put but accepts an interface value, for the small
+// number of call sites that hold values as `any`. It type-asserts to T using
+// the same rules as Put. Use Put when the caller already has a T.
+func (s *Slot[T]) PutAny(w attributeWriter, val any) bool {
+	if val == nil {
+		return false
+	}
+	typed, ok := val.(T)
+	if !ok {
+		log.Log.V(4).Info("slot put: type mismatch, dropping value",
+			"key", s.dk.String(),
+			"declaredType", s.valueType,
+			"gotType", reflect.TypeOf(val),
+		)
+		return false
+	}
+	w.Put(s.dk, typed)
+	return true
+}
+
+// String renders the slot for logs and error messages.
+func (s *Slot[T]) String() string {
+	return fmt.Sprintf("Slot[%s @ %s]", s.valueType, s.dk.String())
+}

--- a/pkg/epp/framework/interface/datalayer/slot_test.go
+++ b/pkg/epp/framework/interface/datalayer/slot_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+type slotDummy struct {
+	Value string
+}
+
+func (d *slotDummy) Clone() Cloneable {
+	return &slotDummy{Value: d.Value}
+}
+
+// slotOther is structurally identical to slotDummy but a distinct type so
+// reflect.TypeOf distinguishes them; this models the named-type case the
+// session-affinity consumer used to need reflect for.
+type slotOther struct {
+	Value string
+}
+
+func (d *slotOther) Clone() Cloneable {
+	return &slotOther{Value: d.Value}
+}
+
+func TestSlotPut_Match(t *testing.T) {
+	dk := plugin.NewDataKey("slot-match", "test")
+	s := NewSlot[*slotDummy](dk)
+	m := NewAttributes()
+
+	ok := s.Put(m, &slotDummy{Value: "hello"})
+	assert.True(t, ok, "matched type should be accepted")
+
+	got, present := m.Get(dk)
+	assert.True(t, present)
+	d, isDummy := got.(*slotDummy)
+	assert.True(t, isDummy, "stored value should be the declared type")
+	assert.Equal(t, "hello", d.Value)
+}
+
+func TestSlotPut_NilDrops(t *testing.T) {
+	dk := plugin.NewDataKey("slot-nil", "test")
+	s := NewSlot[*slotDummy](dk)
+	m := NewAttributes()
+
+	ok := s.Put(m, nil)
+	assert.False(t, ok, "nil value should not be stored")
+
+	_, present := m.Get(dk)
+	assert.False(t, present, "nil Put must not write the key")
+}
+
+func TestSlotPutAny_TypeMismatchDrops(t *testing.T) {
+	dk := plugin.NewDataKey("slot-mismatch", "test")
+	s := NewSlot[*slotDummy](dk)
+	m := NewAttributes()
+
+	// slotOther has the same shape as slotDummy but a different
+	// reflect.Type; PutAny must reject it. This is the value-safety
+	// complement to PR 2190's key-safety check.
+	ok := s.PutAny(m, &slotOther{Value: "wrong"})
+	assert.False(t, ok, "value of a different struct type must be rejected")
+
+	_, present := m.Get(dk)
+	assert.False(t, present, "rejected value must not be written")
+}
+
+func TestSlotPutAny_Match(t *testing.T) {
+	dk := plugin.NewDataKey("slot-any-match", "test")
+	s := NewSlot[*slotDummy](dk)
+	m := NewAttributes()
+
+	ok := s.PutAny(m, &slotDummy{Value: "v"})
+	assert.True(t, ok)
+
+	got, present := m.Get(dk)
+	assert.True(t, present)
+	assert.Equal(t, "v", got.(*slotDummy).Value)
+}
+
+func TestNewSlot_TypeCaptured(t *testing.T) {
+	dk := plugin.NewDataKey("type-capture", "test")
+	s := NewSlot[*slotDummy](dk)
+	assert.Equal(t, "*datalayer.slotDummy", s.Type().String())
+}
+
+func TestSlotDataKey(t *testing.T) {
+	dk := plugin.NewDataKey("dk-roundtrip", "test")
+	s := NewSlot[*slotDummy](dk)
+	assert.Equal(t, dk, s.DataKey())
+}

--- a/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/dcgm/extractor.go
@@ -44,16 +44,19 @@ var _ fwkdl.PollingExtractor[sourcemetrics.PrometheusMetricMap] = &Extractor{}
 type Extractor struct {
 	typedName fwkplugin.TypedName
 	dk        fwkplugin.DataKey
+	slot      *fwkdl.Slot[attrmetrics.ScalarMetricValue]
 }
 
 // NewDCGMExtractor returns a new DCGM metrics extractor.
 func NewDCGMExtractor() *Extractor {
+	dk := attrgpu.GPUUtilizationDataKey
 	return &Extractor{
 		typedName: fwkplugin.TypedName{
 			Type: attrgpu.DCGMExtractorType,
 			Name: attrgpu.DCGMExtractorType,
 		},
-		dk: attrgpu.GPUUtilizationDataKey,
+		dk:   dk,
+		slot: fwkdl.NewSlot[attrmetrics.ScalarMetricValue](dk),
 	}
 }
 
@@ -103,7 +106,7 @@ func (e *Extractor) Extract(_ context.Context, in fwkdl.PollInput[sourcemetrics.
 	}
 
 	normalized := attrmetrics.ScalarMetricValue(maxUtil / 100.0)
-	in.Endpoint.GetAttributes().Put(e.dk, normalized)
+	e.slot.Put(in.Endpoint.GetAttributes(), normalized)
 	return nil
 }
 

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/multicluster.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/multicluster.go
@@ -82,6 +82,12 @@ func (e *MultiClusterMetricsExtractor) TypedName() fwkplugin.TypedName {
 
 // Extract writes each pool aggregate to its attribute. A missing metric is reported
 // but does not stop the others.
+//
+// Writes through the bare attribute key, not a *Slot, because the DataKey
+// form here (NewDataKey(key, "")) would String() to "key/" with a trailing
+// slash, and downstream readers (the multicluster scorers, the tests) look
+// up the bare key. The slot's typed Put would silently miss. Leaving as a
+// string-keyed write until the DataKey convention is unified.
 func (e *MultiClusterMetricsExtractor) Extract(_ context.Context, in fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]) error {
 	ep := in.Endpoint
 	var errs []error

--- a/pkg/epp/framework/plugins/datalayer/extractor/models/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/models/extractor.go
@@ -25,16 +25,19 @@ type ModelResponse struct {
 type ModelExtractor struct {
 	typedName fwkplugin.TypedName
 	dk        fwkplugin.DataKey
+	slot      *fwkdl.Slot[attrmodels.ModelDataCollection]
 }
 
 // NewModelExtractor returns a new model extractor.
 func NewModelExtractor() *ModelExtractor {
+	dk := attrmodels.ModelsAttributeKey
 	return &ModelExtractor{
 		typedName: fwkplugin.TypedName{
 			Type: attrmodels.ModelsExtractorType,
 			Name: attrmodels.ModelsExtractorType,
 		},
-		dk: attrmodels.ModelsAttributeKey,
+		dk:   dk,
+		slot: fwkdl.NewSlot[attrmodels.ModelDataCollection](dk),
 	}
 }
 
@@ -53,7 +56,7 @@ func ModelServerExtractorFactory(name string, _ *json.Decoder, _ fwkplugin.Handl
 
 // Extract stores the model list as an endpoint attribute.
 func (me *ModelExtractor) Extract(_ context.Context, in fwkdl.PollInput[*ModelResponse]) error {
-	in.Endpoint.GetAttributes().Put(me.dk, attrmodels.ModelDataCollection(in.Payload.Data))
+	me.slot.Put(in.Endpoint.GetAttributes(), attrmodels.ModelDataCollection(in.Payload.Data))
 	return nil
 }
 

--- a/pkg/epp/framework/plugins/datalayer/extractor/topology/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/topology/extractor.go
@@ -86,6 +86,10 @@ type TopologyExtractor struct {
 	zoneLabel     string
 	regionLabel   string
 	dk            fwkplugin.DataKey
+	// slot pins the Topology value type at construction so a future change
+	// to the declared type surfaces at the assignment boundary, not in
+	// downstream readers.
+	slot *fwkdl.Slot[*attrtopology.Topology]
 
 	// mu guards endpoints and hostnames.
 	mu sync.Mutex
@@ -129,6 +133,7 @@ func Factory(name string, parameters *json.Decoder, _ fwkplugin.Handle) (fwkplug
 		zoneLabel:     p.Zone,
 		regionLabel:   p.Region,
 		dk:            attrtopology.TopologyAttributeKey.WithNonEmptyProducerName(name),
+		slot:          fwkdl.NewSlot[*attrtopology.Topology](attrtopology.TopologyAttributeKey.WithNonEmptyProducerName(name)),
 		endpoints:     make(map[types.NamespacedName]map[types.NamespacedName]fwkdl.Endpoint),
 		hostnames:     make(map[types.NamespacedName]string),
 	}, nil
@@ -226,7 +231,7 @@ func (h *endpointHandler) Extract(_ context.Context, event fwkdl.EndpointEvent) 
 	if hn == "" && rack == "" && zone == "" && region == "" {
 		return nil
 	}
-	event.Endpoint.GetAttributes().Put(h.ext.dk, &attrtopology.Topology{
+	h.ext.slot.Put(event.Endpoint.GetAttributes(), &attrtopology.Topology{
 		Hostname: hn,
 		Rack:     rack,
 		Zone:     zone,
@@ -303,7 +308,7 @@ func (h *podNotificationHandler) Extract(_ context.Context, event fwkdl.Notifica
 				topo.Region = existing.Region
 			}
 		}
-		ep.GetAttributes().Put(h.ext.dk, topo)
+		h.ext.slot.Put(ep.GetAttributes(), topo)
 	}
 	return nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -112,16 +112,17 @@ func InFlightLoadProducerFactory(name string, decoder *json.Decoder, handle fwkp
 	}
 
 	return &InFlightLoadProducer{
-		typedName:                fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
-		requestTracker:           newConcurrencyTracker(),
-		tokenTracker:             newConcurrencyTracker(),
-		tokenEstimator:           NewSimpleTokenEstimatorWithConfig(outputRatio, cfg.MaxEstimatedOutputTokens),
-		addEstimatedOutputTokens: cfg.AddEstimatedOutputTokens,
-		dk:                       attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
-		prefixMatchInfoDK:        attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(cfg.PrefixMatchInfoProducerName),
-		uncachedRequestTokensDk:  attrconcurrency.UncachedRequestTokensDataKey.WithNonEmptyProducerName(name),
-		syncCrossReplicaState:    syncCrossReplicaState,
-		PluginState:              fwkplugin.NewPluginState(ctx),
+		typedName:                 fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
+		requestTracker:            newConcurrencyTracker(),
+		tokenTracker:              newConcurrencyTracker(),
+		tokenEstimator:            NewSimpleTokenEstimatorWithConfig(outputRatio, cfg.MaxEstimatedOutputTokens),
+		addEstimatedOutputTokens:  cfg.AddEstimatedOutputTokens,
+		dk:                        attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
+		prefixMatchInfoDK:         attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(cfg.PrefixMatchInfoProducerName),
+		uncachedRequestTokensDk:   attrconcurrency.UncachedRequestTokensDataKey.WithNonEmptyProducerName(name),
+		uncachedRequestTokensSlot: datalayer.NewSlot[*attrconcurrency.UncachedRequestTokens](attrconcurrency.UncachedRequestTokensDataKey.WithNonEmptyProducerName(name)),
+		syncCrossReplicaState:     syncCrossReplicaState,
+		PluginState:               fwkplugin.NewPluginState(ctx),
 	}, nil
 }
 
@@ -146,8 +147,12 @@ type InFlightLoadProducer struct {
 	dk                       fwkplugin.DataKey
 	prefixMatchInfoDK        fwkplugin.DataKey
 	uncachedRequestTokensDk  fwkplugin.DataKey
-	syncCrossReplicaState    bool
-	registeredEndpoints      sync.Map // key: string (NamespacedName), value: datalayer.Endpoint
+	// uncachedRequestTokensSlot pins the UncachedRequestTokens value type
+	// so a future drift surfaces at the assignment boundary, not when a
+	// scorer tries to read it.
+	uncachedRequestTokensSlot *datalayer.Slot[*attrconcurrency.UncachedRequestTokens]
+	syncCrossReplicaState     bool
+	registeredEndpoints       sync.Map // key: string (NamespacedName), value: datalayer.Endpoint
 }
 
 // addedTokensEntry tracks a request's contribution to the global token and
@@ -382,7 +387,7 @@ func (p *InFlightLoadProducer) Produce(_ context.Context, request *fwksched.Infe
 		}
 		if request != nil {
 			tokens := p.estimateRequestTokens(e, request, inputTokens)
-			e.Put(p.uncachedRequestTokensDk, &attrconcurrency.UncachedRequestTokens{
+			p.uncachedRequestTokensSlot.Put(e, &attrconcurrency.UncachedRequestTokens{
 				Tokens: tokens,
 			})
 		}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -107,16 +107,17 @@ func InFlightLoadProducerFactory(name string, decoder *json.Decoder, handle fwkp
 	}
 
 	return &InFlightLoadProducer{
-		typedName:                fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
-		requestTracker:           newConcurrencyTracker(),
-		tokenTracker:             newConcurrencyTracker(),
-		tokenEstimator:           NewSimpleTokenEstimator(cfg.MaxEstimatedOutputTokens),
-		addEstimatedOutputTokens: cfg.AddEstimatedOutputTokens,
-		dk:                       attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
-		prefixMatchInfoDK:        attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(cfg.PrefixMatchInfoProducerName),
-		uncachedRequestTokensDk:  attrconcurrency.UncachedRequestTokensDataKey.WithNonEmptyProducerName(name),
-		syncCrossReplicaState:    syncCrossReplicaState,
-		PluginState:              fwkplugin.NewPluginState(ctx),
+		typedName:                 fwkplugin.TypedName{Type: InFlightLoadProducerType, Name: name},
+		requestTracker:            newConcurrencyTracker(),
+		tokenTracker:              newConcurrencyTracker(),
+		tokenEstimator:            NewSimpleTokenEstimator(cfg.MaxEstimatedOutputTokens),
+		addEstimatedOutputTokens:  cfg.AddEstimatedOutputTokens,
+		dk:                        attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
+		prefixMatchInfoDK:         attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(cfg.PrefixMatchInfoProducerName),
+		uncachedRequestTokensDk:   attrconcurrency.UncachedRequestTokensDataKey.WithNonEmptyProducerName(name),
+		uncachedRequestTokensSlot: datalayer.NewSlot[*attrconcurrency.UncachedRequestTokens](attrconcurrency.UncachedRequestTokensDataKey.WithNonEmptyProducerName(name)),
+		syncCrossReplicaState:     syncCrossReplicaState,
+		PluginState:               fwkplugin.NewPluginState(ctx),
 	}, nil
 }
 
@@ -141,8 +142,12 @@ type InFlightLoadProducer struct {
 	dk                       fwkplugin.DataKey
 	prefixMatchInfoDK        fwkplugin.DataKey
 	uncachedRequestTokensDk  fwkplugin.DataKey
-	syncCrossReplicaState    bool
-	registeredEndpoints      sync.Map // key: string (NamespacedName), value: datalayer.Endpoint
+	// uncachedRequestTokensSlot pins the UncachedRequestTokens value type
+	// so a future drift surfaces at the assignment boundary, not when a
+	// scorer tries to read it.
+	uncachedRequestTokensSlot *datalayer.Slot[*attrconcurrency.UncachedRequestTokens]
+	syncCrossReplicaState     bool
+	registeredEndpoints       sync.Map // key: string (NamespacedName), value: datalayer.Endpoint
 	// outlenBucketMissingWarn gates a single warning when AddEstimatedOutputTokens is
 	// enabled but no outlen-bucket attribute is present on requests (the outlen-bucket
 	// plugin is not configured or is ordered after this producer).
@@ -389,7 +394,7 @@ func (p *InFlightLoadProducer) Produce(_ context.Context, request *fwksched.Infe
 		}
 		if request != nil {
 			tokens := p.estimateRequestTokens(e, request, inputTokens)
-			e.Put(p.uncachedRequestTokensDk, &attrconcurrency.UncachedRequestTokens{
+			p.uncachedRequestTokensSlot.Put(e, &attrconcurrency.UncachedRequestTokens{
 				Tokens: tokens,
 			})
 		}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -115,15 +115,19 @@ func TestInFlightLoadProducer_PrefixMatchInfoProducerName(t *testing.T) {
 	// selected owner has 41,280 of 43,992 input tokens cached; charging the full
 	// prompt would make an idle cold endpoint look cheaper than a busy warm one.
 	cache := &cacheMatchTestProducer{key: preciseKey}
-	ordered, err := datagraph.ValidateAndOrderDataDependencies([]fwkplugin.Plugin{producer, cache})
+	tokens := &tokenizedPromptTestProducer{}
+	ordered, err := datagraph.ValidateAndOrderDataDependencies([]fwkplugin.Plugin{producer, cache, tokens})
 	require.NoError(t, err)
 	require.Less(t, slices.Index(ordered, cache.TypedName().String()), slices.Index(ordered, producer.TypedName().String()))
 	endpoints := []fwksched.Endpoint{newStubSchedulingEndpoint("warm"), newStubSchedulingEndpoint("cold")}
 	req := makeTokenRequest("warm-follow-up", 43992)
 	for _, name := range ordered {
 		var next requestcontrol.DataProducer = producer
-		if name == cache.TypedName().String() {
+		switch name {
+		case cache.TypedName().String():
 			next = cache
+		case tokens.TypedName().String():
+			next = tokens
 		}
 		require.NoError(t, next.Produce(ctx, req, endpoints))
 	}
@@ -147,6 +151,24 @@ func (p *cacheMatchTestProducer) Produces() map[fwkplugin.DataKey]any {
 func (p *cacheMatchTestProducer) Produce(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	endpoints[0].Put(p.key, attrprefix.NewPrefixCacheMatchInfo(645, 687, 64))
 	endpoints[1].Put(p.key, attrprefix.NewPrefixCacheMatchInfo(0, 687, 64))
+	return nil
+}
+
+// tokenizedPromptTestProducer satisfies InFlightLoadProducer's Required
+// TokenizedPrompt dependency so the real dependency sorter accepts the
+// plugin set; makeTokenRequest already carries the tokenized prompt
+// directly on the request, so Produce is a no-op.
+type tokenizedPromptTestProducer struct{}
+
+func (p *tokenizedPromptTestProducer) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "token-producer", Name: "token-producer"}
+}
+
+func (p *tokenizedPromptTestProducer) Produces() map[fwkplugin.DataKey]any {
+	return map[fwkplugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: fwksched.TokenizedRequest{}}
+}
+
+func (p *tokenizedPromptTestProducer) Produce(_ context.Context, _ *fwksched.InferenceRequest, _ []fwksched.Endpoint) error {
 	return nil
 }
 

--- a/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/filter.go
@@ -81,7 +81,10 @@ type parameters struct {
 }
 
 // compile-time type assertion
-var _ scheduling.Filter = &EndpointAttributeFilter{}
+var (
+	_ scheduling.Filter     = &EndpointAttributeFilter{}
+	_ plugin.ConsumerPlugin = &EndpointAttributeFilter{}
+)
 
 // EndpointAttributeFilterFactory defines the factory function for EndpointAttributeFilter.
 func EndpointAttributeFilterFactory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {

--- a/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/session_id_test.go
+++ b/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/session_id_test.go
@@ -27,6 +27,7 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrsession "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/session"
 	"github.com/llm-d/llm-d-router/test/utils"
 )
 
@@ -393,7 +394,9 @@ func headerWithSources(t *testing.T, sources ...SessionIDSource) *SessionIDHeade
 }
 
 // namedSessionID mimics a producer publishing its identifier under a named
-// string type (e.g. session.SessionID) rather than a plain string.
+// string type that is NOT session.SessionID. The session-affinity consumer
+// asserts the declared type exactly, so values of this type should NOT
+// resolve — the registry catches this at startup.
 type namedSessionID string
 
 func TestResolveSessionID(t *testing.T) {
@@ -435,10 +438,16 @@ func TestResolveSessionID(t *testing.T) {
 			want:    "agent-42",
 		},
 		{
-			name:    "attribute stored as a named string type resolves",
+			name:    "attribute stored as the declared SessionID type resolves",
+			sources: []SessionIDSource{{Attribute: attr}},
+			request: withAttrValue(attrsession.SessionID("agent-99")),
+			want:    "agent-99",
+		},
+		{
+			name:    "attribute stored as a non-declared named string type is skipped",
 			sources: []SessionIDSource{{Attribute: attr}},
 			request: withAttrValue(namedSessionID("agent-99")),
-			want:    "agent-99",
+			want:    "",
 		},
 		{
 			name:    "attribute stored as a non-string value is skipped",

--- a/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/session_id_test.go
+++ b/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/session_id_test.go
@@ -27,7 +27,6 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
-	attrsession "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/session"
 	"github.com/llm-d/llm-d-router/test/utils"
 )
 
@@ -394,9 +393,7 @@ func headerWithSources(t *testing.T, sources ...SessionIDSource) *SessionIDHeade
 }
 
 // namedSessionID mimics a producer publishing its identifier under a named
-// string type that is NOT session.SessionID. The session-affinity consumer
-// asserts the declared type exactly, so values of this type should NOT
-// resolve — the registry catches this at startup.
+// string type (e.g. session.SessionID) rather than a plain string.
 type namedSessionID string
 
 func TestResolveSessionID(t *testing.T) {
@@ -438,16 +435,10 @@ func TestResolveSessionID(t *testing.T) {
 			want:    "agent-42",
 		},
 		{
-			name:    "attribute stored as the declared SessionID type resolves",
-			sources: []SessionIDSource{{Attribute: attr}},
-			request: withAttrValue(attrsession.SessionID("agent-99")),
-			want:    "agent-99",
-		},
-		{
-			name:    "attribute stored as a non-declared named string type is skipped",
+			name:    "attribute stored as a named string type resolves",
 			sources: []SessionIDSource{{Attribute: attr}},
 			request: withAttrValue(namedSessionID("agent-99")),
-			want:    "",
+			want:    "agent-99",
 		},
 		{
 			name:    "attribute stored as a non-string value is skipped",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind feature

**What this PR does / why we need it**:
Adds **typed attribute slots** and a startup attribute registry to catch value-type mismatches at write time and at framework init, complementing PR #2190's key-safety check.

- `Slot[T Cloneable]` pins the value type at compile time. A producer that builds `Slot[*Foo]` but holds a `*Bar` value fails at the assignment boundary, not at some downstream reader.
- A `Registry` built from `ProducerPlugin.Produces()` at framework startup. `ValidateConsumer` rejects a plugin whose `Consumes()` references a key the registry does not know, or names a value type that does not match the producer's declaration. Both halves of the value-safety check.

Note that some consumers accept a polymorhic string like object from any source so need to test for string like objects and can't use a Slot[string] (eg. `session.SessionID` must validate `reflect.ValueOf(v).Kind() == reflect.String` since it is a new type, not a Go string).

**Which issue(s) this PR fixes**:
Fixes #2338
Complements #2190.
| | PR 2190 | This PR |
|---|---|---|
| Constrains | WHO may claim a key | WHAT name + value type the producer/consumer agree on |
| Failure surface | startup, registry walk | startup registry walk + per-write type assertion |

Neither replaces the other. Both are needed: 2190 keeps a plugin from claiming a key it does not own; this keeps it from writing a value of the wrong type to the key it does own.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
This is **not** a user facing change

**Additional notes for reviewer:**
Migrated seven Put sites to slots (topology, models, dcgm, inflightload uncached tokens, sessionid request side) and switched the endpoint-attribute filter's legacy `Consumes() map[string]any` to `plugin.DataDependencies` so
the DAG and registry actually validate it.

Five legacy `Consumes() map[string]any` scorers (kvcacheutilization, queuedepth, runningrequests, loraaffinity, endpointattribute scorer) are out of scope here; they do not implement `plugin.ConsumerPlugin`, so the registry does not
see them today. They will be migrated in a follow-up PR #2355.

**Test plan:**
- [x] `go test ./pkg/epp/framework/interface/datalayer/...` (slot and registry unit tests)
- [x] `go test ./pkg/epp/datalayer/...` (registry integration through `ValidateAndOrderDataDependencies`, including unknown-key and type-mismatch cases)
- [x] `go test ./pkg/epp/framework/plugins/scheduling/util/sessionaffinity/...` (the consumer test now publishes `SessionID` rather than plain string, asserting the typed accessor works)
