### PR TITLE
perf(epp): parse only metric families consumed by extractors

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -101,6 +101,27 @@ func (ext *Extractor) Produces() map[fwkplugin.DataKey]any {
 	return produced
 }
 
+var _ sourcemetrics.FamilyNamer = &Extractor{}
+
+// MetricNames declares every family this extractor can read, letting the
+// metrics data source discard the rest of a scrape before parsing it. The
+// engine of an endpoint is only known at extraction time, so the declaration
+// is the union over all registered mappings.
+func (ext *Extractor) MetricNames() []string {
+	seen := map[string]struct{}{}
+	var names []string
+	for _, mapping := range ext.registry.Mappings() {
+		for _, name := range mapping.MetricNames() {
+			if _, dup := seen[name]; dup {
+				continue
+			}
+			seen[name] = struct{}{}
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
 // Extract transforms the typed metrics payload into endpoint attributes.
 func (ext *Extractor) Extract(ctx context.Context, in fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]) error {
 	families := in.Payload

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
@@ -64,6 +64,8 @@ type HTTPDataSource[T any] struct {
 	useNodeAddress bool
 	// interval is the desired scrape period; zero means every base tick.
 	interval time.Duration
+	// extractorHook, when set, observes each extractor as it binds.
+	extractorHook func(fwkplugin.Plugin)
 
 	client Client
 	// parser converts the response body to T. MUST NOT return (zero, nil) for nilable T;
@@ -95,6 +97,7 @@ type options struct {
 	portOverride   int
 	useNodeAddress bool
 	interval       time.Duration
+	extractorHook  func(fwkplugin.Plugin)
 }
 
 // WithPortOverride makes the source scrape podIP:port instead of the
@@ -116,6 +119,15 @@ func WithUseNodeAddress() Option {
 // every base tick (the default).
 func WithInterval(d time.Duration) Option {
 	return func(o *options) { o.interval = d }
+}
+
+// WithExtractorHook registers fn to run each time an extractor binds to the
+// source. A source uses it to specialize polling to what its extractors
+// actually consume; the metrics source, for example, learns which metric
+// families to keep. fn runs under the source's lock during configuration and
+// must not call back into the source.
+func WithExtractorHook(fn func(fwkplugin.Plugin)) Option {
+	return func(o *options) { o.extractorHook = fn }
 }
 
 // ParseIntervalOption parses a duration string from plugin parameters and
@@ -174,6 +186,7 @@ func NewHTTPDataSource[T any](scheme, path string, tlsOpts TLSOptions,
 		portOverride:   cfg.portOverride,
 		useNodeAddress: cfg.useNodeAddress,
 		interval:       cfg.interval,
+		extractorHook:  cfg.extractorHook,
 		client:         cl,
 		parser:         parser,
 	}, nil
@@ -300,6 +313,9 @@ func (s *HTTPDataSource[T]) AppendExtractor(ext fwkplugin.Plugin) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.exts = append(s.exts, typed)
+	if s.extractorHook != nil {
+		s.extractorHook(ext)
+	}
 	return nil
 }
 

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -67,8 +68,9 @@ type metricsDatasourceParams struct {
 // InsecureSkipVerify defaults to true (matching the factory default).
 // Use this function directly in tests to bypass JSON parameter marshaling.
 func NewHTTPMetricsDataSource(scheme, path, name string) (*http.HTTPDataSource[PrometheusMetricMap], error) {
+	parser, selector := newFilteringParser()
 	return http.NewHTTPDataSource(scheme, path, http.TLSOptions{SkipVerify: defaultMetricsInsecureSkipVerify},
-		MetricsDataSourceType, name, parseMetrics)
+		MetricsDataSourceType, name, parser, http.WithExtractorHook(selector.observe))
 }
 
 // MetricsDataSourceFactory is a factory function used to instantiate data layer's
@@ -96,6 +98,9 @@ func MetricsDataSourceFactory(name string, parameters *json.Decoder, handle fwkp
 		opts = append(opts, http.WithPortOverride(*cfg.Port))
 	}
 
+	parser, selector := newFilteringParser()
+	opts = append(opts, http.WithExtractorHook(selector.observe))
+
 	return http.NewHTTPDataSource(cfg.Scheme, cfg.Path,
 		http.TLSOptions{
 			SkipVerify:     cfg.InsecureSkipVerify,
@@ -103,7 +108,7 @@ func MetricsDataSourceFactory(name string, parameters *json.Decoder, handle fwkp
 			ClientCertPath: cfg.ClientCertPath,
 			ClientKeyPath:  cfg.ClientKeyPath,
 		},
-		MetricsDataSourceType, name, parseMetrics, opts...)
+		MetricsDataSourceType, name, parser, opts...)
 }
 
 func defaultDataSourceConfigParams() *metricsDatasourceParams {
@@ -112,6 +117,33 @@ func defaultDataSourceConfigParams() *metricsDatasourceParams {
 		Path:               defaultMetricsPath,
 		InsecureSkipVerify: defaultMetricsInsecureSkipVerify,
 	}
+}
+
+// newFilteringParser returns a parser that discards the families no bound
+// extractor declared before handing the scrape to expfmt. A model server
+// exposes far more families than the endpoint picker reads, and parsing the
+// remainder costs CPU and garbage on every scrape of every endpoint.
+//
+// The returned selector must be fed by the data source's extractor hook. Until
+// an extractor declares a family the parser keeps the whole scrape, so a source
+// bound to extractors that do not implement FamilyNamer behaves as before.
+func newFilteringParser() (func(io.Reader) (PrometheusMetricMap, error), *familySelector) {
+	selector := &familySelector{}
+	return func(data io.Reader) (PrometheusMetricMap, error) {
+		want := selector.wanted()
+		if want == nil {
+			return parseMetrics(data)
+		}
+
+		buf, _ := bufferPool.Get().(*bytes.Buffer)
+		buf.Reset()
+		defer bufferPool.Put(buf)
+
+		if err := filterFamilies(buf, data, want); err != nil {
+			return nil, err
+		}
+		return parseMetrics(buf)
+	}, selector
 }
 
 func parseMetrics(data io.Reader) (PrometheusMetricMap, error) {

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
@@ -17,13 +17,8 @@ limitations under the License.
 package metrics
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
-
-	"github.com/prometheus/common/expfmt"
-	"github.com/prometheus/common/model"
 
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
@@ -68,9 +63,9 @@ type metricsDatasourceParams struct {
 // InsecureSkipVerify defaults to true (matching the factory default).
 // Use this function directly in tests to bypass JSON parameter marshaling.
 func NewHTTPMetricsDataSource(scheme, path, name string) (*http.HTTPDataSource[PrometheusMetricMap], error) {
-	parser, selector := newFilteringParser()
+	parser := newFamilyFilteringParser()
 	return http.NewHTTPDataSource(scheme, path, http.TLSOptions{SkipVerify: defaultMetricsInsecureSkipVerify},
-		MetricsDataSourceType, name, parser, http.WithExtractorHook(selector.observe))
+		MetricsDataSourceType, name, parser.parse, http.WithExtractorHook(parser.observeExtractor))
 }
 
 // MetricsDataSourceFactory is a factory function used to instantiate data layer's
@@ -98,8 +93,8 @@ func MetricsDataSourceFactory(name string, parameters *json.Decoder, handle fwkp
 		opts = append(opts, http.WithPortOverride(*cfg.Port))
 	}
 
-	parser, selector := newFilteringParser()
-	opts = append(opts, http.WithExtractorHook(selector.observe))
+	parser := newFamilyFilteringParser()
+	opts = append(opts, http.WithExtractorHook(parser.observeExtractor))
 
 	return http.NewHTTPDataSource(cfg.Scheme, cfg.Path,
 		http.TLSOptions{
@@ -108,7 +103,7 @@ func MetricsDataSourceFactory(name string, parameters *json.Decoder, handle fwkp
 			ClientCertPath: cfg.ClientCertPath,
 			ClientKeyPath:  cfg.ClientKeyPath,
 		},
-		MetricsDataSourceType, name, parser, opts...)
+		MetricsDataSourceType, name, parser.parse, opts...)
 }
 
 func defaultDataSourceConfigParams() *metricsDatasourceParams {
@@ -117,36 +112,4 @@ func defaultDataSourceConfigParams() *metricsDatasourceParams {
 		Path:               defaultMetricsPath,
 		InsecureSkipVerify: defaultMetricsInsecureSkipVerify,
 	}
-}
-
-// newFilteringParser returns a parser that discards the families no bound
-// extractor declared before handing the scrape to expfmt. A model server
-// exposes far more families than the endpoint picker reads, and parsing the
-// remainder costs CPU and garbage on every scrape of every endpoint.
-//
-// The returned selector must be fed by the data source's extractor hook. Until
-// an extractor declares a family the parser keeps the whole scrape, so a source
-// bound to extractors that do not implement FamilyNamer behaves as before.
-func newFilteringParser() (func(io.Reader) (PrometheusMetricMap, error), *familySelector) {
-	selector := &familySelector{}
-	return func(data io.Reader) (PrometheusMetricMap, error) {
-		want := selector.wanted()
-		if want == nil {
-			return parseMetrics(data)
-		}
-
-		buf, _ := bufferPool.Get().(*bytes.Buffer)
-		buf.Reset()
-		defer bufferPool.Put(buf)
-
-		if err := filterFamilies(buf, data, want); err != nil {
-			return nil, err
-		}
-		return parseMetrics(buf)
-	}, selector
-}
-
-func parseMetrics(data io.Reader) (PrometheusMetricMap, error) {
-	parser := expfmt.NewTextParser(model.LegacyValidation)
-	return parser.TextToMetricFamilies(data)
 }

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/filter.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/filter.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"sync"
+	"sync/atomic"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// FamilyNamer is the optional contract an extractor implements to declare the
+// Prometheus metric families it reads. The metrics data source unions the
+// declarations of its bound extractors and discards every other family before
+// parsing. An extractor that does not implement it forces a full parse, so the
+// interface is safe to adopt incrementally.
+type FamilyNamer interface {
+	MetricNames() []string
+}
+
+// suffixes a scrape may append to a family name for histogram and summary series.
+var seriesSuffixes = [...]string{"_bucket", "_sum", "_count"}
+
+// familySelector holds the union of family names the bound extractors declared.
+// Extractors bind during configuration and the set is read on every scrape, so
+// the resolved set is published through an atomic pointer rather than a mutex:
+// scrapes never contend with each other.
+type familySelector struct {
+	mu    sync.Mutex
+	names map[string]struct{}
+	// resolved is nil until at least one extractor declares a family. A nil
+	// value means "keep everything", which is the behaviour of a data source
+	// whose extractors do not implement FamilyNamer.
+	resolved atomic.Pointer[map[string]struct{}]
+}
+
+// observe records the families ext declares, if it declares any.
+func (s *familySelector) observe(ext fwkplugin.Plugin) {
+	namer, ok := ext.(FamilyNamer)
+	if !ok {
+		return
+	}
+	names := namer.MetricNames()
+	if len(names) == 0 {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.names == nil {
+		s.names = make(map[string]struct{}, len(names))
+	}
+	for _, name := range names {
+		if name != "" {
+			s.names[name] = struct{}{}
+		}
+	}
+	// Publish a copy so readers never observe a map being written.
+	published := make(map[string]struct{}, len(s.names))
+	for name := range s.names {
+		published[name] = struct{}{}
+	}
+	s.resolved.Store(&published)
+}
+
+// wanted returns the published set, or nil when no extractor declared anything.
+func (s *familySelector) wanted() map[string]struct{} {
+	if p := s.resolved.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// bufferPool recycles the scratch buffers filterFamilies writes into. A scrape
+// keeps only the families an extractor reads, so the buffer stays small and
+// steady-state scrapes allocate nothing.
+var bufferPool = sync.Pool{
+	New: func() any { return new(bytes.Buffer) },
+}
+
+// lineReaderPool recycles the readers used to split a scrape into lines.
+var lineReaderPool = sync.Pool{
+	New: func() any { return bufio.NewReaderSize(nil, defaultReadBufferSize) },
+}
+
+// defaultReadBufferSize is the initial line-splitting buffer. Lines longer than
+// this are handled by accumulating fragments, so the value bounds memory rather
+// than the accepted line length.
+const defaultReadBufferSize = 16 << 10
+
+// maxFamilyNameSize preallocates the buffer holding the family name in force.
+// Longer names still work; the buffer grows.
+const maxFamilyNameSize = 128
+
+// filterFamilies copies the text-exposition lines belonging to want from src
+// into dst, dropping everything else.
+//
+// A scrape groups a family's "# HELP"/"# TYPE" headers immediately before its
+// samples, so the decision made for a header usually carries to the samples
+// that follow it. Carrying it blindly would be wrong, because headers are
+// optional and a scrape may start a new family with a bare sample line, so a
+// sample is only granted the standing decision when its own name belongs to
+// the family that header named. Any other sample is matched on its own name.
+func filterFamilies(dst *bytes.Buffer, src io.Reader, want map[string]struct{}) error {
+	reader, _ := lineReaderPool.Get().(*bufio.Reader)
+	reader.Reset(src)
+	defer func() {
+		reader.Reset(nil)
+		lineReaderPool.Put(reader)
+	}()
+
+	var state filterState
+	state.family = make([]byte, 0, maxFamilyNameSize)
+	for {
+		line, err := readLine(reader)
+		if len(line) > 0 && state.keepLine(line, want) {
+			dst.Write(line)
+		}
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+// filterState carries the decision made for the family a header named, so the
+// samples that follow it are admitted without repeating the lookup.
+type filterState struct {
+	// family is the name from the most recent header, empty when no header is
+	// in force. It is copied because the line it came from is reused.
+	family []byte
+	// keep is the decision made for family.
+	keep bool
+}
+
+// keepLine reports whether line survives filtering, updating the state.
+func (s *filterState) keepLine(line []byte, want map[string]struct{}) bool {
+	trimmed := trimLeadingSpace(line)
+	if isBlank(trimmed) {
+		s.family = s.family[:0]
+		return false
+	}
+
+	if trimmed[0] == '#' {
+		name, ok := headerFamilyName(trimmed[1:])
+		if !ok {
+			// A free-form comment belongs to no family and ends none.
+			return false
+		}
+		s.family = append(s.family[:0], name...)
+		s.keep = matches(name, want)
+		return s.keep
+	}
+
+	name := sampleFamilyName(trimmed)
+	if len(s.family) > 0 && inFamily(name, s.family) {
+		return s.keep
+	}
+	// A sample that does not belong to the named family starts a new one.
+	s.family = s.family[:0]
+	return matches(name, want)
+}
+
+// inFamily reports whether a sample named name is a series of family.
+func inFamily(name, family []byte) bool {
+	if !bytes.HasPrefix(name, family) {
+		return false
+	}
+	rest := name[len(family):]
+	if len(rest) == 0 {
+		return true
+	}
+	for _, suffix := range seriesSuffixes {
+		if string(rest) == suffix {
+			return true
+		}
+	}
+	return false
+}
+
+// isBlank reports whether a line carries no content.
+func isBlank(line []byte) bool {
+	for _, c := range line {
+		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+			return false
+		}
+	}
+	return true
+}
+
+// headerFamilyName extracts the family name from a "# HELP name ..." or
+// "# TYPE name ..." line, with the leading '#' already removed. It reports
+// false for any other comment.
+func headerFamilyName(comment []byte) ([]byte, bool) {
+	rest := trimLeadingSpace(comment)
+	keyword := rest[:fieldEnd(rest)]
+	if !bytes.Equal(keyword, []byte("HELP")) && !bytes.Equal(keyword, []byte("TYPE")) {
+		return nil, false
+	}
+	rest = trimLeadingSpace(rest[len(keyword):])
+	name := rest[:fieldEnd(rest)]
+	if len(name) == 0 {
+		return nil, false
+	}
+	return name, true
+}
+
+// sampleFamilyName returns the metric name of a sample line, which ends at the
+// label list or at the whitespace before the value.
+func sampleFamilyName(line []byte) []byte {
+	for i := range line {
+		switch line[i] {
+		case '{', ' ', '\t', '\n', '\r':
+			return line[:i]
+		}
+	}
+	return line
+}
+
+// matches reports whether name, or the family it is a series of, is wanted.
+func matches(name []byte, want map[string]struct{}) bool {
+	if len(name) == 0 {
+		return false
+	}
+	// A []byte key in a map lookup does not allocate.
+	if _, ok := want[string(name)]; ok {
+		return true
+	}
+	for _, suffix := range seriesSuffixes {
+		base, found := bytes.CutSuffix(name, []byte(suffix))
+		if !found {
+			continue
+		}
+		if _, ok := want[string(base)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func trimLeadingSpace(b []byte) []byte {
+	for len(b) > 0 && (b[0] == ' ' || b[0] == '\t') {
+		b = b[1:]
+	}
+	return b
+}
+
+// fieldEnd returns the index that ends the leading whitespace-delimited field.
+func fieldEnd(b []byte) int {
+	for i := range b {
+		switch b[i] {
+		case ' ', '\t', '\n', '\r':
+			return i
+		}
+	}
+	return len(b)
+}
+
+// readLine returns one line including its terminator. Lines longer than the
+// reader's buffer are reassembled, so no scrape is rejected for line length.
+// The returned slice is only valid until the next call.
+func readLine(r *bufio.Reader) ([]byte, error) {
+	line, err := r.ReadSlice('\n')
+	if err != bufio.ErrBufferFull {
+		return line, err
+	}
+	// Rare path: the line exceeds the buffer, so copy it out and keep reading.
+	joined := make([]byte, len(line))
+	copy(joined, line)
+	for {
+		line, err = r.ReadSlice('\n')
+		joined = append(joined, line...)
+		if err != bufio.ErrBufferFull {
+			return joined, err
+		}
+	}
+}

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/filter_bench_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/filter_bench_test.go
@@ -86,23 +86,23 @@ func BenchmarkFilteringParser(b *testing.B) {
 	payload := vllmScrapeFixture()
 
 	b.Run("undeclared", func(b *testing.B) {
-		parse, _ := newFilteringParser()
+		parser := newFamilyFilteringParser()
 		b.ReportAllocs()
 		b.SetBytes(int64(len(payload)))
 		for b.Loop() {
-			if _, err := parse(strings.NewReader(payload)); err != nil {
+			if _, err := parser.parse(strings.NewReader(payload)); err != nil {
 				b.Fatal(err)
 			}
 		}
 	})
 
 	b.Run("declared", func(b *testing.B) {
-		parse, selector := newFilteringParser()
-		selector.observe(namerStub{names: vllmConsumedFamilies})
+		parser := newFamilyFilteringParser()
+		parser.observeExtractor(namerStub{names: vllmConsumedFamilies})
 		b.ReportAllocs()
 		b.SetBytes(int64(len(payload)))
 		for b.Loop() {
-			if _, err := parse(strings.NewReader(payload)); err != nil {
+			if _, err := parser.parse(strings.NewReader(payload)); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/filter_bench_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/filter_bench_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// BenchmarkParseScrape contrasts the cost of one scrape parsed whole against the
+// same scrape filtered to the families an extractor reads. Every endpoint is
+// scraped on its own ticker, so this cost scales with fleet size and is paid
+// whether or not the endpoint picker is serving traffic.
+func BenchmarkParseScrape(b *testing.B) {
+	payload := vllmScrapeFixture()
+	want := nameSet(vllmConsumedFamilies...)
+
+	b.Run("unfiltered", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(payload)))
+		for b.Loop() {
+			families, err := parseMetrics(strings.NewReader(payload))
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(families) == 0 {
+				b.Fatal("no families parsed")
+			}
+		}
+	})
+
+	b.Run("filtered", func(b *testing.B) {
+		var buf bytes.Buffer
+		b.ReportAllocs()
+		b.SetBytes(int64(len(payload)))
+		for b.Loop() {
+			buf.Reset()
+			if err := filterFamilies(&buf, strings.NewReader(payload), want); err != nil {
+				b.Fatal(err)
+			}
+			families, err := parseMetrics(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(families) != len(vllmConsumedFamilies) {
+				b.Fatalf("got %d families, want %d", len(families), len(vllmConsumedFamilies))
+			}
+		}
+	})
+}
+
+// BenchmarkFilterFamilies isolates the filter from the parse that follows it.
+func BenchmarkFilterFamilies(b *testing.B) {
+	payload := vllmScrapeFixture()
+	want := nameSet(vllmConsumedFamilies...)
+	var buf bytes.Buffer
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	for b.Loop() {
+		buf.Reset()
+		if err := filterFamilies(&buf, strings.NewReader(payload), want); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkFilteringParser measures the parser as the data source uses it,
+// including the pooled buffers.
+func BenchmarkFilteringParser(b *testing.B) {
+	payload := vllmScrapeFixture()
+
+	b.Run("undeclared", func(b *testing.B) {
+		parse, _ := newFilteringParser()
+		b.ReportAllocs()
+		b.SetBytes(int64(len(payload)))
+		for b.Loop() {
+			if _, err := parse(strings.NewReader(payload)); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("declared", func(b *testing.B) {
+		parse, selector := newFilteringParser()
+		selector.observe(namerStub{names: vllmConsumedFamilies})
+		b.ReportAllocs()
+		b.SetBytes(int64(len(payload)))
+		for b.Loop() {
+			if _, err := parse(strings.NewReader(payload)); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/filter_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/filter_test.go
@@ -281,10 +281,10 @@ func TestFamilySelectorPublishesSnapshots(t *testing.T) {
 }
 
 func TestFilteringParserFallsBackWithoutDeclarations(t *testing.T) {
-	parse, selector := newFilteringParser()
+	parser := newFamilyFilteringParser()
 	payload := vllmScrapeFixture()
 
-	families, err := parse(strings.NewReader(payload))
+	families, err := parser.parse(strings.NewReader(payload))
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -292,9 +292,9 @@ func TestFilteringParserFallsBackWithoutDeclarations(t *testing.T) {
 		t.Fatalf("undeclared parser kept %d families, expected the whole scrape", len(families))
 	}
 
-	selector.observe(namerStub{names: vllmConsumedFamilies})
+	parser.observeExtractor(namerStub{names: vllmConsumedFamilies})
 
-	families, err = parse(strings.NewReader(payload))
+	families, err = parser.parse(strings.NewReader(payload))
 	if err != nil {
 		t.Fatalf("parse after declaration: %v", err)
 	}
@@ -307,8 +307,8 @@ func TestFilteringParserFallsBackWithoutDeclarations(t *testing.T) {
 // source serves every endpoint it is configured for, and their collectors poll
 // on independent goroutines.
 func TestFilteringParserIsConcurrencySafe(t *testing.T) {
-	parse, selector := newFilteringParser()
-	selector.observe(namerStub{names: vllmConsumedFamilies})
+	parser := newFamilyFilteringParser()
+	parser.observeExtractor(namerStub{names: vllmConsumedFamilies})
 	payload := vllmScrapeFixture()
 
 	var wg sync.WaitGroup
@@ -318,7 +318,7 @@ func TestFilteringParserIsConcurrencySafe(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range 20 {
-				families, err := parse(strings.NewReader(payload))
+				families, err := parser.parse(strings.NewReader(payload))
 				if err != nil {
 					errs <- err
 					return

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/filter_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/filter_test.go
@@ -1,0 +1,338 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// namerStub is an extractor-shaped plugin that declares metric families.
+type namerStub struct {
+	names []string
+}
+
+func (n namerStub) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "stub", Name: "stub"}
+}
+func (n namerStub) MetricNames() []string { return n.names }
+
+// plainStub is a plugin that declares nothing, as extractors predating
+// FamilyNamer do.
+type plainStub struct{}
+
+func (plainStub) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "plain", Name: "plain"}
+}
+
+func nameSet(names ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		set[n] = struct{}{}
+	}
+	return set
+}
+
+func filterToString(t *testing.T, payload string, want map[string]struct{}) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := filterFamilies(&buf, strings.NewReader(payload), want); err != nil {
+		t.Fatalf("filterFamilies: %v", err)
+	}
+	return buf.String()
+}
+
+func TestFilterFamiliesKeepsOnlyWantedFamilies(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    map[string]struct{}
+		expect  string
+	}{
+		{
+			name: "drops unwanted family with its headers",
+			payload: "# HELP a_metric help.\n# TYPE a_metric gauge\na_metric 1\n" +
+				"# HELP b_metric help.\n# TYPE b_metric gauge\nb_metric 2\n",
+			want:   nameSet("a_metric"),
+			expect: "# HELP a_metric help.\n# TYPE a_metric gauge\na_metric 1\n",
+		},
+		{
+			name: "keeps histogram series of a wanted family",
+			payload: "# HELP h help.\n# TYPE h histogram\n" +
+				"h_bucket{le=\"1\"} 1\nh_sum 2\nh_count 3\n" +
+				"# HELP other help.\n# TYPE other counter\nother 9\n",
+			want: nameSet("h"),
+			expect: "# HELP h help.\n# TYPE h histogram\n" +
+				"h_bucket{le=\"1\"} 1\nh_sum 2\nh_count 3\n",
+		},
+		{
+			name:    "matches samples by name when headers are absent",
+			payload: "a_metric 1\nb_metric 2\na_metric{x=\"y\"} 3\n",
+			want:    nameSet("a_metric"),
+			expect:  "a_metric 1\na_metric{x=\"y\"} 3\n",
+		},
+		{
+			name:    "matches histogram series by name when headers are absent",
+			payload: "h_bucket{le=\"1\"} 1\nh_sum 2\nother_sum 5\n",
+			want:    nameSet("h"),
+			expect:  "h_bucket{le=\"1\"} 1\nh_sum 2\n",
+		},
+		{
+			name: "a free-form comment does not end the current family",
+			payload: "# HELP a help.\n# TYPE a gauge\n# a note\na 1\n" +
+				"# HELP b help.\n# TYPE b gauge\nb 2\n",
+			want:   nameSet("a"),
+			expect: "# HELP a help.\n# TYPE a gauge\na 1\n",
+		},
+		{
+			name:    "a blank line ends the current family",
+			payload: "# HELP a help.\n# TYPE a gauge\na 1\n\nb 2\n",
+			want:    nameSet("a"),
+			expect:  "# HELP a help.\n# TYPE a gauge\na 1\n",
+		},
+		{
+			name:    "a label value containing a brace does not confuse name scanning",
+			payload: "a{note=\"{b_metric}\"} 1\nb_metric 2\n",
+			want:    nameSet("a"),
+			expect:  "a{note=\"{b_metric}\"} 1\n",
+		},
+		{
+			name:    "a family whose name prefixes another is not confused with it",
+			payload: "a_metric 1\na_metric_extra 2\n",
+			want:    nameSet("a_metric"),
+			expect:  "a_metric 1\n",
+		},
+		{
+			name: "a bare sample after a wanted family is judged on its own name",
+			payload: "# HELP a help.\n# TYPE a gauge\na 1\n" +
+				"b 2\na_bucket 3\n",
+			want:   nameSet("a"),
+			expect: "# HELP a help.\n# TYPE a gauge\na 1\na_bucket 3\n",
+		},
+		{
+			name: "a bare sample after an unwanted family is judged on its own name",
+			payload: "# HELP z help.\n# TYPE z gauge\nz 1\n" +
+				"a 2\n",
+			want:   nameSet("a"),
+			expect: "a 2\n",
+		},
+		{
+			name: "a family named like a series of the previous one is judged on its own name",
+			payload: "# HELP a help.\n# TYPE a gauge\na 1\n" +
+				"# HELP a_count help.\n# TYPE a_count gauge\na_count 2\n",
+			want:   nameSet("a_count"),
+			expect: "# HELP a_count help.\n# TYPE a_count gauge\na_count 2\n",
+		},
+		{
+			name:    "final line without a trailing newline is kept",
+			payload: "a_metric 1",
+			want:    nameSet("a_metric"),
+			expect:  "a_metric 1",
+		},
+		{
+			name:    "empty want set drops everything",
+			payload: "a_metric 1\nb_metric 2\n",
+			want:    nameSet(),
+			expect:  "",
+		},
+		{
+			name:    "empty payload yields empty output",
+			payload: "",
+			want:    nameSet("a_metric"),
+			expect:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := filterToString(t, tc.payload, tc.want); got != tc.expect {
+				t.Errorf("filtered output mismatch\n got: %q\nwant: %q", got, tc.expect)
+			}
+		})
+	}
+}
+
+// TestFilterFamiliesHandlesLinesLongerThanReadBuffer covers the reassembly path:
+// a LoRA info metric can carry hundreds of adapter names on a single line.
+func TestFilterFamiliesHandlesLinesLongerThanReadBuffer(t *testing.T) {
+	adapters := strings.Repeat("adapter-with-a-long-name,", (defaultReadBufferSize/25)+64)
+	long := fmt.Sprintf("lora{running_lora_adapters=%q} 1\n", adapters)
+	payload := "dropped 0\n" + long + "also_dropped 0\n"
+
+	got := filterToString(t, payload, nameSet("lora"))
+	if got != long {
+		t.Errorf("long line not reassembled intact: got %d bytes, want %d", len(got), len(long))
+	}
+}
+
+// TestFilteredParseMatchesFullParse is the contract the optimization rests on:
+// for every family an extractor reads, parsing the filtered scrape must yield
+// exactly what parsing the whole scrape yields.
+func TestFilteredParseMatchesFullParse(t *testing.T) {
+	payload := vllmScrapeFixture()
+	want := nameSet(vllmConsumedFamilies...)
+
+	fullParser := expfmt.NewTextParser(model.LegacyValidation)
+	full, err := fullParser.TextToMetricFamilies(strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("full parse: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := filterFamilies(&buf, strings.NewReader(payload), want); err != nil {
+		t.Fatalf("filterFamilies: %v", err)
+	}
+	filteredParser := expfmt.NewTextParser(model.LegacyValidation)
+	filtered, err := filteredParser.TextToMetricFamilies(&buf)
+	if err != nil {
+		t.Fatalf("filtered parse: %v", err)
+	}
+
+	if len(filtered) != len(vllmConsumedFamilies) {
+		t.Fatalf("filtered parse produced %d families, want %d", len(filtered), len(vllmConsumedFamilies))
+	}
+	for _, name := range vllmConsumedFamilies {
+		expected, ok := full[name]
+		if !ok {
+			t.Fatalf("fixture does not expose %s", name)
+		}
+		got, ok := filtered[name]
+		if !ok {
+			t.Fatalf("filtered parse dropped %s", name)
+		}
+		if expected.String() != got.String() {
+			t.Errorf("%s differs after filtering\n full: %s\nfiltered: %s", name, expected, got)
+		}
+	}
+}
+
+func TestFamilySelectorUnionsDeclarations(t *testing.T) {
+	var s familySelector
+	if s.wanted() != nil {
+		t.Fatal("a selector with no declarations must keep everything")
+	}
+
+	s.observe(plainStub{})
+	if s.wanted() != nil {
+		t.Fatal("a plugin that declares nothing must keep everything")
+	}
+
+	s.observe(namerStub{names: []string{"a", "b"}})
+	s.observe(namerStub{names: []string{"b", "c"}})
+
+	got := s.wanted()
+	if len(got) != 3 {
+		t.Fatalf("union has %d names, want 3: %v", len(got), got)
+	}
+	for _, name := range []string{"a", "b", "c"} {
+		if _, ok := got[name]; !ok {
+			t.Errorf("union is missing %q", name)
+		}
+	}
+}
+
+func TestFamilySelectorIgnoresEmptyNames(t *testing.T) {
+	var s familySelector
+	s.observe(namerStub{names: []string{"", "a"}})
+
+	got := s.wanted()
+	if len(got) != 1 {
+		t.Fatalf("selector kept %d names, want 1: %v", len(got), got)
+	}
+	if _, ok := got["a"]; !ok {
+		t.Error("selector dropped the non-empty name")
+	}
+}
+
+// TestFamilySelectorPublishesSnapshots guards the read path: scrapes read the
+// selector concurrently while extractors may still be binding.
+func TestFamilySelectorPublishesSnapshots(t *testing.T) {
+	var s familySelector
+	s.observe(namerStub{names: []string{"a"}})
+	first := s.wanted()
+
+	s.observe(namerStub{names: []string{"b"}})
+
+	if _, leaked := first["b"]; leaked {
+		t.Error("a previously published set was mutated in place")
+	}
+}
+
+func TestFilteringParserFallsBackWithoutDeclarations(t *testing.T) {
+	parse, selector := newFilteringParser()
+	payload := vllmScrapeFixture()
+
+	families, err := parse(strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(families) <= len(vllmConsumedFamilies) {
+		t.Fatalf("undeclared parser kept %d families, expected the whole scrape", len(families))
+	}
+
+	selector.observe(namerStub{names: vllmConsumedFamilies})
+
+	families, err = parse(strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("parse after declaration: %v", err)
+	}
+	if len(families) != len(vllmConsumedFamilies) {
+		t.Fatalf("declared parser kept %d families, want %d", len(families), len(vllmConsumedFamilies))
+	}
+}
+
+// TestFilteringParserIsConcurrencySafe exercises the pooled buffers: one data
+// source serves every endpoint it is configured for, and their collectors poll
+// on independent goroutines.
+func TestFilteringParserIsConcurrencySafe(t *testing.T) {
+	parse, selector := newFilteringParser()
+	selector.observe(namerStub{names: vllmConsumedFamilies})
+	payload := vllmScrapeFixture()
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 64)
+	for range 64 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 20 {
+				families, err := parse(strings.NewReader(payload))
+				if err != nil {
+					errs <- err
+					return
+				}
+				if len(families) != len(vllmConsumedFamilies) {
+					errs <- fmt.Errorf("got %d families, want %d", len(families), len(vllmConsumedFamilies))
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+}

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/fixture_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/fixture_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// vllmConsumedFamilies is what the vLLM mapping in the metrics extractor reads.
+// The families a scrape exposes beyond these are parsed today and discarded.
+var vllmConsumedFamilies = []string{
+	"vllm:num_requests_waiting",
+	"vllm:num_requests_running",
+	"vllm:kv_cache_usage_perc",
+	"vllm:lora_requests_info",
+	"vllm:cache_config_info",
+}
+
+var (
+	fixtureOnce sync.Once
+	fixture     string
+)
+
+// vllmScrapeFixture approximates a vLLM /metrics response: the five families the
+// endpoint picker reads, plus the counters, histograms and process metrics it
+// does not. Shape and proportions follow a single-model vLLM server; a server
+// hosting several models or LoRA adapters emits proportionally more of the
+// families that are discarded.
+func vllmScrapeFixture() string {
+	fixtureOnce.Do(func() { fixture = buildVLLMScrape() })
+	return fixture
+}
+
+func buildVLLMScrape() string {
+	var b strings.Builder
+	const labels = `{model_name="meta-llama/Llama-3.1-8B-Instruct",engine="0"}`
+
+	gauge := func(name, value, lbl string) {
+		fmt.Fprintf(&b, "# HELP %s help text.\n# TYPE %s gauge\n%s%s %s\n", name, name, name, lbl, value)
+	}
+	gauge("vllm:num_requests_running", "12.0", labels)
+	gauge("vllm:num_requests_waiting", "3.0", labels)
+	gauge("vllm:kv_cache_usage_perc", "0.4213", labels)
+	gauge("vllm:lora_requests_info", "1.0",
+		`{max_lora="4",running_lora_adapters="adapter-a,adapter-b",waiting_lora_adapters=""}`)
+	gauge("vllm:cache_config_info", "1.0", `{block_size="16",num_gpu_blocks="32768"}`)
+
+	for _, name := range []string{
+		"vllm:prompt_tokens_total", "vllm:generation_tokens_total",
+		"vllm:num_preemptions_total", "vllm:request_success_total",
+		"vllm:gpu_prefix_cache_queries_total", "vllm:gpu_prefix_cache_hits_total",
+		"vllm:num_requests_swapped", "vllm:cpu_cache_usage_perc",
+		"vllm:gpu_cache_usage_perc", "vllm:iteration_tokens_total_sum",
+	} {
+		fmt.Fprintf(&b, "# HELP %s help text.\n# TYPE %s counter\n%s%s 123456.0\n", name, name, name, labels)
+	}
+
+	buckets := []string{
+		"0.001", "0.005", "0.01", "0.02", "0.04", "0.06", "0.08", "0.1",
+		"0.25", "0.5", "0.75", "1.0", "2.5", "5.0", "7.5", "10.0", "20.0",
+		"40.0", "80.0", "+Inf",
+	}
+	for _, name := range []string{
+		"vllm:time_to_first_token_seconds", "vllm:time_per_output_token_seconds",
+		"vllm:e2e_request_latency_seconds", "vllm:request_queue_time_seconds",
+		"vllm:request_inference_time_seconds", "vllm:request_prefill_time_seconds",
+		"vllm:request_decode_time_seconds", "vllm:request_prompt_tokens",
+		"vllm:request_generation_tokens", "vllm:request_max_num_generation_tokens",
+		"vllm:request_params_n", "vllm:request_params_max_tokens",
+		"vllm:iteration_tokens_total", "vllm:time_in_queue_requests",
+		"vllm:model_forward_time_milliseconds",
+	} {
+		fmt.Fprintf(&b, "# HELP %s help text.\n# TYPE %s histogram\n", name, name)
+		for i, le := range buckets {
+			fmt.Fprintf(&b, "%s_bucket{model_name=%q,engine=\"0\",le=%q} %d.0\n",
+				name, "meta-llama/Llama-3.1-8B-Instruct", le, (i+1)*37)
+		}
+		fmt.Fprintf(&b, "%s_sum%s 4321.5\n%s_count%s 740.0\n", name, labels, name, labels)
+	}
+
+	for _, name := range []string{
+		"python_gc_objects_collected_total", "python_gc_objects_uncollectable_total",
+		"python_gc_collections_total", "process_virtual_memory_bytes",
+		"process_resident_memory_bytes", "process_start_time_seconds",
+		"process_cpu_seconds_total", "process_open_fds", "process_max_fds",
+	} {
+		fmt.Fprintf(&b, "# HELP %s help.\n# TYPE %s counter\n%s{generation=\"0\"} 99.0\n", name, name, name)
+	}
+
+	return b.String()
+}

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/parser.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/parser.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+)
+
+// familyFilteringParser discards the families no bound extractor declared
+// before handing the scrape to expfmt. A model server exposes far more families
+// than the endpoint picker reads, and parsing the remainder costs CPU and
+// garbage on every scrape of every endpoint.
+type familyFilteringParser struct {
+	selector familySelector
+}
+
+func newFamilyFilteringParser() *familyFilteringParser {
+	return &familyFilteringParser{}
+}
+
+// observeExtractor feeds the parser's selector from the data source's extractor
+// hook. Until an extractor declares a family the parser keeps the whole scrape,
+// so a source bound to extractors that do not implement FamilyNamer behaves as
+// before.
+func (p *familyFilteringParser) observeExtractor(ext fwkplugin.Plugin) {
+	p.selector.observe(ext)
+}
+
+func (p *familyFilteringParser) parse(data io.Reader) (PrometheusMetricMap, error) {
+	want := p.selector.wanted()
+	if want == nil {
+		return parseMetrics(data)
+	}
+
+	buf, _ := bufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer bufferPool.Put(buf)
+
+	if err := filterFamilies(buf, data, want); err != nil {
+		return nil, err
+	}
+	return parseMetrics(buf)
+}
+
+func parseMetrics(data io.Reader) (PrometheusMetricMap, error) {
+	parser := expfmt.NewTextParser(model.LegacyValidation)
+	return parser.TextToMetricFamilies(data)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR reduces model-server metrics parsing overhead in the EPP data layer.

`core-metrics-extractor` now declares the Prometheus metric families it consumes based on the existing engine metric mappings. `metrics-data-source` uses those declarations to filter model-server `/metrics` responses before passing them to the Prometheus text parser.

This avoids parsing metric families that EPP does not use for scheduling, such as extra runtime/process metrics exposed by vLLM.

The behavior is conservative: if no bound extractor declares metric families, the data source keeps the existing full-parse behavior.

**Which issue(s) this PR fixes**:

Fixes #2441

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE