### PR TITLE
perf(kvcache): fused ScoredLookup path for the precise prefix index

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -374,8 +374,8 @@ Prefix `llm_d_epp_`. Registered only when the embedded llm-d-kv-cache metrics ar
 | `kv_cache_index_admissions_total` | Counter | Blocks admitted to the index. |
 | `kv_cache_index_evictions_total` | Counter | Blocks evicted from the index. |
 | `kv_cache_index_lookup_requests_total` | Counter | Index lookups performed. |
-| `kv_cache_index_lookup_hits_total` | Counter | Lookups that matched at least one block. |
-| `kv_cache_index_max_pod_hit_count_total` | Counter | Best per-pod hit count observed per lookup. |
+| `kv_cache_index_lookup_hits_total` | Counter | Contiguous prefix blocks matched by the best pod per lookup. |
+| `kv_cache_index_max_pod_hit_count_total` | Counter | Longest contiguous per-pod prefix chain observed per lookup. |
 | `kv_cache_index_lookup_latency_seconds` | Histogram | Index lookup latency. |
 | `kv_cache_events_dedup_removed_hashes_suppressed_total` | Counter | Deduplicated removal hashes suppressed. |
 | `kv_cache_events_dedup_removed_hashes_forwarded_total` | Counter | Deduplicated removal hashes forwarded. |

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -397,7 +397,11 @@ func (p *Producer) produceFromBlockKeys(ctx context.Context, span trace.Span,
 	}
 
 	maxMatch := 0
