### PR TITLE
feat(metrics): extract vLLM kv_offload_tiering_chunk_* metrics and add storage tier weight

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/README.md
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/README.md
@@ -18,6 +18,7 @@ The Core Metrics Extractor is a data layer plugin responsible for extracting mod
     -   **KV Cache Usage**: Percentage of KV cache currently utilized.
     -   **LoRA Adapters**: Information about active and waiting LoRA adapters.
     -   **Cache Configuration**: Block size and total number of GPU blocks.
+    -   **Tiered Offloading** (optional): KV cache tiering metrics (`kv_offload_tiering_*`) when vLLM is configured with `TieringOffloadingSpec`. Silently skipped on non-tiering deployments.
 5.  Stores these values as attributes on the endpoint, making them available to scheduling plugins.
 
 ## Attributes produced
@@ -32,6 +33,15 @@ The plugin populates several standard keys on the endpoint:
 -   `WaitingModels` (int)
 -   `UpdateTime` (time.Time)
 
+When tiered offloading metrics are detected, the following scalar metric attributes are also produced (stored via `ScalarMetricDataKey`):
+
+-   `tiering_block_hits` (float64)
+-   `tiering_block_queries` (float64)
+-   `tiering_read_bytes` (float64)
+-   `tiering_read_time` (float64)
+-   `tiering_promotion_failures` (float64)
+-   `tiering_allocation_failures` (float64)
+
 ## Configuration
 
 The plugin config supports:
@@ -41,8 +51,11 @@ The plugin config supports:
     but will be removed in a future release.
 -   `defaultEngine`: The engine type to use if the label is missing. Defaults to `vllm`.
 -   `engineConfigs`: A list of engine-specific metric specifications.
-    Each engine config can also include `customMetrics` entries. Each entry
-    maps a scalar metric selector to an endpoint attribute key.
+    Each engine config can include `tieredOffloadingSpecs` and `customMetrics`
+    entries. Each entry maps a scalar metric selector to an endpoint attribute key.
+    The built-in vLLM config includes tiered offloading specs for the default
+    single-tier filesystem configuration (`tier="1:fs"`). Multi-tier deployments
+    should override with per-tier entries (see example below).
 
 ### Built-in Engine Configurations
 
@@ -86,6 +99,43 @@ metadata:
 
 ```
 
+### Multi-Tier Offloading Configuration
+
+The built-in vLLM config extracts tiered offloading metrics for tier `1:fs`
+(the default single filesystem tier). Single-tier deployments need no
+configuration.
+
+Multi-tier deployments must override the vLLM engine config to add entries
+for each tier. The tier label format is `{index}:{type}`, where `index` is
+the position in the `secondary_tiers` list (starting at 1) and `type` is the
+tier type (`fs`, `p2p`, `obj` for S3-compatible stores, or a custom type).
+Check your vLLM `TieringOffloadingSpec` config or scrape output to confirm
+the exact labels.
+
+> [!NOTE]
+> Overriding `engineConfigs` for `"vllm"` replaces the entire built-in
+> config, so all standard metric specs must be re-specified alongside the
+> tiering entries.
+
+```yaml
+type: core-metrics-extractor
+parameters:
+  engineConfigs:
+    - name: "vllm"
+      # Standard specs (required — overriding replaces the built-in config)
+      queuedRequestsSpec: "vllm:num_requests_waiting"
+      runningRequestsSpec: "vllm:num_requests_running"
+      kvUsageSpec: "vllm:kv_cache_usage_perc"
+      loraSpec: "vllm:lora_requests_info"
+      cacheInfoSpec: "vllm:cache_config_info"
+      # Per-tier offloading specs
+      tieredOffloadingSpecs:
+        - attributeKey: "tiering_block_hits_fs"
+          metricSpec: "vllm:kv_offload_tiering_block_hits_total{tier=\"1:fs\"}"
+        - attributeKey: "tiering_block_hits_p2p"
+          metricSpec: "vllm:kv_offload_tiering_block_hits_total{tier=\"2:p2p\"}"
+        - attributeKey: "tiering_block_hits_obj"
+          metricSpec: "vllm:kv_offload_tiering_block_hits_total{tier=\"3:obj\"}"
 ```
 
 ## Multi-cluster support

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -94,6 +94,9 @@ var _ fwkplugin.ProducerPlugin = &Extractor{}
 func (ext *Extractor) Produces() map[fwkplugin.DataKey]any {
 	produced := map[fwkplugin.DataKey]any{}
 	for _, mapping := range ext.registry.Mappings() {
+		for _, tiered := range mapping.TieredOffloading {
+			produced[attrmetrics.ScalarMetricDataKey(tiered.AttributeKey)] = attrmetrics.ScalarMetricValue(0)
+		}
 		for _, custom := range mapping.CustomMetrics {
 			produced[attrmetrics.ScalarMetricDataKey(custom.AttributeKey)] = attrmetrics.ScalarMetricValue(0)
 		}
@@ -184,6 +187,28 @@ func (ext *Extractor) Extract(ctx context.Context, in fwkdl.PollInput[sourcemetr
 		} else {
 			clone.CacheNumBlocks = int(extractValue(metric))
 			updated = true
+		}
+	}
+
+	if len(mapping.TieredOffloading) > 0 { // only work on vLLM as it is configured with TieredOffloading
+		metrics := make([]*dto.Metric, len(mapping.TieredOffloading))
+		fetchErrs := make([]error, len(mapping.TieredOffloading))
+		tieringDetected := false
+		for i, tiered := range mapping.TieredOffloading {
+			metrics[i], fetchErrs[i] = tiered.Spec.getLatestMetric(families)
+			if fetchErrs[i] == nil {
+				tieringDetected = true
+			}
+		}
+		if tieringDetected { // when none tiering metrics exist, skip adding into attribute
+			for i, tiered := range mapping.TieredOffloading {
+				if fetchErrs[i] != nil { // only report missing tiering metrics
+					errs = append(errs, fmt.Errorf("tiering metric %q: %w", tiered.AttributeKey, fetchErrs[i]))
+					continue
+				}
+				ep.GetAttributes().Put(attrmetrics.ScalarMetricDataKey(tiered.AttributeKey), attrmetrics.ScalarMetricValue(extractValue(metrics[i])))
+				updated = true
+			}
 		}
 	}
 

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
@@ -29,6 +29,7 @@ import (
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
 	sourcemetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/metrics"
 )
 
@@ -767,5 +768,137 @@ func TestGetEngineTypeFromEndpoint(t *testing.T) {
 				t.Errorf("getEngineTypeFromEndpoint() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestTieredOffloadingExtraction(t *testing.T) {
+	ctx := context.Background()
+
+	tieringSpecs := []AttributeMetric{
+		{AttributeKey: "tiering_block_hits", Spec: mustSpec(t, "vllm:kv_offload_tiering_block_hits_total{tier=\"1:fs\"}")},
+		{AttributeKey: "tiering_block_queries", Spec: mustSpec(t, "vllm:kv_offload_tiering_block_queries_total{tier=\"1:fs\"}")},
+		{AttributeKey: "tiering_allocation_failures", Spec: mustSpec(t, "vllm:kv_offload_tiering_promotion_allocation_failures_total")},
+	}
+
+	registry := NewMappingRegistry()
+	mapping, err := NewMappingFromConfig(MappingConfig{
+		Queue:            defaultTotalQueuedRequestsMetric,
+		Running:          defaultTotalRunningRequestsMetric,
+		TieredOffloading: tieringSpecs,
+	})
+	if err != nil {
+		t.Fatalf("failed to create mapping: %v", err)
+	}
+	if err := registry.Register(DefaultEngineType, mapping); err != nil {
+		t.Fatalf("failed to register mapping: %v", err)
+	}
+
+	extractor, err := NewCoreMetricsExtractor(registry, "")
+	if err != nil {
+		t.Fatalf("failed to create extractor: %v", err)
+	}
+
+	tierLabel := []*dto.LabelPair{{Name: proto.String("tier"), Value: proto.String("1:fs")}}
+
+	t.Run("all tiering metrics present", func(t *testing.T) {
+		ep := fwkdl.NewEndpoint(nil, nil)
+		data := sourcemetrics.PrometheusMetricMap{
+			defaultTotalQueuedRequestsMetric:  gaugeFamily(5),
+			defaultTotalRunningRequestsMetric: gaugeFamily(1),
+			"vllm:kv_offload_tiering_block_hits_total": &dto.MetricFamily{
+				Type:   dto.MetricType_COUNTER.Enum(),
+				Metric: []*dto.Metric{{Label: tierLabel, Counter: &dto.Counter{Value: ptr.To(100.0)}}},
+			},
+			"vllm:kv_offload_tiering_block_queries_total": &dto.MetricFamily{
+				Type:   dto.MetricType_COUNTER.Enum(),
+				Metric: []*dto.Metric{{Label: tierLabel, Counter: &dto.Counter{Value: ptr.To(200.0)}}},
+			},
+			"vllm:kv_offload_tiering_promotion_allocation_failures_total": &dto.MetricFamily{
+				Type:   dto.MetricType_COUNTER.Enum(),
+				Metric: []*dto.Metric{{Counter: &dto.Counter{Value: ptr.To(0.0)}}},
+			},
+		}
+
+		err := extractor.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: ep})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		assertScalarMetric(t, ep, "tiering_block_hits", 100.0)
+		assertScalarMetric(t, ep, "tiering_block_queries", 200.0)
+		assertScalarMetric(t, ep, "tiering_allocation_failures", 0.0)
+	})
+
+	t.Run("no tiering metrics, non-tiering deployment", func(t *testing.T) {
+		ep := fwkdl.NewEndpoint(nil, nil)
+		data := sourcemetrics.PrometheusMetricMap{
+			defaultTotalQueuedRequestsMetric:  gaugeFamily(5),
+			defaultTotalRunningRequestsMetric: gaugeFamily(1),
+		}
+
+		err := extractor.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: ep})
+		if err != nil {
+			t.Errorf("unexpected error on non-tiering deployment: %v", err)
+		}
+
+		assertNoScalarMetric(t, ep, "tiering_block_hits")
+		assertNoScalarMetric(t, ep, "tiering_block_queries")
+		assertNoScalarMetric(t, ep, "tiering_allocation_failures")
+	})
+
+	t.Run("partial tiering metrics, error on missing", func(t *testing.T) {
+		ep := fwkdl.NewEndpoint(nil, nil)
+		data := sourcemetrics.PrometheusMetricMap{
+			defaultTotalQueuedRequestsMetric:  gaugeFamily(5),
+			defaultTotalRunningRequestsMetric: gaugeFamily(1),
+			"vllm:kv_offload_tiering_block_hits_total": &dto.MetricFamily{
+				Type:   dto.MetricType_COUNTER.Enum(),
+				Metric: []*dto.Metric{{Label: tierLabel, Counter: &dto.Counter{Value: ptr.To(50.0)}}},
+			},
+		}
+
+		err := extractor.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: ep})
+		if err == nil {
+			t.Error("expected error for partial tiering metrics, got nil")
+		}
+
+		assertScalarMetric(t, ep, "tiering_block_hits", 50.0)
+		assertNoScalarMetric(t, ep, "tiering_block_queries")
+		assertNoScalarMetric(t, ep, "tiering_allocation_failures")
+	})
+}
+
+func mustSpec(t *testing.T, s string) *Spec {
+	t.Helper()
+	spec, err := parseStringToSpec(s)
+	if err != nil {
+		t.Fatalf("failed to parse spec %q: %v", s, err)
+	}
+	return spec
+}
+
+func gaugeFamily(value float64) *dto.MetricFamily {
+	return &dto.MetricFamily{
+		Type:   dto.MetricType_GAUGE.Enum(),
+		Metric: []*dto.Metric{{Gauge: &dto.Gauge{Value: ptr.To(value)}}},
+	}
+}
+
+func assertScalarMetric(t *testing.T, ep fwkdl.Endpoint, key string, want float64) {
+	t.Helper()
+	val, ok := attrmetrics.ReadScalarMetricValue(ep.GetAttributes(), attrmetrics.ScalarMetricDataKey(key))
+	if !ok {
+		t.Errorf("expected attribute %q to be set", key)
+		return
+	}
+	if float64(val) != want {
+		t.Errorf("attribute %q = %v, want %v", key, val, want)
+	}
+}
+
+func assertNoScalarMetric(t *testing.T, ep fwkdl.Endpoint, key string) {
+	t.Helper()
+	if _, ok := attrmetrics.ReadScalarMetricValue(ep.GetAttributes(), attrmetrics.ScalarMetricDataKey(key)); ok {
+		t.Errorf("expected attribute %q to not be set", key)
 	}
 }

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
@@ -61,16 +61,24 @@ type (
 		// CacheNumBlocksSpec defines the metric specification string for retrieving num GPU blocks directly
 		// as a gauge value (alternative to CacheInfoSpec labels). Used by engines like Triton TRT-LLM.
 		CacheNumBlocksSpec string `json:"cacheNumBlocksSpec,omitempty"`
+		// TieredOffloadingSpecs lists metric specifications for kv_offload_tiering_*
+		// metrics exposed when TieringOffloadingSpec is the kv_connector.
+		TieredOffloadingSpecs []attributeMetricConfigParams `json:"tieredOffloadingSpecs,omitempty"`
 		// CustomMetrics defines engine-specific scalar metrics to extract as endpoint attributes.
 		CustomMetrics []customMetricConfigParams `json:"customMetrics,omitempty"`
 	}
 
-	customMetricConfigParams struct {
+	// attributeMetricConfigParams holds a metric spec paired with the
+	// endpoint attribute key where its extracted value is stored.
+	attributeMetricConfigParams struct {
 		// AttributeKey is the endpoint attribute key where the scalar value is stored.
 		AttributeKey string `json:"attributeKey"`
 		// MetricSpec defines the source metric specification string.
 		MetricSpec string `json:"metricSpec"`
 	}
+
+	// customMetricConfigParams is an alias for attributeMetricConfigParams.
+	customMetricConfigParams = attributeMetricConfigParams
 
 	// modelServerExtractorParams holds the configuration parameters for the core metrics extractor plugin.
 	modelServerExtractorParams struct {
@@ -95,6 +103,18 @@ var defaultEngineConfigs = []engineConfigParams{
 		KVUsageSpec:         "vllm:kv_cache_usage_perc",
 		LoRASpec:            "vllm:lora_requests_info",
 		CacheInfoSpec:       "vllm:cache_config_info",
+		// Defaults target tier "1:fs" (single filesystem tier).
+		// Multi-tier deployments override via engineConfigs JSON with
+		// per-tier attribute keys (e.g. "tiering_block_hits_fs",
+		// "tiering_block_hits_p2p").
+		TieredOffloadingSpecs: []attributeMetricConfigParams{
+			{AttributeKey: "tiering_block_hits", MetricSpec: "vllm:kv_offload_tiering_block_hits_total{tier=\"1:fs\"}"},
+			{AttributeKey: "tiering_block_queries", MetricSpec: "vllm:kv_offload_tiering_block_queries_total{tier=\"1:fs\"}"},
+			{AttributeKey: "tiering_read_bytes", MetricSpec: "vllm:kv_offload_tiering_read_bytes_total{tier=\"1:fs\"}"},
+			{AttributeKey: "tiering_read_time", MetricSpec: "vllm:kv_offload_tiering_read_time_total{tier=\"1:fs\"}"},
+			{AttributeKey: "tiering_promotion_failures", MetricSpec: "vllm:kv_offload_tiering_promotion_job_failures_total{tier=\"1:fs\"}"},
+			{AttributeKey: "tiering_allocation_failures", MetricSpec: "vllm:kv_offload_tiering_promotion_allocation_failures_total"},
+		},
 	},
 	{
 		Name:                    "sglang",
@@ -207,7 +227,11 @@ func newCoreMetricsExtractorPlugin(ctx context.Context, name string, params *mod
 			return nil, fmt.Errorf("engine config name cannot be %q (reserved)", DefaultEngineType)
 		}
 
-		customMetrics, customMetricErrs := customMetricConfigs(engineConfig.CustomMetrics)
+		tieredOffloading, tieredErrs := parseAttributeMetricConfigs(engineConfig.TieredOffloadingSpecs)
+		if len(tieredErrs) != 0 {
+			return nil, fmt.Errorf("failed to create mapping for engine %q: %w", engineConfig.Name, errors.Join(tieredErrs...))
+		}
+		customMetrics, customMetricErrs := parseAttributeMetricConfigs(engineConfig.CustomMetrics)
 		if len(customMetricErrs) != 0 {
 			return nil, fmt.Errorf("failed to create mapping for engine %q: %w", engineConfig.Name, errors.Join(customMetricErrs...))
 		}
@@ -222,6 +246,7 @@ func newCoreMetricsExtractorPlugin(ctx context.Context, name string, params *mod
 			CacheNumBlocksLabel: engineConfig.CacheNumBlocksLabelName,
 			CacheBlockSize:      engineConfig.CacheBlockSizeSpec,
 			CacheNumBlocks:      engineConfig.CacheNumBlocksSpec,
+			TieredOffloading:    tieredOffloading,
 			CustomMetrics:       customMetrics,
 		})
 		if err != nil {
@@ -257,21 +282,21 @@ func newCoreMetricsExtractorPlugin(ctx context.Context, name string, params *mod
 	return extractor, nil
 }
 
-func customMetricConfigs(configs []customMetricConfigParams) ([]CustomMetric, []error) {
-	custom := make([]CustomMetric, 0, len(configs))
+func parseAttributeMetricConfigs(configs []attributeMetricConfigParams) ([]AttributeMetric, []error) {
+	metrics := make([]AttributeMetric, 0, len(configs))
 	var errs []error
 	for _, cfg := range configs {
 		spec, err := parseStringToSpec(cfg.MetricSpec)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("custom metric %q: %w", cfg.AttributeKey, err))
+			errs = append(errs, fmt.Errorf("attribute metric %q: %w", cfg.AttributeKey, err))
 			continue
 		}
-		custom = append(custom, CustomMetric{
+		metrics = append(metrics, AttributeMetric{
 			AttributeKey: cfg.AttributeKey,
 			Spec:         spec,
 		})
 	}
-	return custom, errs
+	return metrics, errs
 }
 
 func defaultExtractorParams() *modelServerExtractorParams {

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
@@ -42,7 +42,11 @@ type Mapping struct {
 	// (e.g. Triton TRT-LLM).
 	CacheBlockSize *Spec
 	CacheNumBlocks *Spec
-	CustomMetrics  []CustomMetric
+	// TieredOffloading holds specs for vLLM kv_offload_tiering_* metrics.
+	// When no tiering metric is found the block is silently skipped;
+	// when at least one is present, missing metrics are treated as errors.
+	TieredOffloading []AttributeMetric
+	CustomMetrics    []CustomMetric
 }
 
 // MappingConfig holds configuration used to build a Mapping.
@@ -56,13 +60,20 @@ type MappingConfig struct {
 	CacheNumBlocksLabel string
 	CacheBlockSize      string
 	CacheNumBlocks      string
+	TieredOffloading    []AttributeMetric
 	CustomMetrics       []CustomMetric
 }
 
-type CustomMetric struct {
+// AttributeMetric pairs a metric spec with the endpoint attribute key where
+// its extracted value is stored.
+type AttributeMetric struct {
 	AttributeKey string
 	Spec         *Spec
 }
+
+// CustomMetric is an alias for AttributeMetric, retained for the
+// core-metrics-extractor's CustomMetrics configuration parameter.
+type CustomMetric = AttributeMetric
 
 type namedSpec struct {
 	name    string
@@ -75,7 +86,7 @@ func (m *Mapping) specs() []namedSpec {
 	if m.LoraRequestInfo != nil {
 		loraSpec = m.LoraRequestInfo.Spec
 	}
-	specs := make([]namedSpec, 0, 5+len(m.CustomMetrics))
+	specs := make([]namedSpec, 0, 5+len(m.TieredOffloading)+len(m.CustomMetrics))
 	specs = append(specs,
 		namedSpec{"queue", m.TotalQueuedRequests, m.TotalQueuedRequests != nil},
 		namedSpec{"running", m.TotalRunningRequests, m.TotalRunningRequests != nil},
@@ -83,6 +94,13 @@ func (m *Mapping) specs() []namedSpec {
 		namedSpec{"lora", loraSpec, m.LoraRequestInfo != nil},
 		namedSpec{"cacheInfo", m.CacheInfo, m.CacheInfo != nil},
 	)
+	for _, tiered := range m.TieredOffloading {
+		specs = append(specs, namedSpec{
+			name:    tiered.AttributeKey,
+			spec:    tiered.Spec,
+			enabled: tiered.Spec != nil,
+		})
+	}
 	for _, custom := range m.CustomMetrics {
 		specs = append(specs, namedSpec{
 			name:    custom.AttributeKey,
@@ -161,6 +179,8 @@ func NewMappingFromConfig(cfg MappingConfig) (*Mapping, error) {
 	if err != nil {
 		errs = append(errs, err)
 	}
+	tieredOffloading, tieredErrs := parseCustomMetrics(cfg.TieredOffloading)
+	errs = append(errs, tieredErrs...)
 	customMetrics, customErrs := parseCustomMetrics(cfg.CustomMetrics)
 	errs = append(errs, customErrs...)
 
@@ -177,6 +197,7 @@ func NewMappingFromConfig(cfg MappingConfig) (*Mapping, error) {
 		CacheNumBlocksLabel:  cfg.CacheNumBlocksLabel,
 		CacheBlockSize:       cacheBlockSizeSpec,
 		CacheNumBlocks:       cacheNumBlocksSpec,
+		TieredOffloading:     tieredOffloading,
 		CustomMetrics:        customMetrics,
 	}, nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md
@@ -39,6 +39,27 @@ upstream. No-op otherwise.
 Set `kvEventsConfig.engineType` to `sglang` for SGLang KV-events. It defaults
 to `vllm` when omitted.
 
+### Device tier weights
+
+`indexerConfig.kvCacheBackendConfigs` controls how much a cached block
+on each device tier contributes to an endpoint's prefix match score.
+Defaults: `gpu=1.0`, `cpu=0.8`, `storage=0.3`. The `storage` tier
+covers filesystem-backed offloading (vLLM `TieringOffloadingSpec`);
+the conservative default suits most media. Override for fast storage (e.g. NVMe):
+
+```yaml
+indexerConfig:
+  kvCacheBackendConfigs:
+    - name: "gpu"
+      weight: 1.0
+    - name: "cpu"
+      weight: 0.8
+    - name: "storage"
+      weight: 0.6
+```
+
+Omit `kvCacheBackendConfigs` entirely to use the defaults. When overriding any tier, all tiers must be specified. The list replaces the defaults entirely.
+
 See [llm-d-kv-cache/docs/configuration.md](https://github.com/llm-d/llm-d-kv-cache/blob/main/docs/configuration.md)
 for nested parameter details.
 

--- a/pkg/kvcache/backend.go
+++ b/pkg/kvcache/backend.go
@@ -16,16 +16,23 @@ limitations under the License.
 
 package kvcache
 
+// KVCacheBackendConfig assigns a scoring weight to a device tier, identified
+// by the medium field in KV-cache events.
 type KVCacheBackendConfig struct {
-	// Name is the identifier for this medium (e.g., "gpu", "cpu", "disk")
+	// Name must match the medium string in KV-cache events (lowercased): "gpu", "cpu", "storage".
 	Name string `json:"name"`
 	// Weight is the scoring weight for blocks stored on this medium
 	Weight float64 `json:"weight"`
 }
 
+// DefaultKVCacheBackendConfig returns the default tier weights.
+// "storage" is set conservatively at 0.3 because promotion speed varies
+// widely across media (NVMe vs CephFS vs S3). Deployments with fast
+// storage should raise this value; slow storage may lower it further.
 func DefaultKVCacheBackendConfig() []*KVCacheBackendConfig {
 	return []*KVCacheBackendConfig{
 		{Name: "gpu", Weight: 1.0},
 		{Name: "cpu", Weight: 0.8},
+		{Name: "storage", Weight: 0.3},
 	}
 }

--- a/pkg/kvcache/kvblock_scorer_test.go
+++ b/pkg/kvcache/kvblock_scorer_test.go
@@ -99,6 +99,43 @@ func TestLongestPrefixScorerDifferentTiers(t *testing.T) {
 	}
 }
 
+func TestLongestPrefixScorerStorageTier(t *testing.T) {
+	mediumWeights := map[string]float64{
+		"gpu":     1.0,
+		"cpu":     0.8,
+		"storage": 0.3,
+	}
+
+	scorer := &kvcache.LongestPrefixScorer{
+		MediumWeights: mediumWeights,
+	}
+	blockKeys := int64KeysToKVBlockKeys([]uint64{1001, 1002, 1003, 1004})
+
+	hitmap := map[kvblock.BlockHash][]kvblock.PodEntry{
+		1001: {
+			{PodIdentifier: podA, DeviceTier: "cpu"},
+			{PodIdentifier: podB, DeviceTier: "gpu"},
+		},
+		1002: {
+			{PodIdentifier: podA, DeviceTier: "cpu"},
+			{PodIdentifier: podB, DeviceTier: "gpu"},
+		},
+		1003: {{PodIdentifier: podA, DeviceTier: "storage"}},
+		1004: {{PodIdentifier: podA, DeviceTier: "storage"}},
+	}
+
+	expected := map[string]float64{
+		podA: 2.2,
+		podB: 2.0,
+	}
+
+	scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+	assert.NoError(t, err)
+	for pod, score := range scored {
+		assert.InDelta(t, expected[pod], score, 0.0001)
+	}
+}
+
 func int64KeysToKVBlockKeys(keys []uint64) []kvblock.BlockHash {
 	kvKeys := make([]kvblock.BlockHash, len(keys))
 	for i, key := range keys {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add native support for vLLM `kv_offload_tiering_chunk_*` Prometheus metrics in the metrics extractor, and add a `"storage"` tier weight to the precise prefix cache producer so storage-tier blocks score lower than GPU/CPU.

**Extraction:**
- Extract `kv_offload_tiering_chunk_*` metrics as new endpoint attributes.
- Skip missing tiering series without erroring: vLLM creates a tier's counter only after that tier's first event, so an absent series cannot be distinguished from a misconfigured tier label. Attributes stay unset until the series appears, keeping  non-tiering endpoint distinguishable from an idle tiering one.
- Default vLLM config targets tier `1:fs`. Deployments with multiple  external media override via `engineConfigs`.
- Rename `CustomMetric` to `AttributeMetric` for reuse; retain `CustomMetric` as a type alias.

**Scoring:**
- Add `"storage"` (weight 0.3) to `DefaultKVCacheBackendConfig`:   gpu=1.0, cpu=0.8, storage=0.3.
- default suits varied media. Deployments with fast storage  (e.g. NVMe) should raise it via precise-prefix-cache-producer's `parameters.indexerConfig.kvCacheBackendConfigs`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Add extraction of vLLM kv_offload_tiering_chunk_* metrics. Storage-tier KV cache blocks (from TieringOffloadingSpec offloading) now score at 0.3 by default. Adjust it via kvCacheBackendConfigs for faster or slower media.
```
