### PR TITLE
perf(kvcache): make index lookup recency read-only

### DIFF
--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -120,7 +120,7 @@ func (m *InMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 	highestHitIdx := 0
 
 	for idx, requestKey := range requestKeys {
-		if pods, found := m.data.Get(requestKey); found { //nolint:nestif // TODO: can this be optimized?
+		if pods, found := m.data.Peek(requestKey); found { //nolint:nestif // TODO: can this be optimized?
 			if pods == nil || pods.cache.Len() == 0 {
 				traceLogger.Info("no pods found for key, cutting search", "key", requestKey)
 				return podsPerKey, nil // early stop since prefix-chain breaks here

--- a/pkg/kvcache/kvblock/in_memory_bench_test.go
+++ b/pkg/kvcache/kvblock/in_memory_bench_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	. "github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
+)
+
+func BenchmarkInMemoryIndexLookup(b *testing.B) {
+	for _, tc := range []struct {
+		blocks  int
+		entries int
+	}{
+		{blocks: 225, entries: 2},
+		{blocks: 225, entries: 10},
+		{blocks: 1034, entries: 2},
+	} {
+		b.Run(fmt.Sprintf("blocks=%d/entries=%d", tc.blocks, tc.entries), func(b *testing.B) {
+			ctx := log.IntoContext(b.Context(), logr.Discard())
+			index, err := NewInMemoryIndex(&InMemoryIndexConfig{
+				Size:         tc.blocks + 1,
+				PodCacheSize: tc.entries,
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			keys := make([]BlockHash, tc.blocks)
+			for i := range keys {
+				keys[i] = BlockHash(i + 1)
+			}
+			entries := make([]PodEntry, tc.entries)
+			for i := range entries {
+				entries[i] = PodEntry{
+					PodIdentifier: fmt.Sprintf("pod-%d", i),
+					DeviceTier:    "gpu",
+				}
+			}
+			if err := index.Add(ctx, nil, keys, entries); err != nil {
+				b.Fatal(err)
+			}
+
+			b.Run("serial", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					if _, err := index.Lookup(ctx, keys, nil); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+			b.Run("parallel", func(b *testing.B) {
+				b.ReportAllocs()
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						if _, err := index.Lookup(ctx, keys, nil); err != nil {
+							b.Error(err)
+							return
+						}
+					}
+				})
+			})
+		})
+	}
+}

--- a/pkg/kvcache/kvblock/in_memory_test.go
+++ b/pkg/kvcache/kvblock/in_memory_test.go
@@ -222,3 +222,26 @@ func TestAddWithNilEngineKeys(t *testing.T) {
 	_, err = index.GetRequestKey(ctx, requestKey)
 	assert.Error(t, err, "GetRequestKey should fail since no engineKey mapping was created")
 }
+
+// Lookup reads recency without refreshing it, so a looked-up key stays in its
+// original eviction position.
+func TestLookupDoesNotRefreshIndexLRU(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(t.Context())
+	index, err := NewInMemoryIndex(&InMemoryIndexConfig{Size: 2, PodCacheSize: 1})
+	require.NoError(t, err)
+
+	entry := []PodEntry{{PodIdentifier: "pod-a", DeviceTier: "gpu"}}
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{10}, entry))
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{20}, entry))
+
+	pods, err := index.Lookup(ctx, []BlockHash{10}, nil)
+	require.NoError(t, err)
+	require.Contains(t, pods, BlockHash(10))
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{30}, entry))
+
+	pods, err = index.Lookup(ctx, []BlockHash{10, 20}, nil)
+	require.NoError(t, err)
+	assert.NotContains(t, pods, BlockHash(10))
+	assert.Contains(t, pods, BlockHash(20))
+}

--- a/pkg/kvcache/kvblock/in_memory_test.go
+++ b/pkg/kvcache/kvblock/in_memory_test.go
@@ -245,3 +245,22 @@ func TestLookupDoesNotRefreshIndexLRU(t *testing.T) {
 	assert.NotContains(t, pods, BlockHash(10))
 	assert.Contains(t, pods, BlockHash(20))
 }
+
+// Add refreshes an existing key's recency, so the next capacity eviction
+// removes the older key.
+func TestAddRefreshesIndexLRU(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(t.Context())
+	index, err := NewInMemoryIndex(&InMemoryIndexConfig{Size: 2, PodCacheSize: 1})
+	require.NoError(t, err)
+
+	entry := []PodEntry{{PodIdentifier: "pod-a", DeviceTier: "gpu"}}
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{10}, entry))
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{20}, entry))
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{10}, entry))
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{30}, entry))
+
+	pods, err := index.Lookup(ctx, []BlockHash{10, 20}, nil)
+	require.NoError(t, err)
+	assert.Contains(t, pods, BlockHash(10))
+	assert.NotContains(t, pods, BlockHash(20))
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

`InMemoryIndex.Lookup` promoted LRU recency for every key it touched, taking the
cache write lock on what is otherwise a read path and letting read traffic
reorder eviction. `Peek` reads the entry without promoting it, so eviction order
now reflects admission and update traffic only.

This is a deliberate behavior change: a block that is looked up often but never
re-admitted is no longer held in the index by lookups alone.

**Test plan**:

- [x] `TestLookupDoesNotRefreshIndexLRU` - verified failing before the change and
      passing after, so it gates the behavior rather than describing it
- [x] `make presubmit`
- [x] `make test-unit`

**Which issue(s) this PR fixes**:

Fixes #2399

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
KV-block index lookups no longer refresh an entry's LRU recency. Index eviction
order now reflects block admission and updates rather than lookup traffic.
```
