### PR TITLE
Add endpoint-attribute parity coverage and a benchmark config (#2059 item 1)

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/legacy_parity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/legacy_parity_test.go
@@ -1,0 +1,108 @@
+package endpointattribute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+	extmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/metrics"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/queuedepth"
+)
+
+// Behavioural parity for llm-d-router#2059 item 1.
+//
+// Loading a config proves nothing here. The endpoint-attribute scorer
+// declares its dependency as Optional (Consumes(), this file's package), and
+// datalayer.Scope only builds the set of keys a plugin is allowed to touch —
+// it never checks that something produces what something else consumes. A
+// variant whose customMetrics block is wrong, or absent, therefore loads
+// cleanly, runs, and scores every endpoint 0.0. That is indistinguishable
+// from a scorer that discriminates badly, and a benchmark would report it as
+// a result.
+//
+// So the check is behavioural: both implementations get the same endpoints —
+// the value on the Metrics struct the legacy scorers read AND on the
+// attribute map the endpoint-attribute scorer reads — and the score maps
+// must agree.
+
+func endpointWith(queue int, kvUsage float64) fwksched.Endpoint {
+	attrs := fwkdl.NewAttributes()
+	attrs.Put(attrmetrics.ScalarMetricDataKey(extmetrics.WaitingQueueSizeKey),
+		attrmetrics.ScalarMetricValue(float64(queue)))
+	attrs.Put(attrmetrics.ScalarMetricDataKey(extmetrics.KVCacheUsagePercentKey),
+		attrmetrics.ScalarMetricValue(kvUsage))
+	return fwksched.NewEndpoint(
+		&fwkdl.EndpointMetadata{},
+		&fwkdl.Metrics{WaitingQueueSize: queue, KVCacheUsagePercent: kvUsage},
+		attrs,
+	)
+}
+
+func adaptiveParams(attributeKey string) parameters {
+	return parameters{
+		AttributeKey: attributeKey,
+		Algorithm: algorithmParameters{
+			Type:          algorithmLinearLowerIsBetter,
+			Normalization: normalizationParameters{AdaptiveRange: &adaptiveRangeParameters{}},
+		},
+	}
+}
+
+func fixedParams(attributeKey string, min, max float64) parameters {
+	return parameters{
+		AttributeKey: attributeKey,
+		Algorithm: algorithmParameters{
+			Type:          algorithmLinearLowerIsBetter,
+			Normalization: normalizationParameters{FixedRange: &fixedRangeParameters{Min: min, Max: max}},
+		},
+	}
+}
+
+func TestParityQueueScorer(t *testing.T) {
+	cases := [][]fwksched.Endpoint{
+		{endpointWith(0, 0.1), endpointWith(5, 0.2), endpointWith(10, 0.3)},
+		{endpointWith(3, 0.1), endpointWith(3, 0.2)}, // all equal: neutral 1.0
+		{endpointWith(0, 0.0), endpointWith(1, 0.0)},
+		{endpointWith(7, 0.5)}, // single endpoint
+	}
+	legacy := queuedepth.NewQueueScorer()
+	ea, err := NewEndpointAttributeScorer("ea-queue", adaptiveParams(extmetrics.WaitingQueueSizeKey))
+	require.NoError(t, err)
+
+	for i, endpoints := range cases {
+		want := legacy.Score(context.Background(), nil, endpoints)
+		got := ea.Score(context.Background(), nil, endpoints)
+		require.Len(t, got, len(want), "case %d: score map size", i)
+		for ep, wantScore := range want {
+			assert.InDelta(t, wantScore, got[ep], 1e-9,
+				"case %d: queue parity diverges", i)
+		}
+	}
+}
+
+func TestParityKVCacheScorer(t *testing.T) {
+	cases := [][]fwksched.Endpoint{
+		{endpointWith(0, 0.0), endpointWith(0, 0.5), endpointWith(0, 1.0)},
+		{endpointWith(0, 0.42), endpointWith(0, 0.42)}, // equal: fixed range keeps the value
+		{endpointWith(0, 0.9)},
+	}
+	legacy := kvcacheutilization.NewKVCacheUtilizationScorer()
+	ea, err := NewEndpointAttributeScorer("ea-kv", fixedParams(extmetrics.KVCacheUsagePercentKey, 0.0, 1.0))
+	require.NoError(t, err)
+
+	for i, endpoints := range cases {
+		want := legacy.Score(context.Background(), nil, endpoints)
+		got := ea.Score(context.Background(), nil, endpoints)
+		require.Len(t, got, len(want), "case %d: score map size", i)
+		for ep, wantScore := range want {
+			assert.InDelta(t, wantScore, got[ep], 1e-9,
+				"case %d: kv-cache parity diverges", i)
+		}
+	}
+}

--- a/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/legacy_parity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/legacy_parity_test.go
@@ -10,7 +10,7 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
-	extmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/metrics"
+	extractormetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/queuedepth"
 )
