### PR TITLE
test: freeze the stable plugin config surface

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -135,3 +135,43 @@ jobs:
           path: gosec.sarif
           retention-days: 7
           if-no-files-found: warn
+
+  # The configs under test/testdata/plugins/stable/ are the written-down form of the
+  # backwards-compatibility promise made when a plugin is promoted to Stable. Editing
+  # one to make TestStablePluginConfigs pass would silently retract that promise, so
+  # within a major version they may only be added to, never changed or removed.
+  frozen-stable-configs:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+        with:
+          # The diff below needs the merge base with the target branch.
+          fetch-depth: 0
+
+      - name: Fail on modified or deleted frozen plugin configs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          # Added files (status A) are how a newly promoted plugin lands here, so
+          # only modifications, deletions and renames are rejected.
+          changed=$(git diff --name-status --diff-filter=MDR "$BASE_SHA...HEAD" \
+            -- 'test/testdata/plugins/stable/v*' || true)
+
+          if [ -n "$changed" ]; then
+            echo "::error::This PR changes frozen stable plugin configs:"
+            echo "$changed"
+            echo
+            echo "Files under test/testdata/plugins/stable/v*/ record the config surface a"
+            echo "Stable plugin promised to keep working for the whole major version, so they"
+            echo "may only be added to. If TestStablePluginConfigs is failing, the plugin"
+            echo "changed incompatibly: fix the plugin or drop it back to Beta. A change that"
+            echo "cannot be made compatibly belongs in the next major version's directory."
+            exit 1
+          fi
+
+          echo "No frozen stable plugin configs were changed."

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -142,3 +142,43 @@ jobs:
           path: gosec.sarif
           retention-days: 7
           if-no-files-found: warn
+
+  # The configs under test/testdata/plugins/stable/ are the written-down form of the
+  # backwards-compatibility promise made when a plugin is promoted to Stable. Editing
+  # one to make TestStablePluginConfigs pass would silently retract that promise, so
+  # within a major version they may only be added to, never changed or removed.
+  frozen-stable-configs:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+        with:
+          # The diff below needs the merge base with the target branch.
+          fetch-depth: 0
+
+      - name: Fail on modified or deleted frozen plugin configs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          # Added files (status A) are how a newly promoted plugin lands here, so
+          # only modifications, deletions and renames are rejected.
+          changed=$(git diff --name-status --diff-filter=MDR "$BASE_SHA...HEAD" \
+            -- 'test/testdata/plugins/stable/v*' || true)
+
+          if [ -n "$changed" ]; then
+            echo "::error::This PR changes frozen stable plugin configs:"
+            echo "$changed"
+            echo
+            echo "Files under test/testdata/plugins/stable/v*/ record the config surface a"
+            echo "Stable plugin promised to keep working for the whole major version, so they"
+            echo "may only be added to. If TestStablePluginConfigs is failing, the plugin"
+            echo "changed incompatibly: fix the plugin or drop it back to Beta. A change that"
+            echo "cannot be made compatibly belongs in the next major version's directory."
+            exit 1
+          fi
+
+          echo "No frozen stable plugin configs were changed."

--- a/cmd/epp/runner/stable_plugin_configs_test.go
+++ b/cmd/epp/runner/stable_plugin_configs_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/datastore"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	runserver "github.com/llm-d/llm-d-router/pkg/epp/server"
+)
+
+// stableConfigsGlob matches every frozen plugin config, across major versions.
+const stableConfigsGlob = "../../../test/testdata/plugins/stable/v*/*.yaml"
+
+// TestStablePluginConfigs loads every frozen config under test/testdata/plugins/stable/
+// and fails if one no longer parses, no longer instantiates its plugins, or pulls in a
+// plugin that is not at least Beta.
+//
+// These configs are the written-down form of the promise made when a plugin is promoted
+// to Stable: a configuration valid today stays valid for the whole major version. The
+// files must not be edited to make this test pass — a failure means a stable plugin
+// changed incompatibly. See test/testdata/plugins/stable/README.md.
+func TestStablePluginConfigs(t *testing.T) {
+	files, err := filepath.Glob(stableConfigsGlob)
+	require.NoError(t, err, "failed to glob stable plugin configs")
+	require.NotEmpty(t, files, "no stable plugin configs found at %s", stableConfigsGlob)
+
+	for _, file := range files {
+		t.Run(testName(file), func(t *testing.T) {
+			configText, err := os.ReadFile(file)
+			require.NoError(t, err, "failed to read %s", file)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			opts := runserver.NewOptions()
+			opts.ConfigText = string(configText)
+			opts.PoolName = "stable-config-pool"
+			// Stable configs must load on a default command line. Leaving this false
+			// also asserts that no config here depends on an Alpha plugin.
+			opts.AllowExperimentalPlugins = false
+
+			r := NewRunner()
+			rawConfig, err := r.parseConfigurationPhaseOne(ctx, opts)
+			require.NoError(t, err, "stable config %s no longer parses", file)
+
+			ds := datastore.NewDatastore(ctx, r.setupMetricsCollection(opts))
+			_, err = r.parseConfigurationPhaseTwo(ctx, rawConfig, ds)
+			require.NoError(t, err, "stable config %s no longer instantiates its plugins", file)
+
+			require.NoError(t, fwkplugin.ValidatePluginStability(r.PluginHandle, opts.AllowExperimentalPlugins),
+				"stable config %s references a plugin that is not at least Beta", file)
+		})
+	}
+}
+
+// testName renders a config path as "<version>/<plugin type>" so a failure names the
+// plugin whose contract broke.
+func testName(file string) string {
+	return filepath.Join(filepath.Base(filepath.Dir(file)), filepath.Base(file))
+}

