### PR TITLE
Strip coordinator-internal headers from decode-leg responses

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -101,7 +101,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestattributereporter"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity"
-	topologystamp "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp"
 	disaggregatedsetrollout "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout"
 	testresponsereceived "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/test/responsereceived"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/anthropic"

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -101,6 +101,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestattributereporter"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity"
+	topologystamp "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp"
 	disaggregatedsetrollout "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout"
 	testresponsereceived "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/test/responsereceived"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/anthropic"
@@ -559,6 +560,10 @@ func (r *Runner) registerInTreePlugins() {
 	// request control screeners
 	// Alpha
 	fwkplugin.Register(disaggregatedsetrollout.PluginType, fwkplugin.StabilityAlpha, disaggregatedsetrollout.Factory)
+
+	// request control response-received handlers
+	// Alpha
+	fwkplugin.Register(topologystamp.PluginType, fwkplugin.StabilityAlpha, topologystamp.Factory)
 
 	// bylabel role filters
 	// Beta

--- a/pkg/common/request/constants.go
+++ b/pkg/common/request/constants.go
@@ -18,6 +18,11 @@ package request
 
 const (
 	RequestIDHeaderKey = "x-request-id"
+	// PeerTopologyHeaderKey carries the prefill endpoint's encoded topology
+	// from the prefill EPP's response, through the coordinator, to the decode
+	// EPP's request, for topology-affinity-filter and topology-affinity-scorer
+	// running in coordinator deployments.
+	PeerTopologyHeaderKey = "x-peer-topology"
 
 	FieldKVTransferParams     = "kv_transfer_params"
 	FieldECTransferParams     = "ec_transfer_params"

--- a/pkg/coordinator/gateway/paths.go
+++ b/pkg/coordinator/gateway/paths.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package gateway
 
-import "strings"
+import (
+	"strings"
+
+	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
+)
 
 const (
 	PathChatCompletions = "/v1/chat/completions"
@@ -24,10 +28,9 @@ const (
 	DefaultGeneratePath = "/inference/v1/generate"
 
 	EPPProfileHeader = "EPP-Profile"
-	// PeerTopologyHeader must match the default headerName in
-	// pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp
-	// and peerTopologyHeaderName in pkg/epp/util/request/headers.go.
-	PeerTopologyHeader = "x-peer-topology"
+	// PeerTopologyHeader is reqcommon.PeerTopologyHeaderKey, the single
+	// definition topology-stamp-handler's default headerName must match.
+	PeerTopologyHeader = reqcommon.PeerTopologyHeaderKey
 	ContentTypeHeader  = "Content-Type"
 	ContentTypeJSON    = "application/json"
 

--- a/pkg/coordinator/gateway/paths.go
+++ b/pkg/coordinator/gateway/paths.go
@@ -23,9 +23,10 @@ const (
 	PathCompletions     = "/v1/completions"
 	DefaultGeneratePath = "/inference/v1/generate"
 
-	EPPProfileHeader  = "EPP-Profile"
-	ContentTypeHeader = "Content-Type"
-	ContentTypeJSON   = "application/json"
+	EPPProfileHeader   = "EPP-Profile"
+	PeerTopologyHeader = "x-peer-topology"
+	ContentTypeHeader  = "Content-Type"
+	ContentTypeJSON    = "application/json"
 
 	PhaseEncode  = "encode"
 	PhasePrefill = "prefill"

--- a/pkg/coordinator/gateway/paths.go
+++ b/pkg/coordinator/gateway/paths.go
@@ -23,7 +23,10 @@ const (
 	PathCompletions     = "/v1/completions"
 	DefaultGeneratePath = "/inference/v1/generate"
 
-	EPPProfileHeader   = "EPP-Profile"
+	EPPProfileHeader = "EPP-Profile"
+	// PeerTopologyHeader must match the default headerName in
+	// pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp
+	// and peerTopologyHeaderName in pkg/epp/util/request/headers.go.
 	PeerTopologyHeader = "x-peer-topology"
 	ContentTypeHeader  = "Content-Type"
 	ContentTypeJSON    = "application/json"

--- a/pkg/coordinator/pipeline/context.go
+++ b/pkg/coordinator/pipeline/context.go
@@ -34,7 +34,8 @@ var hopByHopHeaders = map[string]bool{
 }
 
 var internalForwardingHeaders = map[string]bool{
-	"epp-profile": true,
+	"epp-profile":     true,
+	"x-peer-topology": true,
 }
 
 // ForwardedHeaders returns original request headers suitable for forwarding
@@ -86,6 +87,13 @@ type RequestContext struct {
 	// decode step. Populated by PrefillStep from the prefill response; consumed
 	// by the KV connector when building the decode request.
 	KVTransferParams map[string]any
+	// PeerTopology carries the prefill endpoint's encoded topology from the
+	// prefill response to the decode request, for topology-affinity-filter
+	// and topology-affinity-scorer running in the decode EPP's profile.
+	// Populated by PrefillStep from the x-peer-topology response header;
+	// forwarded onto the decode request by newDecodeProxyRequest. Empty when
+	// the prefill EPP's config has no topology-stamp-handler.
+	PeerTopology string
 
 	// ResponseWriter is used by decode steps to stream the final response to the client.
 	ResponseWriter http.ResponseWriter

--- a/pkg/coordinator/pipeline/context.go
+++ b/pkg/coordinator/pipeline/context.go
@@ -20,6 +20,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 )
 
 var hopByHopHeaders = map[string]bool{
@@ -34,8 +36,19 @@ var hopByHopHeaders = map[string]bool{
 }
 
 var internalForwardingHeaders = map[string]bool{
-	"epp-profile":     true,
-	"x-peer-topology": true,
+	"epp-profile":                   true,
+	reqcommon.PeerTopologyHeaderKey: true,
+}
+
+// StripInternalHeaders removes headers the coordinator alone injects into
+// requests it forwards (e.g. x-peer-topology, copied from the prefill
+// response onto the decode request). Call this on a client request's headers
+// as soon as they are received, so a client-supplied value is never mistaken
+// for one the coordinator generated itself.
+func StripInternalHeaders(headers http.Header) {
+	for key := range internalForwardingHeaders {
+		headers.Del(key)
+	}
 }
 
 // ForwardedHeaders returns original request headers suitable for forwarding

--- a/pkg/coordinator/pipeline/context_test.go
+++ b/pkg/coordinator/pipeline/context_test.go
@@ -112,6 +112,20 @@ func TestForwardedHeaders_ExcludesInternalRoutingHeaders(t *testing.T) {
 	}
 }
 
+func TestForwardedHeaders_ExcludesClientSuppliedPeerTopology(t *testing.T) {
+	rc := &RequestContext{
+		OriginalHeaders: http.Header{
+			"X-Peer-Topology": {"host=spoofed"},
+		},
+	}
+
+	out := rc.ForwardedHeaders()
+
+	if _, ok := out["x-peer-topology"]; ok {
+		t.Fatalf("x-peer-topology should not be forwarded: %v", out)
+	}
+}
+
 func TestForwardedHeaders_NilOriginalHeaders(t *testing.T) {
 	rc := &RequestContext{}
 	if out := rc.ForwardedHeaders(); len(out) != 0 {

--- a/pkg/coordinator/server/handlers.go
+++ b/pkg/coordinator/server/handlers.go
@@ -76,10 +76,13 @@ func (s *Server) handleInference(w http.ResponseWriter, r *http.Request) {
 		requestID = uuid.New().String()
 	}
 
+	headers := r.Header.Clone()
+	pipeline.StripInternalHeaders(headers)
+
 	reqCtx := &pipeline.RequestContext{
 		RequestID:        requestID,
 		OriginalPath:     r.URL.Path,
-		OriginalHeaders:  r.Header.Clone(),
+		OriginalHeaders:  headers,
 		OriginalBody:     body,
 		Body:             parsed,
 		Model:            model,

--- a/pkg/coordinator/server/handlers_test.go
+++ b/pkg/coordinator/server/handlers_test.go
@@ -44,6 +44,19 @@ func (s stubStep) Name() string { return s.name }
 
 func (s stubStep) Execute(context.Context, *pipeline.RequestContext) error { return s.err }
 
+// capturingStep records the RequestContext it saw, for assertions on what the
+// handler populated before the pipeline ran.
+type capturingStep struct {
+	captured *pipeline.RequestContext
+}
+
+func (s *capturingStep) Name() string { return "capture" }
+
+func (s *capturingStep) Execute(_ context.Context, rc *pipeline.RequestContext) error {
+	s.captured = rc
+	return nil
+}
+
 func newTestServer(stepErr error) *Server {
 	p := pipeline.New([]pipeline.Step{stubStep{name: "stub", err: stepErr}})
 	srv, err := New(config.ServerConfig{}, p)
@@ -233,6 +246,38 @@ func TestHandleInference_OverlongRequestIDIsRejected(t *testing.T) {
 	rec := postInferenceWithRequestID(t, newTestServer(stepErr), overlong)
 	if strings.Contains(rec.Body.String(), overlong) {
 		t.Fatalf("overlong request_id must not leak to the client: %q", rec.Body.String())
+	}
+}
+
+func TestHandleInference_StripsClientSuppliedInternalHeaders(t *testing.T) {
+	// x-peer-topology and epp-profile are headers the coordinator alone injects
+	// (copied from the prefill response, or set to select a profile); a
+	// client-supplied value must never survive into OriginalHeaders, since a
+	// later step trusts it as coordinator-generated.
+	step := &capturingStep{}
+	p := pipeline.New([]pipeline.Step{step})
+	srv, err := New(config.ServerConfig{}, p)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"m"}`))
+	req.Header.Set(reqcommon.PeerTopologyHeaderKey, "host=attacker,zone=evil")
+	req.Header.Set(gateway.EPPProfileHeader, "decode")
+	req.Header.Set("x-user-data", "keep-me")
+	rec := httptest.NewRecorder()
+	srv.handleInference(rec, req)
+
+	if step.captured == nil {
+		t.Fatal("pipeline step did not run")
+	}
+	if got := step.captured.OriginalHeaders.Get(reqcommon.PeerTopologyHeaderKey); got != "" {
+		t.Fatalf("client-supplied x-peer-topology must be stripped, got %q", got)
+	}
+	if got := step.captured.OriginalHeaders.Get(gateway.EPPProfileHeader); got != "" {
+		t.Fatalf("client-supplied epp-profile must be stripped, got %q", got)
+	}
+	if got := step.captured.OriginalHeaders.Get("x-user-data"); got != "keep-me" {
+		t.Fatalf("unrelated headers must pass through, got %q", got)
 	}
 }
 

--- a/pkg/coordinator/steps/decode_proxy.go
+++ b/pkg/coordinator/steps/decode_proxy.go
@@ -104,11 +104,21 @@ func newDecodeProxyRequest(ctx context.Context, logger logr.Logger, step string,
 // request-scoped logger to make the truncation observable with the request id.
 func newDecodeProxy(logger logr.Logger, transport http.RoundTripper, modifyResponse func(*http.Response) error) *httputil.ReverseProxy {
 	return &httputil.ReverseProxy{
-		Director:       func(_ *http.Request) {},
-		FlushInterval:  -1,
-		Transport:      transport,
-		ModifyResponse: modifyResponse,
-		ErrorLog:       log.New(&proxyErrorLogWriter{logger: logger}, "", 0),
+		Director:      func(_ *http.Request) {},
+		FlushInterval: -1,
+		Transport:     transport,
+		// A decode profile's response headers are otherwise copied verbatim to
+		// the client; strip coordinator-internal headers (e.g. x-peer-topology,
+		// meaningful only between the prefill and decode legs) so a plugin
+		// configured on the decode profile can't leak them to the caller.
+		ModifyResponse: func(resp *http.Response) error {
+			pipeline.StripInternalHeaders(resp.Header)
+			if modifyResponse != nil {
+				return modifyResponse(resp)
+			}
+			return nil
+		},
+		ErrorLog: log.New(&proxyErrorLogWriter{logger: logger}, "", 0),
 		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, proxyErr error) {
 			if errors.Is(proxyErr, errCacheMiss) {
 				return

--- a/pkg/coordinator/steps/decode_proxy.go
+++ b/pkg/coordinator/steps/decode_proxy.go
@@ -70,6 +70,9 @@ func newDecodeProxyRequest(ctx context.Context, logger logr.Logger, step string,
 	}
 	proxyReq.Header.Set(reqcommon.RequestIDHeaderKey, reqCtx.RequestID)
 	proxyReq.Header.Set(gateway.EPPProfileHeader, gateway.PhaseDecode)
+	if reqCtx.PeerTopology != "" {
+		proxyReq.Header.Set(gateway.PeerTopologyHeader, reqCtx.PeerTopology)
+	}
 	for k, v := range extraHeaders {
 		proxyReq.Header.Set(k, v)
 	}

--- a/pkg/coordinator/steps/decode_proxy_test.go
+++ b/pkg/coordinator/steps/decode_proxy_test.go
@@ -24,8 +24,54 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
+
+	"github.com/llm-d/llm-d-router/pkg/coordinator/config"
+	"github.com/llm-d/llm-d-router/pkg/coordinator/gateway"
+	"github.com/llm-d/llm-d-router/pkg/coordinator/pipeline"
 )
+
+// TestNewDecodeProxyRequest_ForwardsPeerTopology verifies that a non-empty
+// reqCtx.PeerTopology, captured by PrefillStep from the prefill response, is
+// set on the outgoing decode request's x-peer-topology header.
+func TestNewDecodeProxyRequest_ForwardsPeerTopology(t *testing.T) {
+	gwClient := gateway.New(config.GatewayConfig{Address: "http://example.invalid"})
+
+	reqCtx := &pipeline.RequestContext{
+		RequestID:    "req-1",
+		OriginalPath: "/inference/v1/generate",
+		PeerTopology: "host=node12,zone=us-east1-a",
+	}
+
+	req, err := newDecodeProxyRequest(context.Background(), logr.Discard(), "decode", reqCtx, gwClient, map[string]any{}, nil)
+	if err != nil {
+		t.Fatalf("newDecodeProxyRequest: %v", err)
+	}
+	if got, want := req.Header.Get(gateway.PeerTopologyHeader), "host=node12,zone=us-east1-a"; got != want {
+		t.Fatalf("x-peer-topology header = %q, want %q", got, want)
+	}
+}
+
+// TestNewDecodeProxyRequest_OmitsPeerTopologyWhenEmpty verifies that no
+// x-peer-topology header is set on the decode request when the prefill
+// response carried none (single-EPP-in-coordinator or no topology-stamp-handler).
+func TestNewDecodeProxyRequest_OmitsPeerTopologyWhenEmpty(t *testing.T) {
+	gwClient := gateway.New(config.GatewayConfig{Address: "http://example.invalid"})
+
+	reqCtx := &pipeline.RequestContext{
+		RequestID:    "req-1",
+		OriginalPath: "/inference/v1/generate",
+	}
+
+	req, err := newDecodeProxyRequest(context.Background(), logr.Discard(), "decode", reqCtx, gwClient, map[string]any{}, nil)
+	if err != nil {
+		t.Fatalf("newDecodeProxyRequest: %v", err)
+	}
+	if got := req.Header.Get(gateway.PeerTopologyHeader); got != "" {
+		t.Fatalf("expected no x-peer-topology header, got %q", got)
+	}
+}
 
 // TestNewDecodeProxy_MidStreamTruncationLogged drives the proxy against an
 // upstream that promises a large Content-Length, writes a few bytes, then drops

--- a/pkg/coordinator/steps/decode_proxy_test.go
+++ b/pkg/coordinator/steps/decode_proxy_test.go
@@ -73,6 +73,33 @@ func TestNewDecodeProxyRequest_OmitsPeerTopologyWhenEmpty(t *testing.T) {
 	}
 }
 
+// TestNewDecodeProxy_StripsPeerTopologyFromClientResponse verifies that
+// x-peer-topology never reaches the client, even if a decode profile's
+// response carries it (e.g. topology-stamp-handler misconfigured on decode
+// rather than prefill). The header is meaningful only between the prefill and
+// decode legs; ModifyResponse must strip it before ReverseProxy copies
+// upstream response headers to the client.
+func TestNewDecodeProxy_StripsPeerTopologyFromClientResponse(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(gateway.PeerTopologyHeader, "host=node12,zone=us-east1-a")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, upstream.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	proxy := newDecodeProxy(logr.Discard(), http.DefaultTransport, nil)
+	rec := httptest.NewRecorder()
+	proxy.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get(gateway.PeerTopologyHeader); got != "" {
+		t.Fatalf("x-peer-topology leaked to client response, got %q", got)
+	}
+}
+
 // TestNewDecodeProxy_MidStreamTruncationLogged drives the proxy against an
 // upstream that promises a large Content-Length, writes a few bytes, then drops
 // the connection. The copy fails after the 200 has been sent, so the only

--- a/pkg/coordinator/steps/prefill.go
+++ b/pkg/coordinator/steps/prefill.go
@@ -116,6 +116,8 @@ func (s *PrefillStep) Execute(ctx context.Context, reqCtx *pipeline.RequestConte
 		return upstreamError(PrefillStepName, resp.StatusCode, respBody)
 	}
 
+	reqCtx.PeerTopology = resp.Header.Get(gateway.PeerTopologyHeader)
+
 	var prefillResp prefillResponse
 	if err := json.NewDecoder(resp.Body).Decode(&prefillResp); err != nil {
 		return fmt.Errorf("prefill: decode response: %w", err)

--- a/pkg/coordinator/steps/prefill_test.go
+++ b/pkg/coordinator/steps/prefill_test.go
@@ -649,6 +649,38 @@ func TestPrefillStep_ConflictingECParams_RejectsRequest(t *testing.T) {
 	}
 }
 
+// TestPrefillStep_CapturesPeerTopologyHeader verifies that the x-peer-topology
+// response header set by the prefill EPP's topology-stamp-handler is captured
+// into reqCtx.PeerTopology for later forwarding to the decode request.
+func TestPrefillStep_CapturesPeerTopologyHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(gateway.PeerTopologyHeader, "host=node12,zone=us-east1-a")
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer server.Close()
+
+	gwClient := gateway.New(config.GatewayConfig{Address: server.URL})
+
+	step, err := NewPrefillStep(gwClient, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reqCtx := &pipeline.RequestContext{
+		RequestID:        "req-1",
+		Model:            "test",
+		TokenIDs:         []int{1, 2345},
+		KVTransferParams: make(map[string]any),
+	}
+
+	if err := step.Execute(context.Background(), reqCtx); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := reqCtx.PeerTopology, "host=node12,zone=us-east1-a"; got != want {
+		t.Fatalf("reqCtx.PeerTopology = %q, want %q", got, want)
+	}
+}
+
 func TestPrefillStep_GatewayError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)

--- a/pkg/epp/framework/plugins/datalayer/attribute/topology/README.md
+++ b/pkg/epp/framework/plugins/datalayer/attribute/topology/README.md
@@ -25,6 +25,12 @@ The following plugins produce this attribute:
 - **`topology-extractor`** (Data Layer): Sets the `Topology` attribute using
   `spec.hostname` from the Pod object, or the value of a configured endpoint label.
 
+In coordinator deployments, where prefill and decode are picked by separate EPPs, the
+prefill EPP's **`topology-stamp-handler`** (Request Control) reads this attribute off its
+selected endpoint and encodes it onto the `x-peer-topology` response header, so the
+decode EPP's `topology-affinity-filter`/`-scorer` can read the same locality data without
+the `Topology` attribute itself crossing the wire.
+
 ## Consumers
 
 The following plugins consume this attribute:

--- a/pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp/README.md
@@ -1,0 +1,48 @@
+# Topology Stamp Handler Plugin
+
+**Type:** `topology-stamp-handler`
+
+This plugin stamps the topology of a scheduling profile's selected endpoint onto the
+response, for a coordinator to forward from the prefill response to the decode request.
+
+## What it does
+
+Scoped to coordinator deployments, where prefill and decode are picked by separate EPPs
+and the peer's topology must cross the wire rather than stay in a request attribute.
+
+Runs after response headers are received (`ResponseHeader`). Reads the encoded topology
+of the endpoint selected by `profileName` (the primary profile's endpoint when unset) and
+writes it to `headerName` on the response headers, using the same `key=value` wire format
+`topology-affinity-filter` and `topology-affinity-scorer` decode on the decode side.
+
+Sets nothing when the profile did not run (e.g. a decode-only request that skipped
+prefill), the selected endpoint has no `Topology` attribute, or the response has no
+header map to write to.
+
+## Inputs consumed
+
+Reads the `Topology` attribute (`topology-extractor`) from the endpoint selected by
+`profileName`, resolved from `request.SchedulingResult`.
+
+## Configuration
+
+| Parameter               | Required | Default            | Description                                                                  |
+|--------------------------|----------|---------------------|--------------------------------------------------------------------------------|
+| `headerName`             | no       | `x-peer-topology`   | Response header the encoded topology is written to.                          |
+| `profileName`            | no       | primary profile      | Scheduling profile whose selected endpoint's topology is stamped.            |
+| `topologyProducerName`   | no       | default producer     | `topology-extractor` instance to read the `Topology` attribute from.         |
+
+**Configuration Example:**
+```yaml
+plugins:
+  - type: topology-extractor
+  - type: topology-stamp-handler
+    name: prefill-topology-stamp
+    parameters:
+      profileName: prefill
+```
+
+## See also
+
+`topology-affinity-filter` and `topology-affinity-scorer` decode `headerName` on the
+decode side when configured with a matching `peerTopologyHeader` parameter.

--- a/pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp/stamp.go
+++ b/pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp/stamp.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package topologystamp provides a response-header processor that stamps the
+// prefill endpoint's topology onto the response, for a coordinator to forward
+// to the decode request.
+package topologystamp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+	topoutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/util/topology"
+)
+
+// PluginType is the plugin type for the topology stamp handler.
+const PluginType = "topology-stamp-handler"
+
+// defaultHeaderName is the response header the encoded topology is written
+// to, and the header topology-affinity-filter/-scorer read the peer topology
+// from in coordinator deployments.
+const defaultHeaderName = "x-peer-topology"
+
+type parameters struct {
+	// HeaderName is the response header the encoded topology is written to.
+	// Defaults to "x-peer-topology".
+	HeaderName string `json:"headerName,omitempty"`
+	// ProfileName selects the scheduling profile whose selected endpoint's
+	// topology is stamped. Empty selects the primary profile's endpoint.
+	ProfileName string `json:"profileName,omitempty"`
+	// TopologyProducerName selects the topology-extractor instance to read
+	// endpoint topology from. Defaults to the extractor's default producer.
+	TopologyProducerName string `json:"topologyProducerName,omitempty"`
+}
+
+var _ fwkrc.ResponseHeaderProcessor = &Handler{}
+
+// Factory creates a topology stamp handler.
+func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	params := parameters{}
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&params); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' handler - %w", PluginType, err)
+		}
+	}
+	if params.HeaderName == "" {
+		params.HeaderName = defaultHeaderName
+	}
+	if name == "" {
+		name = PluginType
+	}
+	return &Handler{
+		typedName:   fwkplugin.TypedName{Type: PluginType, Name: name},
+		headerName:  params.HeaderName,
+		profileName: params.ProfileName,
+		dataKey:     attrtopology.TopologyAttributeKey.WithNonEmptyProducerName(params.TopologyProducerName),
+	}, nil
+}
+
+// Handler stamps the encoded Topology of a scheduling profile's selected
+// endpoint onto the response headers.
+type Handler struct {
+	typedName   fwkplugin.TypedName
+	headerName  string
+	profileName string
+	dataKey     fwkplugin.DataKey
+}
+
+func (h *Handler) TypedName() fwkplugin.TypedName {
+	return h.typedName
+}
+
+// ResponseHeader stamps h.headerName on response with the encoded topology of
+// the endpoint selected by h.profileName (the primary profile's endpoint when
+// unset). It sets nothing when the profile did not run, the endpoint has no
+// Topology attribute, or response has no header map to write to.
+func (h *Handler) ResponseHeader(_ context.Context, request *fwksched.InferenceRequest, response *fwkrc.Response, _ *fwkdl.EndpointMetadata) {
+	if response == nil || response.Headers == nil || request == nil || request.SchedulingResult == nil {
+		return
+	}
+	profileName := h.profileName
+	if profileName == "" {
+		profileName = request.SchedulingResult.PrimaryProfileName
+	}
+	result := request.SchedulingResult.ProfileResults[profileName]
+	if result == nil || len(result.TargetEndpoints) == 0 || result.TargetEndpoints[0] == nil {
+		return
+	}
+	topo, ok := fwkdl.ReadAttribute[*attrtopology.Topology](result.TargetEndpoints[0], h.dataKey.String())
+	if !ok {
+		return
+	}
+	response.Headers[h.headerName] = topoutil.Encode(topo)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp/stamp.go
+++ b/pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp/stamp.go
@@ -23,7 +23,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
+	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
@@ -37,10 +39,9 @@ const PluginType = "topology-stamp-handler"
 
 // defaultHeaderName is the response header the encoded topology is written
 // to, and the header topology-affinity-filter/-scorer read the peer topology
-// from in coordinator deployments. Must match gateway.PeerTopologyHeader in
-// pkg/coordinator/gateway and peerTopologyHeaderName in
-// pkg/epp/util/request/headers.go.
-const defaultHeaderName = "x-peer-topology"
+// from in coordinator deployments. Defaults to reqcommon.PeerTopologyHeaderKey,
+// the single definition gateway.PeerTopologyHeader must match.
+const defaultHeaderName = reqcommon.PeerTopologyHeaderKey
 
 type parameters struct {
 	// HeaderName is the response header the encoded topology is written to.
@@ -54,7 +55,10 @@ type parameters struct {
 	TopologyProducerName string `json:"topologyProducerName,omitempty"`
 }
 
-var _ fwkrc.ResponseHeaderProcessor = &Handler{}
+var (
+	_ fwkrc.ResponseHeaderProcessor = &Handler{}
+	_ fwkplugin.ConsumerPlugin      = &Handler{}
+)
 
 // Factory creates a topology stamp handler.
 func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
@@ -72,7 +76,7 @@ func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkp
 	}
 	return &Handler{
 		typedName:   fwkplugin.TypedName{Type: PluginType, Name: name},
-		headerName:  params.HeaderName,
+		headerName:  strings.ToLower(params.HeaderName),
 		profileName: params.ProfileName,
 		dataKey:     attrtopology.TopologyAttributeKey.WithNonEmptyProducerName(params.TopologyProducerName),
 	}, nil
@@ -89,6 +93,15 @@ type Handler struct {
 
 func (h *Handler) TypedName() fwkplugin.TypedName {
 	return h.typedName
+}
+
+// Consumes returns the Topology attribute as optional: a missing producer
+// logs a startup warning rather than an error, since ResponseHeader already
+// no-ops when the attribute is absent.
+func (h *Handler) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
+		Optional: map[fwkplugin.DataKey]any{h.dataKey: attrtopology.Topology{}},
+	}
 }
 
 // ResponseHeader stamps h.headerName on response with the encoded topology of

--- a/pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp/stamp.go
+++ b/pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp/stamp.go
@@ -37,7 +37,9 @@ const PluginType = "topology-stamp-handler"
 
 // defaultHeaderName is the response header the encoded topology is written
 // to, and the header topology-affinity-filter/-scorer read the peer topology
-// from in coordinator deployments.
+// from in coordinator deployments. Must match gateway.PeerTopologyHeader in
+// pkg/coordinator/gateway and peerTopologyHeaderName in
+// pkg/epp/util/request/headers.go.
 const defaultHeaderName = "x-peer-topology"
 
 type parameters struct {

--- a/pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp/stamp_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp/stamp_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologystamp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+)
+
+func makeEndpoint(t *testing.T, topo *attrtopology.Topology) fwksched.Endpoint {
+	t.Helper()
+	meta := &fwkdl.EndpointMetadata{ID: types.NamespacedName{Name: "prefill-1", Namespace: "default"}}
+	ep := fwksched.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
+	if topo != nil {
+		ep.Put(attrtopology.TopologyAttributeKey.String(), topo)
+	}
+	return ep
+}
+
+func newTestHandler() *Handler {
+	return &Handler{
+		typedName:  fwkplugin.TypedName{Type: PluginType, Name: "test"},
+		headerName: defaultHeaderName,
+		dataKey:    attrtopology.TopologyAttributeKey,
+	}
+}
+
+func schedulingResult(endpoint fwksched.Endpoint) *fwksched.SchedulingResult {
+	return &fwksched.SchedulingResult{
+		PrimaryProfileName: "prefill",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"prefill": {TargetEndpoints: []fwksched.Endpoint{endpoint}},
+		},
+	}
+}
+
+func TestResponseHeader_StampsFromPrimaryProfile(t *testing.T) {
+	ep := makeEndpoint(t, &attrtopology.Topology{Hostname: "node12", Rack: "r7"})
+	request := &fwksched.InferenceRequest{SchedulingResult: schedulingResult(ep)}
+	response := &fwkrc.Response{Headers: map[string]string{}}
+
+	h := newTestHandler()
+	h.ResponseHeader(context.Background(), request, response, nil)
+
+	assert.Equal(t, "host=node12,rack=r7", response.Headers[defaultHeaderName])
+}
+
+func TestResponseHeader_StampsFromConfiguredProfile(t *testing.T) {
+	ep := makeEndpoint(t, &attrtopology.Topology{Hostname: "node12"})
+	request := &fwksched.InferenceRequest{SchedulingResult: schedulingResult(ep)}
+	response := &fwkrc.Response{Headers: map[string]string{}}
+
+	h := newTestHandler()
+	h.profileName = "prefill"
+	h.ResponseHeader(context.Background(), request, response, nil)
+
+	assert.Equal(t, "host=node12", response.Headers[defaultHeaderName])
+}
+
+func TestResponseHeader_NoopWhenProfileDidNotRun(t *testing.T) {
+	request := &fwksched.InferenceRequest{SchedulingResult: &fwksched.SchedulingResult{PrimaryProfileName: "decode"}}
+	response := &fwkrc.Response{Headers: map[string]string{}}
+
+	h := newTestHandler()
+	h.ResponseHeader(context.Background(), request, response, nil)
+
+	assert.Empty(t, response.Headers)
+}
+
+func TestResponseHeader_NoopWhenEndpointMissingAttribute(t *testing.T) {
+	ep := makeEndpoint(t, nil)
+	request := &fwksched.InferenceRequest{SchedulingResult: schedulingResult(ep)}
+	response := &fwkrc.Response{Headers: map[string]string{}}
+
+	h := newTestHandler()
+	h.ResponseHeader(context.Background(), request, response, nil)
+
+	assert.Empty(t, response.Headers)
+}
+
+func TestResponseHeader_NoopWhenSchedulingResultNil(t *testing.T) {
+	request := &fwksched.InferenceRequest{}
+	response := &fwkrc.Response{Headers: map[string]string{}}
+
+	h := newTestHandler()
+	h.ResponseHeader(context.Background(), request, response, nil)
+
+	assert.Empty(t, response.Headers)
+}
+
+func TestResponseHeader_NoopWhenResponseHeadersNil(t *testing.T) {
+	ep := makeEndpoint(t, &attrtopology.Topology{Hostname: "node12"})
+	request := &fwksched.InferenceRequest{SchedulingResult: schedulingResult(ep)}
+	response := &fwkrc.Response{}
+
+	h := newTestHandler()
+	assert.NotPanics(t, func() {
+		h.ResponseHeader(context.Background(), request, response, nil)
+	})
+}
+
+func TestFactory_Defaults(t *testing.T) {
+	p, err := Factory("", nil, nil)
+	require.NoError(t, err)
+	h, ok := p.(*Handler)
+	require.True(t, ok)
+	assert.Equal(t, defaultHeaderName, h.headerName)
+	assert.Equal(t, PluginType, h.TypedName().Name)
+}
+
+func TestFactory_CustomHeaderName(t *testing.T) {
+	p, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"headerName": "x-custom-topology"}`)), nil)
+	require.NoError(t, err)
+	h, ok := p.(*Handler)
+	require.True(t, ok)
+	assert.Equal(t, "x-custom-topology", h.headerName)
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/README.md
@@ -7,15 +7,22 @@ in an earlier scheduling phase.
 
 ## What it does
 
-Scoped to single-EPP disaggregated deployments, where one EPP process runs both the
-`decode` and `prefill` scheduling profiles for a request. Coordinator deployments, where
-prefill and decode are picked by separate EPPs, are not yet supported.
+Supports two deployment modes:
 
-For a disaggregated prefill/decode request, `disagg-profile-handler` selects the decode
-endpoint first, then runs the `prefill` profile to select a prefill endpoint. This plugin
-runs in the `prefill` profile and keeps only the candidates whose topology is co-located
-with the decode pick at `minAffinity` or tighter (host, rack, zone, or region; same host
-implies same rack, zone, and region).
+- **Single EPP**: one EPP process runs both the `decode` and `prefill` scheduling
+  profiles for a request. `disagg-profile-handler` selects the decode endpoint first,
+  then runs the `prefill` profile to select a prefill endpoint. This plugin runs in the
+  `prefill` profile and compares candidates against the decode pick, resolved from a
+  request attribute.
+- **Coordinator, separate P/D EPPs**: the prefill EPP is picked first, in a different
+  process. The prefill EPP's `topology-stamp-handler` plugin encodes its selected
+  endpoint's topology onto a response header; the coordinator forwards that header onto
+  the decode request. This plugin runs in the decode EPP's `decode` profile and resolves
+  the peer topology from that header via `peerTopologyHeader`.
+
+In both modes the plugin keeps only the candidates whose topology is co-located with the
+peer at `minAffinity` or tighter (host, rack, zone, or region; same host implies same
+rack, zone, and region).
 
 Two rules make the filter fail open rather than restrict routing when locality is unknown
 or unreachable:
@@ -38,9 +45,12 @@ bandwidth. On that hardware, use `minAffinity: rack`, if the extractor populates
 
 ## Inputs consumed
 
-Reads the `Topology` attribute (`topology-extractor`) from the candidate endpoints and
-from the peer endpoint. The peer endpoint is resolved from the `peer-endpoint` request
-attribute, published by `disagg-profile-handler` before running the `prefill` profile.
+Reads the `Topology` attribute (`topology-extractor`) from the candidate endpoints.
+
+The peer topology is resolved first from the `peer-endpoint` request attribute (single
+EPP, published by `disagg-profile-handler` before running the `prefill` profile), falling
+back to the `peerTopologyHeader` request header (coordinator mode) when the attribute is
+absent.
 
 Declares `Topology` as an optional data dependency: a config with no `topology-extractor`
 logs a startup warning rather than an error, since the filter fails open when the
@@ -52,8 +62,9 @@ attribute is absent.
 |--------------------------|----------|---------|----------------------------------------------------------------------------------------|
 | `minAffinity`            | no       | `host`  | Tightest-to-loosest floor an endpoint must meet: `host`, `rack`, `zone`, or `region`.  |
 | `topologyProducerName`   | no       | default producer | `topology-extractor` instance to read the `Topology` attribute from.        |
+| `peerTopologyHeader`     | no       | unset   | Request header carrying the peer topology in coordinator deployments. Set to `x-peer-topology` when running in a decode EPP behind the coordinator; unused in single-EPP deployments. |
 
-**Configuration Example:**
+**Configuration Example, single EPP:**
 ```yaml
 plugins:
   - type: topology-extractor
@@ -65,6 +76,21 @@ schedulingProfiles:
   - name: prefill
     plugins:
       - pluginRef: prefill-topology-affinity
+```
+
+**Configuration Example, coordinator (decode EPP):**
+```yaml
+plugins:
+  - type: topology-extractor
+  - type: topology-affinity-filter
+    name: decode-topology-affinity
+    parameters:
+      minAffinity: host
+      peerTopologyHeader: x-peer-topology
+schedulingProfiles:
+  - name: decode
+    plugins:
+      - pluginRef: decode-topology-affinity
 ```
 
 ## See also

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/README.md
@@ -64,6 +64,10 @@ attribute is absent.
 | `topologyProducerName`   | no       | default producer | `topology-extractor` instance to read the `Topology` attribute from.        |
 | `peerTopologyHeader`     | no       | unset   | Request header carrying the peer topology in coordinator deployments. Set to `x-peer-topology` when running in a decode EPP behind the coordinator; unused in single-EPP deployments. |
 
+The plugin trusts `peerTopologyHeader` without re-verifying its source. Only set it on a
+profile reachable exclusively through the coordinator's forwarded header; a decode EPP
+reachable directly by a client would let that client spoof its own peer topology.
+
 **Configuration Example, single EPP:**
 ```yaml
 plugins:

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter.go
@@ -39,6 +39,11 @@ type parameters struct {
 	// TopologyProducerName selects the topology-extractor instance to read
 	// endpoint topology from. Defaults to the extractor's default producer.
 	TopologyProducerName string `json:"topologyProducerName,omitempty"`
+	// PeerTopologyHeader names the request header carrying the peer's
+	// encoded topology in coordinator deployments, where the peer endpoint
+	// is not in-process. Unset by default: single-EPP deployments resolve
+	// the peer through the peer-endpoint request attribute instead.
+	PeerTopologyHeader string `json:"peerTopologyHeader,omitempty"`
 }
 
 var _ fwksched.Filter = &Filter{}
@@ -63,9 +68,10 @@ func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkp
 		name = FilterType
 	}
 	return &Filter{
-		typedName:   fwkplugin.TypedName{Type: FilterType, Name: name},
-		minAffinity: minAffinity,
-		dataKey:     attrtopology.TopologyAttributeKey.WithNonEmptyProducerName(params.TopologyProducerName),
+		typedName:          fwkplugin.TypedName{Type: FilterType, Name: name},
+		minAffinity:        minAffinity,
+		dataKey:            attrtopology.TopologyAttributeKey.WithNonEmptyProducerName(params.TopologyProducerName),
+		peerTopologyHeader: params.PeerTopologyHeader,
 	}, nil
 }
 
@@ -79,9 +85,10 @@ func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkp
 // topology affinity is a preference and must never make a request
 // unroutable.
 type Filter struct {
-	typedName   fwkplugin.TypedName
-	minAffinity topoutil.Level
-	dataKey     fwkplugin.DataKey
+	typedName          fwkplugin.TypedName
+	minAffinity        topoutil.Level
+	dataKey            fwkplugin.DataKey
+	peerTopologyHeader string
 }
 
 func (f *Filter) TypedName() fwkplugin.TypedName {
@@ -99,7 +106,7 @@ func (f *Filter) Consumes() fwkplugin.DataDependencies {
 }
 
 func (f *Filter) Filter(_ context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
-	peer, ok := topoutil.PeerTopology(request, f.dataKey.String())
+	peer, ok := topoutil.PeerTopology(request, f.dataKey.String(), f.peerTopologyHeader)
 	if !ok {
 		return endpoints
 	}

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter_test.go
@@ -125,6 +125,17 @@ func TestFilter_EndpointMissingAttributeIsDropped(t *testing.T) {
 	assert.Equal(t, "same-host", got[0].GetMetadata().ID.Name)
 }
 
+func TestFilter_MatchesPeerFromHeaderWhenNoAttribute(t *testing.T) {
+	sameHost := makeEndpoint(t, "same-host", &attrtopology.Topology{Hostname: "h1"})
+
+	f := newTestFilter(topoutil.LevelHost)
+	f.peerTopologyHeader = "x-peer-topology"
+	req := &fwksched.InferenceRequest{Headers: map[string]string{"x-peer-topology": "host=h1"}}
+	got := f.Filter(context.Background(), req, []fwksched.Endpoint{sameHost})
+	require.Len(t, got, 1)
+	assert.Equal(t, "same-host", got[0].GetMetadata().ID.Name)
+}
+
 func TestFilter_Consumes(t *testing.T) {
 	f := newTestFilter(topoutil.LevelHost)
 
@@ -142,6 +153,15 @@ func TestFactory_Defaults(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, topoutil.LevelHost, f.minAffinity)
 	assert.Equal(t, FilterType, f.TypedName().Name)
+	assert.Empty(t, f.peerTopologyHeader)
+}
+
+func TestFactory_PeerTopologyHeader(t *testing.T) {
+	p, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"peerTopologyHeader": "x-peer-topology"}`)), nil)
+	require.NoError(t, err)
+	f, ok := p.(*Filter)
+	require.True(t, ok)
+	assert.Equal(t, "x-peer-topology", f.peerTopologyHeader)
 }
 
 func TestFactory_InvalidMinAffinity(t *testing.T) {

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
@@ -86,6 +86,10 @@ attribute is absent.
 | `topologyProducerName`   | no       | default producer | `topology-extractor` instance to read the `Topology` attribute from. |
 | `peerTopologyHeader`     | no       | unset   | Request header carrying the peer topology in coordinator deployments. Set to `x-peer-topology` when running in a decode EPP behind the coordinator; unused in single-EPP deployments. |
 
+The plugin trusts `peerTopologyHeader` without re-verifying its source. Only set it on a
+profile reachable exclusively through the coordinator's forwarded header; a decode EPP
+reachable directly by a client would let that client spoof its own peer topology.
+
 **Configuration Example, single EPP:**
 ```yaml
 plugins:

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/README.md
@@ -9,15 +9,22 @@ in an earlier scheduling phase.
 
 ## What it does
 
-Scoped to single-EPP disaggregated deployments, where one EPP process runs both the
-`decode` and `prefill` scheduling profiles for a request. Coordinator deployments, where
-prefill and decode are picked by separate EPPs, are not yet supported.
+Supports two deployment modes:
 
-For a disaggregated prefill/decode request, `disagg-profile-handler` selects the decode
-endpoint first, then runs the `prefill` profile to select a prefill endpoint. This plugin
-runs in the `prefill` profile and grades each candidate by the tightest topology level it
-shares with the decode pick (host, rack, zone, or region; same host implies same rack,
-zone, and region), using a fixed proximity curve:
+- **Single EPP**: one EPP process runs both the `decode` and `prefill` scheduling
+  profiles for a request. `disagg-profile-handler` selects the decode endpoint first,
+  then runs the `prefill` profile to select a prefill endpoint. This plugin runs in the
+  `prefill` profile and grades candidates against the decode pick, resolved from a
+  request attribute.
+- **Coordinator, separate P/D EPPs**: the prefill EPP is picked first, in a different
+  process. The prefill EPP's `topology-stamp-handler` plugin encodes its selected
+  endpoint's topology onto a response header; the coordinator forwards that header onto
+  the decode request. This plugin runs in the decode EPP's `decode` profile and resolves
+  the peer topology from that header via `peerTopologyHeader`.
+
+In both modes the plugin grades each candidate by the tightest topology level it shares
+with the peer (host, rack, zone, or region; same host implies same rack, zone, and
+region), using a fixed proximity curve:
 
 | Common level | Score | KV-transfer path        |
 |--------------|-------|--------------------------|
@@ -61,9 +68,12 @@ physical enclosure.
 
 ## Inputs consumed
 
-Reads the `Topology` attribute (`topology-extractor`) from the candidate endpoints and
-from the peer endpoint. The peer endpoint is resolved from the `peer-endpoint` request
-attribute, published by `disagg-profile-handler` before running the `prefill` profile.
+Reads the `Topology` attribute (`topology-extractor`) from the candidate endpoints.
+
+The peer topology is resolved first from the `peer-endpoint` request attribute (single
+EPP, published by `disagg-profile-handler` before running the `prefill` profile), falling
+back to the `peerTopologyHeader` request header (coordinator mode) when the attribute is
+absent.
 
 Declares `Topology` as an optional data dependency: a config with no `topology-extractor`
 logs a startup warning rather than an error, since every candidate scores 0 when the
@@ -74,8 +84,9 @@ attribute is absent.
 | Parameter               | Required | Default | Description                                                                  |
 |--------------------------|----------|---------|--------------------------------------------------------------------------------|
 | `topologyProducerName`   | no       | default producer | `topology-extractor` instance to read the `Topology` attribute from. |
+| `peerTopologyHeader`     | no       | unset   | Request header carrying the peer topology in coordinator deployments. Set to `x-peer-topology` when running in a decode EPP behind the coordinator; unused in single-EPP deployments. |
 
-**Configuration Example:**
+**Configuration Example, single EPP:**
 ```yaml
 plugins:
   - type: topology-extractor
@@ -85,6 +96,21 @@ schedulingProfiles:
   - name: prefill
     plugins:
       - pluginRef: prefill-topology-affinity
+        weight: 1
+```
+
+**Configuration Example, coordinator (decode EPP):**
+```yaml
+plugins:
+  - type: topology-extractor
+  - type: topology-affinity-scorer
+    name: decode-topology-affinity
+    parameters:
+      peerTopologyHeader: x-peer-topology
+schedulingProfiles:
+  - name: decode
+    plugins:
+      - pluginRef: decode-topology-affinity
         weight: 1
 ```
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer.go
@@ -54,6 +54,11 @@ type parameters struct {
 	// TopologyProducerName selects the topology-extractor instance to read
 	// endpoint topology from. Defaults to the extractor's default producer.
 	TopologyProducerName string `json:"topologyProducerName,omitempty"`
+	// PeerTopologyHeader names the request header carrying the peer's
+	// encoded topology in coordinator deployments, where the peer endpoint
+	// is not in-process. Unset by default: single-EPP deployments resolve
+	// the peer through the peer-endpoint request attribute instead.
+	PeerTopologyHeader string `json:"peerTopologyHeader,omitempty"`
 }
 
 var _ fwksched.Scorer = &Scorer{}
@@ -71,8 +76,9 @@ func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkp
 		name = ScorerType
 	}
 	return &Scorer{
-		typedName: fwkplugin.TypedName{Type: ScorerType, Name: name},
-		dataKey:   attrtopology.TopologyAttributeKey.WithNonEmptyProducerName(params.TopologyProducerName),
+		typedName:          fwkplugin.TypedName{Type: ScorerType, Name: name},
+		dataKey:            attrtopology.TopologyAttributeKey.WithNonEmptyProducerName(params.TopologyProducerName),
+		peerTopologyHeader: params.PeerTopologyHeader,
 	}, nil
 }
 
@@ -80,8 +86,9 @@ func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkp
 // endpoint, using the fixed levelScores curve. Endpoints score 0 when no peer
 // topology is available, or when the endpoint has no matching field.
 type Scorer struct {
-	typedName fwkplugin.TypedName
-	dataKey   fwkplugin.DataKey
+	typedName          fwkplugin.TypedName
+	dataKey            fwkplugin.DataKey
+	peerTopologyHeader string
 }
 
 func (s *Scorer) TypedName() fwkplugin.TypedName {
@@ -105,7 +112,7 @@ func (s *Scorer) Category() fwksched.ScorerCategory {
 func (s *Scorer) Score(_ context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
 	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 
-	peer, ok := topoutil.PeerTopology(request, s.dataKey.String())
+	peer, ok := topoutil.PeerTopology(request, s.dataKey.String(), s.peerTopologyHeader)
 	if !ok {
 		for _, endpoint := range endpoints {
 			scores[endpoint] = 0

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer_test.go
@@ -116,6 +116,16 @@ func TestScorer_Category(t *testing.T) {
 	assert.Equal(t, fwksched.Affinity, s.Category())
 }
 
+func TestScorer_ScoresPeerFromHeaderWhenNoAttribute(t *testing.T) {
+	sameHost := makeEndpoint(t, "same-host", &attrtopology.Topology{Hostname: "h1"})
+
+	s := newTestScorer()
+	s.peerTopologyHeader = "x-peer-topology"
+	req := &fwksched.InferenceRequest{Headers: map[string]string{"x-peer-topology": "host=h1"}}
+	got := s.Score(context.Background(), req, []fwksched.Endpoint{sameHost})
+	assert.Equal(t, 1.00, got[sameHost])
+}
+
 func TestScorer_Consumes(t *testing.T) {
 	s := newTestScorer()
 
@@ -132,4 +142,13 @@ func TestFactory_Defaults(t *testing.T) {
 	s, ok := p.(*Scorer)
 	require.True(t, ok)
 	assert.Equal(t, ScorerType, s.TypedName().Name)
+	assert.Empty(t, s.peerTopologyHeader)
+}
+
+func TestFactory_PeerTopologyHeader(t *testing.T) {
+	p, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"peerTopologyHeader": "x-peer-topology"}`)), nil)
+	require.NoError(t, err)
+	s, ok := p.(*Scorer)
+	require.True(t, ok)
+	assert.Equal(t, "x-peer-topology", s.peerTopologyHeader)
 }