+	results := make([]endpointResult, 0, len(endpoints))
 	for _, ep := range endpoints {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		md := ep.GetMetadata()
 		if md == nil {
 			continue
@@ -421,7 +425,10 @@ func (p *Producer) produceFromBlockKeys(ctx context.Context, span trace.Span,
 		if len(mmBlockIndices) > 0 {
 			info.WithMM(attrprefix.MMMatchInfo{MatchBlocks: countMMMatchedBlocks(mmBlockIndices, cachedBlocks)})
 		}
-		ep.Put(p.dk, info)
+		results = append(results, endpointResult{endpoint: ep, info: info})
+	}
+	if err := p.publishEndpointResults(ctx, results); err != nil {
+		return err
 	}
 
 	if p.speculativeEnabled {
@@ -481,7 +488,11 @@ func (p *Producer) produceFused(ctx context.Context, span trace.Span,
 	}
 
 	maxMatch := 0
+	results := make([]endpointResult, 0, len(endpoints))
 	for _, ep := range endpoints {
+		if err := ctx.Err(); err != nil {
+			return true, err
+		}
 		md := ep.GetMetadata()
 		if md == nil {
 			continue
@@ -501,7 +512,10 @@ func (p *Producer) produceFused(ctx context.Context, span trace.Span,
 		if len(mmBlockIndices) > 0 {
 			info.WithMM(attrprefix.MMMatchInfo{MatchBlocks: countMMMatchedBlocks(mmBlockIndices, cachedBlocks)})
 		}
-		ep.Put(p.dk, info)
+		results = append(results, endpointResult{endpoint: ep, info: info})
+	}
+	if err := p.publishEndpointResults(ctx, results); err != nil {
+		return true, err
 	}
 
 	if p.speculativeEnabled {
@@ -522,4 +536,19 @@ func (p *Producer) produceFused(ctx context.Context, span trace.Span,
 		v.Info("Produce completed", "blockKeys", totalBlocks, "scores", scores)
 	}
 	return true, nil
+}
+
+type endpointResult struct {
+	endpoint scheduling.Endpoint
+	info     *attrprefix.PrefixCacheMatchInfo
+}
+
+func (p *Producer) publishEndpointResults(ctx context.Context, results []endpointResult) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	for _, result := range results {
+		result.endpoint.Put(p.dk, result.info)
+	}
+	return nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -22,8 +22,10 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync/atomic"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/llm-d/llm-d-router/pkg/kvcache"
 	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
@@ -32,6 +34,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
@@ -99,6 +102,9 @@ type Producer struct {
 	kvEventsConfig     *kvevents.Config
 
 	kvBlockScorer kvcache.KVBlockScorer
+	// tierWeights mirrors the scorer's device-tier weights for the fused
+	// ScoredLookup path.
+	tierWeights map[string]float64
 
 	dk plugin.DataKey
 
@@ -109,6 +115,10 @@ type Producer struct {
 	speculativeEnabled bool
 
 	blockSizeTokens int
+
+	// scoredLookupOff latches after the index reports the fused path
+	// unsupported, so later requests skip the probe and its span.
+	scoredLookupOff atomic.Bool
 
 	// Plugin-lifetime, not request-scoped: SubscriberManager binds each
 	// subscriber's goroutine to the ctx passed at registration.
@@ -181,6 +191,10 @@ func New(ctx context.Context, name string, config PluginConfig) (*Producer, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to create KVBlockScorer: %w", err)
 	}
+	tierWeights := map[string]float64{}
+	if lps, ok := kvBlockScorer.(*kvcache.LongestPrefixScorer); ok {
+		tierWeights = lps.MediumWeights
+	}
 
 	adapter, err := engineadapter.NewAdapter(config.KVEventsConfig.EngineType)
 	if err != nil {
@@ -206,6 +220,7 @@ func New(ctx context.Context, name string, config PluginConfig) (*Producer, erro
 		typedName:          plugin.TypedName{Type: PluginType, Name: name},
 		kvCacheIndexer:     indexer,
 		kvBlockScorer:      kvBlockScorer,
+		tierWeights:        tierWeights,
 		subscribersManager: subscribersManager,
 		kvEventsConfig:     config.KVEventsConfig,
 		dk:                 attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(name),
@@ -344,6 +359,17 @@ func (p *Producer) produceFromBlockKeys(ctx context.Context, span trace.Span,
 	logger := log.FromContext(ctx).WithName(p.typedName.String())
 	endpointSet := extractEndpointSet(endpoints)
 
+	// Fused fast path: one index walk yields the weighted score, contiguous
+	// block count, and per-tier counts per pod, without materializing the
+	// per-key pod entry map or re-walking it per endpoint.
+	if scoredIndex, ok := p.kvCacheIndexer.KVBlockIndex().(kvblock.ScoredLookupIndex); ok && !p.scoredLookupOff.Load() {
+		handled, err := p.produceFused(ctx, span, request, endpoints, perPromptKeys, mmBlockIndices,
+			scoredIndex, endpointSet, logger)
+		if handled || err != nil {
+			return err
+		}
+	}
+
 	type promptLookup struct {
 		keys      []kvblock.BlockHash
 		keyToPods map[kvblock.BlockHash][]kvblock.PodEntry
@@ -411,4 +437,89 @@ func (p *Producer) produceFromBlockKeys(ctx context.Context, span trace.Span,
 	logger.V(logging.TRACE).Info("Produce completed",
 		"blockKeys", totalBlocks, "scores", aggregatedScores)
 	return nil
+}
+
+// produceFused writes PrefixCacheMatchInfo for every candidate endpoint from
+// fused ScoredLookup results. Returns handled=false when the index backend
+// does not support scored lookups, in which case the caller falls back to
+// Lookup plus external scoring.
+func (p *Producer) produceFused(ctx context.Context, span trace.Span,
+	request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint,
+	perPromptKeys [][]kvblock.BlockHash, mmBlockIndices []int,
+	scoredIndex kvblock.ScoredLookupIndex, endpointSet sets.Set[string], logger logr.Logger,
+) (handled bool, err error) {
+	type podAgg struct {
+		score  float64
+		blocks int
+		byTier map[string]int
+	}
+	agg := make(map[string]*podAgg)
+	totalBlocks := 0
+	for _, blockKeys := range perPromptKeys {
+		stats, err := scoredIndex.ScoredLookup(ctx, blockKeys, endpointSet, p.tierWeights)
+		if err != nil {
+			if errors.Is(err, kvblock.ErrScoredLookupUnsupported) {
+				p.scoredLookupOff.Store(true)
+				return false, nil
+			}
+			span.SetStatus(codes.Error, err.Error())
+			return true, fmt.Errorf("failed to lookup block keys: %w", err)
+		}
+		for pod, s := range stats {
+			a := agg[pod]
+			if a == nil {
+				a = &podAgg{byTier: map[string]int{}}
+				agg[pod] = a
+			}
+			a.score += s.WeightedScore
+			a.blocks += s.MatchedBlocks
+			for tier, count := range s.BlocksByTier {
+				a.byTier[tier] += count
+			}
+		}
+		totalBlocks += len(blockKeys)
+	}
+
+	maxMatch := 0
+	for _, ep := range endpoints {
+		md := ep.GetMetadata()
+		if md == nil {
+			continue
+		}
+		addr := fmt.Sprintf("%s:%s", md.Address, md.Port)
+		matchLen, cachedBlocks := 0, 0
+		byTier := map[string]int{}
+		if a := agg[addr]; a != nil {
+			matchLen, cachedBlocks, byTier = int(a.score), a.blocks, a.byTier
+		}
+		if matchLen > maxMatch {
+			maxMatch = matchLen
+		}
+		info := attrprefix.NewPrefixCacheMatchInfo(matchLen, totalBlocks, p.blockSizeTokens).
+			WithCachedBlockCount(cachedBlocks).
+			WithCachedBlocksByTier(byTier)
+		if len(mmBlockIndices) > 0 {
+			info.WithMM(attrprefix.MMMatchInfo{MatchBlocks: countMMMatchedBlocks(mmBlockIndices, cachedBlocks)})
+		}
+		ep.Put(p.dk, info)
+	}
+
+	if p.speculativeEnabled {
+		p.pluginState.Write(request.RequestID, blockKeysStateKey,
+			&blockKeysState{perPromptKeys: perPromptKeys})
+	}
+
+	span.SetAttributes(
+		attribute.Int("llm_d.epp.producer.total_blocks", totalBlocks),
+		attribute.Int("llm_d.epp.producer.max_match_blocks", maxMatch),
+	)
+
+	if v := logger.V(logging.TRACE); v.Enabled() {
+		scores := make(map[string]float64, len(agg))
+		for pod, a := range agg {
+			scores[pod] = a.score
+		}
+		v.Info("Produce completed", "blockKeys", totalBlocks, "scores", scores)
+	}
+	return true, nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -41,7 +41,7 @@ import (
 
 type fakeKVCacheIndexer struct {
 	computeFromTokens func(ctx context.Context, tokens []uint32, model string, extra []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error)
-	index             *fakeKVBlockIndex
+	index             kvblock.Index
 }
 
 func (f *fakeKVCacheIndexer) ComputeBlockKeysFromTokens(ctx context.Context, tokens []uint32, model string, extra []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error) {
@@ -86,6 +86,17 @@ func (f *fakeKVBlockIndex) Clear(ctx context.Context, podIdentifier string) erro
 		return f.clearFn(ctx, podIdentifier)
 	}
 	return nil
+}
+
+type fakeScoredKVBlockIndex struct {
+	*fakeKVBlockIndex
+	scoredLookup func(ctx context.Context, keys []kvblock.BlockHash, podSet sets.Set[string], tierWeights map[string]float64) (map[string]kvblock.PodMatchStats, error)
+}
+
+func (f *fakeScoredKVBlockIndex) ScoredLookup(ctx context.Context, keys []kvblock.BlockHash,
+	podSet sets.Set[string], tierWeights map[string]float64,
+) (map[string]kvblock.PodMatchStats, error) {
+	return f.scoredLookup(ctx, keys, podSet, tierWeights)
 }
 
 type fakeKVBlockScorer struct {
@@ -135,6 +146,21 @@ func freshEndpoints() []scheduling.Endpoint {
 				Port:    "8080",
 			}, nil, nil),
 	}
+}
+
+type cancelOnMetadataEndpoint struct {
+	scheduling.Endpoint
+	cancel   context.CancelFunc
+	calls    int
+	cancelOn int
+}
+
+func (e *cancelOnMetadataEndpoint) GetMetadata() *fwkdl.EndpointMetadata {
+	e.calls++
+	if e.calls == e.cancelOn {
+		e.cancel()
+	}
+	return e.Endpoint.GetMetadata()
 }
 
 func newProducerWithIndexer(ctx context.Context, idx kvCacheIndexer, scorer kvcache.KVBlockScorer) *Producer {
@@ -205,6 +231,71 @@ func TestProduce_UsesTokenizedPrompt(t *testing.T) {
 	assert.Equal(t, 0, info2.MatchBlocks())
 	assert.Equal(t, 1, info2.TotalBlocks())
 	assert.Nil(t, info2.MM(), "text-only request must leave MM untracked")
+}
+
+func TestProduce_CancellationPublishesNoEndpointResults(t *testing.T) {
+	for _, fused := range []bool{false, true} {
+		t.Run(fmt.Sprintf("fused=%t", fused), func(t *testing.T) {
+			baseCtx := utils.NewTestContext(t)
+			ctx, cancel := context.WithCancel(baseCtx)
+			defer cancel()
+
+			const key = kvblock.BlockHash(0xCAFE)
+			baseIndex := &fakeKVBlockIndex{
+				lookup: func(_ context.Context, _ []kvblock.BlockHash, _ sets.Set[string]) (map[kvblock.BlockHash][]kvblock.PodEntry, error) {
+					return map[kvblock.BlockHash][]kvblock.PodEntry{
+						key: {{PodIdentifier: "10.0.0.1:8080"}},
+					}, nil
+				},
+			}
+			var index kvblock.Index = baseIndex
+			if fused {
+				index = &fakeScoredKVBlockIndex{
+					fakeKVBlockIndex: baseIndex,
+					scoredLookup: func(_ context.Context, _ []kvblock.BlockHash, _ sets.Set[string], _ map[string]float64) (map[string]kvblock.PodMatchStats, error) {
+						return map[string]kvblock.PodMatchStats{
+							"10.0.0.1:8080": {
+								WeightedScore: 1,
+								MatchedBlocks: 1,
+								BlocksByTier:  map[string]int{"gpu": 1},
+							},
+						}, nil
+					},
+				}
+			}
+
+			idx := &fakeKVCacheIndexer{
+				computeFromTokens: func(_ context.Context, _ []uint32, _ string, _ []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error) {
+					return []kvblock.BlockHash{key}, nil
+				},
+				index: index,
+			}
+			scorer := &fakeKVBlockScorer{
+				score: func(_ context.Context, _ []kvblock.BlockHash, _ map[kvblock.BlockHash][]kvblock.PodEntry) (map[string]float64, error) {
+					return map[string]float64{"10.0.0.1:8080": 1}, nil
+				},
+			}
+			p := newProducerWithIndexer(baseCtx, idx, scorer)
+			endpoints := freshEndpoints()
+			endpoints[1] = &cancelOnMetadataEndpoint{
+				Endpoint: endpoints[1], cancel: cancel, cancelOn: 2,
+			}
+			req := &scheduling.InferenceRequest{
+				RequestID:   "req-cancel-publish",
+				TargetModel: "test-model",
+				Body: &fwkrh.InferenceRequestBody{
+					TokenizedPrompt: &fwkrh.TokenizedPrompt{PerPromptTokens: [][]uint32{make([]uint32, testBlockSize)}},
+				},
+			}
+
+			err := p.Produce(ctx, req, endpoints)
+			require.ErrorIs(t, err, context.Canceled)
+			for _, ep := range endpoints {
+				_, published := ep.Get(p.dk)
+				assert.False(t, published, "canceled production must not publish a partial result")
+			}
+		})
+	}
 }
 
 // No tokens → no-op (no prompt-string fallback).

--- a/pkg/kvcache/export_test.go
+++ b/pkg/kvcache/export_test.go
@@ -23,9 +23,14 @@ import (
 // NewIndexerForTest constructs an Indexer with injected dependencies.
 // Exported only for testing via the export_test.go pattern.
 func NewIndexerForTest(tp kvblock.TokenProcessor, idx kvblock.Index, scorer KVBlockScorer) *Indexer {
+	tierWeights := map[string]float64{}
+	if lps, ok := scorer.(*LongestPrefixScorer); ok {
+		tierWeights = lps.MediumWeights
+	}
 	return &Indexer{
 		tokenProcessor: tp,
 		kvBlockIndex:   idx,
 		kvBlockScorer:  scorer,
+		tierWeights:    tierWeights,
 	}
 }

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -18,7 +18,9 @@ package kvcache
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -65,6 +67,10 @@ type Indexer struct {
 	tokenProcessor kvblock.TokenProcessor // turns tokens to kv block keys
 	kvBlockIndex   kvblock.Index          // looks up pods for block keys
 	kvBlockScorer  KVBlockScorer          // scores pods based on block hits
+	tierWeights    map[string]float64     // device tier -> scoring weight, for the fused lookup path
+	// scoredLookupOff latches after the index reports the fused path
+	// unsupported, so later requests skip the probe and its span.
+	scoredLookupOff atomic.Bool
 }
 
 // NewKVCacheIndexer creates a KVCacheIndex given a Config. Callers tokenize
@@ -97,11 +103,17 @@ func NewKVCacheIndexer(ctx context.Context, config *Config, tokenProcessor kvblo
 	// When tracing is not configured, the tracer is a no-op implementation.
 	scorer = NewTracedScorer(scorer)
 
+	tierWeights := make(map[string]float64)
+	for _, medium := range config.KVBlockScorerConfig.BackendConfigs {
+		tierWeights[medium.Name] = medium.Weight
+	}
+
 	indexer := &Indexer{
 		config:         config,
 		tokenProcessor: tokenProcessor,
 		kvBlockIndex:   kvBlockIndex,
 		kvBlockScorer:  scorer,
+		tierWeights:    tierWeights,
 	}
 
 	return indexer, nil
@@ -180,13 +192,42 @@ func (k *Indexer) ScoreTokens(
 	}
 	traceLogger.Info("found tokens", "tokens", tokens, "block-keys", blockKeys)
 
+	// Fused fast path: score during the index walk, without materializing the
+	// per-key pod entry map. An unsupported report latches the legacy path.
+	if scoredIndex, ok := k.kvBlockIndex.(kvblock.ScoredLookupIndex); ok && !k.scoredLookupOff.Load() {
+		stats, err := scoredIndex.ScoredLookup(ctx, blockKeys, sets.New(podIdentifiers...), k.tierWeights)
+		switch {
+		case err == nil:
+			podScores := make(map[string]float64, len(stats))
+			blocksFound := 0
+			for pod, s := range stats {
+				podScores[pod] = s.WeightedScore
+				if s.MatchedBlocks > blocksFound {
+					blocksFound = s.MatchedBlocks
+				}
+			}
+			span.SetAttributes(
+				attribute.Float64("llm_d.kv_cache.block_hit_ratio", float64(blocksFound)/float64(len(blockKeys))),
+				attribute.Int("llm_d.kv_cache.blocks_found", blocksFound),
+			)
+			return podScores, nil
+		case errors.Is(err, kvblock.ErrScoredLookupUnsupported):
+			k.scoredLookupOff.Store(true)
+		default:
+			span.SetStatus(codes.Error, err.Error())
+			return nil, fmt.Errorf("failed to query kvblock indexer: %w", err)
+		}
+	}
+
 	keyToPods, err := k.kvBlockIndex.Lookup(ctx, blockKeys, sets.New(podIdentifiers...))
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return nil, fmt.Errorf("failed to query kvblock indexer: %w", err)
 	}
-	traceLogger.Info("found block keys", "block-keys", blockKeys,
-		"pods", podsPerKeyPrintHelper(keyToPods))
+	if traceLogger.Enabled() {
+		traceLogger.Info("found block keys", "block-keys", blockKeys,
+			"pods", podsPerKeyPrintHelper(keyToPods))
+	}
 
 	// Calculate block-level hit ratio (blocks found / blocks requested).
 	blocksFound := 0

--- a/pkg/kvcache/indexer_bench_test.go
+++ b/pkg/kvcache/indexer_bench_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvcache_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/llm-d/llm-d-router/pkg/kvcache"
+	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
+)
+
+// BenchmarkScoreTokens measures the full request-time scoring path — block-key
+// derivation, index lookup, and longest-prefix scoring — for a 240K-token
+// prompt at block size 64 against a fully warm index.
+func BenchmarkScoreTokens(b *testing.B) {
+	const (
+		numTokens = 240_000
+		blockSize = 64
+	)
+	for _, numPods := range []int{8, 96} {
+		b.Run(fmt.Sprintf("tokens=240K/pods=%d", numPods), func(b *testing.B) {
+			ctx := context.Background()
+			tp, err := kvblock.NewChunkedTokenDatabase(&kvblock.TokenProcessorConfig{BlockSizeTokens: blockSize})
+			if err != nil {
+				b.Fatal(err)
+			}
+			cfg, err := kvcache.NewDefaultConfig()
+			if err != nil {
+				b.Fatal(err)
+			}
+			cfg.KVBlockIndexConfig.InMemoryConfig = &kvblock.InMemoryIndexConfig{
+				Size:         1 << 20,
+				PodCacheSize: 128,
+			}
+			indexer, err := kvcache.NewKVCacheIndexer(ctx, cfg, tp)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			tokens := make([]uint32, numTokens)
+			for i := range tokens {
+				tokens[i] = uint32(i%50000 + 1)
+			}
+
+			keys, err := indexer.ComputeBlockKeysFromTokens(ctx, tokens, "bench-model", nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			entries := make([]kvblock.PodEntry, numPods)
+			for p := range entries {
+				entries[p] = kvblock.PodEntry{
+					PodIdentifier: fmt.Sprintf("10.0.%d.%d:8000", p/256, p%256),
+					DeviceTier:    "gpu",
+				}
+			}
+			if err := indexer.KVBlockIndex().Add(ctx, nil, keys, entries); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				scores, err := indexer.ScoreTokens(ctx, tokens, "bench-model", nil, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(scores) != numPods {
+					b.Fatalf("unexpected score count %d", len(scores))
+				}
+			}
+		})
+	}
+}

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -57,6 +57,12 @@ func NewInMemoryIndex(cfg *InMemoryIndexConfig) (*InMemoryIndex, error) {
 	if cfg == nil {
 		cfg = DefaultInMemoryIndexConfig()
 	}
+	// Apply the default for an omitted field so partial configs (e.g. only
+	// size set) work correctly.
+	podCacheSize := cfg.PodCacheSize
+	if podCacheSize <= 0 {
+		podCacheSize = defaultPodsPerKey
+	}
 
 	cache, err := lru.New[BlockHash, *PodCache](cfg.Size)
 	if err != nil {
@@ -71,7 +77,9 @@ func NewInMemoryIndex(cfg *InMemoryIndexConfig) (*InMemoryIndex, error) {
 	return &InMemoryIndex{
 		data:                cache,
 		engineToRequestKeys: engineToRequestKeys,
-		podCacheSize:        cfg.PodCacheSize,
+		podCacheSize:        podCacheSize,
+		pods:                newInterner(),
+		tiers:               newInterner(),
 	}, nil
 }
 
@@ -86,17 +94,143 @@ type InMemoryIndex struct {
 	engineToRequestKeys *lru.Cache[BlockHash, []BlockHash]
 	// podCacheSize is the maximum number of pod entries per key.
 	podCacheSize int
+	// pods and tiers intern PodIdentifier and DeviceTier strings to dense
+	// indices so ScoredLookup accumulates per-pod state in slices instead of
+	// string-keyed maps. Both grow with the distinct values seen over the
+	// process lifetime and are never compacted; entries are a few tens of
+	// bytes each.
+	pods  *interner
+	tiers *interner
 }
 
 var _ Index = &InMemoryIndex{}
 
-// PodCache represents a cache for pod entries.
+// PodCache holds one request key's pod entries in LRU order (least recent
+// first), bounded by the index's podCacheSize. At per-key pod counts the
+// linear slice operations are cheaper than a map-backed LRU, and iteration
+// allocates nothing.
 type PodCache struct {
-	// cache is an LRU cache that maps PodEntry to their last access time.
-	// thread-safe.
-	cache *lru.Cache[PodEntry, struct{}]
-	// mu protects the cache from concurrent access during check-and-set operations.
+	// mu protects entries.
 	mu sync.Mutex
+	// entries is ordered least recently added first.
+	entries []podRecord
+	// capacity bounds len(entries); adding beyond it evicts the least
+	// recent entry.
+	capacity int
+}
+
+// podRecord pairs a PodEntry with interned identifiers so ScoredLookup can
+// accumulate per-pod state without hashing strings.
+type podRecord struct {
+	entry PodEntry
+	// podIdx interns entry.PodIdentifier.
+	podIdx uint32
+	// weightTierIdx interns entry.DeviceTier, keying scoring weights.
+	weightTierIdx uint32
+	// statTierIdx interns the tier reported in per-tier match counts:
+	// SpeculativeTier for speculative entries, else entry.DeviceTier.
+	statTierIdx uint32
+}
+
+// addAll inserts records with LRU semantics: an existing entry refreshes its
+// recency, a new entry appends, and overflow evicts the least recent entry.
+func (pc *PodCache) addAll(recs []podRecord) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	for _, rec := range recs {
+		found := false
+		for i := range pc.entries {
+			if pc.entries[i].entry == rec.entry {
+				copy(pc.entries[i:], pc.entries[i+1:])
+				pc.entries[len(pc.entries)-1] = rec
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+		if pc.capacity > 0 && len(pc.entries) >= pc.capacity {
+			copy(pc.entries, pc.entries[1:])
+			pc.entries[len(pc.entries)-1] = rec
+			continue
+		}
+		pc.entries = append(pc.entries, rec)
+	}
+}
+
+// removeAll deletes the given entries and reports whether the cache is empty
+// afterwards.
+func (pc *PodCache) removeAll(entries []PodEntry) (empty bool) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	for _, entry := range entries {
+		for i := range pc.entries {
+			if pc.entries[i].entry == entry {
+				pc.entries = append(pc.entries[:i], pc.entries[i+1:]...)
+				break
+			}
+		}
+	}
+	return len(pc.entries) == 0
+}
+
+// size returns the number of entries.
+func (pc *PodCache) size() int {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	return len(pc.entries)
+}
+
+// filteredEntries returns the entries whose PodIdentifier is in allowed (all
+// entries when allowed is empty) plus the unfiltered entry count.
+func (pc *PodCache) filteredEntries(allowed sets.Set[string]) (filtered []PodEntry, total int) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	total = len(pc.entries)
+	if total == 0 {
+		return nil, 0
+	}
+	if allowed.Len() == 0 {
+		filtered = make([]PodEntry, 0, total)
+		for i := range pc.entries {
+			filtered = append(filtered, pc.entries[i].entry)
+		}
+		return filtered, total
+	}
+	for i := range pc.entries {
+		if allowed.Has(pc.entries[i].entry.PodIdentifier) {
+			filtered = append(filtered, pc.entries[i].entry)
+		}
+	}
+	return filtered, total
+}
+
+// matching returns the entries belonging to podIdentifier.
+func (pc *PodCache) matching(podIdentifier string) []PodEntry {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	var matched []PodEntry
+	for i := range pc.entries {
+		if pc.entries[i].entry.PodIdentifier == podIdentifier {
+			matched = append(matched, pc.entries[i].entry)
+		}
+	}
+	return matched
+}
+
+// internRecord builds the interned representation of a PodEntry.
+func (m *InMemoryIndex) internRecord(entry PodEntry) podRecord {
+	statTier := entry.DeviceTier
+	if entry.Speculative {
+		statTier = SpeculativeTier
+	}
+	return podRecord{
+		entry:         entry,
+		podIdx:        m.pods.intern(entry.PodIdentifier),
+		weightTierIdx: m.tiers.intern(entry.DeviceTier),
+		statTierIdx:   m.tiers.intern(statTier),
+	}
 }
 
 // Lookup receives a list of requestKeys and a set of pod identifiers,
@@ -120,32 +254,39 @@ func (m *InMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 	highestHitIdx := 0
 
 	for idx, requestKey := range requestKeys {
-		if pods, found := m.data.Get(requestKey); found { //nolint:nestif // TODO: can this be optimized?
-			if pods == nil || pods.cache.Len() == 0 {
+		if idx&cancellationCheckMask == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		pods, found := m.data.Get(requestKey)
+		if !found {
+			if traceLogger.Enabled() {
+				traceLogger.Info("key not found in index", "key", requestKey)
+			}
+			continue
+		}
+		var filtered []PodEntry
+		total := 0
+		if pods != nil {
+			filtered, total = pods.filteredEntries(podIdentifierSet)
+		}
+		if total == 0 {
+			if traceLogger.Enabled() {
 				traceLogger.Info("no pods found for key, cutting search", "key", requestKey)
-				return podsPerKey, nil // early stop since prefix-chain breaks here
 			}
+			return podsPerKey, nil // early stop since prefix-chain breaks here
+		}
 
-			highestHitIdx = idx
+		highestHitIdx = idx
 
-			if podIdentifierSet.Len() == 0 {
-				// If no pod identifiers are provided, return all pods
-				podsPerKey[requestKey] = pods.cache.Keys()
-			} else {
-				// Filter pods based on the provided pod identifiers
-				for _, pod := range pods.cache.Keys() {
-					if podIdentifierSet.Has(pod.PodIdentifier) {
-						podsPerKey[requestKey] = append(podsPerKey[requestKey], pod)
-					}
-				}
-			}
-		} else {
-			traceLogger.Info("key not found in index", "key", requestKey)
+		if len(filtered) > 0 {
+			podsPerKey[requestKey] = filtered
 		}
 	}
 
-	traceLogger.Info("lookup completed", "highest-hit-index", highestHitIdx,
-		"pods-per-key", podsPerKeyPrintHelper(podsPerKey))
+	if traceLogger.Enabled() {
+		traceLogger.Info("lookup completed", "highest-hit-index", highestHitIdx,
+			"pods-per-key", podsPerKeyPrintHelper(podsPerKey))
+	}
 
 	return podsPerKey, nil
 }
@@ -173,6 +314,12 @@ func (m *InMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys []Block
 		}
 	}
 
+	// Intern once per call; the same entries apply to every request key.
+	records := make([]podRecord, len(entries))
+	for i, entry := range entries {
+		records[i] = m.internRecord(entry)
+	}
+
 	// Store requestKey -> PodCache mappings for all request keys.
 	// Hold m.mu to prevent Evict from checking emptiness and removing the
 	// engine→request mapping while we are inserting pod entries.
@@ -180,22 +327,9 @@ func (m *InMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys []Block
 	defer m.mu.Unlock()
 
 	for _, requestKey := range requestKeys {
-		var podCache *PodCache
-		var found bool
-
-		// Try to get existing cache first
-		podCache, found = m.data.Get(requestKey)
-		//nolint:nestif // double-checked locking pattern
+		podCache, found := m.data.Get(requestKey)
 		if !found {
-			// Create new cache
-			cache, err := lru.New[PodEntry, struct{}](m.podCacheSize)
-			if err != nil {
-				return fmt.Errorf("failed to create pod cache for key %s: %w", requestKey.String(), err)
-			}
-
-			newPodCache := &PodCache{
-				cache: cache,
-			}
+			newPodCache := &PodCache{capacity: m.podCacheSize}
 
 			// Try to add, but use existing if another thread added it first
 			// This is a bounded retry (1) - not perfectly safe but for practical use-cases and scenarios
@@ -213,13 +347,11 @@ func (m *InMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys []Block
 			}
 		}
 
-		podCache.mu.Lock()
-		for _, entry := range entries {
-			podCache.cache.Add(entry, struct{}{})
-		}
-		podCache.mu.Unlock()
+		podCache.addAll(records)
 
-		traceLogger.Info("added pods to key", "requestKey", requestKey, "pods", entries)
+		if traceLogger.Enabled() {
+			traceLogger.Info("added pods to key", "requestKey", requestKey, "pods", entries)
+		}
 	}
 
 	return nil
@@ -250,7 +382,7 @@ func (m *InMemoryIndex) Evict(ctx context.Context, key BlockHash, keyType KeyTyp
 		m.mu.Lock()
 		allEmpty := true
 		for _, rk := range rks {
-			if pc, found := m.data.Get(rk); found && pc != nil && pc.cache.Len() > 0 {
+			if pc, found := m.data.Get(rk); found && pc != nil && pc.size() > 0 {
 				allEmpty = false
 				break
 			}
@@ -277,13 +409,7 @@ func (m *InMemoryIndex) evictPodsFromRequestKey(requestKey, engineKey BlockHash,
 		return
 	}
 
-	podCache.mu.Lock()
-	for _, entry := range entries {
-		podCache.cache.Remove(entry)
-	}
-
-	isEmpty := podCache.cache.Len() == 0
-	podCache.mu.Unlock()
+	isEmpty := podCache.removeAll(entries)
 
 	traceLogger.Info("evicted pods from key", "requestKey", requestKey, "engineKey", engineKey, "pods", entries)
 
@@ -299,7 +425,7 @@ func (m *InMemoryIndex) evictPodsFromRequestKey(requestKey, engineKey BlockHash,
 	}
 
 	currentCache.mu.Lock()
-	if currentCache.cache.Len() == 0 {
+	if len(currentCache.entries) == 0 {
 		m.data.Remove(requestKey)
 		traceLogger.Info("removed requestKey from index as no pods remain", "requestKey", requestKey)
 	}
@@ -318,21 +444,17 @@ func (m *InMemoryIndex) evictPodsFromRequestKey(requestKey, engineKey BlockHash,
 func (m *InMemoryIndex) Clear(ctx context.Context, podIdentifier string) error {
 	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Clear")
 
-	for _, requestKey := range m.data.Keys() {
+	for idx, requestKey := range m.data.Keys() {
+		if idx&cancellationCheckMask == 0 && ctx.Err() != nil {
+			return ctx.Err()
+		}
 		// Peek so a clear does not promote LRU recency on keys it scans.
 		podCache, found := m.data.Peek(requestKey)
 		if !found || podCache == nil {
 			continue
 		}
 
-		podCache.mu.Lock()
-		var matched []PodEntry
-		for _, entry := range podCache.cache.Keys() {
-			if entry.PodIdentifier == podIdentifier {
-				matched = append(matched, entry)
-			}
-		}
-		podCache.mu.Unlock()
+		matched := podCache.matching(podIdentifier)
 
 		if len(matched) > 0 {
 			m.evictPodsFromRequestKey(requestKey, EmptyBlockHash, matched, traceLogger)

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -327,25 +327,9 @@ func (m *InMemoryIndex) Add(ctx context.Context, engineKeys, requestKeys []Block
 	defer m.mu.Unlock()
 
 	for _, requestKey := range requestKeys {
-		podCache, found := m.data.Get(requestKey)
-		if !found {
-			newPodCache := &PodCache{capacity: m.podCacheSize}
-
-			// Try to add, but use existing if another thread added it first
-			// This is a bounded retry (1) - not perfectly safe but for practical use-cases and scenarios
-			// this should be sufficient
-			contains, _ := m.data.ContainsOrAdd(requestKey, newPodCache)
-			if contains {
-				podCache, found = m.data.Get(requestKey)
-				if !found { // Extremely irregular workload pattern - key evicted
-					m.data.Add(requestKey, newPodCache)
-					podCache = newPodCache
-				}
-			} else {
-				// We successfully added our cache
-				podCache = newPodCache
-			}
-		}
+		podCache, _, _ := m.data.GetOrAdd(requestKey, func() *PodCache {
+			return &PodCache{capacity: m.podCacheSize}
+		})
 
 		podCache.addAll(records)
 
@@ -444,14 +428,18 @@ func (m *InMemoryIndex) evictPodsFromRequestKey(requestKey, engineKey BlockHash,
 func (m *InMemoryIndex) Clear(ctx context.Context, podIdentifier string) error {
 	traceLogger := log.FromContext(ctx).V(logging.TRACE).WithName("kvblock.InMemoryIndex.Clear")
 
-	for idx, requestKey := range m.data.Keys() {
+	idx := 0
+	var walkErr error
+	m.data.RangeKeys(func(requestKey BlockHash) bool {
 		if idx&cancellationCheckMask == 0 && ctx.Err() != nil {
-			return ctx.Err()
+			walkErr = ctx.Err()
+			return false
 		}
+		idx++
 		// Peek so a clear does not promote LRU recency on keys it scans.
 		podCache, found := m.data.Peek(requestKey)
 		if !found || podCache == nil {
-			continue
+			return true
 		}
 
 		matched := podCache.matching(podIdentifier)
@@ -459,6 +447,10 @@ func (m *InMemoryIndex) Clear(ctx context.Context, podIdentifier string) error {
 		if len(matched) > 0 {
 			m.evictPodsFromRequestKey(requestKey, EmptyBlockHash, matched, traceLogger)
 		}
+		return true
+	})
+	if walkErr != nil {
+		return walkErr
 	}
 
 	traceLogger.Info("cleared pod from index", "pod", podIdentifier)

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -64,7 +64,7 @@ func NewInMemoryIndex(cfg *InMemoryIndexConfig) (*InMemoryIndex, error) {
 		podCacheSize = defaultPodsPerKey
 	}
 
-	cache, err := lru.New[BlockHash, *PodCache](cfg.Size)
+	cache, err := newRequestKeyCache(cfg.Size)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize in-memory index: %w", err)
 	}
@@ -89,7 +89,7 @@ type InMemoryIndex struct {
 	// check + mapping removal vs Add's pod entry insertion) to prevent TOCTOU races.
 	mu sync.Mutex
 	// data holds the mapping of requestKeys to sets of pod identifiers.
-	data *lru.Cache[BlockHash, *PodCache]
+	data *requestKeyCache
 	// engineToRequestKeys holds the mapping of engineKeys to requestKeys.
 	engineToRequestKeys *lru.Cache[BlockHash, []BlockHash]
 	// podCacheSize is the maximum number of pod entries per key.

--- a/pkg/kvcache/kvblock/in_memory_bench_test.go
+++ b/pkg/kvcache/kvblock/in_memory_bench_test.go
@@ -173,6 +173,39 @@ func BenchmarkScoredLookup(b *testing.B) {
 	}
 }
 
+// BenchmarkScoredLookupParallel measures the fused walk under concurrent
+// request traffic sharing one index.
+func BenchmarkScoredLookupParallel(b *testing.B) {
+	const numKeys = 3750
+	tierWeights := map[string]float64{"gpu": 1.0, "cpu": 0.8}
+	for _, numPods := range []int{8, 96} {
+		b.Run(fmt.Sprintf("keys=3750/pods=%d", numPods), func(b *testing.B) {
+			idx, keys := populateIndex(b, numKeys, numPods)
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			// Only a size check runs in the timed loop, and it reports with
+			// Error rather than Fatal: FailNow from a RunParallel worker
+			// would exit that goroutine and stall the benchmark instead of
+			// failing it. TestScoredLookupConcurrentReadersAgree validates
+			// full per-pod results under the same contention.
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					stats, err := idx.ScoredLookup(ctx, keys, nil, tierWeights)
+					if err != nil {
+						b.Error(err)
+						return
+					}
+					if len(stats) != numPods {
+						b.Errorf("unexpected stats size %d", len(stats))
+						return
+					}
+				}
+			})
+		})
+	}
+}
+
 // BenchmarkScoredLookupAfterChurn measures the fused walk after 10,000
 // since-cleared pods have been interned, pinning that per-request cost tracks
 // live candidates rather than interner history.

--- a/pkg/kvcache/kvblock/in_memory_bench_test.go
+++ b/pkg/kvcache/kvblock/in_memory_bench_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
+)
+
+// populateIndex fills an in-memory index with numKeys request keys, each held
+// by numPods pods on the gpu tier. Returns the index and the ordered keys.
+func populateIndex(b *testing.B, numKeys, numPods int) (*kvblock.InMemoryIndex, []kvblock.BlockHash) {
+	b.Helper()
+	idx, err := kvblock.NewInMemoryIndex(&kvblock.InMemoryIndexConfig{
+		Size:         1 << 20,
+		PodCacheSize: 128,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	keys := make([]kvblock.BlockHash, numKeys)
+	for i := range keys {
+		keys[i] = kvblock.BlockHash(uint64(i) + 1)
+	}
+	entries := make([]kvblock.PodEntry, numPods)
+	for p := range entries {
+		entries[p] = kvblock.PodEntry{
+			PodIdentifier: fmt.Sprintf("10.0.%d.%d:8000", p/256, p%256),
+			DeviceTier:    "gpu",
+		}
+	}
+	if err := idx.Add(context.Background(), nil, keys, entries); err != nil {
+		b.Fatal(err)
+	}
+	return idx, keys
+}
+
+// BenchmarkInMemoryIndexLookup measures a full-hit lookup of the block keys a
+// 240K-token prompt produces at block size 64 (3750 keys), across fleet sizes.
+func BenchmarkInMemoryIndexLookup(b *testing.B) {
+	const numKeys = 3750
+	for _, numPods := range []int{8, 96} {
+		for _, filtered := range []bool{false, true} {
+			name := fmt.Sprintf("keys=3750/pods=%d/filtered=%v", numPods, filtered)
+			b.Run(name, func(b *testing.B) {
+				idx, keys := populateIndex(b, numKeys, numPods)
+				podSet := sets.New[string]()
+				if filtered {
+					for p := 0; p < numPods/2; p++ {
+						podSet.Insert(fmt.Sprintf("10.0.%d.%d:8000", p/256, p%256))
+					}
+				}
+				ctx := context.Background()
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					res, err := idx.Lookup(ctx, keys, podSet)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if len(res) != numKeys {
+						b.Fatalf("unexpected result size %d", len(res))
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkInMemoryIndexAdd measures ingesting one BlockStored event's worth
+// of keys (64 blocks) for a single pod entry, over a warm index.
+func BenchmarkInMemoryIndexAdd(b *testing.B) {
+	idx, _ := populateIndex(b, 1<<16, 4)
+	entries := []kvblock.PodEntry{{PodIdentifier: "10.0.0.1:8000", DeviceTier: "gpu"}}
+	engineKeys := make([]kvblock.BlockHash, 64)
+	requestKeys := make([]kvblock.BlockHash, 64)
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		base := uint64(i)*64 + 1
+		for j := range engineKeys {
+			engineKeys[j] = kvblock.BlockHash(base + uint64(j))
+			requestKeys[j] = kvblock.BlockHash(base + uint64(j))
+		}
+		if err := idx.Add(ctx, engineKeys, requestKeys, entries); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkInMemoryIndexMixed measures lookup latency while concurrent
+// writers ingest events, approximating the 96-rank firehose against
+// per-request scoring reads.
+func BenchmarkInMemoryIndexMixed(b *testing.B) {
+	const numKeys = 3750
+	idx, keys := populateIndex(b, numKeys, 16)
+	ctx := context.Background()
+
+	stop := make(chan struct{})
+	defer close(stop)
+	for w := 0; w < 4; w++ {
+		go func(w int) {
+			entries := []kvblock.PodEntry{{PodIdentifier: fmt.Sprintf("10.1.0.%d:8000", w), DeviceTier: "gpu"}}
+			engineKeys := make([]kvblock.BlockHash, 64)
+			requestKeys := make([]kvblock.BlockHash, 64)
+			for i := uint64(0); ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				base := (uint64(w)<<32 | i*64) + 1
+				for j := range engineKeys {
+					engineKeys[j] = kvblock.BlockHash(base + uint64(j))
+					requestKeys[j] = kvblock.BlockHash(base + uint64(j))
+				}
+				_ = idx.Add(ctx, engineKeys, requestKeys, entries)
+			}
+		}(w)
+	}
+
+	podSet := sets.New[string]()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := idx.Lookup(ctx, keys, podSet); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkScoredLookup measures the fused lookup-and-score walk over the
+// same workload as BenchmarkInMemoryIndexLookup.
+func BenchmarkScoredLookup(b *testing.B) {
+	const numKeys = 3750
+	tierWeights := map[string]float64{"gpu": 1.0, "cpu": 0.8}
+	for _, numPods := range []int{8, 96} {
+		b.Run(fmt.Sprintf("keys=3750/pods=%d", numPods), func(b *testing.B) {
+			idx, keys := populateIndex(b, numKeys, numPods)
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				stats, err := idx.ScoredLookup(ctx, keys, nil, tierWeights)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(stats) != numPods {
+					b.Fatalf("unexpected stats size %d", len(stats))
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkScoredLookupAfterChurn measures the fused walk after 10,000
+// since-cleared pods have been interned, pinning that per-request cost tracks
+// live candidates rather than interner history.
+func BenchmarkScoredLookupAfterChurn(b *testing.B) {
+	const numKeys = 3750
+	tierWeights := map[string]float64{"gpu": 1.0, "cpu": 0.8}
+	idx, keys := populateIndex(b, numKeys, 96)
+	ctx := context.Background()
+	churnKey := []kvblock.BlockHash{1 << 40}
+	for i := 0; i < 10_000; i++ {
+		pod := fmt.Sprintf("10.9.%d.%d:8000", i/256, i%256)
+		if err := idx.Add(ctx, nil, churnKey, []kvblock.PodEntry{{PodIdentifier: pod, DeviceTier: "gpu"}}); err != nil {
+			b.Fatal(err)
+		}
+		if err := idx.Clear(ctx, pod); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		stats, err := idx.ScoredLookup(ctx, keys, nil, tierWeights)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(stats) != 96 {
+			b.Fatalf("unexpected stats size %d", len(stats))
+		}
+	}
+}

--- a/pkg/kvcache/kvblock/in_memory_bench_test.go
+++ b/pkg/kvcache/kvblock/in_memory_bench_test.go
@@ -19,6 +19,8 @@ package kvblock_test
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -231,6 +233,130 @@ func BenchmarkScoredLookupParallel(b *testing.B) {
 			})
 		})
 	}
+}
+
+// BenchmarkScoredLookupEarlyBreak measures a cached request whose candidate
+// chain ends at the second key, so later request-key batches are not fetched.
+func BenchmarkScoredLookupEarlyBreak(b *testing.B) {
+	const numKeys = 3750
+	idx, err := kvblock.NewInMemoryIndex(&kvblock.InMemoryIndexConfig{
+		Size:         1 << 20,
+		PodCacheSize: 128,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	keys := make([]kvblock.BlockHash, numKeys)
+	for i := range keys {
+		keys[i] = kvblock.BlockHash(uint64(i) + 1)
+	}
+	ctx := context.Background()
+	requireAdd := func(keys []kvblock.BlockHash, pod string) {
+		b.Helper()
+		entries := []kvblock.PodEntry{{PodIdentifier: pod, DeviceTier: "gpu"}}
+		if err := idx.Add(ctx, nil, keys, entries); err != nil {
+			b.Fatal(err)
+		}
+	}
+	requireAdd(keys[:1], "10.0.0.1:8000")
+	requireAdd(keys[1:], "10.0.0.2:8000")
+	tierWeights := map[string]float64{"gpu": 1.0}
+	lookup := func(b *testing.B) {
+		stats, err := idx.ScoredLookup(ctx, keys, nil, tierWeights)
+		if err != nil {
+			b.Error(err)
+			return
+		}
+		first, found := stats["10.0.0.1:8000"]
+		if len(stats) != 1 || !found || first.MatchedBlocks != 1 {
+			b.Errorf("unexpected stats: pods=%d first-found=%t first-matched=%d", len(stats), found, first.MatchedBlocks)
+		}
+	}
+
+	b.Run("serial", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			lookup(b)
+		}
+	})
+	b.Run("parallel", func(b *testing.B) {
+		b.ReportAllocs()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				lookup(b)
+			}
+		})
+	})
+}
+
+// BenchmarkScoredLookupMixed measures concurrent fused scoring while event
+// writers insert new block mappings into the same index.
+func BenchmarkScoredLookupMixed(b *testing.B) {
+	const (
+		numKeys    = 3750
+		numPods    = 16
+		numWriters = 4
+	)
+	idx, keys := populateIndex(b, numKeys, numPods)
+	ctx := context.Background()
+	tierWeights := map[string]float64{"gpu": 1.0, "cpu": 0.8}
+
+	start := make(chan struct{})
+	stop := make(chan struct{})
+	var writers sync.WaitGroup
+	var writeOps atomic.Uint64
+	writers.Add(numWriters)
+	for w := 0; w < numWriters; w++ {
+		go func(w int) {
+			defer writers.Done()
+			entries := []kvblock.PodEntry{{PodIdentifier: fmt.Sprintf("10.1.0.%d:8000", w), DeviceTier: "gpu"}}
+			engineKeys := make([]kvblock.BlockHash, 64)
+			requestKeys := make([]kvblock.BlockHash, 64)
+			<-start
+			for i := uint64(0); ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				base := (uint64(1) << 48) + uint64(w)*(uint64(1)<<44) + i*64 + 1
+				for j := range engineKeys {
+					engineKeys[j] = kvblock.BlockHash(base + uint64(j))
+					requestKeys[j] = kvblock.BlockHash(base + uint64(j))
+				}
+				if err := idx.Add(ctx, engineKeys, requestKeys, entries); err != nil {
+					b.Error(err)
+					return
+				}
+				writeOps.Add(1)
+			}
+		}(w)
+	}
+
+	// Allocation metrics include both lookup and writer work.
+	b.ReportAllocs()
+	b.ResetTimer()
+	close(start)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			stats, err := idx.ScoredLookup(ctx, keys, nil, tierWeights)
+			if err != nil {
+				b.Error(err)
+				return
+			}
+			first, found := stats["10.0.0.0:8000"]
+			if len(stats) != numPods || !found || first.MatchedBlocks != numKeys {
+				b.Errorf("unexpected stats: pods=%d first-found=%t first-matched=%d", len(stats), found, first.MatchedBlocks)
+				return
+			}
+		}
+	})
+	b.StopTimer()
+	elapsed := b.Elapsed()
+	completedWrites := writeOps.Load()
+	close(stop)
+	writers.Wait()
+	b.ReportMetric(float64(completedWrites)/elapsed.Seconds(), "writes/s")
 }
 
 // BenchmarkScoredLookupAfterChurn measures the fused walk after 10,000

--- a/pkg/kvcache/kvblock/in_memory_bench_test.go
+++ b/pkg/kvcache/kvblock/in_memory_bench_test.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/llm-d/llm-d-router/pkg/kvcache"
 	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
 )
 
@@ -107,6 +108,69 @@ func BenchmarkInMemoryIndexLookupParallel(b *testing.B) {
 					}
 					if len(res) != numKeys {
 						b.Errorf("unexpected result size %d", len(res))
+						return
+					}
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkLookupAndScore measures the materialized lookup followed by the
+// longest-prefix scorer over the same workload as BenchmarkScoredLookup.
+func BenchmarkLookupAndScore(b *testing.B) {
+	const numKeys = 3750
+	tierWeights := map[string]float64{"gpu": 1.0, "cpu": 0.8}
+	for _, numPods := range []int{8, 96} {
+		b.Run(fmt.Sprintf("keys=3750/pods=%d", numPods), func(b *testing.B) {
+			idx, keys := populateIndex(b, numKeys, numPods)
+			scorer := &kvcache.LongestPrefixScorer{MediumWeights: tierWeights}
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				keyToPods, err := idx.Lookup(ctx, keys, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				scores, err := scorer.Score(ctx, keys, keyToPods)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(scores) != numPods || scores["10.0.0.0:8000"] != numKeys {
+					b.Fatalf("unexpected scores: pods=%d first=%v", len(scores), scores["10.0.0.0:8000"])
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkLookupAndScoreParallel measures the materialized lookup and
+// longest-prefix scorer under concurrent request traffic sharing one index.
+func BenchmarkLookupAndScoreParallel(b *testing.B) {
+	const numKeys = 3750
+	tierWeights := map[string]float64{"gpu": 1.0, "cpu": 0.8}
+	for _, numPods := range []int{8, 96} {
+		b.Run(fmt.Sprintf("keys=3750/pods=%d", numPods), func(b *testing.B) {
+			idx, keys := populateIndex(b, numKeys, numPods)
+			scorer := &kvcache.LongestPrefixScorer{MediumWeights: tierWeights}
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					keyToPods, err := idx.Lookup(ctx, keys, nil)
+					if err != nil {
+						b.Error(err)
+						return
+					}
+					scores, err := scorer.Score(ctx, keys, keyToPods)
+					if err != nil {
+						b.Error(err)
+						return
+					}
+					if len(scores) != numPods || scores["10.0.0.0:8000"] != numKeys {
+						b.Errorf("unexpected scores: pods=%d first=%v", len(scores), scores["10.0.0.0:8000"])
 						return
 					}
 				}
@@ -236,7 +300,7 @@ func BenchmarkScoredLookupParallel(b *testing.B) {
 }
 
 // BenchmarkScoredLookupEarlyBreak measures a cached request whose candidate
-// chain ends at the second key, so later request-key batches are not fetched.
+// chain ends at the second key, so later request keys are not fetched.
 func BenchmarkScoredLookupEarlyBreak(b *testing.B) {
 	const numKeys = 3750
 	idx, err := kvblock.NewInMemoryIndex(&kvblock.InMemoryIndexConfig{

--- a/pkg/kvcache/kvblock/in_memory_bench_test.go
+++ b/pkg/kvcache/kvblock/in_memory_bench_test.go
@@ -86,6 +86,33 @@ func BenchmarkInMemoryIndexLookup(b *testing.B) {
 	}
 }
 
+// BenchmarkInMemoryIndexLookupParallel measures the materializing lookup path
+// under concurrent request traffic sharing one index.
+func BenchmarkInMemoryIndexLookupParallel(b *testing.B) {
+	const numKeys = 3750
+	for _, numPods := range []int{8, 96} {
+		b.Run(fmt.Sprintf("keys=3750/pods=%d", numPods), func(b *testing.B) {
+			idx, keys := populateIndex(b, numKeys, numPods)
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					res, err := idx.Lookup(ctx, keys, nil)
+					if err != nil {
+						b.Error(err)
+						return
+					}
+					if len(res) != numKeys {
+						b.Errorf("unexpected result size %d", len(res))
+						return
+					}
+				}
+			})
+		})
+	}
+}
+
 // BenchmarkInMemoryIndexAdd measures ingesting one BlockStored event's worth
 // of keys (64 blocks) for a single pod entry, over a warm index.
 func BenchmarkInMemoryIndexAdd(b *testing.B) {

--- a/pkg/kvcache/kvblock/instrumented_index.go
+++ b/pkg/kvcache/kvblock/instrumented_index.go
@@ -59,7 +59,9 @@ func (m *instrumentedIndex) Lookup(
 		return nil, err
 	}
 
-	go recordHitMetrics(pods)
+	// Synchronous: callers own requestKeys and the result map after return,
+	// so a deferred fold would race their reuse.
+	recordHitMetrics(requestKeys, pods)
 
 	return pods, nil
 }
@@ -72,25 +74,56 @@ func (m *instrumentedIndex) Clear(ctx context.Context, podIdentifier string) err
 	return m.next.Clear(ctx, podIdentifier)
 }
 
-func recordHitMetrics(keyToPods map[BlockHash][]PodEntry) {
-	podCount := make(map[string]int)
-	for _, pods := range keyToPods {
-		for _, p := range pods {
-			// First time seeing this pod in current lookup window.
-			// set to 1 because counts are local to this call (not cumulative over time).
-			// This ensures compatibility with sliding window attention (SWA) and cache eviction,
-			// where only recent hits within the active window are considered.
-			podCount[p.PodIdentifier]++
-		}
-	}
-
-	maxHit := 0
-	for _, count := range podCount {
-		if count > maxHit {
-			maxHit = count
-		}
-	}
-
+func recordHitMetrics(requestKeys []BlockHash, keyToPods map[BlockHash][]PodEntry) {
+	maxHit := maxContiguousPodHits(requestKeys, keyToPods)
 	metrics.MaxPodHitCount.Add(float64(maxHit))
 	metrics.LookupHits.Add(float64(maxHit))
+}
+
+// maxContiguousPodHits returns the longest contiguous prefix chain any single
+// pod holds, counting from the first request key. One state map serves the
+// whole fold; a pod stays in the chain while its last-seen key is the
+// preceding one, and duplicate device tiers at a key count once.
+func maxContiguousPodHits(requestKeys []BlockHash, keyToPods map[BlockHash][]PodEntry) int {
+	if len(requestKeys) == 0 {
+		return 0
+	}
+	type podState struct {
+		lastKey int
+		count   int
+	}
+	state := make(map[string]podState, len(keyToPods[requestKeys[0]]))
+	best := 0
+	for i, key := range requestKeys {
+		entries := keyToPods[key]
+		if len(entries) == 0 {
+			break // no pod holds this key: every chain from key 0 ends here
+		}
+		advanced := false
+		for _, e := range entries {
+			s, ok := state[e.PodIdentifier]
+			switch {
+			case i == 0 && !ok:
+				state[e.PodIdentifier] = podState{lastKey: 0, count: 1}
+				advanced = true
+				if best == 0 {
+					best = 1
+				}
+			case ok && s.lastKey == i-1:
+				s.lastKey = i
+				s.count++
+				state[e.PodIdentifier] = s
+				advanced = true
+				if s.count > best {
+					best = s.count
+				}
+			default:
+				// Duplicate tier at this key, or a pod outside the chain.
+			}
+		}
+		if !advanced {
+			break // no chain advanced at this key; later keys cannot either
+		}
+	}
+	return best
 }

--- a/pkg/kvcache/kvblock/instrumented_index.go
+++ b/pkg/kvcache/kvblock/instrumented_index.go
@@ -66,6 +66,39 @@ func (m *instrumentedIndex) Lookup(
 	return pods, nil
 }
 
+// ScoredLookup forwards the fused lookup capability with the same request,
+// latency, and hit metrics as Lookup. Returns ErrScoredLookupUnsupported when
+// the wrapped backend lacks the capability.
+func (m *instrumentedIndex) ScoredLookup(ctx context.Context, requestKeys []BlockHash,
+	podIdentifierSet sets.Set[string], tierWeights map[string]float64,
+) (map[string]PodMatchStats, error) {
+	inner, ok := m.next.(ScoredLookupIndex)
+	if !ok {
+		return nil, ErrScoredLookupUnsupported
+	}
+
+	timer := prometheus.NewTimer(metrics.LookupLatency)
+	defer timer.ObserveDuration()
+
+	metrics.LookupRequests.Inc()
+
+	result, err := inner.ScoredLookup(ctx, requestKeys, podIdentifierSet, tierWeights)
+	if err != nil {
+		return nil, err
+	}
+
+	maxHit := 0
+	for _, stats := range result {
+		if stats.MatchedBlocks > maxHit {
+			maxHit = stats.MatchedBlocks
+		}
+	}
+	metrics.MaxPodHitCount.Add(float64(maxHit))
+	metrics.LookupHits.Add(float64(maxHit))
+
+	return result, nil
+}
+
 func (m *instrumentedIndex) GetRequestKey(ctx context.Context, engineKey BlockHash) (BlockHash, error) {
 	return m.next.GetRequestKey(ctx, engineKey)
 }
@@ -81,7 +114,8 @@ func recordHitMetrics(requestKeys []BlockHash, keyToPods map[BlockHash][]PodEntr
 }
 
 // maxContiguousPodHits returns the longest contiguous prefix chain any single
-// pod holds, counting from the first request key. One state map serves the
+// pod holds, counting from the first request key - the same quantity the
+// fused ScoredLookup path reports as MatchedBlocks. One state map serves the
 // whole fold; a pod stays in the chain while its last-seen key is the
 // preceding one, and duplicate device tiers at a key count once.
 func maxContiguousPodHits(requestKeys []BlockHash, keyToPods map[BlockHash][]PodEntry) int {

--- a/pkg/kvcache/kvblock/instrumented_index_internal_test.go
+++ b/pkg/kvcache/kvblock/instrumented_index_internal_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaxContiguousPodHits(t *testing.T) {
+	gpu := func(pod string) PodEntry { return PodEntry{PodIdentifier: pod, DeviceTier: "gpu"} }
+	cpu := func(pod string) PodEntry { return PodEntry{PodIdentifier: pod, DeviceTier: "cpu"} }
+	keys := []BlockHash{1, 2, 3}
+
+	tests := []struct {
+		name       string
+		keys       []BlockHash
+		keyToPods  map[BlockHash][]PodEntry
+		wantResult int
+	}{
+		{
+			name:       "no request keys",
+			keys:       nil,
+			keyToPods:  map[BlockHash][]PodEntry{},
+			wantResult: 0,
+		},
+		{
+			name:       "first key held by nobody breaks every chain",
+			keys:       keys,
+			keyToPods:  map[BlockHash][]PodEntry{2: {gpu("pod-a")}},
+			wantResult: 0,
+		},
+		{
+			name: "one pod holds the whole prefix",
+			keys: keys,
+			keyToPods: map[BlockHash][]PodEntry{
+				1: {gpu("pod-a")}, 2: {gpu("pod-a")}, 3: {gpu("pod-a")},
+			},
+			wantResult: 3,
+		},
+		{
+			name: "longest chain wins",
+			keys: keys,
+			keyToPods: map[BlockHash][]PodEntry{
+				1: {gpu("pod-a"), gpu("pod-b")}, 2: {gpu("pod-a")}, 3: {gpu("pod-a")},
+			},
+			wantResult: 3,
+		},
+		{
+			name: "a gap ends the chain even if the pod reappears",
+			keys: keys,
+			keyToPods: map[BlockHash][]PodEntry{
+				1: {gpu("pod-a")}, 3: {gpu("pod-a")},
+			},
+			wantResult: 1,
+		},
+		{
+			name: "a pod that joins after the first key never starts a chain",
+			keys: keys,
+			keyToPods: map[BlockHash][]PodEntry{
+				1: {gpu("pod-a")}, 2: {gpu("pod-a"), gpu("pod-b")}, 3: {gpu("pod-b")},
+			},
+			wantResult: 2,
+		},
+		{
+			name: "duplicate device tiers at one key count once",
+			keys: keys,
+			keyToPods: map[BlockHash][]PodEntry{
+				1: {gpu("pod-a"), cpu("pod-a")},
+				2: {gpu("pod-a"), cpu("pod-a")},
+				3: {gpu("pod-a"), cpu("pod-a")},
+			},
+			wantResult: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantResult, maxContiguousPodHits(tt.keys, tt.keyToPods))
+		})
+	}
+}

--- a/pkg/kvcache/kvblock/request_key_cache.go
+++ b/pkg/kvcache/kvblock/request_key_cache.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+)
+
+// requestKeyBatchSize amortizes LRU promotion while keeping event-writer lock
+// wait bounded under concurrent scored lookups.
+const requestKeyBatchSize = 16
+
+// requestKeyCache is a thread-safe LRU for request-key entries. It exposes a
+// batched read so scored lookups update prefix recency with bounded lock holds.
+type requestKeyCache struct {
+	mu   sync.RWMutex
+	data *simplelru.LRU[BlockHash, *PodCache]
+}
+
+func newRequestKeyCache(size int) (*requestKeyCache, error) {
+	data, err := simplelru.NewLRU[BlockHash, *PodCache](size, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &requestKeyCache{data: data}, nil
+}
+
+func (c *requestKeyCache) Get(key BlockHash) (*PodCache, bool) {
+	c.mu.Lock()
+	value, found := c.data.Get(key)
+	c.mu.Unlock()
+	return value, found
+}
+
+func (c *requestKeyCache) Peek(key BlockHash) (*PodCache, bool) {
+	c.mu.RLock()
+	value, found := c.data.Peek(key)
+	c.mu.RUnlock()
+	return value, found
+}
+
+// GetPrefixBatch returns and refreshes at most one contiguous cache batch.
+func (c *requestKeyCache) GetPrefixBatch(keys []BlockHash, dst []*PodCache) []*PodCache {
+	clear(dst)
+	dst = dst[:0]
+	keys = keys[:min(len(keys), requestKeyBatchSize)]
+	c.mu.Lock()
+	for _, key := range keys {
+		value, found := c.data.Get(key)
+		if !found || value == nil {
+			break
+		}
+		dst = append(dst, value)
+	}
+	c.mu.Unlock()
+	return dst
+}
+
+func (c *requestKeyCache) Add(key BlockHash, value *PodCache) bool {
+	c.mu.Lock()
+	evicted := c.data.Add(key, value)
+	c.mu.Unlock()
+	return evicted
+}
+
+func (c *requestKeyCache) ContainsOrAdd(key BlockHash, value *PodCache) (bool, bool) {
+	c.mu.Lock()
+	if c.data.Contains(key) {
+		c.mu.Unlock()
+		return true, false
+	}
+	evicted := c.data.Add(key, value)
+	c.mu.Unlock()
+	return false, evicted
+}
+
+func (c *requestKeyCache) Remove(key BlockHash) bool {
+	c.mu.Lock()
+	present := c.data.Remove(key)
+	c.mu.Unlock()
+	return present
+}
+
+func (c *requestKeyCache) Keys() []BlockHash {
+	c.mu.RLock()
+	keys := c.data.Keys()
+	c.mu.RUnlock()
+	return keys
+}

--- a/pkg/kvcache/kvblock/request_key_cache.go
+++ b/pkg/kvcache/kvblock/request_key_cache.go
@@ -17,89 +17,168 @@ limitations under the License.
 package kvblock
 
 import (
+	"errors"
+	"hash/maphash"
 	"sync"
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 )
 
-// requestKeyBatchSize amortizes LRU promotion while keeping event-writer lock
-// wait bounded under concurrent scored lookups.
-const requestKeyBatchSize = 16
+const (
+	maxRequestKeyCacheShards = 64
+	// Keep local quotas large enough that normal hash variance does not cause
+	// meaningful capacity fragmentation.
+	minRequestKeysPerShard = 1024
+)
 
-// requestKeyCache is a thread-safe LRU for request-key entries. It exposes a
-// batched read so scored lookups update prefix recency with bounded lock holds.
+// requestKeyCache shards recency state so unrelated keys do not share an LRU
+// lock. Capacity and recency are exact within a shard; the shard capacities
+// sum to the configured cache size. A full shard evicts locally even when
+// another shard has unused capacity.
 type requestKeyCache struct {
-	mu   sync.RWMutex
-	data *simplelru.LRU[BlockHash, *PodCache]
+	shards []requestKeyCacheShard
+	mask   uint64
+	seed   maphash.Seed
+}
+
+type requestKeyCacheShard struct {
+	mu       sync.RWMutex
+	data     *simplelru.LRU[BlockHash, *PodCache]
+	capacity int
 }
 
 func newRequestKeyCache(size int) (*requestKeyCache, error) {
-	data, err := simplelru.NewLRU[BlockHash, *PodCache](size, nil)
-	if err != nil {
-		return nil, err
+	if size <= 0 {
+		return nil, errors.New("must provide a positive size")
 	}
-	return &requestKeyCache{data: data}, nil
+	shardCount := 1
+	for shardCount < maxRequestKeyCacheShards && size/(shardCount*2) >= minRequestKeysPerShard {
+		shardCount *= 2
+	}
+	return newRequestKeyCacheWithShards(size, shardCount)
+}
+
+func newRequestKeyCacheWithShards(size, shardCount int) (*requestKeyCache, error) {
+	if size <= 0 {
+		return nil, errors.New("must provide a positive size")
+	}
+	if shardCount <= 0 || shardCount > maxRequestKeyCacheShards || shardCount > size || shardCount&(shardCount-1) != 0 {
+		return nil, errors.New("shard count must be a positive power of two no larger than the cache size or shard limit")
+	}
+
+	cache := &requestKeyCache{
+		shards: make([]requestKeyCacheShard, shardCount),
+		mask:   uint64(shardCount - 1),
+		seed:   maphash.MakeSeed(),
+	}
+	baseCapacity := size / shardCount
+	remainder := size % shardCount
+	for i := range cache.shards {
+		capacity := baseCapacity
+		if i < remainder {
+			capacity++
+		}
+		data, err := simplelru.NewLRU[BlockHash, *PodCache](capacity, nil)
+		if err != nil {
+			return nil, err
+		}
+		cache.shards[i] = requestKeyCacheShard{data: data, capacity: capacity}
+	}
+	return cache, nil
+}
+
+func (c *requestKeyCache) shardIndex(key BlockHash) int {
+	if c.mask == 0 {
+		return 0
+	}
+	// Rehash with a process-local seed so externally derived block hashes
+	// cannot directly select a shard through their low bits.
+	return int(maphash.Comparable(c.seed, key) & c.mask)
+}
+
+func (c *requestKeyCache) shard(key BlockHash) *requestKeyCacheShard {
+	return &c.shards[c.shardIndex(key)]
 }
 
 func (c *requestKeyCache) Get(key BlockHash) (*PodCache, bool) {
-	c.mu.Lock()
-	value, found := c.data.Get(key)
-	c.mu.Unlock()
+	shard := c.shard(key)
+	shard.mu.Lock()
+	value, found := shard.data.Get(key)
+	shard.mu.Unlock()
 	return value, found
 }
 
 func (c *requestKeyCache) Peek(key BlockHash) (*PodCache, bool) {
-	c.mu.RLock()
-	value, found := c.data.Peek(key)
-	c.mu.RUnlock()
+	shard := c.shard(key)
+	shard.mu.RLock()
+	value, found := shard.data.Peek(key)
+	shard.mu.RUnlock()
 	return value, found
 }
 
-// GetPrefixBatch returns and refreshes at most one contiguous cache batch.
-func (c *requestKeyCache) GetPrefixBatch(keys []BlockHash, dst []*PodCache) []*PodCache {
-	clear(dst)
-	dst = dst[:0]
-	keys = keys[:min(len(keys), requestKeyBatchSize)]
-	c.mu.Lock()
-	for _, key := range keys {
-		value, found := c.data.Get(key)
-		if !found || value == nil {
-			break
-		}
-		dst = append(dst, value)
+// GetOrAdd returns and refreshes the resident value or creates it atomically.
+func (c *requestKeyCache) GetOrAdd(key BlockHash, newValue func() *PodCache) (value *PodCache, loaded, evicted bool) {
+	shard := c.shard(key)
+	shard.mu.Lock()
+	if value, loaded = shard.data.Get(key); loaded {
+		shard.mu.Unlock()
+		return value, true, false
 	}
-	c.mu.Unlock()
-	return dst
+	value = newValue()
+	evicted = shard.data.Add(key, value)
+	shard.mu.Unlock()
+	return value, false, evicted
 }
 
 func (c *requestKeyCache) Add(key BlockHash, value *PodCache) bool {
-	c.mu.Lock()
-	evicted := c.data.Add(key, value)
-	c.mu.Unlock()
+	shard := c.shard(key)
+	shard.mu.Lock()
+	evicted := shard.data.Add(key, value)
+	shard.mu.Unlock()
 	return evicted
 }
 
-func (c *requestKeyCache) ContainsOrAdd(key BlockHash, value *PodCache) (bool, bool) {
-	c.mu.Lock()
-	if c.data.Contains(key) {
-		c.mu.Unlock()
-		return true, false
-	}
-	evicted := c.data.Add(key, value)
-	c.mu.Unlock()
-	return false, evicted
-}
-
 func (c *requestKeyCache) Remove(key BlockHash) bool {
-	c.mu.Lock()
-	present := c.data.Remove(key)
-	c.mu.Unlock()
+	shard := c.shard(key)
+	shard.mu.Lock()
+	present := shard.data.Remove(key)
+	shard.mu.Unlock()
 	return present
 }
 
+// Keys returns separately timed per-shard snapshots. Global recency order is
+// unspecified.
 func (c *requestKeyCache) Keys() []BlockHash {
-	c.mu.RLock()
-	keys := c.data.Keys()
-	c.mu.RUnlock()
+	total := 0
+	for i := range c.shards {
+		shard := &c.shards[i]
+		shard.mu.RLock()
+		total += shard.data.Len()
+		shard.mu.RUnlock()
+	}
+	keys := make([]BlockHash, 0, total)
+	for i := range c.shards {
+		shard := &c.shards[i]
+		shard.mu.RLock()
+		keys = append(keys, shard.data.Keys()...)
+		shard.mu.RUnlock()
+	}
 	return keys
+}
+
+// RangeKeys visits separately timed per-shard snapshots without retaining an
+// all-shard key copy or holding a shard lock during yield. Returning false
+// stops the walk.
+func (c *requestKeyCache) RangeKeys(yield func(BlockHash) bool) {
+	for i := range c.shards {
+		shard := &c.shards[i]
+		shard.mu.RLock()
+		keys := shard.data.Keys()
+		shard.mu.RUnlock()
+		for _, key := range keys {
+			if !yield(key) {
+				return
+			}
+		}
+	}
 }

--- a/pkg/kvcache/kvblock/request_key_cache_test.go
+++ b/pkg/kvcache/kvblock/request_key_cache_test.go
@@ -17,80 +17,390 @@ limitations under the License.
 package kvblock
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func TestRequestKeyCacheGetPrefixBatchRefreshesKeys(t *testing.T) {
-	cache, err := newRequestKeyCache(2)
+func requestKeysForShard(cache *requestKeyCache, shardIdx, count int) []BlockHash {
+	keys := make([]BlockHash, 0, count)
+	for key := BlockHash(1); len(keys) < count; key++ {
+		if cache.shardIndex(key) == shardIdx {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+func TestRequestKeyCacheShardSelectionAndCapacity(t *testing.T) {
+	tests := []struct {
+		name       string
+		size       int
+		wantShards int
+	}{
+		{name: "minimum", size: 1, wantShards: 1},
+		{name: "small", size: 2, wantShards: 1},
+		{name: "below first split", size: 2*minRequestKeysPerShard - 1, wantShards: 1},
+		{name: "first split", size: 2 * minRequestKeysPerShard, wantShards: 2},
+		{name: "below second split", size: 4*minRequestKeysPerShard - 1, wantShards: 2},
+		{name: "second split", size: 4 * minRequestKeysPerShard, wantShards: 4},
+		{name: "below maximum split", size: maxRequestKeyCacheShards*minRequestKeysPerShard - 1, wantShards: maxRequestKeyCacheShards / 2},
+		{name: "maximum", size: maxRequestKeyCacheShards * minRequestKeysPerShard, wantShards: maxRequestKeyCacheShards},
+		{name: "maximum plus remainder", size: maxRequestKeyCacheShards*minRequestKeysPerShard + 17, wantShards: maxRequestKeyCacheShards},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache, err := newRequestKeyCache(tt.size)
+			require.NoError(t, err)
+			require.Len(t, cache.shards, tt.wantShards)
+
+			total := 0
+			minCapacity, maxCapacity := tt.size, 0
+			for i := range cache.shards {
+				capacity := cache.shards[i].capacity
+				assert.Positive(t, capacity)
+				total += capacity
+				minCapacity = min(minCapacity, capacity)
+				maxCapacity = max(maxCapacity, capacity)
+			}
+			assert.Equal(t, tt.size, total)
+			assert.LessOrEqual(t, maxCapacity-minCapacity, 1)
+		})
+	}
+}
+
+func TestRequestKeyCacheRejectsInvalidConfiguration(t *testing.T) {
+	_, err := newRequestKeyCache(0)
+	assert.Error(t, err)
+	_, err = newRequestKeyCache(-1)
+	assert.Error(t, err)
+	_, err = newRequestKeyCacheWithShards(8, 0)
+	assert.Error(t, err)
+	_, err = newRequestKeyCacheWithShards(8, 3)
+	assert.Error(t, err)
+	_, err = newRequestKeyCacheWithShards(2, 4)
+	assert.Error(t, err)
+	_, err = newRequestKeyCacheWithShards(1024, 2*maxRequestKeyCacheShards)
+	assert.Error(t, err)
+}
+
+func TestRequestKeyCacheGetRefreshesWithinShard(t *testing.T) {
+	cache, err := newRequestKeyCacheWithShards(8, 4)
 	require.NoError(t, err)
 
+	keys := requestKeysForShard(cache, 0, 3)
 	first := &PodCache{}
 	second := &PodCache{}
-	cache.Add(10, first)
-	cache.Add(20, second)
+	cache.Add(keys[0], first)
+	cache.Add(keys[1], second)
 
-	values := cache.GetPrefixBatch([]BlockHash{10}, nil)
-	require.Equal(t, []*PodCache{first}, values)
-	cache.Add(30, &PodCache{})
+	value, found := cache.Get(keys[0])
+	require.True(t, found)
+	assert.Same(t, first, value)
+	cache.Add(keys[2], &PodCache{})
 
-	_, firstFound := cache.Peek(10)
-	_, secondFound := cache.Peek(20)
+	_, firstFound := cache.Peek(keys[0])
+	_, secondFound := cache.Peek(keys[1])
 	assert.True(t, firstFound)
 	assert.False(t, secondFound)
 }
 
-func TestRequestKeyCacheGetPrefixBatchPreservesRequestOrder(t *testing.T) {
-	cache, err := newRequestKeyCache(3)
+func TestRequestKeyCacheShardQuotaCanEvictBelowGlobalCapacity(t *testing.T) {
+	cache, err := newRequestKeyCacheWithShards(4, 2)
+	require.NoError(t, err)
+
+	keys := requestKeysForShard(cache, 0, 3)
+	for _, key := range keys {
+		cache.Add(key, &PodCache{})
+	}
+
+	keysInCache := cache.Keys()
+	assert.Len(t, keysInCache, 2)
+	assert.Less(t, len(keysInCache), 4)
+}
+
+func TestRequestKeyCacheReadOnlyOperationsDoNotRefresh(t *testing.T) {
+	cache, err := newRequestKeyCacheWithShards(2, 1)
 	require.NoError(t, err)
 
 	cache.Add(10, &PodCache{})
 	cache.Add(20, &PodCache{})
-	cache.Add(30, &PodCache{})
-	cache.GetPrefixBatch([]BlockHash{10, 20}, nil)
-	cache.Add(40, &PodCache{})
-	cache.Add(50, &PodCache{})
-
-	_, firstFound := cache.Peek(10)
-	_, secondFound := cache.Peek(20)
-	_, untouchedFound := cache.Peek(30)
-	assert.False(t, firstFound)
-	assert.True(t, secondFound)
-	assert.False(t, untouchedFound)
-}
-
-func TestRequestKeyCacheGetPrefixBatchStopsAtGap(t *testing.T) {
-	cache, err := newRequestKeyCache(3)
-	require.NoError(t, err)
-
-	first := &PodCache{}
-	cache.Add(10, first)
+	_, found := cache.Peek(10)
+	require.True(t, found)
+	cache.Keys()
+	cache.RangeKeys(func(BlockHash) bool { return true })
+	_, found = cache.Get(99)
+	assert.False(t, found)
 	cache.Add(30, &PodCache{})
 
-	values := cache.GetPrefixBatch([]BlockHash{10, 20, 30}, nil)
-	assert.Equal(t, []*PodCache{first}, values)
+	_, oldestFound := cache.Peek(10)
+	_, newerFound := cache.Peek(20)
+	assert.False(t, oldestFound)
+	assert.True(t, newerFound)
 }
 
-func TestRequestKeyCacheGetPrefixBatchLimitsLockScope(t *testing.T) {
-	cache, err := newRequestKeyCache(requestKeyBatchSize + 1)
+func TestRequestKeyCacheGetOrAddRefreshesExistingValue(t *testing.T) {
+	cache, err := newRequestKeyCacheWithShards(2, 1)
 	require.NoError(t, err)
 
-	keys := make([]BlockHash, requestKeyBatchSize+1)
-	for i := range keys {
-		keys[i] = BlockHash(i + 1)
-		cache.Add(keys[i], &PodCache{})
+	existing := &PodCache{}
+	cache.Add(10, existing)
+	cache.Add(20, &PodCache{})
+	factoryCalled := false
+	actual, loaded, evicted := cache.GetOrAdd(10, func() *PodCache {
+		factoryCalled = true
+		return &PodCache{}
+	})
+	assert.Same(t, existing, actual)
+	assert.True(t, loaded)
+	assert.False(t, evicted)
+	assert.False(t, factoryCalled)
+
+	cache.Add(30, &PodCache{})
+	_, existingFound := cache.Peek(10)
+	_, displacedFound := cache.Peek(20)
+	assert.True(t, existingFound)
+	assert.False(t, displacedFound)
+}
+
+func TestRequestKeyCacheGetOrAddCreatesAndReportsEviction(t *testing.T) {
+	cache, err := newRequestKeyCacheWithShards(2, 1)
+	require.NoError(t, err)
+
+	cache.Add(10, &PodCache{})
+	cache.Add(20, &PodCache{})
+	created := &PodCache{}
+	factoryCalls := 0
+	actual, loaded, evicted := cache.GetOrAdd(30, func() *PodCache {
+		factoryCalls++
+		return created
+	})
+
+	assert.Same(t, created, actual)
+	assert.False(t, loaded)
+	assert.True(t, evicted)
+	assert.Equal(t, 1, factoryCalls)
+	_, oldestFound := cache.Peek(10)
+	resident, createdFound := cache.Peek(30)
+	assert.False(t, oldestFound)
+	assert.True(t, createdFound)
+	assert.Same(t, created, resident)
+}
+
+func TestRequestKeyCacheGetOrAddReturnsResidentValue(t *testing.T) {
+	cache, err := newRequestKeyCacheWithShards(8, 4)
+	require.NoError(t, err)
+
+	const workers = 32
+	values := make(chan *PodCache, workers)
+	start := make(chan struct{})
+	var factoryCalls atomic.Int32
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			<-start
+			actual, _, _ := cache.GetOrAdd(10, func() *PodCache {
+				factoryCalls.Add(1)
+				return &PodCache{}
+			})
+			values <- actual
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(values)
+
+	resident, found := cache.Peek(10)
+	require.True(t, found)
+	for value := range values {
+		assert.Same(t, resident, value)
+	}
+	assert.Equal(t, int32(1), factoryCalls.Load())
+}
+
+func TestRequestKeyCacheKeysContainsEveryResidentOnce(t *testing.T) {
+	cache, err := newRequestKeyCacheWithShards(16, 4)
+	require.NoError(t, err)
+
+	want := make(map[BlockHash]struct{})
+	for shardIdx := range cache.shards {
+		for _, key := range requestKeysForShard(cache, shardIdx, 3) {
+			cache.Add(key, &PodCache{})
+			want[key] = struct{}{}
+		}
 	}
 
-	values := cache.GetPrefixBatch(keys, nil)
-	assert.Len(t, values, requestKeyBatchSize)
+	keys := cache.Keys()
+	require.Len(t, keys, len(want))
+	seen := make(map[BlockHash]struct{}, len(keys))
+	for _, key := range keys {
+		_, duplicate := seen[key]
+		assert.False(t, duplicate, "duplicate key %d", key)
+		seen[key] = struct{}{}
+	}
+	assert.Equal(t, want, seen)
+
+	rangeSeen := make(map[BlockHash]struct{}, len(want))
+	cache.RangeKeys(func(key BlockHash) bool {
+		rangeSeen[key] = struct{}{}
+		return true
+	})
+	assert.Equal(t, want, rangeSeen)
+
+	visits := 0
+	cache.RangeKeys(func(BlockHash) bool {
+		visits++
+		return false
+	})
+	assert.Equal(t, 1, visits)
 }
 
-func TestRequestKeyCacheGetPrefixBatchColdMissDoesNotAllocateSnapshot(t *testing.T) {
-	cache, err := newRequestKeyCache(1)
+func TestInMemoryIndexClearVisitsEveryRequestKeyCacheShard(t *testing.T) {
+	ctx := log.IntoContext(t.Context(), logr.Discard())
+	index, err := NewInMemoryIndex(&InMemoryIndexConfig{
+		Size:         4 * minRequestKeysPerShard,
+		PodCacheSize: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, index.data.shards, 4)
+
+	keys := make([]BlockHash, len(index.data.shards))
+	for shardIdx := range index.data.shards {
+		keys[shardIdx] = requestKeysForShard(index.data, shardIdx, 1)[0]
+	}
+	require.NoError(t, index.Add(ctx, nil, keys, []PodEntry{
+		{PodIdentifier: "pod-clear", DeviceTier: "gpu"},
+		{PodIdentifier: "pod-keep", DeviceTier: "gpu"},
+	}))
+	require.NoError(t, index.Clear(ctx, "pod-clear"))
+
+	for _, key := range keys {
+		podCache, found := index.data.Peek(key)
+		require.True(t, found)
+		assert.Empty(t, podCache.matching("pod-clear"))
+		assert.Len(t, podCache.matching("pod-keep"), 1)
+	}
+}
+
+func TestRequestKeyCacheIndependentShardLocks(t *testing.T) {
+	cache, err := newRequestKeyCacheWithShards(8, 4)
 	require.NoError(t, err)
 
-	values := cache.GetPrefixBatch(make([]BlockHash, 1<<16), nil)
-	assert.Zero(t, cap(values))
+	keyA := requestKeysForShard(cache, 0, 1)[0]
+	keyB := requestKeysForShard(cache, 1, 1)[0]
+	cache.Add(keyA, &PodCache{})
+	cache.Add(keyB, &PodCache{})
+
+	locked := make(chan struct{})
+	release := make(chan struct{})
+	holderDone := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseLock := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseLock)
+	go func() {
+		cache.shards[0].mu.Lock()
+		close(locked)
+		<-release
+		cache.shards[0].mu.Unlock()
+		close(holderDone)
+	}()
+	<-locked
+
+	aDone := make(chan struct{})
+	go func() {
+		cache.Get(keyA)
+		close(aDone)
+	}()
+	bDone := make(chan struct{})
+	go func() {
+		cache.Get(keyB)
+		close(bDone)
+	}()
+
+	select {
+	case <-bDone:
+	case <-time.After(time.Second):
+		t.Fatal("operation on an independent shard blocked")
+	}
+	select {
+	case <-aDone:
+		t.Fatal("operation on the locked shard completed")
+	default:
+	}
+	releaseLock()
+
+	select {
+	case <-aDone:
+	case <-time.After(time.Second):
+		t.Fatal("operation did not resume after shard unlock")
+	}
+	<-holderDone
+}
+
+func TestRequestKeyCacheRangeKeysStopsBeforeLaterShard(t *testing.T) {
+	cache, err := newRequestKeyCacheWithShards(8, 4)
+	require.NoError(t, err)
+
+	cache.Add(requestKeysForShard(cache, 0, 1)[0], &PodCache{})
+	cache.Add(requestKeysForShard(cache, 1, 1)[0], &PodCache{})
+	cache.shards[1].mu.Lock()
+	var unlockOnce sync.Once
+	unlock := func() { unlockOnce.Do(cache.shards[1].mu.Unlock) }
+	t.Cleanup(unlock)
+
+	done := make(chan struct{})
+	visits := 0
+	go func() {
+		cache.RangeKeys(func(BlockHash) bool {
+			visits++
+			return false
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		assert.Equal(t, 1, visits)
+	case <-time.After(time.Second):
+		unlock()
+		<-done
+		t.Fatal("range did not stop before the locked later shard")
+	}
+}
+
+func TestRequestKeyCacheConcurrentOperations(t *testing.T) {
+	cache, err := newRequestKeyCacheWithShards(1024, 16)
+	require.NoError(t, err)
+
+	const workers = 32
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for worker := range workers {
+		go func() {
+			defer wg.Done()
+			for i := range 200 {
+				key := BlockHash(worker*200 + i + 1)
+				cache.GetOrAdd(key, func() *PodCache { return &PodCache{} })
+				cache.Get(key)
+				cache.Peek(key)
+				if i%3 == 0 {
+					cache.Remove(key)
+				}
+				if i%50 == 0 {
+					cache.Keys()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	assert.LessOrEqual(t, len(cache.Keys()), 1024)
 }

--- a/pkg/kvcache/kvblock/request_key_cache_test.go
+++ b/pkg/kvcache/kvblock/request_key_cache_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestKeyCacheGetPrefixBatchRefreshesKeys(t *testing.T) {
+	cache, err := newRequestKeyCache(2)
+	require.NoError(t, err)
+
+	first := &PodCache{}
+	second := &PodCache{}
+	cache.Add(10, first)
+	cache.Add(20, second)
+
+	values := cache.GetPrefixBatch([]BlockHash{10}, nil)
+	require.Equal(t, []*PodCache{first}, values)
+	cache.Add(30, &PodCache{})
+
+	_, firstFound := cache.Peek(10)
+	_, secondFound := cache.Peek(20)
+	assert.True(t, firstFound)
+	assert.False(t, secondFound)
+}
+
+func TestRequestKeyCacheGetPrefixBatchPreservesRequestOrder(t *testing.T) {
+	cache, err := newRequestKeyCache(3)
+	require.NoError(t, err)
+
+	cache.Add(10, &PodCache{})
+	cache.Add(20, &PodCache{})
+	cache.Add(30, &PodCache{})
+	cache.GetPrefixBatch([]BlockHash{10, 20}, nil)
+	cache.Add(40, &PodCache{})
+	cache.Add(50, &PodCache{})
+
+	_, firstFound := cache.Peek(10)
+	_, secondFound := cache.Peek(20)
+	_, untouchedFound := cache.Peek(30)
+	assert.False(t, firstFound)
+	assert.True(t, secondFound)
+	assert.False(t, untouchedFound)
+}
+
+func TestRequestKeyCacheGetPrefixBatchStopsAtGap(t *testing.T) {
+	cache, err := newRequestKeyCache(3)
+	require.NoError(t, err)
+
+	first := &PodCache{}
+	cache.Add(10, first)
+	cache.Add(30, &PodCache{})
+
+	values := cache.GetPrefixBatch([]BlockHash{10, 20, 30}, nil)
+	assert.Equal(t, []*PodCache{first}, values)
+}
+
+func TestRequestKeyCacheGetPrefixBatchLimitsLockScope(t *testing.T) {
+	cache, err := newRequestKeyCache(requestKeyBatchSize + 1)
+	require.NoError(t, err)
+
+	keys := make([]BlockHash, requestKeyBatchSize+1)
+	for i := range keys {
+		keys[i] = BlockHash(i + 1)
+		cache.Add(keys[i], &PodCache{})
+	}
+
+	values := cache.GetPrefixBatch(keys, nil)
+	assert.Len(t, values, requestKeyBatchSize)
+}
+
+func TestRequestKeyCacheGetPrefixBatchColdMissDoesNotAllocateSnapshot(t *testing.T) {
+	cache, err := newRequestKeyCache(1)
+	require.NoError(t, err)
+
+	values := cache.GetPrefixBatch(make([]BlockHash, 1<<16), nil)
+	assert.Zero(t, cap(values))
+}

--- a/pkg/kvcache/kvblock/scored_lookup.go
+++ b/pkg/kvcache/kvblock/scored_lookup.go
@@ -198,6 +198,9 @@ const maxTierMaskBits = 64
 // by candidates - bounded by the per-key pod cache - not by every pod ever
 // interned. The walk stops at the first key with no qualifying pod, matching
 // the composition of Lookup and the longest-prefix scorer.
+//
+// Reads do not update the top-level index LRU. KV-event additions determine
+// key recency, while concurrent scoring requests share the cache read lock.
 func (m *InMemoryIndex) ScoredLookup(ctx context.Context, requestKeys []BlockHash,
 	podIdentifierSet sets.Set[string], tierWeights map[string]float64,
 ) (map[string]PodMatchStats, error) {
@@ -251,7 +254,7 @@ retry:
 		if idx&cancellationCheckMask == 0 && ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		pc, found := m.data.Get(key)
+		pc, found := m.data.Peek(key)
 		if !found || pc == nil {
 			break
 		}

--- a/pkg/kvcache/kvblock/scored_lookup.go
+++ b/pkg/kvcache/kvblock/scored_lookup.go
@@ -1,0 +1,366 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/bits"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// SpeculativeTier is the tier name under which speculative entries count in
+// PodMatchStats.BlocksByTier. Speculative entries carry no engine-reported
+// device tier, so they are reported under this sentinel instead.
+const SpeculativeTier = "speculative"
+
+// cancellationCheckMask paces context-cancellation checks in loops over
+// request keys: positions where idx&mask == 0 poll ctx.Err().
+const cancellationCheckMask = 255
+
+// ErrScoredLookupUnsupported is returned by decorating indexes whose wrapped
+// backend does not implement ScoredLookupIndex. Callers fall back to
+// Lookup plus external scoring.
+var ErrScoredLookupUnsupported = errors.New("scored lookup not supported by index backend")
+
+// PodMatchStats aggregates one pod's prefix-match results from a scored
+// lookup. All values cover the contiguous chain of request keys the pod
+// holds, counted from the first key.
+type PodMatchStats struct {
+	// WeightedScore sums, per block of the chain, the highest device-tier
+	// weight among the pod's entries for that block; tiers without a
+	// configured weight count 1.0.
+	WeightedScore float64
+	// MatchedBlocks is the chain length in blocks, regardless of tier.
+	MatchedBlocks int
+	// BlocksByTier is the per-tier chain length: a tier counts a block only
+	// while the pod holds every previous block in that same tier.
+	// Speculative entries count under SpeculativeTier. Never nil.
+	BlocksByTier map[string]int
+}
+
+// ScoredLookupIndex is an optional Index capability that fuses Lookup and
+// longest-consecutive-prefix scoring into one pass, without materializing the
+// per-key pod entry map. tierWeights maps device tier names to scoring
+// weights; unlisted tiers weigh 1.0. The result holds one entry per pod that
+// holds the first request key (after podIdentifierSet filtering, when
+// non-empty).
+type ScoredLookupIndex interface {
+	ScoredLookup(ctx context.Context, requestKeys []BlockHash,
+		podIdentifierSet sets.Set[string], tierWeights map[string]float64) (map[string]PodMatchStats, error)
+}
+
+// interner assigns dense uint32 indices to strings. Indices are stable for
+// the lifetime of the interner and never reused.
+type interner struct {
+	mu    sync.RWMutex
+	ids   map[string]uint32
+	names []string
+}
+
+func newInterner() *interner {
+	return &interner{ids: make(map[string]uint32)}
+}
+
+// intern returns the index for s, assigning the next free index on first use.
+func (in *interner) intern(s string) uint32 {
+	in.mu.RLock()
+	id, ok := in.ids[s]
+	in.mu.RUnlock()
+	if ok {
+		return id
+	}
+	in.mu.Lock()
+	defer in.mu.Unlock()
+	if id, ok := in.ids[s]; ok {
+		return id
+	}
+	id = uint32(len(in.names))
+	in.ids[s] = id
+	in.names = append(in.names, s)
+	return id
+}
+
+// lookup returns the index for s without assigning one.
+func (in *interner) lookup(s string) (uint32, bool) {
+	in.mu.RLock()
+	defer in.mu.RUnlock()
+	id, ok := in.ids[s]
+	return id, ok
+}
+
+// snapshot returns the interned names indexed by id. The backing array of a
+// returned snapshot is never mutated, only appended to under the lock.
+func (in *interner) snapshot() []string {
+	in.mu.RLock()
+	defer in.mu.RUnlock()
+	return in.names
+}
+
+// scoredScratch holds the interned-pod-indexed tables a ScoredLookup call
+// needs, reused through a pool so steady-state per-request cost does not grow
+// with the number of pods ever interned. A cold scratch (pool miss, e.g.
+// after a GC cycle) still allocates ~12 bytes per interned pod. Validity is
+// generation-stamped: an entry is meaningful only when its stamp equals the
+// current call's gen, so reuse needs no zeroing.
+type scoredScratch struct {
+	gen uint32
+	// slotRef maps an interned pod id to its request-local slot: the
+	// validity generation in the high 32 bits, the slot in the low 32.
+	slotRef []uint64
+	// allowGen stamps pods that pass the call's pod-identifier filter.
+	allowGen []uint32
+}
+
+var scoredScratchPool = sync.Pool{New: func() any { return &scoredScratch{} }}
+
+// nextGen advances the scratch generation, resizing the tables to nPods and
+// clearing them on generation wrap-around so stale stamps can never match.
+func (sc *scoredScratch) nextGen(nPods int) uint32 {
+	if len(sc.slotRef) < nPods {
+		sc.slotRef = make([]uint64, nPods)
+		sc.allowGen = make([]uint32, nPods)
+		sc.gen = 0
+	}
+	if sc.gen == ^uint32(0) {
+		clear(sc.slotRef)
+		clear(sc.allowGen)
+		sc.gen = 0
+	}
+	sc.gen++
+	return sc.gen
+}
+
+// slotCursor is one candidate's per-key working state.
+type slotCursor struct {
+	// seen stamps presence at the current key.
+	seen uint32
+	// weight is the highest tier weight at the current key.
+	weight float64
+	// tiers is the tier bitmask at the current key.
+	tiers uint64
+}
+
+// slotChain is one candidate's accumulated chain state.
+type slotChain struct {
+	podIdx uint32
+	// matched is the contiguous matched-block count.
+	matched int
+	// score is the accumulated weighted score.
+	score float64
+	// aliveTiers is the bitmask of tiers still contiguously held.
+	aliveTiers uint64
+}
+
+// maxTierMaskBits bounds the per-tier chain bitmasks. Lookups against an
+// index that has interned more tiers report ErrScoredLookupUnsupported so
+// callers run the legacy path instead of silently dropping tiers.
+const maxTierMaskBits = 64
+
+// ScoredLookup walks requestKeys in order and accumulates per-pod prefix
+// scores directly from the interned pod records. Candidate pods (those
+// holding the first key) get request-local slots, so working state is sized
+// by candidates - bounded by the per-key pod cache - not by every pod ever
+// interned. The walk stops at the first key with no qualifying pod, matching
+// the composition of Lookup and the longest-prefix scorer.
+func (m *InMemoryIndex) ScoredLookup(ctx context.Context, requestKeys []BlockHash,
+	podIdentifierSet sets.Set[string], tierWeights map[string]float64,
+) (map[string]PodMatchStats, error) {
+	if len(requestKeys) == 0 {
+		return nil, fmt.Errorf("no requestKeys provided for lookup")
+	}
+
+	podNames := m.pods.snapshot()
+	nPods := len(podNames)
+	if nPods == 0 {
+		return map[string]PodMatchStats{}, nil
+	}
+
+	sc, _ := scoredScratchPool.Get().(*scoredScratch)
+	defer scoredScratchPool.Put(sc)
+
+	// The tier view is snapshotted per attempt. A record referencing a tier
+	// interned after the snapshot would score with a default weight and drop
+	// out of the per-tier counts, so a walk that observes interner growth at
+	// its end retries under the fresh view instead of paying a staleness
+	// check in the hot loop. Tier count only grows and the sentinel applies
+	// past maxTierMaskBits, so retries are bounded.
+retry:
+	tierNames := m.tiers.snapshot()
+	nTiers := len(tierNames)
+	if nTiers > maxTierMaskBits {
+		return nil, ErrScoredLookupUnsupported
+	}
+
+	weightByTier := make([]float64, nTiers)
+	for i := range weightByTier {
+		weightByTier[i] = 1.0
+	}
+	for name, w := range tierWeights {
+		if idx, ok := m.tiers.lookup(name); ok && int(idx) < nTiers {
+			weightByTier[idx] = w
+		}
+	}
+
+	gen := sc.nextGen(nPods)
+
+	filtered := podIdentifierSet.Len() > 0
+	if filtered {
+		for id := range podIdentifierSet {
+			if idx, ok := m.pods.lookup(id); ok && int(idx) < nPods {
+				sc.allowGen[idx] = gen
+			}
+		}
+	}
+
+	// Per-slot working state for the candidate pods, in slot order.
+	var (
+		cur        []slotCursor // per-key state
+		chains     []slotChain  // accumulated chain state
+		tierCounts []int        // flat [slot*nTiers + tier] chain counters
+		active     []int32      // slots still in the any-tier chain
+		keyStamp   uint32
+	)
+	genRef := uint64(gen) << 32
+
+	for idx, key := range requestKeys {
+		if idx&cancellationCheckMask == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		pc, found := m.data.Get(key)
+		if !found || pc == nil {
+			break
+		}
+		keyStamp++
+		firstKey := idx == 0
+		pc.mu.Lock()
+		for i := range pc.entries {
+			rec := &pc.entries[i]
+			if int(rec.podIdx) >= nPods {
+				continue // interned after this lookup's snapshot
+			}
+			if filtered && sc.allowGen[rec.podIdx] != gen {
+				continue
+			}
+			ref := sc.slotRef[rec.podIdx]
+			var s int32
+			switch {
+			case ref>>32 == uint64(gen):
+				s = int32(uint32(ref))
+			case firstKey:
+				// The first key defines the candidate set: assign slots.
+				s = int32(len(chains))
+				sc.slotRef[rec.podIdx] = genRef | uint64(uint32(s))
+				chains = append(chains, slotChain{podIdx: rec.podIdx})
+				cur = append(cur, slotCursor{})
+				tierCounts = append(tierCounts, make([]int, nTiers)...)
+			default:
+				continue // not a candidate: absent from the first key
+			}
+			w := 1.0
+			if int(rec.weightTierIdx) < nTiers {
+				w = weightByTier[rec.weightTierIdx]
+			}
+			var tierBit uint64
+			if rec.statTierIdx < maxTierMaskBits {
+				tierBit = 1 << rec.statTierIdx
+			}
+			c := &cur[s]
+			if c.seen != keyStamp {
+				c.seen = keyStamp
+				c.weight = w
+				c.tiers = tierBit
+			} else {
+				if w > c.weight {
+					c.weight = w
+				}
+				c.tiers |= tierBit
+			}
+		}
+		pc.mu.Unlock()
+
+		if firstKey {
+			if len(chains) == 0 {
+				break
+			}
+			active = make([]int32, len(chains))
+			for s := range chains {
+				active[s] = int32(s)
+				chains[s].score = cur[s].weight
+				chains[s].matched = 1
+				chains[s].aliveTiers = cur[s].tiers
+				countAliveTiers(tierCounts, int32(s), chains[s].aliveTiers, nTiers)
+			}
+			continue
+		}
+
+		keep := active[:0]
+		for _, s := range active {
+			if cur[s].seen != keyStamp {
+				continue // pod missing at this key: chain breaks
+			}
+			chains[s].score += cur[s].weight
+			chains[s].matched++
+			chains[s].aliveTiers &= cur[s].tiers
+			countAliveTiers(tierCounts, s, chains[s].aliveTiers, nTiers)
+			keep = append(keep, s)
+		}
+		active = keep
+		if len(active) == 0 {
+			break
+		}
+	}
+
+	if len(m.tiers.snapshot()) != nTiers {
+		// A tier was interned mid-walk; its records were scored under the
+		// stale view. Rewalk under the fresh one.
+		goto retry
+	}
+
+	{
+		result := make(map[string]PodMatchStats, len(chains))
+		for s := range chains {
+			byTier := make(map[string]int)
+			for t := 0; t < nTiers; t++ {
+				if c := tierCounts[s*nTiers+t]; c > 0 {
+					byTier[tierNames[t]] = c
+				}
+			}
+			result[podNames[chains[s].podIdx]] = PodMatchStats{
+				WeightedScore: chains[s].score,
+				MatchedBlocks: chains[s].matched,
+				BlocksByTier:  byTier,
+			}
+		}
+		return result, nil
+	}
+}
+
+// countAliveTiers increments the per-tier chain counters for every tier still
+// alive in mask.
+func countAliveTiers(tierCounts []int, slot int32, mask uint64, nTiers int) {
+	for mask != 0 {
+		t := bits.TrailingZeros64(mask)
+		mask &^= 1 << t
+		if t < nTiers {
+			tierCounts[int(slot)*nTiers+t]++
+		}
+	}
+}

--- a/pkg/kvcache/kvblock/scored_lookup.go
+++ b/pkg/kvcache/kvblock/scored_lookup.go
@@ -114,38 +114,56 @@ func (in *interner) snapshot() []string {
 	return in.names
 }
 
-// scoredScratch holds the interned-pod-indexed tables a ScoredLookup call
-// needs, reused through a pool so steady-state per-request cost does not grow
-// with the number of pods ever interned. A cold scratch (pool miss, e.g.
-// after a GC cycle) still allocates ~12 bytes per interned pod. Validity is
-// generation-stamped: an entry is meaningful only when its stamp equals the
-// current call's gen, so reuse needs no zeroing.
+type scoredSlotRef struct {
+	podIdx  uint32
+	slotRef uint32 // request-local slot plus one; zero marks an empty bucket
+}
+
+// scoredScratch maps candidate pod ids to request-local slots in an
+// open-addressed table. It is reused through a pool so both warm and cold
+// request state scale with the first key's live entries rather than the
+// append-only pod interner.
 type scoredScratch struct {
-	gen uint32
-	// slotRef maps an interned pod id to its request-local slot: the
-	// validity generation in the high 32 bits, the slot in the low 32.
-	slotRef []uint64
-	// allowGen stamps pods that pass the call's pod-identifier filter.
-	allowGen []uint32
+	slots []scoredSlotRef
 }
 
 var scoredScratchPool = sync.Pool{New: func() any { return &scoredScratch{} }}
 
-// nextGen advances the scratch generation, resizing the tables to nPods and
-// clearing them on generation wrap-around so stale stamps can never match.
-func (sc *scoredScratch) nextGen(nPods int) uint32 {
-	if len(sc.slotRef) < nPods {
-		sc.slotRef = make([]uint64, nPods)
-		sc.allowGen = make([]uint32, nPods)
-		sc.gen = 0
+func (sc *scoredScratch) reset(numEntries int) {
+	size := 2
+	for size < numEntries*2 {
+		size <<= 1
 	}
-	if sc.gen == ^uint32(0) {
-		clear(sc.slotRef)
-		clear(sc.allowGen)
-		sc.gen = 0
+	if cap(sc.slots) < size {
+		sc.slots = make([]scoredSlotRef, size)
+	} else {
+		sc.slots = sc.slots[:size]
+		clear(sc.slots)
 	}
-	sc.gen++
-	return sc.gen
+}
+
+func (sc *scoredScratch) lookup(podIdx uint32) (int32, bool) {
+	mask := uint32(len(sc.slots) - 1)
+	idx := podIdx * 2654435761 & mask
+	for {
+		ref := sc.slots[idx]
+		if ref.slotRef == 0 {
+			return 0, false
+		}
+		if ref.podIdx == podIdx {
+			return int32(ref.slotRef - 1), true
+		}
+		idx = (idx + 1) & mask
+	}
+}
+
+func (sc *scoredScratch) insert(podIdx uint32, slot int32) {
+	mask := uint32(len(sc.slots) - 1)
+	idx := podIdx * 2654435761 & mask
+	for sc.slots[idx].slotRef != 0 {
+		idx = (idx + 1) & mask
+	}
+	sc.slots[idx] = scoredSlotRef{podIdx: podIdx, slotRef: uint32(slot) + 1}
 }
 
 // slotCursor is one candidate's per-key working state.
@@ -219,16 +237,7 @@ retry:
 		}
 	}
 
-	gen := sc.nextGen(nPods)
-
 	filtered := podIdentifierSet.Len() > 0
-	if filtered {
-		for id := range podIdentifierSet {
-			if idx, ok := m.pods.lookup(id); ok && int(idx) < nPods {
-				sc.allowGen[idx] = gen
-			}
-		}
-	}
 
 	// Per-slot working state for the candidate pods, in slot order.
 	var (
@@ -238,8 +247,6 @@ retry:
 		active     []int32      // slots still in the any-tier chain
 		keyStamp   uint32
 	)
-	genRef := uint64(gen) << 32
-
 	for idx, key := range requestKeys {
 		if idx&cancellationCheckMask == 0 && ctx.Err() != nil {
 			return nil, ctx.Err()
@@ -251,23 +258,24 @@ retry:
 		keyStamp++
 		firstKey := idx == 0
 		pc.mu.Lock()
+		if firstKey {
+			sc.reset(len(pc.entries))
+		}
 		for i := range pc.entries {
 			rec := &pc.entries[i]
 			if int(rec.podIdx) >= nPods {
 				continue // interned after this lookup's snapshot
 			}
-			if filtered && sc.allowGen[rec.podIdx] != gen {
-				continue
-			}
-			ref := sc.slotRef[rec.podIdx]
-			var s int32
+			s, hasSlot := sc.lookup(rec.podIdx)
 			switch {
-			case ref>>32 == uint64(gen):
-				s = int32(uint32(ref))
+			case hasSlot:
 			case firstKey:
+				if filtered && !podIdentifierSet.Has(podNames[rec.podIdx]) {
+					continue
+				}
 				// The first key defines the candidate set: assign slots.
 				s = int32(len(chains))
-				sc.slotRef[rec.podIdx] = genRef | uint64(uint32(s))
+				sc.insert(rec.podIdx, s)
 				chains = append(chains, slotChain{podIdx: rec.podIdx})
 				cur = append(cur, slotCursor{})
 				tierCounts = append(tierCounts, make([]int, nTiers)...)

--- a/pkg/kvcache/kvblock/scored_lookup.go
+++ b/pkg/kvcache/kvblock/scored_lookup.go
@@ -119,16 +119,14 @@ type scoredSlotRef struct {
 	slotRef uint32 // request-local slot plus one; zero marks an empty bucket
 }
 
-// scoredScratch reuses candidate-slot and cached-prefix-batch storage.
-// Candidate state scales with the first key's live entries rather than the
-// append-only pod interner.
+// scoredScratch reuses candidate-slot storage. Candidate state scales with the
+// first key's live entries rather than the append-only pod interner.
 type scoredScratch struct {
-	slots     []scoredSlotRef
-	podCaches []*PodCache
+	slots []scoredSlotRef
 }
 
 func newScoredScratch() any {
-	return &scoredScratch{podCaches: make([]*PodCache, 0, requestKeyBatchSize)}
+	return &scoredScratch{}
 }
 
 var scoredScratchPool = sync.Pool{New: newScoredScratch}
@@ -219,11 +217,7 @@ func (m *InMemoryIndex) ScoredLookup(ctx context.Context, requestKeys []BlockHas
 	}
 
 	sc, _ := scoredScratchPool.Get().(*scoredScratch)
-	defer func() {
-		clear(sc.podCaches)
-		sc.podCaches = sc.podCaches[:0]
-		scoredScratchPool.Put(sc)
-	}()
+	defer scoredScratchPool.Put(sc)
 
 	// The tier view is snapshotted per attempt. A record referencing a tier
 	// interned after the snapshot would score with a default weight and drop
@@ -258,21 +252,14 @@ retry:
 		active     []int32      // slots still in the any-tier chain
 		keyStamp   uint32
 	)
-	for idx := range requestKeys {
+	for idx, key := range requestKeys {
 		if idx&cancellationCheckMask == 0 && ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		batchOffset := idx % requestKeyBatchSize
-		if batchOffset == 0 {
-			end := min(idx+requestKeyBatchSize, len(requestKeys))
-			// Batch promotion amortizes the LRU lock handoff. A scoring break
-			// can refresh the rest of this batch, but no subsequent batch.
-			sc.podCaches = m.data.GetPrefixBatch(requestKeys[idx:end], sc.podCaches)
-		}
-		if batchOffset >= len(sc.podCaches) {
+		pc, found := m.data.Get(key)
+		if !found || pc == nil {
 			break
 		}
-		pc := sc.podCaches[batchOffset]
 		keyStamp++
 		firstKey := idx == 0
 		pc.mu.Lock()

--- a/pkg/kvcache/kvblock/scored_lookup.go
+++ b/pkg/kvcache/kvblock/scored_lookup.go
@@ -199,8 +199,8 @@ const maxTierMaskBits = 64
 // interned. The walk stops at the first key with no qualifying pod, matching
 // the composition of Lookup and the longest-prefix scorer.
 //
-// Reads do not update the top-level index LRU. KV-event additions determine
-// key recency, while concurrent scoring requests share the cache read lock.
+// Successful reads refresh the top-level index LRU so prefixes reused across
+// requests remain resident under capacity pressure.
 func (m *InMemoryIndex) ScoredLookup(ctx context.Context, requestKeys []BlockHash,
 	podIdentifierSet sets.Set[string], tierWeights map[string]float64,
 ) (map[string]PodMatchStats, error) {
@@ -254,7 +254,7 @@ retry:
 		if idx&cancellationCheckMask == 0 && ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		pc, found := m.data.Peek(key)
+		pc, found := m.data.Get(key)
 		if !found || pc == nil {
 			break
 		}

--- a/pkg/kvcache/kvblock/scored_lookup.go
+++ b/pkg/kvcache/kvblock/scored_lookup.go
@@ -119,15 +119,19 @@ type scoredSlotRef struct {
 	slotRef uint32 // request-local slot plus one; zero marks an empty bucket
 }
 
-// scoredScratch maps candidate pod ids to request-local slots in an
-// open-addressed table. It is reused through a pool so both warm and cold
-// request state scale with the first key's live entries rather than the
+// scoredScratch reuses candidate-slot and cached-prefix-batch storage.
+// Candidate state scales with the first key's live entries rather than the
 // append-only pod interner.
 type scoredScratch struct {
-	slots []scoredSlotRef
+	slots     []scoredSlotRef
+	podCaches []*PodCache
 }
 
-var scoredScratchPool = sync.Pool{New: func() any { return &scoredScratch{} }}
+func newScoredScratch() any {
+	return &scoredScratch{podCaches: make([]*PodCache, 0, requestKeyBatchSize)}
+}
+
+var scoredScratchPool = sync.Pool{New: newScoredScratch}
 
 func (sc *scoredScratch) reset(numEntries int) {
 	size := 2
@@ -215,7 +219,11 @@ func (m *InMemoryIndex) ScoredLookup(ctx context.Context, requestKeys []BlockHas
 	}
 
 	sc, _ := scoredScratchPool.Get().(*scoredScratch)
-	defer scoredScratchPool.Put(sc)
+	defer func() {
+		clear(sc.podCaches)
+		sc.podCaches = sc.podCaches[:0]
+		scoredScratchPool.Put(sc)
+	}()
 
 	// The tier view is snapshotted per attempt. A record referencing a tier
 	// interned after the snapshot would score with a default weight and drop
@@ -250,14 +258,21 @@ retry:
 		active     []int32      // slots still in the any-tier chain
 		keyStamp   uint32
 	)
-	for idx, key := range requestKeys {
+	for idx := range requestKeys {
 		if idx&cancellationCheckMask == 0 && ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		pc, found := m.data.Get(key)
-		if !found || pc == nil {
+		batchOffset := idx % requestKeyBatchSize
+		if batchOffset == 0 {
+			end := min(idx+requestKeyBatchSize, len(requestKeys))
+			// Batch promotion amortizes the LRU lock handoff. A scoring break
+			// can refresh the rest of this batch, but no subsequent batch.
+			sc.podCaches = m.data.GetPrefixBatch(requestKeys[idx:end], sc.podCaches)
+		}
+		if batchOffset >= len(sc.podCaches) {
 			break
 		}
+		pc := sc.podCaches[batchOffset]
 		keyStamp++
 		firstKey := idx == 0
 		pc.mu.Lock()

--- a/pkg/kvcache/kvblock/scored_lookup_internal_test.go
+++ b/pkg/kvcache/kvblock/scored_lookup_internal_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Both metric paths must report the same hit quantity: the legacy Lookup fold
+// and the fused MatchedBlocks agree on a duplicate-tier plus prefix-gap
+// fixture, where the per-appearance legacy fold would have reported 3.
+func TestHitMetricPathsAgree(t *testing.T) {
+	ctx := context.Background()
+	index, err := NewInMemoryIndex(nil)
+	require.NoError(t, err)
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{1}, []PodEntry{
+		{PodIdentifier: "pod-a", DeviceTier: "gpu"},
+		{PodIdentifier: "pod-a", DeviceTier: "cpu"},
+	}))
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{2}, []PodEntry{
+		{PodIdentifier: "pod-a", DeviceTier: "gpu"},
+	}))
+	// Key 3 is absent: the prefix chain breaks after two blocks.
+	keys := []BlockHash{1, 2, 3}
+
+	keyToPods, err := index.Lookup(ctx, keys, nil)
+	require.NoError(t, err)
+	legacyHits := maxContiguousPodHits(keys, keyToPods)
+
+	stats, err := index.ScoredLookup(ctx, keys, nil, map[string]float64{"gpu": 1.0, "cpu": 0.8})
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, legacyHits)
+	assert.Equal(t, legacyHits, stats["pod-a"].MatchedBlocks,
+		"legacy and fused paths must feed the hit metrics the same quantity")
+}
+
+// BenchmarkMaxContiguousPodHits measures the hit-metric fold on the legacy
+// path's worst realistic shape: a full-hit lookup result at fleet scale.
+func BenchmarkMaxContiguousPodHits(b *testing.B) {
+	const numKeys, numPods = 3750, 96
+	keys := make([]BlockHash, numKeys)
+	keyToPods := make(map[BlockHash][]PodEntry, numKeys)
+	for i := range keys {
+		keys[i] = BlockHash(i + 1)
+		entries := make([]PodEntry, numPods)
+		for p := range entries {
+			entries[p] = PodEntry{PodIdentifier: podNamesForBench[p], DeviceTier: "gpu"}
+		}
+		keyToPods[keys[i]] = entries
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if got := maxContiguousPodHits(keys, keyToPods); got != numKeys {
+			b.Fatalf("unexpected result %d", got)
+		}
+	}
+}
+
+var podNamesForBench = func() []string {
+	names := make([]string, 96)
+	for i := range names {
+		names[i] = fmt.Sprintf("10.0.%d.%d:8000", i/256, i%256)
+	}
+	return names
+}()

--- a/pkg/kvcache/kvblock/scored_lookup_internal_test.go
+++ b/pkg/kvcache/kvblock/scored_lookup_internal_test.go
@@ -19,10 +19,14 @@ package kvblock
 import (
 	"context"
 	"fmt"
+	"runtime"
+	"sync"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // Both metric paths must report the same hit quantity: the legacy Lookup fold
@@ -53,6 +57,41 @@ func TestHitMetricPathsAgree(t *testing.T) {
 	assert.Equal(t, 2, legacyHits)
 	assert.Equal(t, legacyHits, stats["pod-a"].MatchedBlocks,
 		"legacy and fused paths must feed the hit metrics the same quantity")
+}
+
+func TestScoredLookupColdScratchDoesNotTrackPodHistory(t *testing.T) {
+	measure := func(churnPods int) uint64 {
+		ctx := log.IntoContext(context.Background(), logr.Discard())
+		index, err := NewInMemoryIndex(&InMemoryIndexConfig{Size: 128, PodCacheSize: 128})
+		require.NoError(t, err)
+
+		keys := []BlockHash{10, 20}
+		for i := 0; i < 96; i++ {
+			entry := []PodEntry{{PodIdentifier: fmt.Sprintf("pod-live-%d", i), DeviceTier: "gpu"}}
+			require.NoError(t, index.Add(ctx, nil, keys, entry))
+		}
+		for i := 0; i < churnPods; i++ {
+			pod := fmt.Sprintf("pod-gone-%d", i)
+			require.NoError(t, index.Add(ctx, nil, []BlockHash{999}, []PodEntry{{PodIdentifier: pod, DeviceTier: "gpu"}}))
+			require.NoError(t, index.Clear(ctx, pod))
+		}
+
+		scoredScratchPool = sync.Pool{New: func() any { return &scoredScratch{} }}
+		runtime.GC()
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		stats, err := index.ScoredLookup(ctx, keys, nil, map[string]float64{"gpu": 1})
+		require.NoError(t, err)
+		require.Len(t, stats, 96)
+		runtime.ReadMemStats(&after)
+		return after.TotalAlloc - before.TotalAlloc
+	}
+
+	measure(0) // warm lazy runtime and package initialization
+	withoutChurn := measure(0)
+	withChurn := measure(20_000)
+	assert.Less(t, withChurn, withoutChurn+128*1024,
+		"cold request scratch must scale with live candidates, not interned pod history")
 }
 
 // BenchmarkMaxContiguousPodHits measures the hit-metric fold on the legacy

--- a/pkg/kvcache/kvblock/scored_lookup_internal_test.go
+++ b/pkg/kvcache/kvblock/scored_lookup_internal_test.go
@@ -204,8 +204,9 @@ func benchmarkScoredLookupShards(b *testing.B, shardCount int, skewed bool) {
 				b.Error(lookupErr)
 				return
 			}
-			if len(stats) != numPods {
-				b.Errorf("unexpected stats size %d", len(stats))
+			first, found := stats["pod-0"]
+			if len(stats) != numPods || !found || first.MatchedBlocks != numKeys {
+				b.Errorf("unexpected stats: pods=%d first-found=%t first-matched=%d", len(stats), found, first.MatchedBlocks)
 				return
 			}
 		}

--- a/pkg/kvcache/kvblock/scored_lookup_internal_test.go
+++ b/pkg/kvcache/kvblock/scored_lookup_internal_test.go
@@ -76,7 +76,7 @@ func TestScoredLookupColdScratchDoesNotTrackPodHistory(t *testing.T) {
 			require.NoError(t, index.Clear(ctx, pod))
 		}
 
-		scoredScratchPool = sync.Pool{New: func() any { return &scoredScratch{} }}
+		scoredScratchPool = sync.Pool{New: newScoredScratch}
 		runtime.GC()
 		var before, after runtime.MemStats
 		runtime.ReadMemStats(&before)
@@ -92,6 +92,73 @@ func TestScoredLookupColdScratchDoesNotTrackPodHistory(t *testing.T) {
 	withChurn := measure(20_000)
 	assert.Less(t, withChurn, withoutChurn+128*1024,
 		"cold request scratch must scale with live candidates, not interned pod history")
+}
+
+func TestScoredLookupCrossesRequestKeyBatchBoundary(t *testing.T) {
+	ctx := log.IntoContext(context.Background(), logr.Discard())
+	index, err := NewInMemoryIndex(nil)
+	require.NoError(t, err)
+
+	keys := make([]BlockHash, requestKeyBatchSize+1)
+	for i := range keys {
+		keys[i] = BlockHash(i + 1)
+	}
+	entry := []PodEntry{{PodIdentifier: "pod-a", DeviceTier: "gpu"}}
+	require.NoError(t, index.Add(ctx, nil, keys, entry))
+
+	stats, err := index.ScoredLookup(ctx, keys, nil, map[string]float64{"gpu": 1})
+	require.NoError(t, err)
+	assert.Equal(t, len(keys), stats["pod-a"].MatchedBlocks)
+}
+
+func TestScoredLookupStopsAtRequestKeyBatchBoundaryGap(t *testing.T) {
+	ctx := log.IntoContext(context.Background(), logr.Discard())
+	index, err := NewInMemoryIndex(nil)
+	require.NoError(t, err)
+
+	keys := make([]BlockHash, requestKeyBatchSize+2)
+	for i := range keys {
+		keys[i] = BlockHash(i + 1)
+	}
+	entry := []PodEntry{{PodIdentifier: "pod-a", DeviceTier: "gpu"}}
+	require.NoError(t, index.Add(ctx, nil, keys[:requestKeyBatchSize], entry))
+	require.NoError(t, index.Add(ctx, nil, keys[requestKeyBatchSize+1:], entry))
+
+	stats, err := index.ScoredLookup(ctx, keys, nil, map[string]float64{"gpu": 1})
+	require.NoError(t, err)
+	assert.Equal(t, requestKeyBatchSize, stats["pod-a"].MatchedBlocks)
+}
+
+func TestScoredLookupStopsFetchingAfterCandidateBreak(t *testing.T) {
+	ctx := log.IntoContext(context.Background(), logr.Discard())
+	index, err := NewInMemoryIndex(&InMemoryIndexConfig{
+		Size:         requestKeyBatchSize + 2,
+		PodCacheSize: 1,
+	})
+	require.NoError(t, err)
+
+	requestKeys := make([]BlockHash, requestKeyBatchSize+1)
+	for i := range requestKeys {
+		requestKeys[i] = BlockHash(100 + i)
+	}
+	tailKey := requestKeys[len(requestKeys)-1]
+	const coldKey BlockHash = 50
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{tailKey}, []PodEntry{{PodIdentifier: "pod-tail", DeviceTier: "gpu"}}))
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{coldKey}, []PodEntry{{PodIdentifier: "pod-cold", DeviceTier: "gpu"}}))
+	for i, key := range requestKeys[:requestKeyBatchSize] {
+		entry := []PodEntry{{PodIdentifier: fmt.Sprintf("pod-%d", i), DeviceTier: "gpu"}}
+		require.NoError(t, index.Add(ctx, nil, []BlockHash{key}, entry))
+	}
+
+	stats, err := index.ScoredLookup(ctx, requestKeys, nil, map[string]float64{"gpu": 1})
+	require.NoError(t, err)
+	require.Equal(t, 1, stats["pod-0"].MatchedBlocks)
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{999}, []PodEntry{{PodIdentifier: "pod-new", DeviceTier: "gpu"}}))
+	_, tailFound := index.data.Peek(tailKey)
+	_, coldFound := index.data.Peek(coldKey)
+	assert.False(t, tailFound, "a batch beyond the scoring break must remain cold")
+	assert.True(t, coldFound, "an older key must survive when the unfetched tail remains cold")
 }
 
 // BenchmarkMaxContiguousPodHits measures the hit-metric fold on the legacy

--- a/pkg/kvcache/kvblock/scored_lookup_internal_test.go
+++ b/pkg/kvcache/kvblock/scored_lookup_internal_test.go
@@ -94,12 +94,12 @@ func TestScoredLookupColdScratchDoesNotTrackPodHistory(t *testing.T) {
 		"cold request scratch must scale with live candidates, not interned pod history")
 }
 
-func TestScoredLookupCrossesRequestKeyBatchBoundary(t *testing.T) {
+func TestScoredLookupLongPrefix(t *testing.T) {
 	ctx := log.IntoContext(context.Background(), logr.Discard())
 	index, err := NewInMemoryIndex(nil)
 	require.NoError(t, err)
 
-	keys := make([]BlockHash, requestKeyBatchSize+1)
+	keys := make([]BlockHash, cancellationCheckMask+2)
 	for i := range keys {
 		keys[i] = BlockHash(i + 1)
 	}
@@ -111,33 +111,35 @@ func TestScoredLookupCrossesRequestKeyBatchBoundary(t *testing.T) {
 	assert.Equal(t, len(keys), stats["pod-a"].MatchedBlocks)
 }
 
-func TestScoredLookupStopsAtRequestKeyBatchBoundaryGap(t *testing.T) {
+func TestScoredLookupStopsAtCacheGap(t *testing.T) {
 	ctx := log.IntoContext(context.Background(), logr.Discard())
 	index, err := NewInMemoryIndex(nil)
 	require.NoError(t, err)
 
-	keys := make([]BlockHash, requestKeyBatchSize+2)
+	const gapIndex = 127
+	keys := make([]BlockHash, 2*gapIndex+1)
 	for i := range keys {
 		keys[i] = BlockHash(i + 1)
 	}
 	entry := []PodEntry{{PodIdentifier: "pod-a", DeviceTier: "gpu"}}
-	require.NoError(t, index.Add(ctx, nil, keys[:requestKeyBatchSize], entry))
-	require.NoError(t, index.Add(ctx, nil, keys[requestKeyBatchSize+1:], entry))
+	require.NoError(t, index.Add(ctx, nil, keys[:gapIndex], entry))
+	require.NoError(t, index.Add(ctx, nil, keys[gapIndex+1:], entry))
 
 	stats, err := index.ScoredLookup(ctx, keys, nil, map[string]float64{"gpu": 1})
 	require.NoError(t, err)
-	assert.Equal(t, requestKeyBatchSize, stats["pod-a"].MatchedBlocks)
+	assert.Equal(t, gapIndex, stats["pod-a"].MatchedBlocks)
 }
 
 func TestScoredLookupStopsFetchingAfterCandidateBreak(t *testing.T) {
 	ctx := log.IntoContext(context.Background(), logr.Discard())
+	const livePrefixKeys = 16
 	index, err := NewInMemoryIndex(&InMemoryIndexConfig{
-		Size:         requestKeyBatchSize + 2,
+		Size:         livePrefixKeys + 2,
 		PodCacheSize: 1,
 	})
 	require.NoError(t, err)
 
-	requestKeys := make([]BlockHash, requestKeyBatchSize+1)
+	requestKeys := make([]BlockHash, livePrefixKeys+1)
 	for i := range requestKeys {
 		requestKeys[i] = BlockHash(100 + i)
 	}
@@ -145,7 +147,7 @@ func TestScoredLookupStopsFetchingAfterCandidateBreak(t *testing.T) {
 	const coldKey BlockHash = 50
 	require.NoError(t, index.Add(ctx, nil, []BlockHash{tailKey}, []PodEntry{{PodIdentifier: "pod-tail", DeviceTier: "gpu"}}))
 	require.NoError(t, index.Add(ctx, nil, []BlockHash{coldKey}, []PodEntry{{PodIdentifier: "pod-cold", DeviceTier: "gpu"}}))
-	for i, key := range requestKeys[:requestKeyBatchSize] {
+	for i, key := range requestKeys[:livePrefixKeys] {
 		entry := []PodEntry{{PodIdentifier: fmt.Sprintf("pod-%d", i), DeviceTier: "gpu"}}
 		require.NoError(t, index.Add(ctx, nil, []BlockHash{key}, entry))
 	}
@@ -157,8 +159,69 @@ func TestScoredLookupStopsFetchingAfterCandidateBreak(t *testing.T) {
 	require.NoError(t, index.Add(ctx, nil, []BlockHash{999}, []PodEntry{{PodIdentifier: "pod-new", DeviceTier: "gpu"}}))
 	_, tailFound := index.data.Peek(tailKey)
 	_, coldFound := index.data.Peek(coldKey)
-	assert.False(t, tailFound, "a batch beyond the scoring break must remain cold")
+	assert.False(t, tailFound, "a key beyond the scoring break must remain cold")
 	assert.True(t, coldFound, "an older key must survive when the unfetched tail remains cold")
+}
+
+func benchmarkScoredLookupShards(b *testing.B, shardCount int, skewed bool) {
+	const (
+		numKeys = 3750
+		numPods = 8
+		size    = 1 << 20
+	)
+	ctx := log.IntoContext(context.Background(), logr.Discard())
+	index, err := NewInMemoryIndex(&InMemoryIndexConfig{Size: size, PodCacheSize: numPods})
+	if err != nil {
+		b.Fatal(err)
+	}
+	index.data, err = newRequestKeyCacheWithShards(size, shardCount)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	keys := make([]BlockHash, numKeys)
+	if skewed {
+		copy(keys, requestKeysForShard(index.data, 0, numKeys))
+	} else {
+		for i := range keys {
+			keys[i] = BlockHash(i + 1)
+		}
+	}
+	for pod := range numPods {
+		entry := []PodEntry{{PodIdentifier: fmt.Sprintf("pod-%d", pod), DeviceTier: "gpu"}}
+		if err := index.Add(ctx, nil, keys, entry); err != nil {
+			b.Fatal(err)
+		}
+	}
+	tierWeights := map[string]float64{"gpu": 1}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			stats, lookupErr := index.ScoredLookup(ctx, keys, nil, tierWeights)
+			if lookupErr != nil {
+				b.Error(lookupErr)
+				return
+			}
+			if len(stats) != numPods {
+				b.Errorf("unexpected stats size %d", len(stats))
+				return
+			}
+		}
+	})
+}
+
+func BenchmarkScoredLookupShardCount(b *testing.B) {
+	for _, shardCount := range []int{1, 16, 64} {
+		b.Run(fmt.Sprintf("shards=%d", shardCount), func(b *testing.B) {
+			benchmarkScoredLookupShards(b, shardCount, false)
+		})
+	}
+}
+
+func BenchmarkScoredLookupShardLockSkew(b *testing.B) {
+	benchmarkScoredLookupShards(b, maxRequestKeyCacheShards, true)
 }
 
 // BenchmarkMaxContiguousPodHits measures the hit-metric fold on the legacy

--- a/pkg/kvcache/kvblock/scored_lookup_test.go
+++ b/pkg/kvcache/kvblock/scored_lookup_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	. "github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
+)
+
+var scoredLookupTierWeights = map[string]float64{"gpu": 1.0, "cpu": 0.8}
+
+func TestScoredLookup(t *testing.T) {
+	podA := "pod-a"
+	podB := "pod-b"
+	keys := []BlockHash{10, 20, 30}
+
+	tests := []struct {
+		name        string
+		entries     map[BlockHash][]PodEntry
+		requestKeys []BlockHash
+		podFilter   sets.Set[string]
+		wantStats   map[string]PodMatchStats
+	}{
+		{
+			name: "weighted chains and per-tier counts",
+			entries: map[BlockHash][]PodEntry{
+				10: {
+					{PodIdentifier: podA, DeviceTier: "gpu"},
+					{PodIdentifier: podA, DeviceTier: "cpu"},
+					{PodIdentifier: podB, DeviceTier: "gpu"},
+				},
+				20: {
+					{PodIdentifier: podA, DeviceTier: "gpu"},
+					{PodIdentifier: podB, DeviceTier: "cpu"},
+				},
+				30: {
+					{PodIdentifier: podA, DeviceTier: "cpu"},
+				},
+			},
+			requestKeys: keys,
+			wantStats: map[string]PodMatchStats{
+				// Per block the highest tier weight counts: gpu, gpu, cpu.
+				// gpu chain breaks at key 30, cpu chain at key 20.
+				podA: {WeightedScore: 2.8, MatchedBlocks: 3, BlocksByTier: map[string]int{"gpu": 2, "cpu": 1}},
+				// gpu@10 then cpu@20: any-tier chain spans both, no tier
+				// survives past its own break.
+				podB: {WeightedScore: 1.8, MatchedBlocks: 2, BlocksByTier: map[string]int{"gpu": 1}},
+			},
+		},
+		{
+			name: "chain breaks at missing key",
+			entries: map[BlockHash][]PodEntry{
+				10: {{PodIdentifier: podA, DeviceTier: "gpu"}},
+				30: {{PodIdentifier: podA, DeviceTier: "gpu"}},
+			},
+			requestKeys: keys,
+			wantStats: map[string]PodMatchStats{
+				podA: {WeightedScore: 1.0, MatchedBlocks: 1, BlocksByTier: map[string]int{"gpu": 1}},
+			},
+		},
+		{
+			name: "missing first key yields no stats",
+			entries: map[BlockHash][]PodEntry{
+				20: {{PodIdentifier: podA, DeviceTier: "gpu"}},
+			},
+			requestKeys: keys,
+			wantStats:   map[string]PodMatchStats{},
+		},
+		{
+			name: "pod filter excludes other pods",
+			entries: map[BlockHash][]PodEntry{
+				10: {
+					{PodIdentifier: podA, DeviceTier: "gpu"},
+					{PodIdentifier: podB, DeviceTier: "gpu"},
+				},
+				20: {
+					{PodIdentifier: podA, DeviceTier: "gpu"},
+					{PodIdentifier: podB, DeviceTier: "gpu"},
+				},
+			},
+			requestKeys: []BlockHash{10, 20},
+			podFilter:   sets.New(podB),
+			wantStats: map[string]PodMatchStats{
+				podB: {WeightedScore: 2.0, MatchedBlocks: 2, BlocksByTier: map[string]int{"gpu": 2}},
+			},
+		},
+		{
+			name: "speculative entries count under the speculative tier",
+			entries: map[BlockHash][]PodEntry{
+				10: {{PodIdentifier: podA, Speculative: true}},
+			},
+			requestKeys: []BlockHash{10},
+			wantStats: map[string]PodMatchStats{
+				podA: {WeightedScore: 1.0, MatchedBlocks: 1, BlocksByTier: map[string]int{SpeculativeTier: 1}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := logging.NewTestLoggerIntoContext(t.Context())
+			index, err := NewInMemoryIndex(nil)
+			require.NoError(t, err)
+			for key, entries := range tt.entries {
+				require.NoError(t, index.Add(ctx, nil, []BlockHash{key}, entries))
+			}
+
+			stats, err := index.ScoredLookup(ctx, tt.requestKeys, tt.podFilter, scoredLookupTierWeights)
+			require.NoError(t, err)
+			require.Len(t, stats, len(tt.wantStats))
+			for pod, want := range tt.wantStats {
+				got, ok := stats[pod]
+				require.True(t, ok, "missing pod %q", pod)
+				assert.InDelta(t, want.WeightedScore, got.WeightedScore, 0.0001, "pod %q weighted score", pod)
+				assert.Equal(t, want.MatchedBlocks, got.MatchedBlocks, "pod %q matched blocks", pod)
+				assert.Equal(t, want.BlocksByTier, got.BlocksByTier, "pod %q blocks by tier", pod)
+			}
+		})
+	}
+}
+
+func TestScoredLookupEmptyKeys(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(t.Context())
+	index, err := NewInMemoryIndex(nil)
+	require.NoError(t, err)
+
+	_, err = index.ScoredLookup(ctx, nil, nil, scoredLookupTierWeights)
+	assert.Error(t, err)
+}
+
+// Pod churn (interned ids from pods since cleared) must change neither
+// results nor the candidate slot assignment.
+func TestScoredLookupAfterPodChurn(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(t.Context())
+	index, err := NewInMemoryIndex(nil)
+	require.NoError(t, err)
+
+	entries := []PodEntry{{PodIdentifier: "pod-live", DeviceTier: "gpu"}}
+	keys := []BlockHash{10, 20}
+	require.NoError(t, index.Add(ctx, nil, keys, entries))
+
+	churnKey := []BlockHash{999}
+	for i := 0; i < 2000; i++ {
+		pod := fmt.Sprintf("10.9.%d.%d:8000", i/256, i%256)
+		churn := []PodEntry{{PodIdentifier: pod, DeviceTier: "gpu"}}
+		require.NoError(t, index.Add(ctx, nil, churnKey, churn))
+		require.NoError(t, index.Clear(ctx, pod))
+	}
+
+	stats, err := index.ScoredLookup(ctx, keys, nil, scoredLookupTierWeights)
+	require.NoError(t, err)
+	require.Len(t, stats, 1)
+	got := stats["pod-live"]
+	assert.InDelta(t, 2.0, got.WeightedScore, 0.0001)
+	assert.Equal(t, 2, got.MatchedBlocks)
+	assert.Equal(t, map[string]int{"gpu": 2}, got.BlocksByTier)
+}
+
+// More interned tiers than the chain bitmask represents must fall back to the
+// legacy path via the sentinel, directly and through the wrapper chain.
+func TestScoredLookupUnsupportedBeyond64Tiers(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(t.Context())
+	index, err := NewInMemoryIndex(nil)
+	require.NoError(t, err)
+
+	for i := 0; i < 65; i++ {
+		entry := []PodEntry{{PodIdentifier: "pod-a", DeviceTier: fmt.Sprintf("tier-%d", i)}}
+		require.NoError(t, index.Add(ctx, nil, []BlockHash{BlockHash(i + 1)}, entry))
+	}
+
+	_, err = index.ScoredLookup(ctx, []BlockHash{1}, nil, scoredLookupTierWeights)
+	require.ErrorIs(t, err, ErrScoredLookupUnsupported)
+
+	wrapped, ok := NewTracedIndex(NewInstrumentedIndex(index)).(ScoredLookupIndex)
+	require.True(t, ok)
+	_, err = wrapped.ScoredLookup(ctx, []BlockHash{1}, nil, scoredLookupTierWeights)
+	require.ErrorIs(t, err, ErrScoredLookupUnsupported)
+}
+
+// Concurrent Adds that intern new tiers mid-walk must never yield impossible
+// statistics: a matched pod always carries at least one per-tier count and a
+// weight consistent with its configured tier.
+func TestScoredLookupConcurrentNewTiers(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(t.Context())
+	index, err := NewInMemoryIndex(nil)
+	require.NoError(t, err)
+
+	weights := map[string]float64{}
+	for i := 0; i < 60; i++ {
+		weights[fmt.Sprintf("tier-%d", i)] = 5.0
+	}
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			entry := []PodEntry{{PodIdentifier: "pod-a", DeviceTier: fmt.Sprintf("tier-%d", i%60)}}
+			_ = index.Add(ctx, nil, []BlockHash{10}, entry)
+		}
+	}()
+
+	for i := 0; i < 300; i++ {
+		stats, err := index.ScoredLookup(ctx, []BlockHash{10}, nil, weights)
+		require.NoError(t, err)
+		for pod, s := range stats {
+			require.Positive(t, s.MatchedBlocks, "pod %q", pod)
+			require.NotEmpty(t, s.BlocksByTier,
+				"pod %q matched %d blocks but reports no tier", pod, s.MatchedBlocks)
+			require.InDelta(t, 5.0, s.WeightedScore, 0.0001,
+				"pod %q must score with the configured tier weight, not a stale default", pod)
+		}
+	}
+	close(stop)
+	<-done
+}

--- a/pkg/kvcache/kvblock/scored_lookup_test.go
+++ b/pkg/kvcache/kvblock/scored_lookup_test.go
@@ -149,6 +149,29 @@ func TestScoredLookupEmptyKeys(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestScoredLookupDoesNotRefreshIndexLRU(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(t.Context())
+	index, err := NewInMemoryIndex(&InMemoryIndexConfig{Size: 2, PodCacheSize: 1})
+	require.NoError(t, err)
+
+	entry := []PodEntry{{PodIdentifier: "pod-a", DeviceTier: "gpu"}}
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{10}, entry))
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{20}, entry))
+
+	stats, err := index.ScoredLookup(ctx, []BlockHash{10}, nil, scoredLookupTierWeights)
+	require.NoError(t, err)
+	require.Contains(t, stats, "pod-a")
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{30}, entry))
+
+	stats, err = index.ScoredLookup(ctx, []BlockHash{10}, nil, scoredLookupTierWeights)
+	require.NoError(t, err)
+	assert.Empty(t, stats)
+	stats, err = index.ScoredLookup(ctx, []BlockHash{20}, nil, scoredLookupTierWeights)
+	require.NoError(t, err)
+	assert.Contains(t, stats, "pod-a")
+}
+
 // Pod churn (interned ids from pods since cleared) must change neither
 // results nor the candidate slot assignment.
 func TestScoredLookupAfterPodChurn(t *testing.T) {

--- a/pkg/kvcache/kvblock/scored_lookup_test.go
+++ b/pkg/kvcache/kvblock/scored_lookup_test.go
@@ -197,7 +197,7 @@ func TestScoredLookupCanceledDoesNotRefreshIndexLRU(t *testing.T) {
 	assert.Contains(t, newestStats, "pod-a")
 }
 
-func TestScoredLookupRefreshesFetchedRequestBatch(t *testing.T) {
+func TestScoredLookupRefreshesOnlyVisitedKeys(t *testing.T) {
 	ctx := logging.NewTestLoggerIntoContext(t.Context())
 	index, err := NewInMemoryIndex(&InMemoryIndexConfig{Size: 4, PodCacheSize: 1})
 	require.NoError(t, err)
@@ -223,8 +223,8 @@ func TestScoredLookupRefreshesFetchedRequestBatch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, firstStats, "pod-a")
 	assert.Contains(t, breakStats, "pod-b")
-	assert.Contains(t, tailStats, "pod-c")
-	assert.Empty(t, coldStats)
+	assert.Empty(t, tailStats)
+	assert.Contains(t, coldStats, "pod-cold")
 }
 
 func TestScoredLookupConcurrentReadersAgree(t *testing.T) {

--- a/pkg/kvcache/kvblock/scored_lookup_test.go
+++ b/pkg/kvcache/kvblock/scored_lookup_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package kvblock_test
 
 import (
+	"context"
 	"fmt"
+	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -170,6 +173,98 @@ func TestScoredLookupRefreshesIndexLRU(t *testing.T) {
 	stats, err = index.ScoredLookup(ctx, []BlockHash{20}, nil, scoredLookupTierWeights)
 	require.NoError(t, err)
 	assert.Empty(t, stats)
+}
+
+func TestScoredLookupCanceledDoesNotRefreshIndexLRU(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(t.Context())
+	index, err := NewInMemoryIndex(&InMemoryIndexConfig{Size: 2, PodCacheSize: 1})
+	require.NoError(t, err)
+
+	entry := []PodEntry{{PodIdentifier: "pod-a", DeviceTier: "gpu"}}
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{10}, entry))
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{20}, entry))
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	_, err = index.ScoredLookup(canceledCtx, []BlockHash{10}, nil, scoredLookupTierWeights)
+	require.ErrorIs(t, err, context.Canceled)
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{30}, entry))
+	oldestStats, err := index.ScoredLookup(ctx, []BlockHash{10}, nil, scoredLookupTierWeights)
+	require.NoError(t, err)
+	newestStats, err := index.ScoredLookup(ctx, []BlockHash{20}, nil, scoredLookupTierWeights)
+	require.NoError(t, err)
+	assert.Empty(t, oldestStats)
+	assert.Contains(t, newestStats, "pod-a")
+}
+
+func TestScoredLookupRefreshesFetchedRequestBatch(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(t.Context())
+	index, err := NewInMemoryIndex(&InMemoryIndexConfig{Size: 4, PodCacheSize: 1})
+	require.NoError(t, err)
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{30}, []PodEntry{{PodIdentifier: "pod-c", DeviceTier: "gpu"}}))
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{5}, []PodEntry{{PodIdentifier: "pod-cold", DeviceTier: "gpu"}}))
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{10}, []PodEntry{{PodIdentifier: "pod-a", DeviceTier: "gpu"}}))
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{20}, []PodEntry{{PodIdentifier: "pod-b", DeviceTier: "gpu"}}))
+
+	stats, err := index.ScoredLookup(ctx, []BlockHash{10, 20, 30}, nil, scoredLookupTierWeights)
+	require.NoError(t, err)
+	require.Contains(t, stats, "pod-a")
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{40}, []PodEntry{{PodIdentifier: "pod-d", DeviceTier: "gpu"}}))
+
+	firstStats, err := index.ScoredLookup(ctx, []BlockHash{10}, nil, scoredLookupTierWeights)
+	require.NoError(t, err)
+	breakStats, err := index.ScoredLookup(ctx, []BlockHash{20}, nil, scoredLookupTierWeights)
+	require.NoError(t, err)
+	tailStats, err := index.ScoredLookup(ctx, []BlockHash{30}, nil, scoredLookupTierWeights)
+	require.NoError(t, err)
+	coldStats, err := index.ScoredLookup(ctx, []BlockHash{5}, nil, scoredLookupTierWeights)
+	require.NoError(t, err)
+	assert.Contains(t, firstStats, "pod-a")
+	assert.Contains(t, breakStats, "pod-b")
+	assert.Contains(t, tailStats, "pod-c")
+	assert.Empty(t, coldStats)
+}
+
+func TestScoredLookupConcurrentReadersAgree(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(t.Context())
+	index, err := NewInMemoryIndex(nil)
+	require.NoError(t, err)
+
+	keys := []BlockHash{10, 20, 30}
+	for i := 0; i < 8; i++ {
+		entry := []PodEntry{{PodIdentifier: fmt.Sprintf("pod-%d", i), DeviceTier: "gpu"}}
+		require.NoError(t, index.Add(ctx, nil, keys, entry))
+	}
+	want, err := index.ScoredLookup(ctx, keys, nil, scoredLookupTierWeights)
+	require.NoError(t, err)
+
+	const readers = 16
+	errCh := make(chan error, readers)
+	var wg sync.WaitGroup
+	wg.Add(readers)
+	for range readers {
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				got, lookupErr := index.ScoredLookup(ctx, keys, nil, scoredLookupTierWeights)
+				if lookupErr != nil {
+					errCh <- lookupErr
+					return
+				}
+				if !reflect.DeepEqual(want, got) {
+					errCh <- fmt.Errorf("unexpected stats: got %v, want %v", got, want)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
 }
 
 // Pod churn (interned ids from pods since cleared) must change neither

--- a/pkg/kvcache/kvblock/scored_lookup_test.go
+++ b/pkg/kvcache/kvblock/scored_lookup_test.go
@@ -149,7 +149,7 @@ func TestScoredLookupEmptyKeys(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestScoredLookupDoesNotRefreshIndexLRU(t *testing.T) {
+func TestScoredLookupRefreshesIndexLRU(t *testing.T) {
 	ctx := logging.NewTestLoggerIntoContext(t.Context())
 	index, err := NewInMemoryIndex(&InMemoryIndexConfig{Size: 2, PodCacheSize: 1})
 	require.NoError(t, err)
@@ -166,10 +166,10 @@ func TestScoredLookupDoesNotRefreshIndexLRU(t *testing.T) {
 
 	stats, err = index.ScoredLookup(ctx, []BlockHash{10}, nil, scoredLookupTierWeights)
 	require.NoError(t, err)
-	assert.Empty(t, stats)
+	assert.Contains(t, stats, "pod-a")
 	stats, err = index.ScoredLookup(ctx, []BlockHash{20}, nil, scoredLookupTierWeights)
 	require.NoError(t, err)
-	assert.Contains(t, stats, "pod-a")
+	assert.Empty(t, stats)
 }
 
 // Pod churn (interned ids from pods since cleared) must change neither

--- a/pkg/kvcache/kvblock/traced_index.go
+++ b/pkg/kvcache/kvblock/traced_index.go
@@ -16,6 +16,7 @@ package kvblock
 
 import (
 	"context"
+	"errors"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -102,17 +103,58 @@ func (t *tracedIndex) Lookup(
 		return nil, err
 	}
 
-	// Calculate cache hit metrics
-	blocksFound := 0
-	for _, pods := range result {
-		if len(pods) > 0 {
-			blocksFound++
-		}
-	}
-	cacheHit := blocksFound > 0
+	// Same ordered fold as the fused path, so blocks_found means the longest
+	// contiguous per-pod prefix chain on both.
+	blocksFound := maxContiguousPodHits(requestKeys, result)
 
 	span.SetAttributes(
-		attribute.Bool("llm_d.kv_cache.lookup.cache_hit", cacheHit),
+		attribute.Bool("llm_d.kv_cache.lookup.cache_hit", blocksFound > 0),
+		attribute.Int("llm_d.kv_cache.lookup.blocks_found", blocksFound),
+	)
+
+	return result, nil
+}
+
+// ScoredLookup forwards the fused lookup capability with the same span
+// attribute schema as Lookup. Returns ErrScoredLookupUnsupported when the
+// wrapped backend lacks the capability.
+func (t *tracedIndex) ScoredLookup(ctx context.Context, requestKeys []BlockHash,
+	podIdentifierSet sets.Set[string], tierWeights map[string]float64,
+) (map[string]PodMatchStats, error) {
+	inner, ok := t.next.(ScoredLookupIndex)
+	if !ok {
+		return nil, ErrScoredLookupUnsupported
+	}
+
+	tracer := tracing.Tracer("llm-d-router/pkg/kvcache/kvblock")
+	ctx, span := tracer.Start(ctx, "llm_d.kv_cache.index",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.Int("llm_d.kv_cache.index.lookup.block_count", len(requestKeys)),
+		attribute.Int("llm_d.kv_cache.lookup.pod_filter_count", podIdentifierSet.Len()),
+	)
+
+	result, err := inner.ScoredLookup(ctx, requestKeys, podIdentifierSet, tierWeights)
+	if err != nil {
+		// The unsupported sentinel is an expected signal that callers answer
+		// with the legacy Lookup path, not a failure.
+		if !errors.Is(err, ErrScoredLookupUnsupported) {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		return nil, err
+	}
+
+	blocksFound := 0
+	for _, stats := range result {
+		if stats.MatchedBlocks > blocksFound {
+			blocksFound = stats.MatchedBlocks
+		}
+	}
+	span.SetAttributes(
+		attribute.Bool("llm_d.kv_cache.lookup.cache_hit", blocksFound > 0),
 		attribute.Int("llm_d.kv_cache.lookup.blocks_found", blocksFound),
 	)
 

--- a/pkg/kvcache/metrics/collector.go
+++ b/pkg/kvcache/metrics/collector.go
@@ -116,12 +116,14 @@ var (
 	// LookupRequests counts how many Lookup() calls have been made.
 	LookupRequests = newDualCounter("index", "lookup_requests_total",
 		"kv_cache_index_lookup_requests_total", "Total number of lookup calls")
-	// MaxPodHitCount counts the maximum cache hits on a single pod on Lookup().
+	// MaxPodHitCount counts, per lookup, the longest contiguous prefix chain
+	// any single pod holds counting from the first requested block.
 	MaxPodHitCount = newDualCounter("index", "max_pod_hit_count_total",
-		"kv_cache_index_max_pod_hit_count_total", "Maximum cache hits on a single pod on Lookup()")
-	// LookupHits counts how many keys were found in the cache on Lookup().
+		"kv_cache_index_max_pod_hit_count_total", "Longest contiguous per-pod prefix chain observed per lookup")
+	// LookupHits accumulates the same per-lookup contiguous chain length as
+	// MaxPodHitCount.
 	LookupHits = newDualCounter("index", "lookup_hits_total",
-		"kv_cache_index_lookup_hits_total", "Number of keys found in the cache on Lookup()")
+		"kv_cache_index_lookup_hits_total", "Contiguous prefix blocks matched by the best pod per lookup")
 	// LookupLatency logs latency of lookup calls.
 	LookupLatency = newDualHistogram("index", "lookup_latency_seconds",
 		"kv_cache_index_lookup_latency_seconds", "Latency of Lookup calls in seconds", prometheus.DefBuckets)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds `ScoredLookupIndex`, an optional index capability that fuses block lookup
and per-pod prefix scoring into one walk. `InMemoryIndex` implements the fused
path, so precise-prefix scoring does not materialize every block's `PodEntry`
slice for a second scorer pass. The traced and instrumented decorators forward
the capability. Callers fall back to the legacy path when a backend returns
`ErrScoredLookupUnsupported`.

The request-key cache also uses sharded per-key LRU updates. A successful lookup
must refresh recency: a multi-turn prefix may be admitted once and then reused
through reads alone. A read-only `Peek` leaves that hot prefix at its insertion
age, so unrelated writes can evict an actively reused conversation.

### LRU alternatives evaluated

- Global per-key `Get` preserves exact global LRU recency, but every visited
  block takes the same exclusive mutex. This dominates parallel lookup time for
  long prefixes.
- Global `Peek` removes the LRU write from the read path and is kept only as a
  diagnostic upper bound. It does not preserve multi-turn cache residency.
- A global batch `Get` amortizes lock handoffs, but a 16-key batch can promote
  up to 15 keys that scoring never consumes. Its longer critical sections also
  reduce writer progress under saturated readers.
- `Peek` followed by a deferred touch preserves the consumed-key scope, but a
  key can be evicted between scoring and promotion. It also requires separate
  read and write lock phases and must guard against touching a replacement.
- Asynchronous or coalesced touches reduce synchronous contention by making
  recency eventual. They require queue, drop, and lifecycle policy and retain
  the same eviction window.

The selected implementation uses an immediate per-key `Get` on a keyed,
sharded LRU. It promotes only request keys actually reached by scoring and
unrelated keys no longer contend on one global recency lock. The shard count is
a power of two up to 64, while retaining at least 1,024 configured entries per
shard; small caches remain single-shard. Block hashes are rehashed with a
per-cache `maphash` seed, so shard selection does not depend directly on their
low bits.

Capacity and LRU order are exact within each shard, and shard quotas sum to the
configured cache size. A full shard evicts a local key while another shard still
has unused capacity, so hash imbalance, including normal variance, can leave
aggregate capacity unused. The 1,024-entry minimum limits expected
fragmentation. That policy tradeoff is documented and tested.

### Benchmarks

The LRU alternatives were compared on the same Apple M4 Max, Go 1.26.6,
16-CPU, 3,750-block full-hit workload. Values are medians of five 1-second runs.
The parallel values are saturated `RunParallel` cost per operation, not request
p50 or p99 latency.

| Implementation | 8 pods serial | 8 pods parallel | 96 pods serial | 96 pods parallel |
|---|---:|---:|---:|---:|
| Non-fused + global `Get` | 1.764 ms | 1.307 ms | 17.470 ms | 3.136 ms |
| Fused + global `Peek` (diagnostic only) | 0.217 ms | 0.446 ms | 1.796 ms | 0.433 ms |
| Fused + global per-key `Get` | 0.238 ms | 0.811 ms | 1.766 ms | 1.452 ms |
| Fused + global batch-16 `Get` | 0.217 ms | 0.176 ms | 1.988 ms | 0.324 ms |
| Fused + sharded per-key `Get` | 0.270 ms | 0.124 ms | 1.885 ms | 0.233 ms |
| Non-fused + sharded `Get` | 1.883 ms | 0.409 ms | 17.388 ms | 2.912 ms |

The non-fused rows measure `Lookup` plus `LongestPrefixScorer.Score` against the
same index fixture. This is a conservative core comparison for the fused path:
the legacy precise-prefix producer also re-walks endpoint results to derive
matched-block and tier attribution, which this benchmark does not include.

A separate saturated mixed workload used 16 readers and four writers, with 64
request keys per `Add`:

| Fused LRU implementation | scored read cost/op | 64-key writes/s |
|---|---:|---:|
| Global per-key `Get` | 1.214 ms | 1.8K |
| Global batch-16 `Get` | 0.216 ms | 743 |
| Sharded per-key `Get` | 0.154 ms | 14.2K |

These are paired saturation results: faster writers consume more CPU, so the
table is a throughput tradeoff rather than latency at a fixed event-arrival
rate. Production rollout still needs queue-depth and lookup-latency monitoring.

At 96 pods, the non-fused core path materialized about 18.9 MB and 3,827
allocations per operation; the fused path used about 46.7 KB and 219 allocations
per operation.

Candidate-slot scratch storage is pooled and sized from the first request key's
live entries, rather than from the append-only pod interner. A 20,000-pod churn
test verifies that cold scratch remains candidate-bounded.

**Test plan**:

- [x] Fused and legacy paths agree on per-pod results, tier weighting, and
      contiguous-chain semantics
- [x] LRU recency is refreshed by successful multi-turn reads
- [x] Misses, cancellation, and candidate-chain breaks refresh only keys reached
      by scoring
- [x] Shard quotas sum to the configured size; local eviction and capacity-skew
      behavior are explicit
- [x] Keyed shard selection and independent shard locking are covered
- [x] Concurrent `Get`, `Add`, `Remove`, and scored lookup pass under the race
      detector
- [x] `Clear` walks one shard snapshot at a time and preserves entries belonging
      to other pods
- [x] Decorators propagate `ErrScoredLookupUnsupported` from the tier-limit
      capability boundary
- [x] More than 64 device tiers returns `ErrScoredLookupUnsupported` rather than
      silently mis-scoring
- [x] Mixed, shard-count, and non-fused comparison benchmarks validate the full
      3,750-block result instead of accepting a truncated or empty walk
- [x] `make presubmit`
- [x] `make test-unit`

**Which issue(s) this PR fixes**:

Fixes #2390

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The precise prefix cache scores endpoints in a single index walk and refreshes
multi-turn LRU recency through a sharded request-key cache, reducing scoring
latency, lock contention, and per-request allocations.

`kv_cache_index_lookup_hits_total` and `kv_cache_index_max_pod_hit_count_total`
report the longest contiguous per-pod prefix chain per lookup rather than every
block appearance, so dashboards built on the previous counts read lower.
```