--- a/test/testdata/plugins/stable/README.md
+++ b/test/testdata/plugins/stable/README.md
@@ -1,0 +1,55 @@
+# Stable plugin configurations
+
+This directory holds the frozen configuration surface of plugins registered with
+`plugin.StabilityStable`. Each file is a complete `EndpointPickerConfig` that
+exercises one stable plugin and every parameter it accepts.
+
+## These files must not be changed
+
+A plugin is promoted to Stable on the promise that a configuration valid today
+stays valid for the whole major version. These files *are* that promise, written
+down. `TestStablePluginConfigs` loads every one of them on each run, so a change
+to a stable plugin's parameters, defaults, or validation that would break an
+existing deployment fails CI here first.
+
+That only works if the files themselves never change. Concretely:
+
+- **Do not** edit a file in `v1/` to make a failing test pass. A failure means the
+  plugin changed incompatibly; fix the plugin, or take it back out of Stable.
+- **Do not** rename, move, or delete a file for the lifetime of the major version.
+- **Do** add a new file when a plugin is newly promoted to Stable.
+- **Do** add a parameter to an existing file only when that parameter is itself
+  new and optional, so the file continues to describe a config that a user could
+  already have written.
+
+Changes that cannot be expressed that way belong in the next major version's
+directory (`v2/`), not in an edit to `v1/`.
+
+## Layout
+
+```
+test/testdata/plugins/stable/
+  README.md          <- this file
+  v1/                <- the frozen contract for the v1 line
+    <plugin-type>.yaml
+```
+
+One file per plugin, named after the plugin type it covers, so a reader can find
+the frozen config for a plugin without opening anything.
+
+The directory is versioned by *major* version because that is the unit the
+stability guarantee is scoped to. 0.x carries no stability promise, so configs
+land in `v1/` now and stay put when v1 is cut, rather than moving at the release
+and breaking the "these paths never move" property this directory depends on.
+
+## Adding a newly promoted plugin
+
+1. Flip the plugin's registration in `cmd/epp/runner/runner.go` from
+   `plugin.StabilityBeta` to `plugin.StabilityStable`.
+2. Add `v1/<plugin-type>.yaml` here — a minimal config that instantiates the
+   plugin and sets every parameter it accepts, with values a real deployment
+   would use.
+3. Run `go test ./cmd/epp/runner/ -run TestStablePluginConfigs`.
+
+No test registration is needed; the test discovers files by globbing this
+directory.

--- a/test/testdata/plugins/stable/v1/max-score-picker.yaml
+++ b/test/testdata/plugins/stable/v1/max-score-picker.yaml
@@ -1,0 +1,13 @@
+# Frozen configuration surface of the max-score-picker plugin.
+# See ../README.md: this file must not be edited to fix a failing test.
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: max-score-picker
+  parameters:
+    maxNumOfEndpoints: 1
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: max-score-picker

--- a/test/testdata/plugins/stable/v1/random-picker.yaml
+++ b/test/testdata/plugins/stable/v1/random-picker.yaml
@@ -1,0 +1,13 @@
+# Frozen configuration surface of the random-picker plugin.
+# See ../README.md: this file must not be edited to fix a failing test.
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: random-picker
+  parameters:
+    maxNumOfEndpoints: 1
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: random-picker

--- a/test/testdata/plugins/stable/v1/single-profile-handler.yaml
+++ b/test/testdata/plugins/stable/v1/single-profile-handler.yaml
@@ -1,0 +1,13 @@
+# Frozen configuration surface of the single-profile-handler plugin.
+# The handler takes no parameters; the picker is present only because a
+# scheduling profile needs one.
+# See ../README.md: this file must not be edited to fix a failing test.
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: max-score-picker

--- a/test/testdata/plugins/stable/v1/weighted-random-picker.yaml
+++ b/test/testdata/plugins/stable/v1/weighted-random-picker.yaml
@@ -1,0 +1,13 @@
+# Frozen configuration surface of the weighted-random-picker plugin.
+# See ../README.md: this file must not be edited to fix a failing test.
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: weighted-random-picker
+  parameters:
+    maxNumOfEndpoints: 1
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: weighted-random-picker


### PR DESCRIPTION
/kind test

part of #2261, harness only, no plugin is promoted to stable here.

adds test/testdata/plugins/stable/ with a frozen config per stable plugin, a test that loads them all, and a ci check so the files cant be edited later (adding is fine).

covers max-score-picker, random-picker, weighted-random-picker and single-profile-handler. test lives in cmd/epp/runner so it gets the real plugin registrations without envtest.

went with v1/ not v0.11/ as discussed. left data-parallel-profile-handler out, commented on the issue why.

**Release note**:
```release-note
NONE