--- a/pkg/epp/framework/plugins/scheduling/util/topology/header.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/header.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	"strings"
+
+	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+)
+
+// Encode and Decode use a hand-rolled key=value wire format rather than JSON.
+// JSON would be a smaller diff (struct tags plus Marshal/Unmarshal, with
+// omitempty handling absent levels for free) at the cost of a noisier wire
+// value and log line and a needed size cap. key=value costs a small
+// hand-written parser and buys a self-describing value and
+// order-independent, forward-compatible keys: an unknown key is ignored
+// instead of rejected.
+
+// Encode serializes a Topology as comma-separated key=value pairs, skipping
+// empty fields. Encoding a nil Topology, or one with every field empty,
+// returns "".
+func Encode(t *attrtopology.Topology) string {
+	if t == nil {
+		return ""
+	}
+	fields := []struct {
+		key, value string
+	}{
+		{"host", t.Hostname},
+		{"rack", t.Rack},
+		{"zone", t.Zone},
+		{"region", t.Region},
+	}
+	var pairs []string
+	for _, f := range fields {
+		if f.value == "" || strings.ContainsAny(f.value, ",=") {
+			continue
+		}
+		pairs = append(pairs, f.key+"="+f.value)
+	}
+	return strings.Join(pairs, ",")
+}
+
+// Decode parses a key=value wire value produced by Encode back into a
+// Topology. Unknown keys are ignored, so a future level is additive.
+// Malformed input (a pair with no "=") is skipped rather than rejected.
+// Decode never returns an error; an empty or fully malformed value simply
+// yields a Topology with every field empty.
+func Decode(header string) *attrtopology.Topology {
+	t := &attrtopology.Topology{}
+	for _, pair := range strings.Split(header, ",") {
+		key, value, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "host":
+			t.Hostname = value
+		case "rack":
+			t.Rack = value
+		case "zone":
+			t.Zone = value
+		case "region":
+			t.Region = value
+		}
+	}
+	return t
+}

