### PR TITLE
fix(epp): register default producer for UncachedRequestTokens

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -663,6 +663,7 @@ func (r *Runner) registerInTreePlugins() {
 	// Beta
 	fwkplugin.RegisterAsDefaultProducer(reqdataprodprefix.ApproxPrefixCachePluginType, fwkplugin.StabilityBeta, reqdataprodprefix.ApproxPrefixCacheFactory, attrprefix.PrefixCacheMatchInfoDataKey)
 	fwkplugin.RegisterAsDefaultProducer(inflightload.InFlightLoadProducerType, fwkplugin.StabilityBeta, inflightload.InFlightLoadProducerFactory, attrconcurrency.InFlightLoadDataKey)
+	fwkplugin.RegisterAsDefaultProducer(inflightload.InFlightLoadProducerType, fwkplugin.StabilityBeta, inflightload.InFlightLoadProducerFactory, attrconcurrency.UncachedRequestTokensDataKey)
 	fwkplugin.RegisterAsDefaultProducer(latencyproducer.LatencyDataProviderPluginType, fwkplugin.StabilityBeta, latencyproducer.PredictedLatencyFactory, attrlatency.LatencyPredictionInfoDataKey)
 	fwkplugin.RegisterDeprecated(tokenizer.LegacyPluginType, fwkplugin.StabilityBeta, tokenizer.LegacyPluginFactory, "v0.9.0", "v0.11.0", tokenizer.PluginType) //nolint:staticcheck // deprecated in v0.9.0 (#863)
 	fwkplugin.RegisterAsDefaultProducer(mmproducer.ProducerType, fwkplugin.StabilityBeta, mmproducer.Factory, mmproducer.ProducedKey)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR addresses and resolves the endpoint/request routing and scheduling issue reported in #2406. It fixes the logic to ensure requests are accurately scheduled and dispatched to the intended endpoints without unexpected failure or misrouting.

- Corrected the scheduling/routing decision logic.
- Added/updated unit tests to verify the expected behavior and prevent regressions.

**Which issue(s) this PR fixes**:
Fixes #2406

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Autoregister inflight-load-producer as default producer for UncachedRequestTokens.
Fixes an EPP startup failure that occurred when the token-load-scorer plugin was
enabled. The inflight-load-producer is now registered as the default producer for
UncachedRequestTokensDataKey, so the required data key is available at startup.