### PR TITLE
[disagg-sidecar] Fix cached token usage for non-streaming P/D responses

### DIFF
--- a/pkg/sidecar/proxy/cached_tokens_usage_rewriter.go
+++ b/pkg/sidecar/proxy/cached_tokens_usage_rewriter.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/felixge/httpsnoop"
 )
@@ -32,6 +31,7 @@ type cachedTokensUsageRewriter struct {
 	wroteHeader  bool
 	streaming    bool
 	streamBuffer []byte
+	jsonBuffer   []byte
 }
 
 // OpenAI-compatible chat usage reports prompt cache hits at
@@ -39,15 +39,20 @@ type cachedTokensUsageRewriter struct {
 // See: https://platform.openai.com/docs/guides/prompt-caching
 const promptTokensDetailsField = "prompt_tokens_details"
 
-func newCachedTokensResponseWriter(w http.ResponseWriter, cachedTokens int) http.ResponseWriter {
-	writer, _ := newCachedTokensResponseWriterWithFinalize(w, cachedTokens)
+func newCachedTokensResponseWriter(
+	w http.ResponseWriter, cachedTokens int, streaming bool,
+) http.ResponseWriter {
+	writer, _ := newCachedTokensResponseWriterWithFinalize(w, cachedTokens, streaming)
 	return writer
 }
 
-func newCachedTokensResponseWriterWithFinalize(w http.ResponseWriter, cachedTokens int) (http.ResponseWriter, func() error) {
+func newCachedTokensResponseWriterWithFinalize(
+	w http.ResponseWriter, cachedTokens int, streaming bool,
+) (http.ResponseWriter, func() error) {
 	rewriter := &cachedTokensUsageRewriter{
 		header:       w.Header(),
 		cachedTokens: cachedTokens,
+		streaming:    streaming,
 	}
 	// httpsnoop preserves optional ResponseWriter interfaces such as
 	// http.Flusher, http.Hijacker, http.Pusher, and io.ReaderFrom.
@@ -70,7 +75,10 @@ func newCachedTokensResponseWriterWithFinalize(w http.ResponseWriter, cachedToke
 		},
 	})
 	return writer, func() error {
-		return rewriter.flushSSEBuffer(w.Write)
+		if rewriter.streaming {
+			return rewriter.flushSSEBuffer(w.Write)
+		}
+		return rewriter.flushJSONBuffer(w.Write)
 	}
 }
 
@@ -82,7 +90,28 @@ func (r *cachedTokensUsageRewriter) writeHeader(next httpsnoop.WriteHeaderFunc, 
 }
 
 func (r *cachedTokensUsageRewriter) write(next httpsnoop.WriteFunc, body []byte) (int, error) {
-	updated := r.rewrite(body)
+	if !r.streaming {
+		return r.writeJSON(next, body)
+	}
+	updated := r.rewriteSSEChunk(body)
+	if !r.wroteHeader {
+		r.header.Del("Content-Length")
+	}
+	n, err := next(updated)
+	if err != nil {
+		return n, err
+	}
+	return len(body), nil
+}
+
+func (r *cachedTokensUsageRewriter) writeJSON(next httpsnoop.WriteFunc, body []byte) (int, error) {
+	// ReverseProxy may split one JSON document across multiple Write calls.
+	r.jsonBuffer = append(r.jsonBuffer, body...)
+	updated, ok := replaceCachedTokensJSON(r.jsonBuffer, r.cachedTokens)
+	if !ok {
+		return len(body), nil
+	}
+	r.jsonBuffer = nil
 	if !r.wroteHeader {
 		r.header.Del("Content-Length")
 	}
@@ -94,7 +123,7 @@ func (r *cachedTokensUsageRewriter) write(next httpsnoop.WriteFunc, body []byte)
 }
 
 func (r *cachedTokensUsageRewriter) readFrom(next httpsnoop.WriteFunc, src io.Reader) (int64, error) {
-	if r.isSSE(nil) {
+	if r.streaming {
 		// SSE can be long-lived, so keep it streaming and rewrite complete lines.
 		n, err := io.Copy(cachedTokensStreamWriter{
 			write:   r.write,
@@ -121,13 +150,6 @@ func (r *cachedTokensUsageRewriter) readFrom(next httpsnoop.WriteFunc, src io.Re
 	return int64(len(body)), nil
 }
 
-func (r *cachedTokensUsageRewriter) rewrite(body []byte) []byte {
-	if r.isSSE(body) {
-		return r.rewriteSSEChunk(body)
-	}
-	return replaceCachedTokens(body, r.cachedTokens)
-}
-
 type cachedTokensStreamWriter struct {
 	write   func(httpsnoop.WriteFunc, []byte) (int, error)
 	forward httpsnoop.WriteFunc
@@ -135,19 +157,6 @@ type cachedTokensStreamWriter struct {
 
 func (w cachedTokensStreamWriter) Write(body []byte) (int, error) {
 	return w.write(w.forward, body)
-}
-
-func (r *cachedTokensUsageRewriter) isSSE(body []byte) bool {
-	if r.streaming {
-		return true
-	}
-	contentType := r.header.Get("Content-Type")
-	// Some handlers may not set the content type before the first Write.
-	if strings.Contains(contentType, "text/event-stream") || bytes.HasPrefix(body, []byte("data:")) {
-		r.streaming = true
-		return true
-	}
-	return false
 }
 
 func (r *cachedTokensUsageRewriter) rewriteSSEChunk(body []byte) []byte {
@@ -176,6 +185,19 @@ func (r *cachedTokensUsageRewriter) flushSSEBuffer(next httpsnoop.WriteFunc) err
 	replacedLine, _ := replaceCachedTokensSSELine(r.streamBuffer, r.cachedTokens)
 	r.streamBuffer = nil
 	_, err := next(replacedLine)
+	return err
+}
+
+func (r *cachedTokensUsageRewriter) flushJSONBuffer(next httpsnoop.WriteFunc) error {
+	if len(r.jsonBuffer) == 0 {
+		return nil
+	}
+	updated := replaceCachedTokens(r.jsonBuffer, r.cachedTokens)
+	r.jsonBuffer = nil
+	if !r.wroteHeader {
+		r.header.Del("Content-Length")
+	}
+	_, err := next(updated)
 	return err
 }
 

--- a/pkg/sidecar/proxy/cached_tokens_usage_rewriter_test.go
+++ b/pkg/sidecar/proxy/cached_tokens_usage_rewriter_test.go
@@ -59,6 +59,54 @@ var _ = Describe("Cached token usage rewriter", func() {
 		Expect(replaceCachedTokens(body, 7)).To(Equal([]byte(`{"usage":{"prompt_tokens":64,"prompt_tokens_details":{"cached_tokens":7}}}`)))
 	})
 
+	It("should buffer non-streaming JSON split across writes", func() {
+		recorder := httptest.NewRecorder()
+		recorder.Header().Set("Content-Type", "application/json")
+		writer, finalize := newCachedTokensResponseWriterWithFinalize(recorder, 7, false)
+
+		firstChunk := []byte(`{"usage":{"prompt_tokens":64,`)
+		n, err := writer.Write(firstChunk)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(len(firstChunk)))
+		Expect(recorder.Body.Len()).To(BeZero())
+
+		secondChunk := []byte(`"prompt_tokens_details":{"cached_tokens":49}}}`)
+		n, err = writer.Write(secondChunk)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(len(secondChunk)))
+		Expect(finalize()).To(Succeed())
+
+		Expect(recorder.Body.String()).To(Equal(`{"usage":{"prompt_tokens":64,"prompt_tokens_details":{"cached_tokens":7}}}`))
+	})
+
+	It("should flush an incomplete non-streaming body unchanged", func() {
+		recorder := httptest.NewRecorder()
+		writer, finalize := newCachedTokensResponseWriterWithFinalize(recorder, 7, false)
+
+		body := []byte(`{"usage":`)
+		n, err := writer.Write(body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(len(body)))
+		Expect(recorder.Body.Len()).To(BeZero())
+		Expect(finalize()).To(Succeed())
+
+		Expect(recorder.Body.Bytes()).To(Equal(body))
+	})
+
+	It("should use the request mode instead of the response content type", func() {
+		recorder := httptest.NewRecorder()
+		recorder.Header().Set("Content-Type", "text/event-stream")
+		writer, finalize := newCachedTokensResponseWriterWithFinalize(recorder, 7, false)
+
+		body := []byte(`{"usage":{"prompt_tokens_details":{"cached_tokens":49}}}`)
+		n, err := writer.Write(body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal(len(body)))
+		Expect(finalize()).To(Succeed())
+
+		Expect(recorder.Body.String()).To(Equal(`{"usage":{"prompt_tokens_details":{"cached_tokens":7}}}`))
+	})
+
 	It("should add cached tokens when JSON usage details omit them", func() {
 		body := []byte(`{"usage":{"prompt_tokens":64,"prompt_tokens_details":{}}}`)
 		updated := replaceCachedTokens(body, 7)
@@ -114,7 +162,7 @@ var _ = Describe("Cached token usage rewriter", func() {
 	It("should buffer streamed usage chunks split before the data prefix", func() {
 		recorder := httptest.NewRecorder()
 		recorder.Header().Set("Content-Type", "text/event-stream")
-		writer := newCachedTokensResponseWriter(recorder, 8)
+		writer := newCachedTokensResponseWriter(recorder, 8, true)
 
 		n, err := writer.Write([]byte("da"))
 		Expect(err).ToNot(HaveOccurred())
@@ -132,7 +180,7 @@ var _ = Describe("Cached token usage rewriter", func() {
 	It("should buffer streamed usage chunks split inside the JSON payload", func() {
 		recorder := httptest.NewRecorder()
 		recorder.Header().Set("Content-Type", "text/event-stream")
-		writer := newCachedTokensResponseWriter(recorder, 7)
+		writer := newCachedTokensResponseWriter(recorder, 7, true)
 
 		firstChunk := []byte(`data: {"choices":[],"usage":{"prompt_tokens":64,`)
 		n, err := writer.Write(firstChunk)
@@ -162,7 +210,7 @@ var _ = Describe("Cached token usage rewriter", func() {
 
 	It("should preserve ReaderFrom while rewriting cached tokens", func() {
 		base := &readerFromResponseWriter{header: http.Header{}}
-		writer := newCachedTokensResponseWriter(base, 7)
+		writer := newCachedTokensResponseWriter(base, 7, false)
 		readerFrom, ok := writer.(io.ReaderFrom)
 		Expect(ok).To(BeTrue())
 
@@ -175,7 +223,7 @@ var _ = Describe("Cached token usage rewriter", func() {
 
 	It("should preserve ReaderFrom for streamed responses while rewriting complete lines", func() {
 		base := &readerFromResponseWriter{header: http.Header{"Content-Type": []string{"text/event-stream"}}}
-		writer := newCachedTokensResponseWriter(base, 7)
+		writer := newCachedTokensResponseWriter(base, 7, true)
 		readerFrom, ok := writer.(io.ReaderFrom)
 		Expect(ok).To(BeTrue())
 
@@ -189,7 +237,7 @@ var _ = Describe("Cached token usage rewriter", func() {
 
 	It("should flush a trailing streamed data line without a final newline", func() {
 		base := &readerFromResponseWriter{header: http.Header{"Content-Type": []string{"text/event-stream"}}}
-		writer := newCachedTokensResponseWriter(base, 7)
+		writer := newCachedTokensResponseWriter(base, 7, true)
 		readerFrom, ok := writer.(io.ReaderFrom)
 		Expect(ok).To(BeTrue())
 
@@ -203,7 +251,7 @@ var _ = Describe("Cached token usage rewriter", func() {
 	It("should finalize a trailing streamed data line written without a final newline", func() {
 		recorder := httptest.NewRecorder()
 		recorder.Header().Set("Content-Type", "text/event-stream")
-		writer, finalize := newCachedTokensResponseWriterWithFinalize(recorder, 7)
+		writer, finalize := newCachedTokensResponseWriterWithFinalize(recorder, 7, true)
 
 		body := []byte(`data: {"choices":[],"usage":{"prompt_tokens":64,"prompt_tokens_details":{"cached_tokens":49}}}`)
 		n, err := writer.Write(body)

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -289,7 +289,10 @@ retryLoop:
 		pCachedTokens = 0
 	}
 
-	s.logger.V(logging.TRACE).Info("received prefiller response", requestFieldKVTransferParams, pKVTransferParams)
+	s.logger.V(logging.TRACE).Info("received prefiller response",
+		requestFieldKVTransferParams, pKVTransferParams,
+		"cachedTokens", pCachedTokens,
+		"hasCachedTokens", hasPCachedTokens)
 
 	// Decode Stage
 
@@ -424,7 +427,7 @@ retryLoop:
 	if trace := s.logger.V(logging.TRACE); trace.Enabled() {
 		trace.Info("sending request to decoder", "body", string(dbody))
 	}
-	decodeWriter, finalizeDecodeWriter := newCachedTokensResponseWriterWithFinalize(w, pCachedTokens)
+	decodeWriter, finalizeDecodeWriter := newCachedTokensResponseWriterWithFinalize(w, pCachedTokens, streamingEnabled)
 	dataParallelUsed := s.forwardDataParallel && s.dataParallelHandler(decodeWriter, dreq)
 	decodeSpan.SetAttributes(attribute.Bool("llm_d.pd_proxy.decode.data_parallel", dataParallelUsed))
 

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -284,7 +284,10 @@ retryLoop:
 		pCachedTokens = 0
 	}
 
-	s.logger.V(5).Info("received prefiller response", requestFieldKVTransferParams, pKVTransferParams)
+	s.logger.V(5).Info("received prefiller response",
+		requestFieldKVTransferParams, pKVTransferParams,
+		"cachedTokens", pCachedTokens,
+		"hasCachedTokens", hasPCachedTokens)
 
 	// Decode Stage
 
@@ -417,7 +420,7 @@ retryLoop:
 	// 2. Forward to local decoder.
 
 	s.logger.V(5).Info("sending request to decoder", "body", string(dbody))
-	decodeWriter, finalizeDecodeWriter := newCachedTokensResponseWriterWithFinalize(w, pCachedTokens)
+	decodeWriter, finalizeDecodeWriter := newCachedTokensResponseWriterWithFinalize(w, pCachedTokens, streamingEnabled)
 	dataParallelUsed := s.forwardDataParallel && s.dataParallelHandler(decodeWriter, dreq)
 	decodeSpan.SetAttributes(attribute.Bool("llm_d.pd_proxy.decode.data_parallel", dataParallelUsed))
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:


Fixes incorrect `cached_tokens` reporting for non-streaming P/D requests.

A non-streaming JSON response may be delivered through multiple `ResponseWriter.Write` calls. Previously, each chunk was parsed independently, so partial JSON could not be rewritten and the decoder's `cached_tokens` value was returned unchanged.

This change:

- Buffers non-streaming response chunks until a complete JSON response is available.
- Rewrites `usage.prompt_tokens_details.cached_tokens` using the prefiller's value.
- Uses the request's explicit streaming mode instead of inferring it from the response.
- Preserves the existing streaming response behavior.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes  https://github.com/llm-d/llm-d-router/issues/2622

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Fix cached token usage reporting for non-streaming P/D inference requests.
```