--- a/pkg/epp/framework/plugins/scheduling/util/topology/header_test.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/header_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
+)
+
+func TestEncodeDecode_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		topo *attrtopology.Topology
+	}{
+		{"full", &attrtopology.Topology{Hostname: "node12", Rack: "r7", Zone: "us-east1-a", Region: "us-east1"}},
+		{"partial-no-rack", &attrtopology.Topology{Hostname: "node12", Zone: "us-east1-a"}},
+		{"host-only", &attrtopology.Topology{Hostname: "node12"}},
+		{"empty", &attrtopology.Topology{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Decode(Encode(tc.topo))
+			assert.Equal(t, tc.topo, got)
+		})
+	}
+}
+
+func TestEncode_NilReturnsEmpty(t *testing.T) {
+	assert.Equal(t, "", Encode(nil))
+}
+
+func TestEncode_SkipsValueWithSeparator(t *testing.T) {
+	got := Encode(&attrtopology.Topology{Hostname: "node12", Rack: "r7,r8", Zone: "a=b"})
+	assert.Equal(t, "host=node12", got)
+}
+
+func TestDecode_UnknownKeyIgnored(t *testing.T) {
+	got := Decode("host=node12,gpu=h100")
+	assert.Equal(t, &attrtopology.Topology{Hostname: "node12"}, got)
+}
+
+func TestDecode_MalformedInputYieldsEmptyTopology(t *testing.T) {
+	got := Decode("not-a-pair,,host")
+	assert.Equal(t, &attrtopology.Topology{}, got)
+}
+
+func TestDecode_EmptyString(t *testing.T) {
+	got := Decode("")
+	assert.Equal(t, &attrtopology.Topology{}, got)
+}

