### PR TITLE
feat(predictedlatency): include selected prediction in training entries

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/prediction_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/prediction_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package latencypredictorclient
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,6 +86,58 @@ func TestValidateTrainingEntry_EncoderSizes(t *testing.T) {
 
 	entry.EncoderInputSize, entry.EncoderMatchedSize = 2, 3
 	assert.Error(t, predictor.ValidateTrainingEntry(entry))
+}
+
+func TestTrainingEntry_PredictedFieldsJSONOmitEmpty(t *testing.T) {
+	predTTFT := 80.0
+	predTPOT := 12.0
+
+	withPred := TrainingEntry{
+		KVCachePercentage: 0.5,
+		ActualTTFT:        100,
+		PredictedTTFT:     &predTTFT,
+		Timestamp:         time.Unix(0, 0).UTC(),
+	}
+	raw, err := json.Marshal(withPred)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"predicted_ttft_ms":80`)
+	assert.NotContains(t, string(raw), `predicted_tpot_ms`)
+
+	tpotOnly := TrainingEntry{
+		KVCachePercentage: 0.5,
+		ActualTPOT:        10,
+		PredictedTPOT:     &predTPOT,
+		Timestamp:         time.Unix(0, 0).UTC(),
+	}
+	raw, err = json.Marshal(tpotOnly)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"predicted_tpot_ms":12`)
+	assert.NotContains(t, string(raw), `predicted_ttft_ms`)
+
+	legacy := TrainingEntry{
+		KVCachePercentage: 0.5,
+		ActualTTFT:        100,
+		Timestamp:         time.Unix(0, 0).UTC(),
+	}
+	raw, err = json.Marshal(legacy)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), `predicted_ttft_ms`)
+	assert.NotContains(t, string(raw), `predicted_tpot_ms`)
+}
+
+func TestValidateTrainingEntry_PredictedFields(t *testing.T) {
+	predictor := &Predictor{}
+	neg := -1.0
+	entry := TrainingEntry{
+		KVCachePercentage: 0.5,
+		ActualTTFT:        50,
+		PredictedTTFT:     &neg,
+	}
+	assert.Error(t, predictor.ValidateTrainingEntry(entry))
+
+	ok := 10.0
+	entry.PredictedTTFT = &ok
+	assert.NoError(t, predictor.ValidateTrainingEntry(entry))
 }
 
 // TestPredictBayesianRidge_EncoderCoefficients verifies the TTFT linear model

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/prediction_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/prediction_test.go
@@ -18,6 +18,7 @@ package latencypredictorclient
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 	"time"
 
