### PR TITLE
Point sim-epp token-producer at the render Service

### DIFF
--- a/deploy/config/sim-epp-kvcache-config.yaml
+++ b/deploy/config/sim-epp-kvcache-config.yaml
@@ -7,7 +7,7 @@ plugins:
   parameters:
     modelName: TinyLlama/TinyLlama-1.1B-Chat-v1.0  # replace to use a different model
     vllm:
-      url: http://localhost:8000
+      url: ${VLLM_RENDER_URL}  # substituted by kind-dev-env.sh envsubst (render Service)
 - type: precise-prefix-cache-producer
   parameters:
     tokenProcessorConfig:

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -405,7 +405,7 @@ TEMP_FILE=$(mktemp)
 trap "rm -f \"${TEMP_FILE}\"" EXIT
 
 kubectl --context ${KUBE_CONTEXT} delete configmap epp-config --ignore-not-found
-envsubst '$MODEL_NAME' < ${EPP_CONFIG} > ${TEMP_FILE}
+envsubst '${MODEL_NAME} ${VLLM_RENDER_URL}' < ${EPP_CONFIG} > ${TEMP_FILE}
 kubectl --context ${KUBE_CONTEXT} create configmap epp-config --from-file=epp-config.yaml=${TEMP_FILE}
 
 # The replica count is changed in some end to end tests

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -400,7 +400,7 @@ TEMP_FILE=$(mktemp)
 trap "rm -f \"${TEMP_FILE}\"" EXIT
 
 kubectl --context ${KUBE_CONTEXT} delete configmap epp-config --ignore-not-found
-envsubst '$MODEL_NAME' < ${EPP_CONFIG} > ${TEMP_FILE}
+envsubst '${MODEL_NAME} ${VLLM_RENDER_URL}' < ${EPP_CONFIG} > ${TEMP_FILE}
 kubectl --context ${KUBE_CONTEXT} create configmap epp-config --from-file=epp-config.yaml=${TEMP_FILE}
 
 # The replica count is changed in some end to end tests


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The sim-epp-kvcache EPP config set `token-producer.url` to
http://localhost:8000, but the kind dev env runs the vLLM render server
as a separate Service (vllm-render:8082), not a sidecar. The EPP pod has
no listener on localhost:8000, so every request failed tokenization
before the scorer ran and cache-aware routing never engaged.

Use `VLLM_RENDER_URL` (already exported, defaults to
http://vllm-render:8082) and add it to `kind-dev-env.sh`'s envsubst var
list so it is substituted into the config.

**Which issue(s) this PR fixes**:

Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
