### PR TITLE
feat(coordinator): proxy unregistered paths to the decode profile

### DIFF
--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -91,7 +91,7 @@ func main() {
 	}
 
 	p := pipeline.New(steps)
-	srv, err := server.New(cfg.Server, p)
+	srv, err := server.New(cfg.Server, p, gwClient)
 	if err != nil {
 		log.Error(err, "failed to create server")
 		os.Exit(1)

--- a/pkg/coordinator/server/handlers_test.go
+++ b/pkg/coordinator/server/handlers_test.go
@@ -44,9 +44,20 @@ func (s stubStep) Name() string { return s.name }
 
 func (s stubStep) Execute(context.Context, *pipeline.RequestContext) error { return s.err }
 
+// stubGatewayURL is a placeholder used by tests that never actually issue a
+// passthrough request. A real value only matters in passthrough_test.go.
+const stubGatewayURL = "http://gateway-stub.invalid"
+
 func newTestServer(stepErr error) *Server {
+	return newTestServerWithGateway(stepErr, stubGatewayURL)
+}
+
+func newTestServerWithGateway(stepErr error, gatewayURL string) *Server {
 	p := pipeline.New([]pipeline.Step{stubStep{name: "stub", err: stepErr}})
-	srv, err := New(config.ServerConfig{}, p)
+	// A default *http.Transport{} is safe here: the passthrough handler needs a
+	// non-typed-nil RoundTripper so httputil.ReverseProxy dials the test server.
+	gw := gateway.NewWithTransport(&http.Transport{}, gatewayURL)
+	srv, err := New(config.ServerConfig{}, p, gw)
 	if err != nil {
 		panic(err) // default config is always valid
 	}
@@ -134,7 +145,7 @@ func TestHandleInference_BodyOverConfiguredCapMapsTo413(t *testing.T) {
 	// A body larger than server.max_request_body_size (in MB) is rejected before parsing.
 	// Use a 1 MB cap and send 1 MB + 1 byte to trigger the limit.
 	p := pipeline.New([]pipeline.Step{stubStep{name: "stub"}})
-	srv, err := New(config.ServerConfig{MaxRequestBodySize: 1}, p)
+	srv, err := New(config.ServerConfig{MaxRequestBodySize: 1}, p, gateway.NewWithTransport(nil, stubGatewayURL))
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -149,7 +160,7 @@ func TestHandleInference_BodyOverConfiguredCapMapsTo413(t *testing.T) {
 
 func TestNew_RejectsNegativeMaxRequestBodySize(t *testing.T) {
 	p := pipeline.New([]pipeline.Step{stubStep{name: "stub"}})
-	if _, err := New(config.ServerConfig{MaxRequestBodySize: -1}, p); err == nil {
+	if _, err := New(config.ServerConfig{MaxRequestBodySize: -1}, p, gateway.NewWithTransport(nil, stubGatewayURL)); err == nil {
 		t.Fatal("expected error for negative MaxRequestBodySize")
 	}
 }
@@ -158,8 +169,22 @@ func TestNew_RejectsOverflowMaxRequestBodySize(t *testing.T) {
 	// MaxInt64 would cause maxRequestBodySize+1 to overflow to a negative
 	// io.LimitReader limit, making it return immediate EOF.
 	p := pipeline.New([]pipeline.Step{stubStep{name: "stub"}})
-	if _, err := New(config.ServerConfig{MaxRequestBodySize: math.MaxInt64}, p); err == nil {
+	if _, err := New(config.ServerConfig{MaxRequestBodySize: math.MaxInt64}, p, gateway.NewWithTransport(nil, stubGatewayURL)); err == nil {
 		t.Fatal("expected error for MaxRequestBodySize > MaxInt64-1")
+	}
+}
+
+func TestNew_RejectsNilGatewayClient(t *testing.T) {
+	p := pipeline.New([]pipeline.Step{stubStep{name: "stub"}})
+	if _, err := New(config.ServerConfig{}, p, nil); err == nil {
+		t.Fatal("expected error for nil gateway client")
+	}
+}
+
+func TestNew_RejectsGatewayURLWithoutHost(t *testing.T) {
+	p := pipeline.New([]pipeline.Step{stubStep{name: "stub"}})
+	if _, err := New(config.ServerConfig{}, p, gateway.NewWithTransport(nil, "not-a-url")); err == nil {
+		t.Fatal("expected error for gateway URL without a host")
 	}
 }
 
@@ -237,6 +262,10 @@ func TestHandleInference_OverlongRequestIDIsRejected(t *testing.T) {
 }
 
 func TestRoutesRegistered(t *testing.T) {
+	// With the NotFound passthrough in place, an unregistered path no longer
+	// returns 404 — it reverse-proxies to the stub gateway and returns 502.
+	// Assert 200 to prove the path reaches its handler (stub step + handleHealth
+	// both leave the recorder at its default 200).
 	const inferenceBody = `{"model":"m","token_ids":[1,2,3]}`
 	tests := []struct {
 		name   string
@@ -256,8 +285,8 @@ func TestRoutesRegistered(t *testing.T) {
 			req := httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body))
 			rec := httptest.NewRecorder()
 			srv.httpServer.Handler.ServeHTTP(rec, req)
-			if rec.Code == http.StatusNotFound || rec.Code == http.StatusMethodNotAllowed {
-				t.Fatalf("route %s %s not registered: got HTTP %d", tt.method, tt.path, rec.Code)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("route %s %s expected 200, got HTTP %d", tt.method, tt.path, rec.Code)
 			}
 		})
 	}

--- a/pkg/coordinator/server/handlers_test.go
+++ b/pkg/coordinator/server/handlers_test.go
@@ -298,3 +298,16 @@ func TestRoutesRegistered(t *testing.T) {
 		})
 	}
 }
+
+func TestRoutesRegistered_MethodMismatchReturns405(t *testing.T) {
+	// A registered route with the wrong method must return 405, not fall
+	// through to the passthrough. Chi's default MethodNotAllowed handler
+	// produces this; the coordinator does not override it.
+	srv := newTestServer(nil)
+	req := httptest.NewRequest(http.MethodGet, gateway.PathChatCompletions, nil)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for GET on POST-only %s, got %d", gateway.PathChatCompletions, rec.Code)
+	}
+}

--- a/pkg/coordinator/server/handlers_test.go
+++ b/pkg/coordinator/server/handlers_test.go
@@ -188,6 +188,13 @@ func TestNew_RejectsGatewayURLWithoutHost(t *testing.T) {
 	}
 }
 
+func TestNew_RejectsUnparsableGatewayURL(t *testing.T) {
+	p := pipeline.New([]pipeline.Step{stubStep{name: "stub"}})
+	if _, err := New(config.ServerConfig{}, p, gateway.NewWithTransport(nil, "http://gw:notaport")); err == nil {
+		t.Fatal("expected error for unparsable gateway URL")
+	}
+}
+
 // deadlineRecorder wraps httptest.ResponseRecorder with a SetWriteDeadline
 // method so http.NewResponseController can reach it; it records the deadline
 // the handler sets.

--- a/pkg/coordinator/server/passthrough.go
+++ b/pkg/coordinator/server/passthrough.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
+
+	"github.com/llm-d/llm-d-router/pkg/coordinator/gateway"
+)
+
+// handlePassthrough is the chi NotFound catch-all: any path the coordinator
+// does not register (e.g. /v1/models, /v1/messages, /v1/responses, /v1/embeddings)
+// is reverse-proxied to the gateway with EPP-Profile: decode, so EPP dispatches
+// it to a decode pod. Method, body, query, and forwarded headers are preserved;
+// X-Request-Id is validated and replaced with a UUID if malformed, matching
+// handleInference's sanitization.
+func (s *Server) handlePassthrough(w http.ResponseWriter, r *http.Request) {
+	requestID := r.Header.Get(reqcommon.RequestIDHeaderKey)
+	if !validRequestID.MatchString(requestID) {
+		requestID = uuid.New().String()
+	}
+
+	logger := ctrl.Log.WithName("passthrough").WithValues(reqcommon.RequestIDHeaderKey, requestID)
+	logger.V(logutil.DEFAULT).Info("received request", "method", r.Method, "path", r.URL.Path)
+
+	// A passthrough response may stream (e.g. /v1/messages with stream:true).
+	// Clear the write deadline like handleInference does for streaming so a
+	// long response is not cut by WriteTimeout mid-stream.
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		logger.V(logutil.DEFAULT).Info("could not clear write deadline", "error", err)
+	}
+
+	proxy := newPassthroughProxy(logger, s.gatewayURL, s.gwClient.Transport(), requestID)
+	proxy.ServeHTTP(w, r)
+}
+
+// newPassthroughProxy builds the reverse proxy that streams to the gateway.
+// The director rewrites the outbound scheme/host to the gateway and stamps the
+// decode profile and sanitized request id. Transport errors return 502; a
+// failure after the upstream response has started can only surface through
+// ErrorLog, so it is wired to the request-scoped logger.
+func newPassthroughProxy(logger logr.Logger, gatewayURL *url.URL, transport http.RoundTripper, requestID string) *httputil.ReverseProxy {
+	return &httputil.ReverseProxy{
+		Director: func(r *http.Request) {
+			r.URL.Scheme = gatewayURL.Scheme
+			r.URL.Host = gatewayURL.Host
+			r.Host = gatewayURL.Host
+			r.Header.Set(reqcommon.RequestIDHeaderKey, requestID)
+			r.Header.Set(gateway.EPPProfileHeader, gateway.PhaseDecode)
+		},
+		FlushInterval: -1,
+		Transport:     transport,
+		ErrorLog:      log.New(&passthroughErrorLogWriter{logger: logger}, "", 0),
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			logger.Error(err, "passthrough proxy error")
+			w.WriteHeader(http.StatusBadGateway)
+		},
+	}
+}
+
+// passthroughErrorLogWriter adapts httputil.ReverseProxy's *log.Logger sink to
+// logr. The stdlib proxy writes here when a read fails after the response has
+// started, which is the only signal that the client received a truncated body.
+type passthroughErrorLogWriter struct {
+	logger logr.Logger
+}
+
+func (w *passthroughErrorLogWriter) Write(p []byte) (int, error) {
+	w.logger.Error(errors.New(strings.TrimSpace(string(p))), "passthrough proxy streaming error: client received a partial response")
+	return len(p), nil
+}

--- a/pkg/coordinator/server/passthrough.go
+++ b/pkg/coordinator/server/passthrough.go
@@ -89,9 +89,13 @@ func (h *passthroughHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	logger.V(logutil.DEFAULT).Info("received request", "method", r.Method, "path", r.URL.Path)
 
-	// A passthrough response may stream (e.g. /v1/messages with stream:true).
-	// Clear the write deadline like handleInference does for streaming so a
-	// long response is not cut by WriteTimeout mid-stream.
+	// The passthrough proxies request bodies verbatim and never parses them,
+	// so it cannot detect stream:true without defeating that design. Clear
+	// the write deadline unconditionally: a streaming response (the stated
+	// motivator, e.g. /v1/messages with stream:true) would otherwise be cut
+	// by WriteTimeout mid-stream. The trade-off is that non-streaming
+	// passthrough responses lose the slow-client guard; the gateway and
+	// server IdleTimeout still bound stalled connections.
 	if err := http.NewResponseController(w).SetWriteDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
 		logger.V(logutil.DEFAULT).Info("could not clear write deadline", "error", err)
 	}

--- a/pkg/coordinator/server/passthrough.go
+++ b/pkg/coordinator/server/passthrough.go
@@ -34,6 +34,7 @@ import (
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 
+	"github.com/llm-d/llm-d-router/pkg/coordinator/config"
 	"github.com/llm-d/llm-d-router/pkg/coordinator/gateway"
 )
 
@@ -44,14 +45,17 @@ import (
 // X-Request-Id is validated and replaced with a UUID if malformed, matching
 // handleInference's sanitization.
 type passthroughHandler struct {
-	gatewayURL *url.URL
-	transport  http.RoundTripper
+	gatewayURL         *url.URL
+	transport          http.RoundTripper
+	maxRequestBodySize int64
 }
 
 // newPassthroughHandler resolves and validates the gateway target once, at
 // server construction, so a misconfigured gateway URL fails startup rather
-// than the first passthrough request.
-func newPassthroughHandler(gwClient *gateway.Client) (*passthroughHandler, error) {
+// than the first passthrough request. maxRequestBodySize is the same MB
+// bound New() applies to /v1/chat/completions et al; the passthrough enforces
+// it via http.MaxBytesReader so unregistered paths cannot bypass the cap.
+func newPassthroughHandler(gwClient *gateway.Client, maxRequestBodySize int64) (*passthroughHandler, error) {
 	if gwClient == nil {
 		return nil, errors.New("server: gateway client is required")
 	}
@@ -62,7 +66,11 @@ func newPassthroughHandler(gwClient *gateway.Client) (*passthroughHandler, error
 	if gatewayURL.Host == "" {
 		return nil, fmt.Errorf("server: gateway URL %q is missing a host", gwClient.BaseURL())
 	}
-	return &passthroughHandler{gatewayURL: gatewayURL, transport: gwClient.Transport()}, nil
+	return &passthroughHandler{
+		gatewayURL:         gatewayURL,
+		transport:          gwClient.Transport(),
+		maxRequestBodySize: maxRequestBodySize,
+	}, nil
 }
 
 func (h *passthroughHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -88,6 +96,8 @@ func (h *passthroughHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		logger.V(logutil.DEFAULT).Info("could not clear write deadline", "error", err)
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, h.maxRequestBodySize*config.BytesPerMB)
+
 	proxy := newPassthroughProxy(logger, h.gatewayURL, h.transport, requestID)
 	proxy.ServeHTTP(w, r)
 }
@@ -110,6 +120,12 @@ func newPassthroughProxy(logger logr.Logger, gatewayURL *url.URL, transport http
 		Transport:     transport,
 		ErrorLog:      log.New(&passthroughErrorLogWriter{logger: logger}, "", 0),
 		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				logger.V(logutil.DEFAULT).Info("passthrough proxy: request body exceeds cap", "capBytes", maxBytesErr.Limit)
+				w.WriteHeader(http.StatusRequestEntityTooLarge)
+				return
+			}
 			// Client cancellation and request-context deadlines are routine events on
 			// public routes, not backend faults; keep them out of error dashboards.
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/pkg/coordinator/server/passthrough.go
+++ b/pkg/coordinator/server/passthrough.go
@@ -44,11 +44,18 @@ import (
 // handleInference's sanitization.
 func (s *Server) handlePassthrough(w http.ResponseWriter, r *http.Request) {
 	requestID := r.Header.Get(reqcommon.RequestIDHeaderKey)
-	if !validRequestID.MatchString(requestID) {
+	clientRequestID := requestID
+	requestIDReplaced := !validRequestID.MatchString(requestID)
+	if requestIDReplaced {
 		requestID = uuid.New().String()
 	}
 
 	logger := ctrl.Log.WithName("passthrough").WithValues(reqcommon.RequestIDHeaderKey, requestID)
+	if requestIDReplaced && clientRequestID != "" {
+		// Log the rejected length, never the raw value, to avoid reflecting
+		// attacker-controlled content into the log.
+		logger.V(logutil.DEFAULT).Info("replaced invalid client request ID", "rejectedLength", len(clientRequestID))
+	}
 	logger.V(logutil.DEFAULT).Info("received request", "method", r.Method, "path", r.URL.Path)
 
 	// A passthrough response may stream (e.g. /v1/messages with stream:true).

--- a/pkg/coordinator/server/passthrough.go
+++ b/pkg/coordinator/server/passthrough.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"errors"
 	"log"
 	"net/http"
@@ -79,7 +80,13 @@ func newPassthroughProxy(logger logr.Logger, gatewayURL *url.URL, transport http
 		Transport:     transport,
 		ErrorLog:      log.New(&passthroughErrorLogWriter{logger: logger}, "", 0),
 		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
-			logger.Error(err, "passthrough proxy error")
+			// Client cancellation and request-context deadlines are routine events on
+			// public routes, not backend faults; keep them out of error dashboards.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				logger.V(logutil.VERBOSE).Info("passthrough proxy: client cancelled", "error", err)
+			} else {
+				logger.Error(err, "passthrough proxy error")
+			}
 			w.WriteHeader(http.StatusBadGateway)
 		},
 	}

--- a/pkg/coordinator/server/passthrough.go
+++ b/pkg/coordinator/server/passthrough.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -36,13 +37,35 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/coordinator/gateway"
 )
 
-// handlePassthrough is the chi NotFound catch-all: any path the coordinator
+// passthroughHandler is the chi NotFound catch-all: any path the coordinator
 // does not register (e.g. /v1/models, /v1/messages, /v1/responses, /v1/embeddings)
 // is reverse-proxied to the gateway with EPP-Profile: decode, so EPP dispatches
 // it to a decode pod. Method, body, query, and forwarded headers are preserved;
 // X-Request-Id is validated and replaced with a UUID if malformed, matching
 // handleInference's sanitization.
-func (s *Server) handlePassthrough(w http.ResponseWriter, r *http.Request) {
+type passthroughHandler struct {
+	gatewayURL *url.URL
+	transport  http.RoundTripper
+}
+
+// newPassthroughHandler resolves and validates the gateway target once, at
+// server construction, so a misconfigured gateway URL fails startup rather
+// than the first passthrough request.
+func newPassthroughHandler(gwClient *gateway.Client) (*passthroughHandler, error) {
+	if gwClient == nil {
+		return nil, errors.New("server: gateway client is required")
+	}
+	gatewayURL, err := url.Parse(gwClient.BaseURL())
+	if err != nil {
+		return nil, fmt.Errorf("server: parse gateway URL %q: %w", gwClient.BaseURL(), err)
+	}
+	if gatewayURL.Host == "" {
+		return nil, fmt.Errorf("server: gateway URL %q is missing a host", gwClient.BaseURL())
+	}
+	return &passthroughHandler{gatewayURL: gatewayURL, transport: gwClient.Transport()}, nil
+}
+
+func (h *passthroughHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	requestID := r.Header.Get(reqcommon.RequestIDHeaderKey)
 	clientRequestID := requestID
 	requestIDReplaced := !validRequestID.MatchString(requestID)
@@ -65,7 +88,7 @@ func (s *Server) handlePassthrough(w http.ResponseWriter, r *http.Request) {
 		logger.V(logutil.DEFAULT).Info("could not clear write deadline", "error", err)
 	}
 
-	proxy := newPassthroughProxy(logger, s.gatewayURL, s.gwClient.Transport(), requestID)
+	proxy := newPassthroughProxy(logger, h.gatewayURL, h.transport, requestID)
 	proxy.ServeHTTP(w, r)
 }
 

--- a/pkg/coordinator/server/passthrough.go
+++ b/pkg/coordinator/server/passthrough.go
@@ -17,7 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -123,17 +122,22 @@ func newPassthroughProxy(logger logr.Logger, gatewayURL *url.URL, transport http
 		FlushInterval: -1,
 		Transport:     transport,
 		ErrorLog:      log.New(&passthroughErrorLogWriter{logger: logger}, "", 0),
-		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+		ErrorHandler: func(w http.ResponseWriter, req *http.Request, err error) {
 			var maxBytesErr *http.MaxBytesError
 			if errors.As(err, &maxBytesErr) {
 				logger.V(logutil.DEFAULT).Info("passthrough proxy: request body exceeds cap", "capBytes", maxBytesErr.Limit)
 				w.WriteHeader(http.StatusRequestEntityTooLarge)
 				return
 			}
-			// Client cancellation and request-context deadlines are routine events on
-			// public routes, not backend faults; keep them out of error dashboards.
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				logger.V(logutil.VERBOSE).Info("passthrough proxy: client cancelled", "error", err)
+			// A request whose context already ended (client disconnected, or a
+			// client-set deadline expired) is a routine lifecycle event, not a
+			// backend fault. Check req.Context().Err() rather than err's identity:
+			// Transport.RoundTrip's ResponseHeaderTimeout returns net/http's
+			// errTimeout, which satisfies errors.Is(err, context.DeadlineExceeded)
+			// by stdlib design and would otherwise misclassify a hung backend as
+			// a client cancellation.
+			if ctxErr := req.Context().Err(); ctxErr != nil {
+				logger.V(logutil.VERBOSE).Info("passthrough proxy: client cancelled", "error", ctxErr)
 			} else {
 				logger.Error(err, "passthrough proxy error")
 			}

--- a/pkg/coordinator/server/passthrough_test.go
+++ b/pkg/coordinator/server/passthrough_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
+	"github.com/llm-d/llm-d-router/pkg/coordinator/gateway"
+)
+
+// captured records what an upstream test gateway saw so tests can assert on
+// method, path, query, headers, and body.
+type captured struct {
+	mu      sync.Mutex
+	method  string
+	path    string
+	query   string
+	headers http.Header
+	body    []byte
+}
+
+func (c *captured) get() (string, string, string, http.Header, []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.method, c.path, c.query, c.headers.Clone(), append([]byte(nil), c.body...)
+}
+
+// newCapturingUpstream returns an httptest.Server that records the incoming
+// request and replies with the given status and body.
+func newCapturingUpstream(t *testing.T, status int, respBody string) (*httptest.Server, *captured) {
+	t.Helper()
+	c := &captured{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("upstream read body: %v", err)
+		}
+		c.mu.Lock()
+		c.method = r.Method
+		c.path = r.URL.Path
+		c.query = r.URL.RawQuery
+		c.headers = r.Header.Clone()
+		c.body = body
+		c.mu.Unlock()
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, c
+}
+
+func doPassthrough(t *testing.T, srv *Server, req *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestPassthrough_ForwardsUnregisteredGET(t *testing.T) {
+	// /v1/models is a GET that the coordinator does not register; the passthrough
+	// must forward it verbatim to the gateway with EPP-Profile: decode.
+	upstream, cap := newCapturingUpstream(t, http.StatusOK, `{"data":[]}`)
+	srv := newTestServerWithGateway(nil, upstream.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rec := doPassthrough(t, srv, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if rec.Body.String() != `{"data":[]}` {
+		t.Fatalf("unexpected response body: %q", rec.Body.String())
+	}
+	method, path, _, headers, _ := cap.get()
+	if method != http.MethodGet {
+		t.Fatalf("upstream method: got %q want GET", method)
+	}
+	if path != "/v1/models" {
+		t.Fatalf("upstream path: got %q want /v1/models", path)
+	}
+	if got := headers.Get(gateway.EPPProfileHeader); got != gateway.PhaseDecode {
+		t.Fatalf("upstream %s: got %q want %q", gateway.EPPProfileHeader, got, gateway.PhaseDecode)
+	}
+}
+
+func TestPassthrough_PreservesMethodBodyAndQuery(t *testing.T) {
+	// POST with a body and a query string must reach the gateway unchanged.
+	upstream, cap := newCapturingUpstream(t, http.StatusAccepted, "ok")
+	srv := newTestServerWithGateway(nil, upstream.URL)
+
+	body := `{"prompt":"hi"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages?stream=true", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := doPassthrough(t, srv, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rec.Code)
+	}
+	method, path, query, headers, gotBody := cap.get()
+	if method != http.MethodPost {
+		t.Fatalf("method: got %q want POST", method)
+	}
+	if path != "/v1/messages" {
+		t.Fatalf("path: got %q want /v1/messages", path)
+	}
+	if query != "stream=true" {
+		t.Fatalf("query: got %q want %q", query, "stream=true")
+	}
+	if string(gotBody) != body {
+		t.Fatalf("body: got %q want %q", string(gotBody), body)
+	}
+	if got := headers.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("content-type: got %q want application/json", got)
+	}
+}
+
+func TestPassthrough_MaliciousRequestIDReplaced(t *testing.T) {
+	// A request id with disallowed characters must be replaced before it reaches
+	// the gateway, matching handleInference's sanitization.
+	upstream, cap := newCapturingUpstream(t, http.StatusOK, "")
+	srv := newTestServerWithGateway(nil, upstream.URL)
+
+	malicious := "evil\r\nInjected: value"
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set(reqcommon.RequestIDHeaderKey, malicious)
+	doPassthrough(t, srv, req)
+
+	_, _, _, headers, _ := cap.get()
+	upstreamID := headers.Get(reqcommon.RequestIDHeaderKey)
+	if upstreamID == "" || upstreamID == malicious {
+		t.Fatalf("malicious request_id must not reach the gateway: got %q", upstreamID)
+	}
+	if strings.ContainsAny(upstreamID, "\r\n ") {
+		t.Fatalf("replacement request_id must not contain CR/LF/space: got %q", upstreamID)
+	}
+}
+
+func TestPassthrough_ValidRequestIDPreserved(t *testing.T) {
+	// A well-formed client request id must survive intact so upstream logs can
+	// correlate with the client trace.
+	upstream, cap := newCapturingUpstream(t, http.StatusOK, "")
+	srv := newTestServerWithGateway(nil, upstream.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set(reqcommon.RequestIDHeaderKey, "req-abc-123")
+	doPassthrough(t, srv, req)
+
+	_, _, _, headers, _ := cap.get()
+	if got := headers.Get(reqcommon.RequestIDHeaderKey); got != "req-abc-123" {
+		t.Fatalf("request_id: got %q want %q", got, "req-abc-123")
+	}
+}
+
+func TestPassthrough_TransportErrorReturns502(t *testing.T) {
+	// Point at a closed listener: the transport fails and the passthrough must
+	// answer 502 rather than surface a raw error to the client.
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	closedURL := upstream.URL
+	upstream.Close() // close before serving so subsequent dials get ECONNREFUSED
+
+	srv := newTestServerWithGateway(nil, closedURL)
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rec := doPassthrough(t, srv, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502 on transport error, got %d", rec.Code)
+	}
+}
+
+func TestPassthrough_RegisteredPathsBypass(t *testing.T) {
+	// A registered path must not reach the passthrough. Point the gateway at a
+	// handler that fails the test if hit, then POST a known route.
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("registered path %s reached the passthrough gateway", r.URL.Path)
+	}))
+	defer upstream.Close()
+
+	srv := newTestServerWithGateway(nil, upstream.URL)
+	req := httptest.NewRequest(http.MethodPost, gateway.PathChatCompletions, strings.NewReader(`{"model":"m"}`))
+	rec := doPassthrough(t, srv, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("registered path expected 200, got %d", rec.Code)
+	}
+}

--- a/pkg/coordinator/server/passthrough_test.go
+++ b/pkg/coordinator/server/passthrough_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 
@@ -253,31 +254,79 @@ func (s *logCaptureSink) Error(err error, msg string, _ ...any) {
 func (s *logCaptureSink) WithValues(_ ...any) logr.LogSink { return s }
 func (s *logCaptureSink) WithName(_ string) logr.LogSink   { return s }
 
+// backendTimeoutErr fakes net/http's errTimeout: a transport-level timeout
+// whose Is method matches context.DeadlineExceeded even though the client's
+// request context is not done. The ErrorHandler must not misclassify it as
+// a client cancellation.
+type backendTimeoutErr struct{}
+
+func (backendTimeoutErr) Error() string     { return "net/http: timeout awaiting response headers" }
+func (backendTimeoutErr) Is(err error) bool { return err == context.DeadlineExceeded }
+
 func TestPassthrough_ClientCancelNotLoggedAsError(t *testing.T) {
-	// Client disconnects (context.Canceled) and request-context deadlines are
-	// routine events, not backend faults. They must not surface as Error logs;
-	// non-cancellation errors still must.
+	// Classification is driven by the request context's state, not by the
+	// error argument: a request whose context is done is a client-side
+	// lifecycle event (disconnect or client deadline), anything else is a
+	// backend fault. A transport-level timeout whose Is method matches
+	// context.DeadlineExceeded (net/http's errTimeout, fired by
+	// ResponseHeaderTimeout) must stay in the error log.
 	gwURL, err := url.Parse("http://gw:80")
 	if err != nil {
 		t.Fatalf("parse gateway URL: %v", err)
 	}
 
+	pastDeadline := time.Now().Add(-time.Second)
+
 	cases := []struct {
 		name          string
+		reqCtx        func() (context.Context, context.CancelFunc)
 		err           error
 		wantErrorLogs int
 	}{
-		{"client cancelled", context.Canceled, 0},
-		{"context deadline exceeded", context.DeadlineExceeded, 0},
-		{"transport failure", errors.New("boom"), 1},
+		{
+			name: "client cancelled",
+			reqCtx: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, func() {}
+			},
+			err:           errors.New("connection reset by peer"),
+			wantErrorLogs: 0,
+		},
+		{
+			name: "client deadline exceeded",
+			reqCtx: func() (context.Context, context.CancelFunc) {
+				return context.WithDeadline(context.Background(), pastDeadline)
+			},
+			err:           errors.New("connection reset by peer"),
+			wantErrorLogs: 0,
+		},
+		{
+			name: "backend response header timeout stays an error",
+			reqCtx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+			err:           backendTimeoutErr{},
+			wantErrorLogs: 1,
+		},
+		{
+			name: "transport failure",
+			reqCtx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+			err:           errors.New("boom"),
+			wantErrorLogs: 1,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			sink := &logCaptureSink{}
 			proxy := newPassthroughProxy(logr.New(sink), gwURL, http.DefaultTransport, "req-1")
 
+			ctx, cancel := tt.reqCtx()
+			defer cancel()
 			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+			req := httptest.NewRequest(http.MethodGet, "/v1/models", nil).WithContext(ctx)
 			proxy.ErrorHandler(rec, req, tt.err)
 
 			if rec.Code != http.StatusBadGateway {

--- a/pkg/coordinator/server/passthrough_test.go
+++ b/pkg/coordinator/server/passthrough_test.go
@@ -17,13 +17,18 @@ limitations under the License.
 package server
 
 import (
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/go-logr/logr"
 
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 	"github.com/llm-d/llm-d-router/pkg/coordinator/gateway"
@@ -219,6 +224,67 @@ func TestPassthrough_StreamsChunksAsTheyArrive(t *testing.T) {
 	}
 	if got := rec.Body.String(); got != body {
 		t.Fatalf("body: got %q want %q", got, body)
+	}
+}
+
+// logCaptureSink is a logr.LogSink that records every Info and Error call.
+// Tests use it to assert which log level a code path takes.
+type logCaptureSink struct {
+	infos  []capturedLog
+	errors []capturedLog
+}
+
+type capturedLog struct {
+	level int
+	msg   string
+	err   error
+}
+
+func (s *logCaptureSink) Init(_ logr.RuntimeInfo) {}
+func (s *logCaptureSink) Enabled(_ int) bool      { return true }
+func (s *logCaptureSink) Info(level int, msg string, _ ...any) {
+	s.infos = append(s.infos, capturedLog{level: level, msg: msg})
+}
+func (s *logCaptureSink) Error(err error, msg string, _ ...any) {
+	s.errors = append(s.errors, capturedLog{msg: msg, err: err})
+}
+func (s *logCaptureSink) WithValues(_ ...any) logr.LogSink { return s }
+func (s *logCaptureSink) WithName(_ string) logr.LogSink   { return s }
+
+func TestPassthrough_ClientCancelNotLoggedAsError(t *testing.T) {
+	// Client disconnects (context.Canceled) and request-context deadlines are
+	// routine events, not backend faults. They must not surface as Error logs;
+	// non-cancellation errors still must.
+	gwURL, err := url.Parse("http://gw:80")
+	if err != nil {
+		t.Fatalf("parse gateway URL: %v", err)
+	}
+
+	cases := []struct {
+		name          string
+		err           error
+		wantErrorLogs int
+	}{
+		{"client cancelled", context.Canceled, 0},
+		{"context deadline exceeded", context.DeadlineExceeded, 0},
+		{"transport failure", errors.New("boom"), 1},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			sink := &logCaptureSink{}
+			proxy := newPassthroughProxy(logr.New(sink), gwURL, http.DefaultTransport, "req-1")
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+			proxy.ErrorHandler(rec, req, tt.err)
+
+			if rec.Code != http.StatusBadGateway {
+				t.Fatalf("status: got %d want 502", rec.Code)
+			}
+			if got := len(sink.errors); got != tt.wantErrorLogs {
+				t.Fatalf("Error-level logs: got %d (%v), want %d", got, sink.errors, tt.wantErrorLogs)
+			}
+		})
 	}
 }
 

--- a/pkg/coordinator/server/passthrough_test.go
+++ b/pkg/coordinator/server/passthrough_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -184,6 +185,40 @@ func TestPassthrough_TransportErrorReturns502(t *testing.T) {
 
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("expected 502 on transport error, got %d", rec.Code)
+	}
+}
+
+func TestPassthrough_StreamsChunksAsTheyArrive(t *testing.T) {
+	// Upstream writes two chunks with an explicit Flush() between them. The
+	// upstream sets an explicit Content-Length and a non-SSE Content-Type so
+	// httputil.ReverseProxy's auto-flush for text/event-stream and unknown
+	// (chunked) content lengths does not paper over a missing FlushInterval: -1
+	// on the coordinator's proxy.
+	const body = "chunk1chunk2"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("upstream ResponseWriter is not a Flusher")
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("chunk1"))
+		flusher.Flush()
+		_, _ = w.Write([]byte("chunk2"))
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	srv := newTestServerWithGateway(nil, upstream.URL)
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rec := doPassthrough(t, srv, req)
+
+	if !rec.Flushed {
+		t.Fatal("expected passthrough to flush downstream; FlushInterval: -1 regression?")
+	}
+	if got := rec.Body.String(); got != body {
+		t.Fatalf("body: got %q want %q", got, body)
 	}
 }
 

--- a/pkg/coordinator/server/passthrough_test.go
+++ b/pkg/coordinator/server/passthrough_test.go
@@ -31,7 +31,9 @@ import (
 	"github.com/go-logr/logr"
 
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
+	"github.com/llm-d/llm-d-router/pkg/coordinator/config"
 	"github.com/llm-d/llm-d-router/pkg/coordinator/gateway"
+	"github.com/llm-d/llm-d-router/pkg/coordinator/pipeline"
 )
 
 // captured records what an upstream test gateway saw so tests can assert on
@@ -285,6 +287,35 @@ func TestPassthrough_ClientCancelNotLoggedAsError(t *testing.T) {
 				t.Fatalf("Error-level logs: got %d (%v), want %d", got, sink.errors, tt.wantErrorLogs)
 			}
 		})
+	}
+}
+
+func TestPassthrough_BodyOverConfiguredCapMapsTo413(t *testing.T) {
+	// A body larger than server.max_request_body_size (in MB) must be rejected
+	// on the passthrough path with 413, matching the cap the inference path
+	// enforces. Use a 1 MB cap and send 1 MB + 1 byte to trigger the limit.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The passthrough will tear the outbound body mid-stream when the cap
+		// trips; discard whatever fragment arrives without asserting on the
+		// read error.
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := pipeline.New([]pipeline.Step{stubStep{name: "stub"}})
+	gw := gateway.NewWithTransport(&http.Transport{}, upstream.URL)
+	srv, err := New(config.ServerConfig{MaxRequestBodySize: 1}, p, gw)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	oversize := strings.Repeat("x", config.BytesPerMB+1)
+	req := httptest.NewRequest(http.MethodPost, "/v1/models", strings.NewReader(oversize))
+	rec := doPassthrough(t, srv, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413 for oversize passthrough body, got %d", rec.Code)
 	}
 }
 

--- a/pkg/coordinator/server/server.go
+++ b/pkg/coordinator/server/server.go
@@ -86,10 +86,6 @@ type Server struct {
 }
 
 func New(cfg config.ServerConfig, p *pipeline.Pipeline, gwClient *gateway.Client) (*Server, error) {
-	passthrough, err := newPassthroughHandler(gwClient)
-	if err != nil {
-		return nil, err
-	}
 	maxBodySize := cfg.MaxRequestBodySize
 	if maxBodySize == 0 {
 		// Zero means unset; Viper fills this from the config default in
@@ -105,6 +101,10 @@ func New(cfg config.ServerConfig, p *pipeline.Pipeline, gwClient *gateway.Client
 		// an MB value that overflows int64 when converted to bytes would cause
 		// LimitReader to receive a negative limit and return immediate EOF.
 		return nil, fmt.Errorf("server: MaxRequestBodySize must be at most %d MB, got %d", int64((math.MaxInt64-1)/config.BytesPerMB), maxBodySize)
+	}
+	passthrough, err := newPassthroughHandler(gwClient, maxBodySize)
+	if err != nil {
+		return nil, err
 	}
 	s := &Server{
 		pipeline:           p,

--- a/pkg/coordinator/server/server.go
+++ b/pkg/coordinator/server/server.go
@@ -18,10 +18,12 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"net"
 	"net/http"
+	"net/url"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -82,9 +84,21 @@ type Server struct {
 	httpServer         *http.Server
 	pipeline           *pipeline.Pipeline
 	maxRequestBodySize int64
+	gwClient           *gateway.Client
+	gatewayURL         *url.URL
 }
 
-func New(cfg config.ServerConfig, p *pipeline.Pipeline) (*Server, error) {
+func New(cfg config.ServerConfig, p *pipeline.Pipeline, gwClient *gateway.Client) (*Server, error) {
+	if gwClient == nil {
+		return nil, errors.New("server: gateway client is required")
+	}
+	gatewayURL, err := url.Parse(gwClient.BaseURL())
+	if err != nil {
+		return nil, fmt.Errorf("server: parse gateway URL %q: %w", gwClient.BaseURL(), err)
+	}
+	if gatewayURL.Host == "" {
+		return nil, fmt.Errorf("server: gateway URL %q is missing a host", gwClient.BaseURL())
+	}
 	maxBodySize := cfg.MaxRequestBodySize
 	if maxBodySize == 0 {
 		// Zero means unset; Viper fills this from the config default in
@@ -101,7 +115,12 @@ func New(cfg config.ServerConfig, p *pipeline.Pipeline) (*Server, error) {
 		// LimitReader to receive a negative limit and return immediate EOF.
 		return nil, fmt.Errorf("server: MaxRequestBodySize must be at most %d MB, got %d", int64((math.MaxInt64-1)/config.BytesPerMB), maxBodySize)
 	}
-	s := &Server{pipeline: p, maxRequestBodySize: maxBodySize}
+	s := &Server{
+		pipeline:           p,
+		maxRequestBodySize: maxBodySize,
+		gwClient:           gwClient,
+		gatewayURL:         gatewayURL,
+	}
 
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
@@ -114,6 +133,7 @@ func New(cfg config.ServerConfig, p *pipeline.Pipeline) (*Server, error) {
 	r.Post(gateway.DefaultGeneratePath, s.handleInference)
 	r.Get("/healthz", s.handleHealth)
 	r.Get("/readyz", s.handleHealth)
+	r.NotFound(s.handlePassthrough)
 
 	s.httpServer = &http.Server{
 		Addr:         cfg.ListenAddr,

--- a/pkg/coordinator/server/server.go
+++ b/pkg/coordinator/server/server.go
@@ -18,12 +18,10 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"net"
 	"net/http"
-	"net/url"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -84,20 +82,13 @@ type Server struct {
 	httpServer         *http.Server
 	pipeline           *pipeline.Pipeline
 	maxRequestBodySize int64
-	gwClient           *gateway.Client
-	gatewayURL         *url.URL
+	passthrough        *passthroughHandler
 }
 
 func New(cfg config.ServerConfig, p *pipeline.Pipeline, gwClient *gateway.Client) (*Server, error) {
-	if gwClient == nil {
-		return nil, errors.New("server: gateway client is required")
-	}
-	gatewayURL, err := url.Parse(gwClient.BaseURL())
+	passthrough, err := newPassthroughHandler(gwClient)
 	if err != nil {
-		return nil, fmt.Errorf("server: parse gateway URL %q: %w", gwClient.BaseURL(), err)
-	}
-	if gatewayURL.Host == "" {
-		return nil, fmt.Errorf("server: gateway URL %q is missing a host", gwClient.BaseURL())
+		return nil, err
 	}
 	maxBodySize := cfg.MaxRequestBodySize
 	if maxBodySize == 0 {
@@ -118,8 +109,7 @@ func New(cfg config.ServerConfig, p *pipeline.Pipeline, gwClient *gateway.Client
 	s := &Server{
 		pipeline:           p,
 		maxRequestBodySize: maxBodySize,
-		gwClient:           gwClient,
-		gatewayURL:         gatewayURL,
+		passthrough:        passthrough,
 	}
 
 	r := chi.NewRouter()
@@ -133,7 +123,7 @@ func New(cfg config.ServerConfig, p *pipeline.Pipeline, gwClient *gateway.Client
 	r.Post(gateway.DefaultGeneratePath, s.handleInference)
 	r.Get("/healthz", s.handleHealth)
 	r.Get("/readyz", s.handleHealth)
-	r.NotFound(s.handlePassthrough)
+	r.NotFound(s.passthrough.ServeHTTP)
 
 	s.httpServer = &http.Server{
 		Addr:         cfg.ListenAddr,

--- a/pkg/coordinator/steps/decode_proxy.go
+++ b/pkg/coordinator/steps/decode_proxy.go
@@ -110,7 +110,13 @@ func newDecodeProxy(logger logr.Logger, transport http.RoundTripper, modifyRespo
 			if errors.Is(proxyErr, errCacheMiss) {
 				return
 			}
-			logger.Error(proxyErr, "proxy error")
+			// Client cancellation and request-context deadlines are routine events on
+			// public routes, not backend faults; keep them out of error dashboards.
+			if errors.Is(proxyErr, context.Canceled) || errors.Is(proxyErr, context.DeadlineExceeded) {
+				logger.V(logutil.VERBOSE).Info("decode proxy: client cancelled", "error", proxyErr)
+			} else {
+				logger.Error(proxyErr, "proxy error")
+			}
 			w.WriteHeader(http.StatusBadGateway)
 		},
 	}

--- a/pkg/coordinator/steps/decode_proxy.go
+++ b/pkg/coordinator/steps/decode_proxy.go
@@ -106,14 +106,19 @@ func newDecodeProxy(logger logr.Logger, transport http.RoundTripper, modifyRespo
 		Transport:      transport,
 		ModifyResponse: modifyResponse,
 		ErrorLog:       log.New(&proxyErrorLogWriter{logger: logger}, "", 0),
-		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, proxyErr error) {
+		ErrorHandler: func(w http.ResponseWriter, req *http.Request, proxyErr error) {
 			if errors.Is(proxyErr, errCacheMiss) {
 				return
 			}
-			// Client cancellation and request-context deadlines are routine events on
-			// public routes, not backend faults; keep them out of error dashboards.
-			if errors.Is(proxyErr, context.Canceled) || errors.Is(proxyErr, context.DeadlineExceeded) {
-				logger.V(logutil.VERBOSE).Info("decode proxy: client cancelled", "error", proxyErr)
+			// A request whose context already ended (client disconnected, or a
+			// client-set deadline expired) is a routine lifecycle event, not a
+			// backend fault. Check req.Context().Err() rather than proxyErr's
+			// identity: Transport.RoundTrip's ResponseHeaderTimeout returns
+			// net/http's errTimeout, which satisfies
+			// errors.Is(err, context.DeadlineExceeded) by stdlib design and
+			// would otherwise misclassify a hung backend as a client cancellation.
+			if ctxErr := req.Context().Err(); ctxErr != nil {
+				logger.V(logutil.VERBOSE).Info("decode proxy: client cancelled", "error", ctxErr)
 			} else {
 				logger.Error(proxyErr, "proxy error")
 			}

--- a/pkg/coordinator/steps/decode_proxy_test.go
+++ b/pkg/coordinator/steps/decode_proxy_test.go
@@ -18,12 +18,14 @@ package steps
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
 )
 
@@ -74,4 +76,63 @@ func TestNewDecodeProxy_MidStreamTruncationLogged(t *testing.T) {
 		}
 	}
 	t.Fatalf("expected a partial-response error log, got %v", msgs)
+}
+
+// logCaptureSink is a logr.LogSink that records every Info and Error call.
+// Tests use it to assert which log level a code path takes.
+type logCaptureSink struct {
+	infos  []capturedLog
+	errors []capturedLog
+}
+
+type capturedLog struct {
+	level int
+	msg   string
+	err   error
+}
+
+func (s *logCaptureSink) Init(_ logr.RuntimeInfo) {}
+func (s *logCaptureSink) Enabled(_ int) bool      { return true }
+func (s *logCaptureSink) Info(level int, msg string, _ ...any) {
+	s.infos = append(s.infos, capturedLog{level: level, msg: msg})
+}
+func (s *logCaptureSink) Error(err error, msg string, _ ...any) {
+	s.errors = append(s.errors, capturedLog{msg: msg, err: err})
+}
+func (s *logCaptureSink) WithValues(_ ...any) logr.LogSink { return s }
+func (s *logCaptureSink) WithName(_ string) logr.LogSink   { return s }
+
+func TestNewDecodeProxy_ClientCancelNotLoggedAsError(t *testing.T) {
+	// Client disconnects (context.Canceled) and request-context deadlines are
+	// routine events, not backend faults. They must not surface as Error logs;
+	// non-cancellation errors still must. errCacheMiss stays swallowed (no log,
+	// no response) so the miss can fall through to the rest of the pipeline.
+	cases := []struct {
+		name          string
+		err           error
+		wantStatus    int
+		wantErrorLogs int
+	}{
+		{"client cancelled", context.Canceled, http.StatusBadGateway, 0},
+		{"context deadline exceeded", context.DeadlineExceeded, http.StatusBadGateway, 0},
+		{"transport failure", errors.New("boom"), http.StatusBadGateway, 1},
+		{"cache miss falls through", errCacheMiss, http.StatusOK, 0},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			sink := &logCaptureSink{}
+			proxy := newDecodeProxy(logr.New(sink), http.DefaultTransport, nil)
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			proxy.ErrorHandler(rec, req, tt.err)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status: got %d want %d", rec.Code, tt.wantStatus)
+			}
+			if got := len(sink.errors); got != tt.wantErrorLogs {
+				t.Fatalf("Error-level logs: got %d (%v), want %d", got, sink.errors, tt.wantErrorLogs)
+			}
+		})
+	}
 }

--- a/pkg/coordinator/steps/decode_proxy_test.go
+++ b/pkg/coordinator/steps/decode_proxy_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
@@ -102,29 +103,90 @@ func (s *logCaptureSink) Error(err error, msg string, _ ...any) {
 func (s *logCaptureSink) WithValues(_ ...any) logr.LogSink { return s }
 func (s *logCaptureSink) WithName(_ string) logr.LogSink   { return s }
 
+// backendTimeoutErr fakes net/http's errTimeout: a transport-level timeout
+// whose Is method matches context.DeadlineExceeded even though the client's
+// request context is not done. The ErrorHandler must not misclassify it as
+// a client cancellation.
+type backendTimeoutErr struct{}
+
+func (backendTimeoutErr) Error() string     { return "net/http: timeout awaiting response headers" }
+func (backendTimeoutErr) Is(err error) bool { return err == context.DeadlineExceeded }
+
 func TestNewDecodeProxy_ClientCancelNotLoggedAsError(t *testing.T) {
-	// Client disconnects (context.Canceled) and request-context deadlines are
-	// routine events, not backend faults. They must not surface as Error logs;
-	// non-cancellation errors still must. errCacheMiss stays swallowed (no log,
-	// no response) so the miss can fall through to the rest of the pipeline.
+	// Classification is driven by the request context's state, not by the
+	// error argument: a request whose context is done is a client-side
+	// lifecycle event (disconnect or client deadline), anything else is a
+	// backend fault. A transport-level timeout whose Is method matches
+	// context.DeadlineExceeded (net/http's errTimeout, fired by
+	// ResponseHeaderTimeout) must stay in the error log. errCacheMiss stays
+	// swallowed (no log, no response) so the miss can fall through to the
+	// rest of the pipeline.
+	pastDeadline := time.Now().Add(-time.Second)
+
 	cases := []struct {
 		name          string
+		reqCtx        func() (context.Context, context.CancelFunc)
 		err           error
 		wantStatus    int
 		wantErrorLogs int
 	}{
-		{"client cancelled", context.Canceled, http.StatusBadGateway, 0},
-		{"context deadline exceeded", context.DeadlineExceeded, http.StatusBadGateway, 0},
-		{"transport failure", errors.New("boom"), http.StatusBadGateway, 1},
-		{"cache miss falls through", errCacheMiss, http.StatusOK, 0},
+		{
+			name: "client cancelled",
+			reqCtx: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, func() {}
+			},
+			err:           errors.New("connection reset by peer"),
+			wantStatus:    http.StatusBadGateway,
+			wantErrorLogs: 0,
+		},
+		{
+			name: "client deadline exceeded",
+			reqCtx: func() (context.Context, context.CancelFunc) {
+				return context.WithDeadline(context.Background(), pastDeadline)
+			},
+			err:           errors.New("connection reset by peer"),
+			wantStatus:    http.StatusBadGateway,
+			wantErrorLogs: 0,
+		},
+		{
+			name: "backend response header timeout stays an error",
+			reqCtx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+			err:           backendTimeoutErr{},
+			wantStatus:    http.StatusBadGateway,
+			wantErrorLogs: 1,
+		},
+		{
+			name: "transport failure",
+			reqCtx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+			err:           errors.New("boom"),
+			wantStatus:    http.StatusBadGateway,
+			wantErrorLogs: 1,
+		},
+		{
+			name: "cache miss falls through",
+			reqCtx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+			err:           errCacheMiss,
+			wantStatus:    http.StatusOK,
+			wantErrorLogs: 0,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			sink := &logCaptureSink{}
 			proxy := newDecodeProxy(logr.New(sink), http.DefaultTransport, nil)
 
+			ctx, cancel := tt.reqCtx()
+			defer cancel()
 			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
 			proxy.ErrorHandler(rec, req, tt.err)
 
 			if rec.Code != tt.wantStatus {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Callers hitting the coordinator on a path it does not register today (e.g. `/v1/models`, `/v1/messages`, `/v1/responses`, `/v1/embeddings`, `/tokenize`) get a stock chi 404 and have to bypass the coordinator to reach the equivalent vLLM endpoint.

This PR adds a chi `NotFound` handler that reverse-proxies any unregistered path to the Inference Gateway with `EPP-Profile: decode`, so EPP dispatches the request to a decode pod (a full vLLM instance). Method, body, query, and forwarded headers pass through unchanged; `X-Request-Id` is validated and replaced with a UUID if malformed, matching `handleInference`'s sanitization. Registered paths still hit the pipeline; method-mismatches on registered paths still return 405.

Mirrors the sidecar's existing `mux.Handle("/", decoderProxy)` fallback pattern.

**Which issue(s) this PR fixes**:
Fixes #

**Release note**:
```release-note
Coordinator now forwards requests for unregistered paths (e.g. /v1/models, /v1/messages, /v1/responses, /v1/embeddings) directly to a decode pod via EPP-Profile: decode, so clients no longer need to bypass the coordinator to reach these vLLM endpoints.
Enforce server.max_request_body_size on passthrough (unregistered) paths; oversize requests now return 413.
```