@@ -138,6 +139,14 @@ func TestValidateTrainingEntry_PredictedFields(t *testing.T) {
 	ok := 10.0
 	entry.PredictedTTFT = &ok
 	assert.NoError(t, predictor.ValidateTrainingEntry(entry))
+
+	nan := math.NaN()
+	entry.PredictedTTFT = &nan
+	assert.Error(t, predictor.ValidateTrainingEntry(entry))
+
+	inf := math.Inf(1)
+	entry.PredictedTTFT = &inf
+	assert.Error(t, predictor.ValidateTrainingEntry(entry))
 }
 
 // TestPredictBayesianRidge_EncoderCoefficients verifies the TTFT linear model

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/training.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/training.go
@@ -218,6 +218,12 @@ func (p *Predictor) ValidateTrainingEntry(entry TrainingEntry) error {
 	if entry.ActualTPOT < 0.0 {
 		return fmt.Errorf("actual_tpot_ms must be non-negative, got %f", entry.ActualTPOT)
 	}
+	if entry.PredictedTTFT != nil && *entry.PredictedTTFT < 0.0 {
+		return fmt.Errorf("predicted_ttft_ms must be non-negative, got %f", *entry.PredictedTTFT)
+	}
+	if entry.PredictedTPOT != nil && *entry.PredictedTPOT < 0.0 {
+		return fmt.Errorf("predicted_tpot_ms must be non-negative, got %f", *entry.PredictedTPOT)
+	}
 	if entry.PrefixCacheScore < 0.0 || entry.PrefixCacheScore > 1.0 {
 		return fmt.Errorf("prefix_cache_score must be between 0.0 and 1.0, got %f", entry.PrefixCacheScore)
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/training.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/training.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"time"
 
@@ -221,8 +222,14 @@ func (p *Predictor) ValidateTrainingEntry(entry TrainingEntry) error {
 	if entry.PredictedTTFT != nil && *entry.PredictedTTFT < 0.0 {
 		return fmt.Errorf("predicted_ttft_ms must be non-negative, got %f", *entry.PredictedTTFT)
 	}
+	if entry.PredictedTTFT != nil && (math.IsNaN(*entry.PredictedTTFT) || math.IsInf(*entry.PredictedTTFT, 0)) {
+		return fmt.Errorf("predicted_ttft_ms must be a finite number, got %f", *entry.PredictedTTFT)
+	}
 	if entry.PredictedTPOT != nil && *entry.PredictedTPOT < 0.0 {
 		return fmt.Errorf("predicted_tpot_ms must be non-negative, got %f", *entry.PredictedTPOT)
+	}
+	if entry.PredictedTPOT != nil && (math.IsNaN(*entry.PredictedTPOT) || math.IsInf(*entry.PredictedTPOT, 0)) {
+		return fmt.Errorf("predicted_tpot_ms must be a finite number, got %f", *entry.PredictedTPOT)
 	}
 	if entry.PrefixCacheScore < 0.0 || entry.PrefixCacheScore > 1.0 {
 		return fmt.Errorf("prefix_cache_score must be between 0.0 and 1.0, got %f", entry.PrefixCacheScore)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/types.go
@@ -169,7 +169,12 @@ type TrainingEntry struct {
 	NumTokensGenerated int     `json:"num_tokens_generated"`
 	ActualTTFT         float64 `json:"actual_ttft_ms"`
 	ActualTPOT         float64 `json:"actual_tpot_ms"`
-	PrefixCacheScore   float64 `json:"prefix_cache_score"`
+	// PredictedTTFT and PredictedTPOT are the selected-endpoint predictions
+	// paired with the matching actual for live drift detection. Omitted when
+	// no valid selected prediction was available for that sample.
+	PredictedTTFT    *float64 `json:"predicted_ttft_ms,omitempty"`
+	PredictedTPOT    *float64 `json:"predicted_tpot_ms,omitempty"`
+	PrefixCacheScore float64  `json:"prefix_cache_score"`
 	// EncoderInputSize is the total size of the request's multimodal encoder
 	// items; EncoderMatchedSize is the portion likely present in the target
 	// pod's encoder cache. Both are 0 for text-only requests.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
@@ -47,6 +47,8 @@ type mockPredictor struct {
 	// capturedBulkStrictRequests records the requests passed to the most recent
 	// PredictBulkStrict call, so tests can assert what was sent to the predictor.
 	capturedBulkStrictRequests []latencypredictor.PredictionRequest
+	// capturedTrainingEntries records entries passed to AddTrainingDataBulk.
+	capturedTrainingEntries []latencypredictor.TrainingEntry
 }
 
 func (m *mockPredictor) Predict(ctx context.Context, request latencypredictor.PredictionRequest) (*latencypredictor.PredictionResponse, error) {
@@ -94,6 +96,7 @@ func (m *mockPredictor) PredictBulkStrict(ctx context.Context, requests []latenc
 }
 
 func (m *mockPredictor) AddTrainingDataBulk(data []latencypredictor.TrainingEntry) error {
+	m.capturedTrainingEntries = append(m.capturedTrainingEntries, data...)
 	return nil
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
@@ -201,6 +201,9 @@ func (pl *PredictedLatency) ResponseBody(ctx context.Context, request *fwksched.
 				entry.PrefillTokensInFlight = predictedLatencyCtx.prefillTokensAtDispatch
 				entry.DecodeTokensInFlight = predictedLatencyCtx.decodeTokensAtDispatch
 				entry.NumRequestRunning = predictedLatencyCtx.requestsAtDispatch
+				// Request-average actual TPOT is paired with the scheduling-time
+				// selected decode/primary prediction (avgPredictedTPOT).
+				entry.PredictedTPOT = predictedLatencyMSPtr(predictedLatencyCtx.avgPredictedTPOT)
 				if err := pl.latencypredictor.AddTrainingDataBulk([]latencypredictor.TrainingEntry{entry}); err != nil {
 					logger.V(logutil.DEBUG).Error(err, "record TPOT training failed")
 				}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
@@ -197,13 +197,13 @@ func (pl *PredictedLatency) ResponseBody(ctx context.Context, request *fwksched.
 					0,
 					0,
 					0,
+					trainingEntryOptions{PredictedTPOT: predictedLatencyMSPtr(predictedLatencyCtx.avgPredictedTPOT)},
 				)
 				entry.PrefillTokensInFlight = predictedLatencyCtx.prefillTokensAtDispatch
 				entry.DecodeTokensInFlight = predictedLatencyCtx.decodeTokensAtDispatch
 				entry.NumRequestRunning = predictedLatencyCtx.requestsAtDispatch
 				// Request-average actual TPOT is paired with the scheduling-time
 				// selected decode/primary prediction (avgPredictedTPOT).
-				entry.PredictedTPOT = predictedLatencyMSPtr(predictedLatencyCtx.avgPredictedTPOT)
 				if err := pl.latencypredictor.AddTrainingDataBulk([]latencypredictor.TrainingEntry{entry}); err != nil {
 					logger.V(logutil.DEBUG).Error(err, "record TPOT training failed")
 				}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training.go
@@ -130,9 +130,19 @@ func recordTTFTTrainingData(
 		entry.NumRequestRunning = predictedLatencyCtx.requestsAtDispatch
 	}
 	entry.DecodeTokensInFlight = predictedLatencyCtx.decodeTokensAtDispatch
+	entry.PredictedTTFT = predictedLatencyMSPtr(predictedLatencyCtx.predictedTTFT)
 	if err := predictor.AddTrainingDataBulk([]latencypredictor.TrainingEntry{entry}); err != nil {
 		logger.V(logutil.DEBUG).Error(err, "record TTFT training failed")
 	}
+}
+
+// predictedLatencyMSPtr returns a pointer for optional predicted_* JSON fields.
+// Zero means no selected prediction was available and must be omitted.
+func predictedLatencyMSPtr(ms float64) *float64 {
+	if ms <= 0 {
+		return nil
+	}
+	return &ms
 }
 
 // refreshLastSeenMetrics updates predictedLatencyCtx.lastSeenMetrics from scheduling results.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	latencypredictor "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient"
@@ -137,9 +138,9 @@ func recordTTFTTrainingData(
 }
 
 // predictedLatencyMSPtr returns a pointer for optional predicted_* JSON fields.
-// Zero means no selected prediction was available and must be omitted.
+// Zero or non-finite values mean no usable selected prediction and must be omitted.
 func predictedLatencyMSPtr(ms float64) *float64 {
-	if ms <= 0 {
+	if ms <= 0 || math.IsNaN(ms) || math.IsInf(ms, 0) {
 		return nil
 	}
 	return &ms

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training.go
@@ -59,6 +59,11 @@ func buildPredictionRequest(
 	}
 }
 
+type trainingEntryOptions struct {
+	PredictedTTFT *float64
+	PredictedTPOT *float64
+}
+
 // buildTrainingEntry constructs a training entry from actual latency measurements.
 func buildTrainingEntry(
 	endpointRoleLabel string,
@@ -72,6 +77,7 @@ func buildTrainingEntry(
 	prefixCacheScore float64,
 	encoderInputSize int,
 	encoderMatchedSize int,
+	options trainingEntryOptions,
 ) latencypredictor.TrainingEntry {
 	podType := ""
 	if endpointRoleLabel != "" && targetEndpointMetadata != nil && targetEndpointMetadata.Labels != nil {
@@ -91,6 +97,8 @@ func buildTrainingEntry(
 		EncoderInputSize:   encoderInputSize,
 		EncoderMatchedSize: encoderMatchedSize,
 		PodType:            podType,
+		PredictedTTFT:      options.PredictedTTFT,
+		PredictedTPOT:      options.PredictedTPOT,
 	}
 }
 
@@ -119,6 +127,7 @@ func recordTTFTTrainingData(
 		prefixCacheScore,
 		predictedLatencyCtx.encoderInputSize,
 		encoderMatchedSize,
+		trainingEntryOptions{PredictedTTFT: predictedLatencyMSPtr(predictedLatencyCtx.predictedTTFT)},
 	)
 	// In disaggregated serving TTFT is incurred on the prefill endpoint, so the
 	// in-flight features are snapshotted from that endpoint; otherwise the decode
@@ -131,7 +140,6 @@ func recordTTFTTrainingData(
 		entry.NumRequestRunning = predictedLatencyCtx.requestsAtDispatch
 	}
 	entry.DecodeTokensInFlight = predictedLatencyCtx.decodeTokensAtDispatch
-	entry.PredictedTTFT = predictedLatencyMSPtr(predictedLatencyCtx.predictedTTFT)
 	if err := predictor.AddTrainingDataBulk([]latencypredictor.TrainingEntry{entry}); err != nil {
 		logger.V(logutil.DEBUG).Error(err, "record TTFT training failed")
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
@@ -18,7 +18,9 @@ package predictedlatency
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -303,21 +305,53 @@ func TestBulkPredictWithMetrics_NilMetricsState(t *testing.T) {
 func TestPredictedLatencyMSPtr(t *testing.T) {
 	assert.Nil(t, predictedLatencyMSPtr(0))
 	assert.Nil(t, predictedLatencyMSPtr(-1))
+	assert.Nil(t, predictedLatencyMSPtr(math.NaN()))
+	assert.Nil(t, predictedLatencyMSPtr(math.Inf(1)))
 	require.NotNil(t, predictedLatencyMSPtr(12.5))
 	assert.Equal(t, 12.5, *predictedLatencyMSPtr(12.5))
 }
 
-func TestRecordTTFTTrainingData_IncludesSelectedPredictedTTFT(t *testing.T) {
+func assertPredictedJSONFields(t *testing.T, entry latencypredictor.TrainingEntry, wantTTFT *float64, wantTPOT *float64) {
+	t.Helper()
+	raw, err := json.Marshal(entry)
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(raw, &payload))
+
+	if wantTTFT == nil {
+		_, ok := payload["predicted_ttft_ms"]
+		assert.False(t, ok, "predicted_ttft_ms should be omitted: %s", raw)
+	} else {
+		got, ok := payload["predicted_ttft_ms"].(float64)
+		require.True(t, ok, "predicted_ttft_ms missing: %s", raw)
+		assert.Equal(t, *wantTTFT, got)
+	}
+	if wantTPOT == nil {
+		_, ok := payload["predicted_tpot_ms"]
+		assert.False(t, ok, "predicted_tpot_ms should be omitted: %s", raw)
+	} else {
+		got, ok := payload["predicted_tpot_ms"].(float64)
+		require.True(t, ok, "predicted_tpot_ms missing: %s", raw)
+		assert.Equal(t, *wantTPOT, got)
+	}
+}
+
+func TestRecordTTFTTrainingData_LookupSelectedPredictedTTFT(t *testing.T) {
 	mp := &mockPredictor{}
 	endpoint := createTestEndpoint("selected-pod", 0.5, 1, 1)
 	request := createTestInferenceRequest("ttft-pred", 100, 50)
 	plCtx := newPredictedLatencyContext(request)
 	plCtx.ttft = 120
-	plCtx.predictedTTFT = 80
+	plCtx.targetMetadata = endpoint.GetMetadata()
 	plCtx.predictionsForScheduling = map[string]endpointPredictionResult{
-		"selected-pod": {TTFT: 80, TPOT: 10},
-		"other-pod":    {TTFT: 999, TPOT: 10},
+		"selected-pod": {Endpoint: endpoint, TTFT: 80, TPOT: 10, TTFTValid: false, TPOTValid: false, IsValid: false},
+		"other-pod":    {TTFT: 999, TPOT: 10, TTFTValid: true, TPOTValid: true, IsValid: true},
 	}
+
+	// Resolve selected prediction the same way PreRequest does. SLO-invalid
+	// selected predictions must still train (drift needs those samples).
+	processPreRequestForLatencyPrediction(context.Background(), plCtx)
+	assert.Equal(t, 80.0, plCtx.predictedTTFT)
 
 	recordTTFTTrainingData(
 		context.Background(),
@@ -338,7 +372,8 @@ func TestRecordTTFTTrainingData_IncludesSelectedPredictedTTFT(t *testing.T) {
 	require.NotNil(t, entry.PredictedTTFT)
 	assert.Equal(t, 80.0, *entry.PredictedTTFT)
 	assert.Nil(t, entry.PredictedTPOT)
-	assert.NotEqual(t, 999.0, *entry.PredictedTTFT)
+	want := 80.0
+	assertPredictedJSONFields(t, entry, &want, nil)
 }
 
 func TestRecordTTFTTrainingData_OmitsPredictedWhenMissing(t *testing.T) {
@@ -347,7 +382,11 @@ func TestRecordTTFTTrainingData_OmitsPredictedWhenMissing(t *testing.T) {
 	request := createTestInferenceRequest("ttft-missing", 100, 50)
 	plCtx := newPredictedLatencyContext(request)
 	plCtx.ttft = 100
-	plCtx.predictedTTFT = 0
+	plCtx.targetMetadata = endpoint.GetMetadata()
+	plCtx.predictionsForScheduling = map[string]endpointPredictionResult{}
+
+	processPreRequestForLatencyPrediction(context.Background(), plCtx)
+	assert.Equal(t, 0.0, plCtx.predictedTTFT)
 
 	recordTTFTTrainingData(
 		context.Background(),
@@ -365,20 +404,25 @@ func TestRecordTTFTTrainingData_OmitsPredictedWhenMissing(t *testing.T) {
 	assert.Nil(t, mp.capturedTrainingEntries[0].PredictedTTFT)
 	assert.Nil(t, mp.capturedTrainingEntries[0].PredictedTPOT)
 	assert.Equal(t, 100.0, mp.capturedTrainingEntries[0].ActualTTFT)
+	assertPredictedJSONFields(t, mp.capturedTrainingEntries[0], nil, nil)
 }
 
-func TestRecordTTFTTrainingData_PrefillUsesSelectedPredictedTTFT(t *testing.T) {
+func TestRecordTTFTTrainingData_PrefillLookupSelectedPredictedTTFT(t *testing.T) {
 	mp := &mockPredictor{}
 	prefill := createTestEndpoint("prefill-pod", 0.4, 1, 0)
+	decode := createTestEndpoint("decode-pod", 0.5, 1, 1)
 	request := createTestInferenceRequest("ttft-pd", 100, 50)
 	plCtx := newPredictedLatencyContext(request)
 	plCtx.ttft = 150
-	plCtx.predictedTTFT = 95
+	plCtx.targetMetadata = decode.GetMetadata()
 	plCtx.prefillTargetMetadata = prefill.GetMetadata()
 	plCtx.predictionsForScheduling = map[string]endpointPredictionResult{
-		"prefill-pod": {TTFT: 95, TPOT: 0},
-		"decode-pod":  {TTFT: 40, TPOT: 12},
+		"prefill-pod": {Endpoint: prefill, TTFT: 95, TPOT: 0},
+		"decode-pod":  {Endpoint: decode, TTFT: 40, TPOT: 12},
 	}
+
+	processPreRequestForLatencyPrediction(context.Background(), plCtx)
+	assert.Equal(t, 95.0, plCtx.predictedTTFT, "TTFT must come from prefill, not decode")
 
 	recordTTFTTrainingData(
 		context.Background(),
@@ -396,6 +440,8 @@ func TestRecordTTFTTrainingData_PrefillUsesSelectedPredictedTTFT(t *testing.T) {
 	require.NotNil(t, mp.capturedTrainingEntries[0].PredictedTTFT)
 	assert.Equal(t, 95.0, *mp.capturedTrainingEntries[0].PredictedTTFT)
 	assert.Nil(t, mp.capturedTrainingEntries[0].PredictedTPOT)
+	want := 95.0
+	assertPredictedJSONFields(t, mp.capturedTrainingEntries[0], &want, nil)
 }
 
 func TestResponseBody_TPOTTrainingIncludesSelectedPredictedTPOT(t *testing.T) {
@@ -417,12 +463,13 @@ func TestResponseBody_TPOTTrainingIncludesSelectedPredictedTPOT(t *testing.T) {
 	plCtx.ttft = 80
 	plCtx.avgTPOT = 25
 	plCtx.generatedTokenCount = 1 // keep pre-set avgTPOT; do not recompute
-	plCtx.predictedTTFT = 85
-	plCtx.avgPredictedTPOT = 22
 	plCtx.predictionsForScheduling = map[string]endpointPredictionResult{
-		"decode-pod": {TTFT: 85, TPOT: 22},
+		"decode-pod": {Endpoint: endpoint, TTFT: 85, TPOT: 22},
 		"other-pod":  {TTFT: 10, TPOT: 999},
 	}
+	predictFirstTPOT(context.Background(), plCtx)
+	assert.Equal(t, 22.0, plCtx.avgPredictedTPOT)
+
 	plCtx.lastSeenMetrics["default"] = &fwkdl.Metrics{
 		KVCacheUsagePercent: 0.5,
 		WaitingQueueSize:    1,
@@ -449,7 +496,72 @@ func TestResponseBody_TPOTTrainingIncludesSelectedPredictedTPOT(t *testing.T) {
 	require.NotNil(t, tpotEntry.PredictedTPOT)
 	assert.Equal(t, 22.0, *tpotEntry.PredictedTPOT)
 	assert.Nil(t, tpotEntry.PredictedTTFT)
-	assert.NotEqual(t, 999.0, *tpotEntry.PredictedTPOT)
+	want := 22.0
+	assertPredictedJSONFields(t, *tpotEntry, nil, &want)
+}
+
+func TestResponseBody_PDDecodeTPOTUsesSelectedDecodePrediction(t *testing.T) {
+	router := createTestRouter()
+	mp := &mockPredictor{}
+	router.latencypredictor = mp
+
+	prefill := createTestEndpoint("prefill-pod", 0.4, 1, 0)
+	decodeSelected := createTestEndpoint("decode-selected", 0.5, 1, 1)
+	decodeOther := createTestEndpoint("decode-other", 0.6, 1, 1)
+	request := createTestInferenceRequest("tpot-pd", 100, 50)
+	response := &requestcontrol.Response{EndOfStream: true}
+
+	schedulingResult := &fwksched.SchedulingResult{
+		PrimaryProfileName: "default",
+		ProfileResults: map[string]*fwksched.ProfileRunResult{
+			"default": {TargetEndpoints: []fwksched.Endpoint{decodeSelected}},
+			"prefill": {TargetEndpoints: []fwksched.Endpoint{prefill}},
+		},
+	}
+
+	plCtx := newPredictedLatencyContext(request)
+	plCtx.targetMetadata = decodeSelected.GetMetadata()
+	plCtx.prefillTargetMetadata = prefill.GetMetadata()
+	plCtx.schedulingResult = schedulingResult
+	plCtx.schedulingRequest = *request
+	plCtx.incomingModelName = testModelName
+	plCtx.requestReceivedTimestamp = time.Now().Add(-200 * time.Millisecond)
+	plCtx.ttft = 80
+	plCtx.avgTPOT = 25
+	plCtx.generatedTokenCount = 1
+	plCtx.predictionsForScheduling = map[string]endpointPredictionResult{
+		"prefill-pod":     {Endpoint: prefill, TTFT: 90, TPOT: 1},
+		"decode-selected": {Endpoint: decodeSelected, TTFT: 40, TPOT: 18},
+		"decode-other":    {Endpoint: decodeOther, TTFT: 35, TPOT: 777},
+	}
+	predictFirstTPOT(context.Background(), plCtx)
+	assert.Equal(t, 18.0, plCtx.avgPredictedTPOT, "TPOT must come from selected decode, not prefill/other")
+
+	plCtx.lastSeenMetrics["default"] = &fwkdl.Metrics{KVCacheUsagePercent: 0.5}
+	plCtx.lastSeenMetrics["prefill"] = &fwkdl.Metrics{KVCacheUsagePercent: 0.4}
+	router.setPredictedLatencyContextForRequest(request, plCtx)
+
+	queue := newRequestPriorityQueue()
+	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
+	router.runningRequestLists.Store(decodeSelected.GetMetadata().ID, queue)
+
+	router.ResponseBody(context.Background(), request, response, decodeSelected.GetMetadata())
+
+	require.NotEmpty(t, mp.capturedTrainingEntries)
+	var tpotEntry *latencypredictor.TrainingEntry
+	for i := range mp.capturedTrainingEntries {
+		if mp.capturedTrainingEntries[i].ActualTPOT > 0 {
+			tpotEntry = &mp.capturedTrainingEntries[i]
+			break
+		}
+	}
+	require.NotNil(t, tpotEntry)
+	require.NotNil(t, tpotEntry.PredictedTPOT)
+	assert.Equal(t, 18.0, *tpotEntry.PredictedTPOT)
+	assert.NotEqual(t, 1.0, *tpotEntry.PredictedTPOT)
+	assert.NotEqual(t, 777.0, *tpotEntry.PredictedTPOT)
+	want := 18.0
+	assertPredictedJSONFields(t, *tpotEntry, nil, &want)
 }
 
 func TestResponseBody_TPOTTrainingOmitsPredictedWhenMissing(t *testing.T) {
@@ -488,6 +600,7 @@ func TestResponseBody_TPOTTrainingOmitsPredictedWhenMissing(t *testing.T) {
 			found = true
 			assert.Nil(t, entry.PredictedTPOT)
 			assert.Nil(t, entry.PredictedTTFT)
+			assertPredictedJSONFields(t, entry, nil, nil)
 		}
 	}
 	assert.True(t, found)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
+	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 )
 
@@ -296,4 +298,197 @@ func TestBulkPredictWithMetrics_NilMetricsState(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, results)
 	assert.True(t, strings.Contains(err.Error(), "metrics state at index 0 cannot be nil"))
+}
+
+func TestPredictedLatencyMSPtr(t *testing.T) {
+	assert.Nil(t, predictedLatencyMSPtr(0))
+	assert.Nil(t, predictedLatencyMSPtr(-1))
+	require.NotNil(t, predictedLatencyMSPtr(12.5))
+	assert.Equal(t, 12.5, *predictedLatencyMSPtr(12.5))
+}
+
+func TestRecordTTFTTrainingData_IncludesSelectedPredictedTTFT(t *testing.T) {
+	mp := &mockPredictor{}
+	endpoint := createTestEndpoint("selected-pod", 0.5, 1, 1)
+	request := createTestInferenceRequest("ttft-pred", 100, 50)
+	plCtx := newPredictedLatencyContext(request)
+	plCtx.ttft = 120
+	plCtx.predictedTTFT = 80
+	plCtx.predictionsForScheduling = map[string]endpointPredictionResult{
+		"selected-pod": {TTFT: 80, TPOT: 10},
+		"other-pod":    {TTFT: 999, TPOT: 10},
+	}
+
+	recordTTFTTrainingData(
+		context.Background(),
+		mp,
+		"",
+		plCtx,
+		&fwkdl.Metrics{KVCacheUsagePercent: 0.5, WaitingQueueSize: 1, RunningRequestsSize: 1},
+		endpoint.GetMetadata(),
+		time.Now(),
+		0.4,
+		0,
+	)
+
+	require.Len(t, mp.capturedTrainingEntries, 1)
+	entry := mp.capturedTrainingEntries[0]
+	assert.Equal(t, 120.0, entry.ActualTTFT)
+	assert.Equal(t, 0.0, entry.ActualTPOT)
+	require.NotNil(t, entry.PredictedTTFT)
+	assert.Equal(t, 80.0, *entry.PredictedTTFT)
+	assert.Nil(t, entry.PredictedTPOT)
+	assert.NotEqual(t, 999.0, *entry.PredictedTTFT)
+}
+
+func TestRecordTTFTTrainingData_OmitsPredictedWhenMissing(t *testing.T) {
+	mp := &mockPredictor{}
+	endpoint := createTestEndpoint("pod1", 0.5, 1, 1)
+	request := createTestInferenceRequest("ttft-missing", 100, 50)
+	plCtx := newPredictedLatencyContext(request)
+	plCtx.ttft = 100
+	plCtx.predictedTTFT = 0
+
+	recordTTFTTrainingData(
+		context.Background(),
+		mp,
+		"",
+		plCtx,
+		&fwkdl.Metrics{KVCacheUsagePercent: 0.5},
+		endpoint.GetMetadata(),
+		time.Now(),
+		0,
+		0,
+	)
+
+	require.Len(t, mp.capturedTrainingEntries, 1)
+	assert.Nil(t, mp.capturedTrainingEntries[0].PredictedTTFT)
+	assert.Nil(t, mp.capturedTrainingEntries[0].PredictedTPOT)
+	assert.Equal(t, 100.0, mp.capturedTrainingEntries[0].ActualTTFT)
+}
+
+func TestRecordTTFTTrainingData_PrefillUsesSelectedPredictedTTFT(t *testing.T) {
+	mp := &mockPredictor{}
+	prefill := createTestEndpoint("prefill-pod", 0.4, 1, 0)
+	request := createTestInferenceRequest("ttft-pd", 100, 50)
+	plCtx := newPredictedLatencyContext(request)
+	plCtx.ttft = 150
+	plCtx.predictedTTFT = 95
+	plCtx.prefillTargetMetadata = prefill.GetMetadata()
+	plCtx.predictionsForScheduling = map[string]endpointPredictionResult{
+		"prefill-pod": {TTFT: 95, TPOT: 0},
+		"decode-pod":  {TTFT: 40, TPOT: 12},
+	}
+
+	recordTTFTTrainingData(
+		context.Background(),
+		mp,
+		"",
+		plCtx,
+		&fwkdl.Metrics{KVCacheUsagePercent: 0.4},
+		prefill.GetMetadata(),
+		time.Now(),
+		0.2,
+		0,
+	)
+
+	require.Len(t, mp.capturedTrainingEntries, 1)
+	require.NotNil(t, mp.capturedTrainingEntries[0].PredictedTTFT)
+	assert.Equal(t, 95.0, *mp.capturedTrainingEntries[0].PredictedTTFT)
+	assert.Nil(t, mp.capturedTrainingEntries[0].PredictedTPOT)
+}
+
+func TestResponseBody_TPOTTrainingIncludesSelectedPredictedTPOT(t *testing.T) {
+	router := createTestRouter()
+	mp := &mockPredictor{}
+	router.latencypredictor = mp
+
+	endpoint := createTestEndpoint("decode-pod", 0.5, 1, 1)
+	request := createTestInferenceRequest("tpot-pred", 100, 50)
+	response := &requestcontrol.Response{EndOfStream: true}
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	plCtx := newPredictedLatencyContext(request)
+	plCtx.targetMetadata = endpoint.GetMetadata()
+	plCtx.schedulingResult = schedulingResult
+	plCtx.schedulingRequest = *request
+	plCtx.incomingModelName = testModelName
+	plCtx.requestReceivedTimestamp = time.Now().Add(-200 * time.Millisecond)
+	plCtx.ttft = 80
+	plCtx.avgTPOT = 25
+	plCtx.generatedTokenCount = 1 // keep pre-set avgTPOT; do not recompute
+	plCtx.predictedTTFT = 85
+	plCtx.avgPredictedTPOT = 22
+	plCtx.predictionsForScheduling = map[string]endpointPredictionResult{
+		"decode-pod": {TTFT: 85, TPOT: 22},
+		"other-pod":  {TTFT: 10, TPOT: 999},
+	}
+	plCtx.lastSeenMetrics["default"] = &fwkdl.Metrics{
+		KVCacheUsagePercent: 0.5,
+		WaitingQueueSize:    1,
+		RunningRequestsSize: 1,
+	}
+	router.setPredictedLatencyContextForRequest(request, plCtx)
+
+	queue := newRequestPriorityQueue()
+	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
+	router.runningRequestLists.Store(endpoint.GetMetadata().ID, queue)
+
+	router.ResponseBody(context.Background(), request, response, endpoint.GetMetadata())
+
+	require.NotEmpty(t, mp.capturedTrainingEntries)
+	var tpotEntry *latencypredictor.TrainingEntry
+	for i := range mp.capturedTrainingEntries {
+		if mp.capturedTrainingEntries[i].ActualTPOT > 0 {
+			tpotEntry = &mp.capturedTrainingEntries[i]
+			break
+		}
+	}
+	require.NotNil(t, tpotEntry, "expected a TPOT training entry")
+	assert.Equal(t, 0.0, tpotEntry.ActualTTFT)
+	require.NotNil(t, tpotEntry.PredictedTPOT)
+	assert.Equal(t, 22.0, *tpotEntry.PredictedTPOT)
+	assert.Nil(t, tpotEntry.PredictedTTFT)
+	assert.NotEqual(t, 999.0, *tpotEntry.PredictedTPOT)
+}
+
+func TestResponseBody_TPOTTrainingOmitsPredictedWhenMissing(t *testing.T) {
+	router := createTestRouter()
+	mp := &mockPredictor{}
+	router.latencypredictor = mp
+
+	endpoint := createTestEndpoint("decode-pod", 0.5, 1, 1)
+	request := createTestInferenceRequest("tpot-missing", 100, 50)
+	response := &requestcontrol.Response{EndOfStream: true}
+	schedulingResult := createTestSchedulingResult(endpoint.GetMetadata())
+
+	plCtx := newPredictedLatencyContext(request)
+	plCtx.targetMetadata = endpoint.GetMetadata()
+	plCtx.schedulingResult = schedulingResult
+	plCtx.schedulingRequest = *request
+	plCtx.incomingModelName = testModelName
+	plCtx.requestReceivedTimestamp = time.Now().Add(-200 * time.Millisecond)
+	plCtx.ttft = 80
+	plCtx.avgTPOT = 25
+	plCtx.generatedTokenCount = 1
+	plCtx.avgPredictedTPOT = 0
+	plCtx.lastSeenMetrics["default"] = &fwkdl.Metrics{KVCacheUsagePercent: 0.5}
+	router.setPredictedLatencyContextForRequest(request, plCtx)
+
+	queue := newRequestPriorityQueue()
+	queue.Add(request.Headers[reqcommon.RequestIDHeaderKey], 50.0)
+	router.runningRequestLists.Store(endpoint.GetMetadata().ID, queue)
+
+	router.ResponseBody(context.Background(), request, response, endpoint.GetMetadata())
+
+	require.NotEmpty(t, mp.capturedTrainingEntries)
+	found := false
+	for _, entry := range mp.capturedTrainingEntries {
+		if entry.ActualTPOT > 0 {
+			found = true
+			assert.Nil(t, entry.PredictedTPOT)
+			assert.Nil(t, entry.PredictedTTFT)
+		}
+	}
+	assert.True(t, found)
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
@@ -179,7 +179,7 @@ func TestBuildPredictionRequestAndTrainingEntry_EncoderSizes(t *testing.T) {
 	assert.Equal(t, 5, req.EncoderInputSize)
 	assert.Equal(t, 4, req.EncoderMatchedSize)
 
-	entry := buildTrainingEntry("", pod, m, 10, 100, 0, time.Now(), 0, 0.0, 5, 4)
+	entry := buildTrainingEntry("", pod, m, 10, 100, 0, time.Now(), 0, 0.0, 5, 4, trainingEntryOptions{})
 	assert.Equal(t, 5, entry.EncoderInputSize)
 	assert.Equal(t, 4, entry.EncoderMatchedSize)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The latency predictor needs each actual TTFT/TPOT paired with the prediction used for the selected endpoint so it can compute live prediction error and trigger drift-based retraining ([PR #79](https://github.com/llm-d/llm-d-latency-predictor/pull/79)).

Today the router already stores the selected prediction in request context and measures actuals, but training entries only sent actuals. This PR adds optional `predicted_ttft_ms` / `predicted_tpot_ms` on `TrainingEntry` and populates them from the selected endpoint/stage:

- monolithic / decode: selected prediction with matching actual
- P/D: prefill prediction with actual TTFT; decode prediction with actual TPOT
- missing or non-finite prediction: field omitted (not sent as `0`)
- legacy entries without predicted fields remain valid for supervised training

No new prediction or training HTTP call is added on the request hot path; values are copied into the existing buffered training flush.

**Which issue(s) this PR fixes**:
Fixes #2380

**Test plan**:
- [x] Selected-endpoint lookup then TTFT training includes `predicted_ttft_ms`
- [x] P/D prefill TTFT uses prefill prediction (not decode)
- [x] P/D decode TPOT uses selected decode prediction (not prefill / other candidate)
- [x] Missing prediction omits predicted fields; actuals still train
- [x] Serialized JSON asserts exact field names and omitempty behavior
- [x] SLO-invalid selected prediction still included for live drift
- [x] Non-finite predicted values rejected / omitted
- [x] `go test ./pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/... -count=1`
- [x] Local `/add_training_data_bulk` dump showed `predicted_ttft_ms` with matching `actual_ttft_ms` (HTTP 202)

**Release note**:
```release-note
Include selected predicted TTFT/TPOT in latency-predictor training samples for live drift detection.