--- a/pkg/epp/framework/plugins/scheduling/util/topology/peer.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/peer.go
@@ -17,6 +17,8 @@ limitations under the License.
 package topology
 
 import (
+	"strings"
+
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrtopology "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/topology"
@@ -47,7 +49,7 @@ func PeerTopology(request *fwksched.InferenceRequest, dataKey, headerName string
 	if headerName == "" {
 		return nil, false
 	}
-	header := request.Headers[headerName]
+	header := request.Headers[strings.ToLower(headerName)]
 	if header == "" {
 		return nil, false
 	}

--- a/pkg/epp/framework/plugins/scheduling/util/topology/peer.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/peer.go
@@ -26,18 +26,30 @@ import (
 // PeerTopology returns the topology of the endpoint selected in the peer
 // scheduling phase, or false when no peer topology is available.
 //
-// disagg-profile-handler publishes the peer Endpoint as the
-// disagg.PeerEndpointAttributeKey request attribute before running the
-// prefill profile; its Topology attribute (dataKey) is read directly. Scoped
-// to single-EPP deployments; coordinator deployments, where the peer's
-// topology arrives on a request header instead, are not yet supported.
-func PeerTopology(request *fwksched.InferenceRequest, dataKey string) (*attrtopology.Topology, bool) {
+// Single-EPP deployments: disagg-profile-handler publishes the peer Endpoint
+// as the disagg.PeerEndpointAttributeKey request attribute before running
+// the prefill profile; its Topology attribute (dataKey) is read directly.
+//
+// Coordinator deployments, where prefill and decode are picked by separate
+// EPPs, carry the peer's topology on headerName instead, stamped by
+// topology-stamp-handler on the prefill response and forwarded by the
+// coordinator to the decode request. The attribute is preferred over the
+// header when both are present.
+func PeerTopology(request *fwksched.InferenceRequest, dataKey, headerName string) (*attrtopology.Topology, bool) {
 	if request == nil {
 		return nil, false
 	}
-	peer, ok := fwksched.ReadRequestAttribute[fwksched.Endpoint](request, disagg.PeerEndpointAttributeKey)
-	if !ok || peer == nil {
+	if peer, ok := fwksched.ReadRequestAttribute[fwksched.Endpoint](request, disagg.PeerEndpointAttributeKey); ok && peer != nil {
+		if topo, ok := fwkdl.ReadAttribute[*attrtopology.Topology](peer, dataKey); ok {
+			return topo, true
+		}
+	}
+	if headerName == "" {
 		return nil, false
 	}
-	return fwkdl.ReadAttribute[*attrtopology.Topology](peer, dataKey)
+	header := request.Headers[headerName]
+	if header == "" {
+		return nil, false
+	}
+	return Decode(header), true
 }

--- a/pkg/epp/framework/plugins/scheduling/util/topology/peer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/peer_test.go
@@ -29,13 +29,13 @@ import (
 )
 
 func TestPeerTopology_NilRequest(t *testing.T) {
-	_, ok := PeerTopology(nil, attrtopology.TopologyAttributeKey.String())
+	_, ok := PeerTopology(nil, attrtopology.TopologyAttributeKey.String(), "")
 	assert.False(t, ok)
 }
 
-func TestPeerTopology_NoPeerAttribute(t *testing.T) {
+func TestPeerTopology_NoPeerAttributeNoHeader(t *testing.T) {
 	req := &fwksched.InferenceRequest{}
-	_, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String())
+	_, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "")
 	assert.False(t, ok)
 }
 
@@ -48,7 +48,7 @@ func TestPeerTopology_FromPeerEndpointAttribute(t *testing.T) {
 	req := &fwksched.InferenceRequest{}
 	req.PutAttribute(disagg.PeerEndpointAttributeKey, peerEndpoint)
 
-	got, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String())
+	got, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "")
 	assert.True(t, ok)
 	assert.Equal(t, topo, got)
 }
@@ -60,6 +60,34 @@ func TestPeerTopology_PeerEndpointMissingTopologyAttribute(t *testing.T) {
 	req := &fwksched.InferenceRequest{}
 	req.PutAttribute(disagg.PeerEndpointAttributeKey, peerEndpoint)
 
-	_, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String())
+	_, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "")
 	assert.False(t, ok)
+}
+
+func TestPeerTopology_FromHeaderWhenNoAttribute(t *testing.T) {
+	req := &fwksched.InferenceRequest{Headers: map[string]string{"x-peer-topology": "host=node12,rack=r7"}}
+
+	got, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "x-peer-topology")
+	assert.True(t, ok)
+	assert.Equal(t, &attrtopology.Topology{Hostname: "node12", Rack: "r7"}, got)
+}
+
+func TestPeerTopology_NoHeaderAndNoAttribute(t *testing.T) {
+	req := &fwksched.InferenceRequest{}
+	_, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "x-peer-topology")
+	assert.False(t, ok)
+}
+
+func TestPeerTopology_AttributePreferredOverHeader(t *testing.T) {
+	meta := &fwkdl.EndpointMetadata{ID: types.NamespacedName{Name: "peer", Namespace: "default"}}
+	peerEndpoint := fwksched.NewEndpoint(meta, &fwkdl.Metrics{}, fwkdl.NewAttributes())
+	topo := &attrtopology.Topology{Hostname: "attr-host"}
+	peerEndpoint.Put(attrtopology.TopologyAttributeKey.String(), topo)
+
+	req := &fwksched.InferenceRequest{Headers: map[string]string{"x-peer-topology": "host=header-host"}}
+	req.PutAttribute(disagg.PeerEndpointAttributeKey, peerEndpoint)
+
+	got, ok := PeerTopology(req, attrtopology.TopologyAttributeKey.String(), "x-peer-topology")
+	assert.True(t, ok)
+	assert.Equal(t, topo, got)
 }

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -419,11 +419,12 @@ func TestGenerateResponseHeaders_Sanitization(t *testing.T) {
 	reqCtx := &RequestContext{
 		Response: &Response{
 			Headers: map[string]string{
-				"x-backend-server":              "vllm-v0.6.3",                // should passthrough
-				metadata.ObjectiveKey:           "sensitive-objective-id",     // should be stripped
-				metadata.OldObjectiveKey:        "old-sensitive-objective-id", // should be stripped
-				metadata.DestinationEndpointKey: "10.2.0.5:8080",              // should be stripped
-				"content-length":                "500",                        // should be stripped
+				"x-backend-server":              "vllm-v0.6.3",                 // should passthrough
+				metadata.ObjectiveKey:           "sensitive-objective-id",      // should be stripped
+				metadata.OldObjectiveKey:        "old-sensitive-objective-id",  // should be stripped
+				metadata.DestinationEndpointKey: "10.2.0.5:8080",               // should be stripped
+				"content-length":                "500",                         // should be stripped
+				"x-peer-topology":               "host=node12,zone=us-east1-a", // stamped by topology-stamp-handler, must reach the coordinator
 			},
 		},
 	}
@@ -441,6 +442,7 @@ func TestGenerateResponseHeaders_Sanitization(t *testing.T) {
 	assert.NotContains(t, gotHeaders, metadata.OldObjectiveKey)
 	assert.NotContains(t, gotHeaders, metadata.DestinationEndpointKey)
 	assert.NotContains(t, gotHeaders, "content-length")
+	assert.Equal(t, "host=node12,zone=us-east1-a", gotHeaders["x-peer-topology"])
 }
 
 func TestRewriteModelName(t *testing.T) {

--- a/pkg/epp/util/request/headers.go
+++ b/pkg/epp/util/request/headers.go
@@ -25,6 +25,12 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
 
+// peerTopologyHeaderName is the coordinator's cross-EPP header carrying the
+// prefill endpoint's topology to the decode EPP. A client-supplied value must
+// not reach the backend, since topology-affinity-filter and
+// topology-affinity-scorer trust it as the peer to compare against.
+const peerTopologyHeaderName = "x-peer-topology"
+
 var (
 	// InputControlHeaders are sent by the Gateway/User to control EPP behavior.
 	// We must extract these, then strip them so they don't leak to the backend.
@@ -48,6 +54,7 @@ var (
 			metadata.DestinationEndpointServedKey,
 		),
 		errcommon.RequestDroppedReasonHeaderKey,
+		peerTopologyHeaderName,
 	)
 
 	// ProtocolHeaders are managed by the proxy layer (Envoy/EPP).

--- a/pkg/epp/util/request/headers.go
+++ b/pkg/epp/util/request/headers.go
@@ -28,7 +28,10 @@ import (
 // peerTopologyHeaderName is the coordinator's cross-EPP header carrying the
 // prefill endpoint's topology to the decode EPP. A client-supplied value must
 // not reach the backend, since topology-affinity-filter and
-// topology-affinity-scorer trust it as the peer to compare against.
+// topology-affinity-scorer trust it as the peer to compare against. Must
+// match gateway.PeerTopologyHeader in pkg/coordinator/gateway and
+// defaultHeaderName in
+// pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp.
 const peerTopologyHeaderName = "x-peer-topology"
 
 var (

--- a/pkg/epp/util/request/headers.go
+++ b/pkg/epp/util/request/headers.go
@@ -25,15 +25,6 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
 
-// peerTopologyHeaderName is the coordinator's cross-EPP header carrying the
-// prefill endpoint's topology to the decode EPP. A client-supplied value must
-// not reach the backend, since topology-affinity-filter and
-// topology-affinity-scorer trust it as the peer to compare against. Must
-// match gateway.PeerTopologyHeader in pkg/coordinator/gateway and
-// defaultHeaderName in
-// pkg/epp/framework/plugins/requestcontrol/responsereceived/topologystamp.
-const peerTopologyHeaderName = "x-peer-topology"
-
 var (
 	// InputControlHeaders are sent by the Gateway/User to control EPP behavior.
 	// We must extract these, then strip them so they don't leak to the backend.
@@ -57,7 +48,6 @@ var (
 			metadata.DestinationEndpointServedKey,
 		),
 		errcommon.RequestDroppedReasonHeaderKey,
-		peerTopologyHeaderName,
 	)
 
 	// ProtocolHeaders are managed by the proxy layer (Envoy/EPP).

--- a/pkg/epp/util/request/headers_test.go
+++ b/pkg/epp/util/request/headers_test.go
@@ -47,11 +47,14 @@ func TestIsSystemOwnedHeaderIncludesAliases(t *testing.T) {
 		metadata.DestinationEndpointServedKey,
 		errcommon.RequestDroppedReasonHeaderKey,
 		"Content-Length",
-		"x-peer-topology",
 	}
 
 	for _, header := range systemHeaders {
 		assert.True(t, IsSystemOwnedHeader(header), "header %q should be system-owned", header)
 	}
 	assert.False(t, IsSystemOwnedHeader("x-user-data"))
+	// x-peer-topology must reach both the backend request (harmless, model
+	// servers ignore it) and the response to the coordinator/client
+	// (topology-stamp-handler's own output) unfiltered.
+	assert.False(t, IsSystemOwnedHeader("x-peer-topology"))
 }

--- a/pkg/epp/util/request/headers_test.go
+++ b/pkg/epp/util/request/headers_test.go
@@ -47,6 +47,7 @@ func TestIsSystemOwnedHeaderIncludesAliases(t *testing.T) {
 		metadata.DestinationEndpointServedKey,
 		errcommon.RequestDroppedReasonHeaderKey,
 		"Content-Length",
+		"x-peer-topology",
 	}
 
 	for _, header := range systemHeaders {

--- a/test/integration/epp/e2e_config_smoke_test.go
+++ b/test/integration/epp/e2e_config_smoke_test.go
@@ -149,6 +149,44 @@ schedulingProfiles:
   - pluginRef: queue-scorer
     weight: 1
 `,
+	"coordinatorPrefillTopologyConfig": `apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: prefill-filter
+- type: max-score-picker
+- type: topology-extractor
+- type: topology-stamp-handler
+  parameters:
+    profileName: default
+- type: single-profile-handler
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: prefill-filter
+  - pluginRef: max-score-picker
+`,
+	"coordinatorDecodeTopologyConfig": `apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: decode-filter
+- type: max-score-picker
+- type: topology-extractor
+- type: topology-affinity-filter
+  parameters:
+    peerTopologyHeader: x-peer-topology
+- type: topology-affinity-scorer
+  parameters:
+    peerTopologyHeader: x-peer-topology
+- type: single-profile-handler
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: decode-filter
+  - pluginRef: topology-affinity-filter
+  - pluginRef: max-score-picker
+  - pluginRef: topology-affinity-scorer
+    weight: 1
+`,
 	"epdConfig": `apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`topology-stamp-handler` (#2319) writes the selected endpoint's encoded
topology onto a response header (`x-peer-topology`) for the coordinator to
relay from the prefill leg to the decode leg. The documented deployment
configures this plugin on the `prefill` profile only, whose response is
consumed solely by the coordinator's `PrefillStep`, which reads the one
header it needs and discards the rest.

If the plugin is instead configured on a `decode` profile (or a shared
plugin config applies it to both), the header survives into the client-facing
response: the decode leg is proxied with a stock `httputil.ReverseProxy`
(`newDecodeProxy` in `pkg/coordinator/steps/decode_proxy.go`), which copies
every upstream response header to the client verbatim unless something
strips it first.

This PR wraps `ModifyResponse` in `newDecodeProxy` to strip
coordinator-internal headers (`pipeline.StripInternalHeaders`, the same
denylist already used to strip a client-supplied `x-peer-topology` on
ingress) from the upstream response before headers are copied to the client.
The wrapper applies uniformly to both call sites (`decode.go` and
`conditional_decode.go`) without requiring either to remember to strip
anything, and preserves each caller's own `modifyResponse` hook (e.g. the
conditional cache-probe's 412 detection).

This PR is based on #2319 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2364

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