@@ -33,9 +33,9 @@ import (
 
 func endpointWith(queue int, kvUsage float64) fwksched.Endpoint {
 	attrs := fwkdl.NewAttributes()
-	attrs.Put(attrmetrics.ScalarMetricDataKey(extmetrics.WaitingQueueSizeKey),
+	attrs.Put(attrmetrics.ScalarMetricDataKey(extractormetrics.WaitingQueueSizeKey),
 		attrmetrics.ScalarMetricValue(float64(queue)))
-	attrs.Put(attrmetrics.ScalarMetricDataKey(extmetrics.KVCacheUsagePercentKey),
+	attrs.Put(attrmetrics.ScalarMetricDataKey(extractormetrics.KVCacheUsagePercentKey),
 		attrmetrics.ScalarMetricValue(kvUsage))
 	return fwksched.NewEndpoint(
 		&fwkdl.EndpointMetadata{},
@@ -72,7 +72,7 @@ func TestParityQueueScorer(t *testing.T) {
 		{endpointWith(7, 0.5)}, // single endpoint
 	}
 	legacy := queuedepth.NewQueueScorer()
-	ea, err := NewEndpointAttributeScorer("ea-queue", adaptiveParams(extmetrics.WaitingQueueSizeKey))
+	ea, err := NewEndpointAttributeScorer("ea-queue", adaptiveParams(extractormetrics.WaitingQueueSizeKey))
 	require.NoError(t, err)
 
 	for i, endpoints := range cases {
@@ -86,6 +86,39 @@ func TestParityQueueScorer(t *testing.T) {
 	}
 }
 
+// TestDivergenceWhenAttributeAbsent locks in the asymmetry the comment block
+// above describes. Every case in the parity tests puts the value on both the
+// Metrics struct and the attribute map, so none of them exercises what happens
+// when the attribute is missing — which is the failure a wrong customMetrics
+// block actually produces.
+//
+// The two scorers disagree by construction there. The legacy scorer reads
+// WaitingQueueSize from Metrics, sees 0, and treats an empty queue as the best
+// possible endpoint. The endpoint-attribute scorer finds no attribute and
+// returns 0.0, the worst. Absence reads as best on one path and worst on the
+// other, and nothing in the framework flags it: the dependency is Optional, so
+// the data graph logs a warning and the run proceeds.
+func TestDivergenceWhenAttributeAbsent(t *testing.T) {
+	noAttr := fwksched.NewEndpoint(
+		&fwkdl.EndpointMetadata{},
+		&fwkdl.Metrics{WaitingQueueSize: 0, KVCacheUsagePercent: 0.0},
+		fwkdl.NewAttributes(),
+	)
+	endpoints := []fwksched.Endpoint{noAttr}
+
+	legacy := queuedepth.NewQueueScorer()
+	ea, err := NewEndpointAttributeScorer("ea-queue", adaptiveParams(extractormetrics.WaitingQueueSizeKey))
+	require.NoError(t, err)
+
+	legacyScores := legacy.Score(context.Background(), nil, endpoints)
+	eaScores := ea.Score(context.Background(), nil, endpoints)
+
+	assert.InDelta(t, 1.0, legacyScores[noAttr], 1e-9,
+		"legacy reads WaitingQueueSize 0 from Metrics and scores an empty queue best")
+	assert.InDelta(t, 0.0, eaScores[noAttr], 1e-9,
+		"endpoint-attribute finds no attribute and scores the endpoint worst")
+}
+
 func TestParityKVCacheScorer(t *testing.T) {
 	cases := [][]fwksched.Endpoint{
 		{endpointWith(0, 0.0), endpointWith(0, 0.5), endpointWith(0, 1.0)},
@@ -93,7 +126,7 @@ func TestParityKVCacheScorer(t *testing.T) {
 		{endpointWith(0, 0.9)},
 	}
 	legacy := kvcacheutilization.NewKVCacheUtilizationScorer()
-	ea, err := NewEndpointAttributeScorer("ea-kv", fixedParams(extmetrics.KVCacheUsagePercentKey, 0.0, 1.0))
+	ea, err := NewEndpointAttributeScorer("ea-kv", fixedParams(extractormetrics.KVCacheUsagePercentKey, 0.0, 1.0))
 	require.NoError(t, err)
 
 	for i, endpoints := range cases {

--- a/test/perf/config/router-configs/endpoint-attribute-parity.yaml
+++ b/test/perf/config/router-configs/endpoint-attribute-parity.yaml
@@ -1,0 +1,92 @@
+# Endpoint-attribute variant of optimized-baseline, for the #2059 item-1
+# benchmark. Differs from optimized-baseline.yaml in exactly one respect:
+# queue-scorer and kv-cache-utilization-scorer are replaced by two
+# endpoint-attribute-scorer instances configured to reproduce them. Every
+# other plugin, weight and setting is identical, so a difference in the
+# benchmark is attributable to the scorer swap and nothing else.
+#
+# Why the customMetrics block is not optional: the core metrics extractor
+# lands WaitingQueueSize and KVCacheUsagePercent on the Metrics struct
+# rather than on the attribute map (extractor.go, Produces()), so the
+# endpoint-attribute scorer cannot read them until they are republished as
+# attributes. That is what these two mappings do.
+#
+# Why the whole vllm engineConfig is restated: the merge is per engine, not
+# per list (factories.go, newCoreMetricsExtractorPlugin). Each built-in is
+# appended only if its name is absent from engineConfigs, so declaring vllm
+# to attach customMetrics suppresses the vllm built-in alone — sglang,
+# trtllm-serve and the triton configs still land. All five vllm specs are
+# carried over verbatim; drop one and the Metrics struct loses its source
+# for that signal, which would break the legacy scorers this is compared
+# against rather than the endpoint-attribute ones under test.
+router:
+  extraServicePorts:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+  epp:
+    replicas: 1
+    image:
+      registry: ghcr.io/llm-d
+      repository: llm-d-router-endpoint-picker
+      tag: main
+      pullPolicy: Always
+    flags:
+      v: 4
+      enable-pprof: "true"
+      tracing: "false"
+    pluginsConfigFile: "ea-parity-plugins.yaml"
+    pluginsCustomConfig:
+      ea-parity-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+        - type: core-metrics-extractor
+          parameters:
+            engineConfigs:
+            - name: vllm
+              queuedRequestsSpec: "vllm:num_requests_waiting"
+              runningRequestsSpec: "vllm:num_requests_running"
+              kvUsageSpec: "vllm:kv_cache_usage_perc"
+              loraSpec: "vllm:lora_requests_info"
+              cacheInfoSpec: "vllm:cache_config_info"
+              customMetrics:
+              - attributeKey: WaitingQueueSize
+                metricSpec: "vllm:num_requests_waiting"
+              - attributeKey: KVCacheUsagePercent
+                metricSpec: "vllm:kv_cache_usage_perc"
+        - type: endpoint-attribute-scorer
+          name: ea-queue-scorer
+          parameters:
+            attributeKey: WaitingQueueSize
+            algorithm:
+              type: linear_lower_is_better
+              normalization:
+                adaptiveRange: {}
+        - type: endpoint-attribute-scorer
+          name: ea-kv-cache-scorer
+          parameters:
+            attributeKey: KVCacheUsagePercent
+            algorithm:
+              type: linear_lower_is_better
+              normalization:
+                fixedRange:
+                  min: 0.0
+                  max: 1.0
+        - type: approx-prefix-cache-producer
+          parameters:
+            maxPrefixTokensToMatch: 100000
+        - type: prefix-cache-scorer
+        - type: no-hit-lru-scorer
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: ea-queue-scorer
+            weight: 2
+          - pluginRef: ea-kv-cache-scorer
+            weight: 2
+          - pluginRef: prefix-cache-scorer
+            weight: 3
+          - pluginRef: no-hit-lru-scorer
+            weight: 2


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Item 1 of #2059 asks for a benchmark comparing the legacy metric scorers against the generic endpoint-attribute scorer. This adds the router config that benchmark would run, and the test that makes its result mean something.

**The test first, because it changes what the config has to prove.**

`EndpointAttributeScorer.Consumes()` declares its data dependency as `Optional`, and `datalayer.Scope` only builds the set of `DataKey`s a plugin is permitted to touch — nothing verifies that a producer exists for what a consumer reads. A variant whose `customMetrics` block is wrong, or missing entirely, therefore loads cleanly through both phases of the runner (I checked), runs, and scores every endpoint `0.0`. That is indistinguishable from a scorer that discriminates badly, and a benchmark would report it as a result.

So parity is asserted behaviourally instead. Both implementations receive the same endpoints, each value carried both on the `Metrics` struct the legacy scorers read and on the attribute map the endpoint-attribute scorer reads, and the score maps must agree. Removing either `Put` makes the test fail with `legacy=1` against `ea=0`.

That failure is itself worth recording: **a missing value reads as best under the legacy scorers and worst under the endpoint-attribute scorer.** The legacy path declares a zero default in `Consumes()`, so an endpoint with no scrape yet looks like an empty queue; the endpoint-attribute path sees the attribute as absent and assigns `0.0`. A benchmark should discard its warm-up window for that reason, and any migration should be aware the two disagree about endpoints that have not reported.

**The config.**

`endpoint-attribute-parity.yaml` replaces `queue-scorer` and `kv-cache-utilization-scorer` with two `endpoint-attribute-scorer` instances and changes nothing else — same plugins, same weights — so a difference in the benchmark is attributable to the swap.

- queue → `adaptiveRange` with `linear_lower_is_better`, matching the min-max normalisation the legacy scorer performs across the candidate set, including its neutral `1.0` when all endpoints are equal.
- kv-cache → `fixedRange [0,1]`, since that scorer is absolute (`1 - usage`); adaptive normalisation would not reproduce it.

Two scope notes:

- `running-requests-size-scorer` is deliberately in neither arm. It is not in `optimized-baseline`, and adding it to the baseline in order to have something to compare would change the configuration the project actually runs.
- The `vllm` `engineConfig` is restated in full because the built-in merge is per engine, not per list: declaring `vllm` to attach `customMetrics` suppresses the `vllm` built-in alone, and dropping one of its five specs would break the legacy arm rather than the one under test.

**Which issue(s) this PR fixes**:

Part of #2059 (item 1). Items 2 and 3 are not addressed here.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
