### PR TITLE
chore: correct copyright attribution across migrated and llm-d-original files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ check-latest-tags-strict: ## Check ':latest' image tags in YAML (strict; fails o
 
 .PHONY: presubmit
 presubmit: LINT_NEW_ONLY=true
-presubmit: git-branch-check signed-commits-check go-mod-check format lint vulncheck check-latest-tags-strict
+presubmit: git-branch-check signed-commits-check go-mod-check format lint vulncheck check-latest-tags-strict verify-boilerplate
 
 .PHONY: git-branch-check
 git-branch-check:
@@ -342,6 +342,10 @@ post-deploy-test: ## Run post deployment tests
 .PHONY: verify-manifests
 verify-manifests: kubectl-validate ## Validate deployment manifests.
 	KUBECTL_VALIDATE="$(KUBECTL_VALIDATE)" hack/verify-manifests.sh
+
+.PHONY: verify-boilerplate
+verify-boilerplate: ## Check that .go and .sh files carry a copyright notice.
+	hack/copyright.sh verify
 
 ##@ Helm
 

--- a/apix/config/v1alpha1/doc.go
+++ b/apix/config/v1alpha1/doc.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/apix/config/v1alpha1/endpointpickerconfig_types.go
+++ b/apix/config/v1alpha1/endpointpickerconfig_types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/apix/config/v1alpha1/endpointpickerconfig_types_test.go
+++ b/apix/config/v1alpha1/endpointpickerconfig_types_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/apix/v1alpha2/doc.go
+++ b/apix/v1alpha2/doc.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/apix/v1alpha2/inferencemodelrewrite_types.go
+++ b/apix/v1alpha2/inferencemodelrewrite_types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/apix/v1alpha2/inferenceobjective_types.go
+++ b/apix/v1alpha2/inferenceobjective_types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/epp/main.go
+++ b/cmd/epp/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/epp/runner/feature_gate_test.go
+++ b/cmd/epp/runner/feature_gate_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/epp/runner/health.go
+++ b/cmd/epp/runner/health.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/epp/runner/health_test.go
+++ b/cmd/epp/runner/health_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/epp/runner/multicluster_config_test.go
+++ b/cmd/epp/runner/multicluster_config_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/epp/runner/resolve_discovery_test.go
+++ b/cmd/epp/runner/resolve_discovery_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/epp/runner/run_with_file_discovery_test.go
+++ b/cmd/epp/runner/run_with_file_discovery_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/epp/runner/rungroup.go
+++ b/cmd/epp/runner/rungroup.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/epp/runner/test_runner.go
+++ b/cmd/epp/runner/test_runner.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/copyright.sh
+++ b/hack/copyright.sh
@@ -172,8 +172,7 @@ cmd_fix() {
         continue
         ;;
     esac
-    chmod --reference="${f}" "${tmp}"
-    mv "${tmp}" "${f}"
+    cat "${tmp}" > "${f}" && rm -f "${tmp}"
     echo "fixed: ${f}"
     fixed=$((fixed + 1))
   done < <(in_scope_files)

--- a/hack/copyright.sh
+++ b/hack/copyright.sh
@@ -172,6 +172,7 @@ cmd_fix() {
         continue
         ;;
     esac
+    chmod --reference="${f}" "${tmp}"
     mv "${tmp}" "${f}"
     echo "fixed: ${f}"
     fixed=$((fixed + 1))

--- a/hack/copyright.sh
+++ b/hack/copyright.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Manage copyright notices across .go and .sh files.
+#
+# Files migrated from sigs.k8s.io/gateway-api-inference-extension (GAIE) carry
+# "The Kubernetes Authors"; files that originated in llm-d org repos carry
+# "The llm-d Authors"; GAIE-derived files later modified here carry both.
+#
+# Usage:
+#   hack/copyright.sh verify     Fail if any in-scope file has no recognized
+#                                notice. Does not check which notice; that is
+#                                a provenance question, not a syntax one. This
+#                                is the default and the make presubmit gate.
+#   hack/copyright.sh fix        Insert the llm-d notice into files that have
+#                                no notice at all. Never touches a file that
+#                                already carries any notice - see 'classify'
+#                                for files whose existing notice is wrong.
+#   hack/copyright.sh classify   Report provenance per file, derived from
+#                                local git history, to guide manually
+#                                correcting misattributed notices.
+#
+# Generated files ("Code generated ... DO NOT EDIT." in the first 5 lines)
+# are skipped in every mode.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+MODE="${1:-verify}"
+
+# GAIE commits are self-identifying: scripts/migrate-gaie-paths.sh rewrites bare
+# #NNN issue refs in migrated commit messages to this qualified form.
+GAIE_MARKER='kubernetes-sigs/gateway-api-inference-extension#'
+# Commits that only rewrite import paths after a migration; their bodies record
+# the exact src -> dest map and introduce no new code.
+MECHANICAL_GREP=(--grep='^chore: rewrite imports from' --grep='^chore: rename go model')
+
+LLMD_RE='Copyright [0-9]{4}(, [0-9]{4})* The llm-d Authors\.'
+K8S_RE='Copyright [0-9]{4}(, [0-9]{4})* The Kubernetes Authors\.'
+GENERATED_RE='Code generated .* DO NOT EDIT\.'
+
+LLMD_BLOCK_GO='/*
+Copyright %s The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'
+
+LLMD_BLOCK_SH='# Copyright %s The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'
+
+in_scope_files() {
+  git ls-files '*.go' '*.sh'
+}
+
+is_generated() {
+  head -5 "$1" | grep -qE "${GENERATED_RE}"
+}
+
+has_llmd_notice() { grep -qE "${LLMD_RE}" "$1"; }
+has_k8s_notice()  { grep -qE "${K8S_RE}" "$1"; }
+has_any_notice()  { has_llmd_notice "$1" || has_k8s_notice "$1"; }
+
+# Year of a file's first commit, following renames; falls back to the current
+# year for files git has never seen (new, uncommitted files).
+creation_year() {
+  local year
+  year=$(git log --follow --diff-filter=A --format=%ad --date=format:%Y -- "$1" | tail -1)
+  echo "${year:-$(date +%Y)}"
+}
+
+cmd_verify() {
+  local missing=()
+  local f
+  while IFS= read -r f; do
+    is_generated "${f}" && continue
+    has_any_notice "${f}" || missing+=("${f}")
+  done < <(in_scope_files)
+
+  if [[ ${#missing[@]} -eq 0 ]]; then
+    echo "All in-scope files carry a recognized copyright notice."
+    return 0
+  fi
+
+  echo "ERROR: the following files have no recognized copyright notice:"
+  printf '  %s\n' "${missing[@]}"
+  return 1
+}
+
+cmd_fix() {
+  local fixed=0
+  local f
+  while IFS= read -r f; do
+    is_generated "${f}" && continue
+    has_any_notice "${f}" && continue
+
+    local year block tmp
+    year=$(creation_year "${f}")
+    tmp=$(mktemp)
+    case "${f}" in
+      *.go)
+        # A leading //go:build (or legacy // +build) constraint must stay the
+        # very first thing in the file, ahead of the license block, or
+        # gofmt moves it there itself.
+        local build_lines=0
+        if [[ "$(head -1 "${f}")" == '//go:build'* || "$(head -1 "${f}")" == '// +build'* ]]; then
+          build_lines=$(awk '/^\/\/go:build|^\/\/ \+build|^$/{n++; next} {exit} END{print n+0}' "${f}")
+        fi
+        if [[ "${build_lines}" -gt 0 ]]; then
+          head -n "${build_lines}" "${f}" > "${tmp}"
+          printf "${LLMD_BLOCK_GO}" "${year}" >> "${tmp}"
+          tail -n +"$((build_lines + 1))" "${f}" >> "${tmp}"
+        else
+          printf "${LLMD_BLOCK_GO}" "${year}" > "${tmp}"
+          cat "${f}" >> "${tmp}"
+        fi
+        ;;
+      *.sh)
+        if [[ "$(head -1 "${f}")" == '#!'* ]]; then
+          head -1 "${f}" > "${tmp}"
+          echo >> "${tmp}"
+          printf "${LLMD_BLOCK_SH}" "${year}" >> "${tmp}"
+          tail -n +2 "${f}" >> "${tmp}"
+        else
+          printf "${LLMD_BLOCK_SH}" "${year}" > "${tmp}"
+          cat "${f}" >> "${tmp}"
+        fi
+        ;;
+      *)
+        rm -f "${tmp}"
+        continue
+        ;;
+    esac
+    mv "${tmp}" "${f}"
+    echo "fixed: ${f}"
+    fixed=$((fixed + 1))
+  done < <(in_scope_files)
+  echo "${fixed} file(s) updated"
+}
+
+cmd_classify() {
+  echo "Building GAIE-commit marker set..." >&2
+  local gaie_file mech_file notlocal_file
+  gaie_file=$(mktemp); mech_file=$(mktemp); notlocal_file=$(mktemp)
+  trap 'rm -f "${gaie_file}" "${mech_file}" "${notlocal_file}"' RETURN
+
+  git log --format=%H --grep="${GAIE_MARKER}" -F | sort -u > "${gaie_file}"
+  git log --format=%H "${MECHANICAL_GREP[@]}" | sort -u > "${mech_file}"
+  sort -mu "${gaie_file}" "${mech_file}" > "${notlocal_file}"
+
+  local gaie_count mech_count total_count
+  gaie_count=$(wc -l < "${gaie_file}")
+  mech_count=$(wc -l < "${mech_file}")
+  total_count=$(git rev-list --count HEAD)
+  echo "GAIE-marked commits: ${gaie_count} / ${total_count} total"
+  echo "Mechanical import-rewrite commits: ${mech_count}"
+  echo
+
+  local llmd_only=0 k8s_only=0 both=0
+  local f origin creator
+  while IFS= read -r f; do
+    creator=$(git log --follow --diff-filter=A --format=%H -- "${f}" | tail -1)
+    if [[ -z "${creator}" ]]; then
+      creator=$(git log --format=%H -- "${f}" | tail -1)
+    fi
+    if grep -qxF "${creator}" "${gaie_file}"; then
+      origin="GAIE"
+    else
+      origin="LLMD"
+    fi
+
+    local has_l has_k
+    has_llmd_notice "${f}" && has_l=1 || has_l=0
+    has_k8s_notice "${f}" && has_k=1 || has_k=0
+
+    if [[ "${origin}" == "LLMD" ]]; then
+      llmd_only=$((llmd_only + 1))
+      [[ "${has_k}" == 1 ]] && echo "MISATTRIBUTED(llm-d origin, k8s notice, needs human review): ${f}"
+    else
+      # GAIE origin: k8s-only vs both depends on whether local history added
+      # real changes beyond the mechanical import rewrite.
+      local touches
+      touches=$(comm -23 <(git log --follow --format=%H -- "${f}" | sort -u) "${notlocal_file}" | wc -l)
+      if [[ "${touches}" -eq 0 ]]; then
+        k8s_only=$((k8s_only + 1))
+        [[ "${has_l}" == 1 && "${has_k}" == 0 ]] && \
+          echo "NEEDS-K8S-NOTICE(unmodified GAIE import, llm-d-only notice): ${f}"
+        [[ "${has_l}" == 0 && "${has_k}" == 0 ]] && \
+          echo "NEEDS-K8S-NOTICE(unmodified GAIE import, no notice): ${f}"
+      else
+        both=$((both + 1))
+        [[ "${has_l}" == 0 ]] && echo "NEEDS-LLMD-NOTICE(modified GAIE import): ${f}"
+      fi
+    fi
+  done < <(in_scope_files | grep '\.go$')
+
+  echo
+  echo "Summary (Go files):"
+  echo "  llm-d origin:        ${llmd_only}"
+  echo "  Kubernetes only:     ${k8s_only}"
+  echo "  Both (GAIE + local): ${both}"
+}
+
+case "${MODE}" in
+  verify)   cmd_verify ;;
+  fix)      cmd_fix ;;
+  classify) cmd_classify ;;
+  *)
+    echo "usage: $0 [verify|fix|classify]" >&2
+    exit 2
+    ;;
+esac

--- a/hack/copyright.sh
+++ b/hack/copyright.sh
@@ -232,6 +232,8 @@ cmd_classify() {
       else
         both=$((both + 1))
         [[ "${has_l}" == 0 ]] && echo "NEEDS-LLMD-NOTICE(modified GAIE import): ${f}"
+        [[ "${has_l}" == 1 && "${has_k}" == 0 ]] && \
+          echo "NEEDS-K8S-NOTICE(modified GAIE import, llm-d-only notice): ${f}"
       fi
     fi
   done < <(in_scope_files | grep '\.go$')

--- a/hack/referencer.go
+++ b/hack/referencer.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2024 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/runnable/grpc.go
+++ b/internal/runnable/grpc.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/runnable/leader_election.go
+++ b/internal/runnable/leader_election.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package runnable
 
 import "sigs.k8s.io/controller-runtime/pkg/manager"

--- a/pkg/common/envoy/metadata.go
+++ b/pkg/common/envoy/metadata.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/common/envoy/metadata_test.go
+++ b/pkg/common/envoy/metadata_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/common/error/error.go
+++ b/pkg/common/error/error.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/common/error/error_test.go
+++ b/pkg/common/error/error_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/common/observability/logging/logger.go
+++ b/pkg/common/observability/logging/logger.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/common/observability/metrics/metrics.go
+++ b/pkg/common/observability/metrics/metrics.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/common/observability/profiling/pprof.go
+++ b/pkg/common/observability/profiling/pprof.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/common/observability/tracing/telemetry.go
+++ b/pkg/common/observability/tracing/telemetry.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/common/observability/tracing/telemetry_otlp_test.go
+++ b/pkg/common/observability/tracing/telemetry_otlp_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/common/observability/tracing/telemetry_test.go
+++ b/pkg/common/observability/tracing/telemetry_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/common/routing/common.go
+++ b/pkg/common/routing/common.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package routing contains routing constants and utilities shared between
 // the EPP/Inference-Scheduler and the Routing Sidecar.
 //

--- a/pkg/common/routing/common_test.go
+++ b/pkg/common/routing/common_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package routing contains routing constants and utilities shared between
 // the EPP/Inference-Scheduler and the Routing Sidecar.
 //

--- a/pkg/epp/config/config.go
+++ b/pkg/epp/config/config.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/config/loader/configloader.go
+++ b/pkg/epp/config/loader/configloader.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/config/loader/configloader_test.go
+++ b/pkg/epp/config/loader/configloader_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/config/loader/defaults.go
+++ b/pkg/epp/config/loader/defaults.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/config/loader/defaults_test.go
+++ b/pkg/epp/config/loader/defaults_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/config/loader/flowcontrol_test.go
+++ b/pkg/epp/config/loader/flowcontrol_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/config/loader/testdata_test.go
+++ b/pkg/epp/config/loader/testdata_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/config/loader/validation.go
+++ b/pkg/epp/config/loader/validation.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/controller/inferencemodelrewrite_reconciler.go
+++ b/pkg/epp/controller/inferencemodelrewrite_reconciler.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/controller/inferencemodelrewrite_reconciler_test.go
+++ b/pkg/epp/controller/inferencemodelrewrite_reconciler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/controller/inferenceobjective_reconciler.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/controller/inferenceobjective_reconciler_test.go
+++ b/pkg/epp/controller/inferenceobjective_reconciler_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/controller/inferencepool_reconciler.go
+++ b/pkg/epp/controller/inferencepool_reconciler.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/controller/inferencepool_reconciler_test.go
+++ b/pkg/epp/controller/inferencepool_reconciler_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/controller/pod_reconciler.go
+++ b/pkg/epp/controller/pod_reconciler.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/controller/pod_reconciler_test.go
+++ b/pkg/epp/controller/pod_reconciler_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/controller/setup_test.go
+++ b/pkg/epp/controller/setup_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/collector.go
+++ b/pkg/epp/datalayer/collector.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/collector_test.go
+++ b/pkg/epp/datalayer/collector_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/config.go
+++ b/pkg/epp/datalayer/config.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/data_graph.go
+++ b/pkg/epp/datalayer/data_graph.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/endpoint_pool.go
+++ b/pkg/epp/datalayer/endpoint_pool.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/endpoint_scope.go
+++ b/pkg/epp/datalayer/endpoint_scope.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/endpoint_scope_bench_test.go
+++ b/pkg/epp/datalayer/endpoint_scope_bench_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/endpoint_scope_test.go
+++ b/pkg/epp/datalayer/endpoint_scope_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/factory.go
+++ b/pkg/epp/datalayer/factory.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/factory_test.go
+++ b/pkg/epp/datalayer/factory_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/k8s_bind.go
+++ b/pkg/epp/datalayer/k8s_bind.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/logger/logger.go
+++ b/pkg/epp/datalayer/logger/logger.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/logger/logger_test.go
+++ b/pkg/epp/datalayer/logger/logger_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/manager.go
+++ b/pkg/epp/datalayer/manager.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/manager_test.go
+++ b/pkg/epp/datalayer/manager_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package datalayer
 
 import (

--- a/pkg/epp/datalayer/runtime.go
+++ b/pkg/epp/datalayer/runtime.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/runtime_endpoint_dispatch_test.go
+++ b/pkg/epp/datalayer/runtime_endpoint_dispatch_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/runtime_registrar_test.go
+++ b/pkg/epp/datalayer/runtime_registrar_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/runtime_validate_test.go
+++ b/pkg/epp/datalayer/runtime_validate_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datalayer/test_runtime.go
+++ b/pkg/epp/datalayer/test_runtime.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datastore/datastore_test.go
+++ b/pkg/epp/datastore/datastore_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datastore/modelrewritestore.go
+++ b/pkg/epp/datastore/modelrewritestore.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/datastore/modelrewritestore_test.go
+++ b/pkg/epp/datastore/modelrewritestore_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/benchmark/benchmark_test.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/benchmark/helpers_test.go
+++ b/pkg/epp/flowcontrol/benchmark/helpers_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/config.go
+++ b/pkg/epp/flowcontrol/config.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/config_test.go
+++ b/pkg/epp/flowcontrol/config_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/contracts/errors.go
+++ b/pkg/epp/flowcontrol/contracts/errors.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/contracts/mocks/mocks.go
+++ b/pkg/epp/flowcontrol/contracts/mocks/mocks.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/contracts/registry.go
+++ b/pkg/epp/flowcontrol/contracts/registry.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/controller/config.go
+++ b/pkg/epp/flowcontrol/controller/config.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/controller/config_test.go
+++ b/pkg/epp/flowcontrol/controller/config_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/controller/doc.go
+++ b/pkg/epp/flowcontrol/controller/doc.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/controller/internal/doc.go
+++ b/pkg/epp/flowcontrol/controller/internal/doc.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/eviction/eviction_registry.go
+++ b/pkg/epp/flowcontrol/eviction/eviction_registry.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/eviction/eviction_registry_test.go
+++ b/pkg/epp/flowcontrol/eviction/eviction_registry_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/eviction/evictor.go
+++ b/pkg/epp/flowcontrol/eviction/evictor.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/eviction/evictor_test.go
+++ b/pkg/epp/flowcontrol/eviction/evictor_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/eviction/request_evictor.go
+++ b/pkg/epp/flowcontrol/eviction/request_evictor.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/eviction/request_evictor_test.go
+++ b/pkg/epp/flowcontrol/eviction/request_evictor_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/integration_helpers_test.go
+++ b/pkg/epp/flowcontrol/integration_helpers_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/integration_test.go
+++ b/pkg/epp/flowcontrol/integration_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/queue/benchmark_test.go
+++ b/pkg/epp/flowcontrol/queue/benchmark_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/registry/config.go
+++ b/pkg/epp/flowcontrol/registry/config.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/registry/config_test.go
+++ b/pkg/epp/flowcontrol/registry/config_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/registry/connection.go
+++ b/pkg/epp/flowcontrol/registry/connection.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/registry/doc.go
+++ b/pkg/epp/flowcontrol/registry/doc.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/registry/managedqueue.go
+++ b/pkg/epp/flowcontrol/registry/managedqueue.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/registry/managedqueue_test.go
+++ b/pkg/epp/flowcontrol/registry/managedqueue_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/registry/registry.go
+++ b/pkg/epp/flowcontrol/registry/registry.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/registry/registry_helpers.go
+++ b/pkg/epp/flowcontrol/registry/registry_helpers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/registry/registry_helpers_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_helpers_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/registry/registry_test.go
+++ b/pkg/epp/flowcontrol/registry/registry_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/types/errors.go
+++ b/pkg/epp/flowcontrol/types/errors.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/flowcontrol/types/outcomes.go
+++ b/pkg/epp/flowcontrol/types/outcomes.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/common/request/headers.go
+++ b/pkg/epp/framework/common/request/headers.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/common/request/headers_test.go
+++ b/pkg/epp/framework/common/request/headers_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/datalayer/attributemap.go
+++ b/pkg/epp/framework/interface/datalayer/attributemap.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/datalayer/attributemap_test.go
+++ b/pkg/epp/framework/interface/datalayer/attributemap_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/datalayer/discovery.go
+++ b/pkg/epp/framework/interface/datalayer/discovery.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/datalayer/discovery_test.go
+++ b/pkg/epp/framework/interface/datalayer/discovery_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
+++ b/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/datalayer/endpoint_metadata_test.go
+++ b/pkg/epp/framework/interface/datalayer/endpoint_metadata_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/datalayer/plugin.go
+++ b/pkg/epp/framework/interface/datalayer/plugin.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/datalayer/registrar.go
+++ b/pkg/epp/framework/interface/datalayer/registrar.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/flowcontrol/accessors.go
+++ b/pkg/epp/framework/interface/flowcontrol/accessors.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/flowcontrol/doc.go
+++ b/pkg/epp/framework/interface/flowcontrol/doc.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/flowcontrol/flow.go
+++ b/pkg/epp/framework/interface/flowcontrol/flow.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/flowcontrol/mocks/mocks.go
+++ b/pkg/epp/framework/interface/flowcontrol/mocks/mocks.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/flowcontrol/plugins.go
+++ b/pkg/epp/framework/interface/flowcontrol/plugins.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/flowcontrol/queue.go
+++ b/pkg/epp/framework/interface/flowcontrol/queue.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/flowcontrol/request.go
+++ b/pkg/epp/framework/interface/flowcontrol/request.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/datakey.go
+++ b/pkg/epp/framework/interface/plugin/datakey.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/datakey_test.go
+++ b/pkg/epp/framework/interface/plugin/datakey_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/handle.go
+++ b/pkg/epp/framework/interface/plugin/handle.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/handle_test.go
+++ b/pkg/epp/framework/interface/plugin/handle_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/metrics_recorder.go
+++ b/pkg/epp/framework/interface/plugin/metrics_recorder.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/plugin_state.go
+++ b/pkg/epp/framework/interface/plugin/plugin_state.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/plugin_state_test.go
+++ b/pkg/epp/framework/interface/plugin/plugin_state_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/plugins.go
+++ b/pkg/epp/framework/interface/plugin/plugins.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/plugins_test.go
+++ b/pkg/epp/framework/interface/plugin/plugins_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/registry.go
+++ b/pkg/epp/framework/interface/plugin/registry.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/registry_test.go
+++ b/pkg/epp/framework/interface/plugin/registry_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/shared_state.go
+++ b/pkg/epp/framework/interface/plugin/shared_state.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/shared_state_test.go
+++ b/pkg/epp/framework/interface/plugin/shared_state_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/stability.go
+++ b/pkg/epp/framework/interface/plugin/stability.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/plugin/typedname_test.go
+++ b/pkg/epp/framework/interface/plugin/typedname_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/requestcontrol/types.go
+++ b/pkg/epp/framework/interface/requestcontrol/types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/requesthandling/plugins.go
+++ b/pkg/epp/framework/interface/requesthandling/plugins.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/requesthandling/types_test.go
+++ b/pkg/epp/framework/interface/requesthandling/types_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/scheduling/attributes.go
+++ b/pkg/epp/framework/interface/scheduling/attributes.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/scheduling/attributes_test.go
+++ b/pkg/epp/framework/interface/scheduling/attributes_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/scheduling/plugins.go
+++ b/pkg/epp/framework/interface/scheduling/plugins.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/scheduling/plugins_test.go
+++ b/pkg/epp/framework/interface/scheduling/plugins_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/interface/scheduling/types_test.go
+++ b/pkg/epp/framework/interface/scheduling/types_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/attribute/concurrency/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/concurrency/data_types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/attribute/latency/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/latency/data_types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/attribute/metrics/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/metrics/data_types.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2025 The Kubernetes Authors.
 Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/epp/framework/plugins/datalayer/attribute/metrics/data_types_multicluster.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/metrics/data_types_multicluster.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/attribute/models/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/models/data_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types_test.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/attribute/session/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/session/data_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/attribute/topology/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/topology/data_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/multicluster.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/multicluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/multicluster_test.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/multicluster_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/discovery/file/plugin_test.go
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/plugin_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/loraspec.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/loraspec.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping_registry.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping_registry.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/multicluster.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/multicluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/multicluster_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/multicluster_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/mocks/endpoint_extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/mocks/endpoint_extractor.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/mocks/k8s_notification_extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/mocks/k8s_notification_extractor.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/models/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/models/extractor.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package models
 
 import (

--- a/pkg/epp/framework/plugins/datalayer/extractor/models/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/models/extractor_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package models
 
 import (

--- a/pkg/epp/framework/plugins/datalayer/extractor/topology/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/topology/extractor.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/extractor/topology/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/topology/extractor_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/http/client.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/client.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource_catls_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource_catls_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource_isolation_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource_isolation_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package http
 
 import (

--- a/pkg/epp/framework/plugins/datalayer/source/http/httptest/parsercontract.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/httptest/parsercontract.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package httptest provides test helpers for HTTPDataSource parser
 // implementations.
 package httptest

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_config_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_config_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/multicluster.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/multicluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/multicluster_security_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/multicluster_security_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/multicluster_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/multicluster_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/parsercontract_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/parsercontract_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package metrics
 
 import (

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/types.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/mocks/data_source_mock.go
+++ b/pkg/epp/framework/plugins/datalayer/source/mocks/data_source_mock.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/models/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/datasource.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package models
 
 import (

--- a/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package models
 package models
 

--- a/pkg/epp/framework/plugins/datalayer/source/models/parsercontract_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/parsercontract_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package models
 
 import (

--- a/pkg/epp/framework/plugins/datalayer/source/notifications/endpoint_datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/notifications/endpoint_datasource.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/notifications/endpoint_datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/notifications/endpoint_datasource_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/notifications/factory.go
+++ b/pkg/epp/framework/plugins/datalayer/source/notifications/factory.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/notifications/k8s_datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/notifications/k8s_datasource.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/datalayer/source/notifications/k8s_datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/notifications/k8s_datasource_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/eviction/filtering/sheddable.go
+++ b/pkg/epp/framework/plugins/flowcontrol/eviction/filtering/sheddable.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/eviction/ordering/priority_time.go
+++ b/pkg/epp/framework/plugins/flowcontrol/eviction/ordering/priority_time.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/functional_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/functional_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict/global_strict.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict/global_strict.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict/global_strict_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/globalstrict/global_strict_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package programaware implements a flow-control fairness policy that
 // schedules per-program queues using a swappable scoring strategy.
 package programaware

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package programaware
 
 import (

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/programmetrics.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/programmetrics.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package programaware
 
 import (

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/programmetrics_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/programmetrics_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package programaware
 
 import (

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/prometheus.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/prometheus.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package programaware
 
 import (

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package programaware
 
 import (

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy_las.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy_las.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package programaware
 
 import (

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy_las_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/strategy_las_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package programaware
 
 import (

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin/roundrobin_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/doc.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/doc.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/edf/edf.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/edf/edf.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/edf/edf_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/edf/edf_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs/fcfs.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs/fcfs.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs/fcfs_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs/fcfs_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/functional_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/functional_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/slo_deadline_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/config.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/config.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/usagelimits/priorityholdback/config.go
+++ b/pkg/epp/framework/plugins/flowcontrol/usagelimits/priorityholdback/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/usagelimits/priorityholdback/priority_holdback.go
+++ b/pkg/epp/framework/plugins/flowcontrol/usagelimits/priorityholdback/priority_holdback.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/usagelimits/priorityholdback/priority_holdback_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/usagelimits/priorityholdback/priority_holdback_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/usagelimits/softreflectiveceiling/policy.go
+++ b/pkg/epp/framework/plugins/flowcontrol/usagelimits/softreflectiveceiling/policy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/usagelimits/softreflectiveceiling/policy_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/usagelimits/softreflectiveceiling/policy_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/flowcontrol/usagelimits/usagelimitpolicy.go
+++ b/pkg/epp/framework/plugins/flowcontrol/usagelimits/usagelimitpolicy.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/latencyslo/plugin_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/constants.go
+++ b/pkg/epp/framework/plugins/requestcontrol/constants.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2025 The Kubernetes Authors.
 Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/constants/constants.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/constants/constants.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/metrics.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/metrics_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/multicluster.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/multicluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/multicluster_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/multicluster_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/assign_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/constants/constants.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/constants/constants.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/metrics.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/metrics_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/doc.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/doc.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2025 The Kubernetes Authors.
 Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/constants/constants.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/constants/constants.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/coalescer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/coalescer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/latencypredictor_async.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/latencypredictor_async.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/latencypredictor_async_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/latencypredictor_async_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/metrics.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/prediction.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/prediction.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/tests/main.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/tests/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/training.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/training.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/metrics.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/metrics_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/prediction_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/running_request_tpot_slo_queue.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/running_request_tpot_slo_queue.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/training_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/constants/constants.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/constants/constants.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/producer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid/producer_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/requestattributereporter/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestattributereporter/plugin.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout/config.go
+++ b/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout/config_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout/config_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout/metrics.go
+++ b/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout/metrics.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout/metrics_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout/plugin.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout/plugin_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout/screener.go
+++ b/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout/screener.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go
+++ b/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/test/responsereceived/destination_endpoint_served_verifier_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/common.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/common.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_extractusage_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_extractusage_test.go
@@ -1,4 +1,20 @@
 /*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
 Copyright 2025 The llm-d Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/passthrough/passthrough_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/util/grpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/util/grpc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/util/grpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/util/grpc_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vertexai/vertexai_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/constants.go
+++ b/pkg/epp/framework/plugins/scheduling/constants.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2025 The Kubernetes Authors.
 Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/doc.go
@@ -1,2 +1,18 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package bylabel provides filter plugins for the epp.
 package bylabel

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/filter.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package bylabel
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/filter_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package bylabel
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/roles.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/roles.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package bylabel
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/roles_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/roles_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package bylabel
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/selector.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/selector.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package bylabel
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/filter/bylabel/selector_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/bylabel/selector_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package bylabel_test
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/doc.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/filter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/filter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/doc.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/encoded_endpoint_header.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/encoded_endpoint_header.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/multicluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/multicluster_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/multicluster_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_id_header.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_id_header.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_id_header_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_id_header_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/plugin_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/doc.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/utilization/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/utilization/doc.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package utilization provides a filter that drops endpoints whose
 // utilization metric exceeds a configured maximum.
 package utilization

--- a/pkg/epp/framework/plugins/scheduling/filter/utilization/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/utilization/filter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/filter/utilization/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/utilization/filter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/picker/common.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/common.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker_test.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/picker/random/picker.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/random/picker.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/picker/random/picker_test.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/random/picker_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/picker.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/picker.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/picker_test.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/weightedrandom/picker_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package dataparallel provides a data-parallel profile handler plugin for the epp.
 package dataparallel
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dataparallel
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/always_disagg_mm_decider.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/always_disagg_mm_decider.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package disagg
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/always_disagg_pd_decider.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/always_disagg_pd_decider.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package disagg
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/decider_plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/decider_plugin.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package disagg provides profile handler plugins for the epp.
 package disagg
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package disagg provides pre-request plugins for GIE.
 package disagg
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_headers_handler_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package disagg
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package disagg provides profile handler plugins for the epp.
 package disagg
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package disagg
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/metrics.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/metrics.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/metrics_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/metrics_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/multimodal_helpers.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/multimodal_helpers.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package disagg
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package disagg provides profile handler plugin for the epp.
 package disagg
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/pd_profile_handler_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package disagg
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package disagg
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package disagg
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/scheduler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/scheduler_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package disagg_test
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/single/single_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/single/single_profile_handler.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/single/single_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/single/single_profile_handler_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package activerequest
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/active_request_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package activerequest
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/scorer/activerequest/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/activerequest/doc.go
@@ -1,2 +1,18 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package activerequest provides an active request scorer plugin for the epp.
 package activerequest

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package contextlengthaware
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package contextlengthaware
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/doc.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package contextlengthaware provides plugins that implement multiple extension points
 // (e.g., both Filter and Scorer interfaces).
 package contextlengthaware

--- a/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/endpointattribute.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/endpointattribute.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/endpointattribute_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/endpointattribute/endpointattribute_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/headerlabelaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/headerlabelaffinity/plugin.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/headerlabelaffinity/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/headerlabelaffinity/plugin_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/multicluster_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/latency/plugin_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/loadaware/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loadaware/doc.go
@@ -1,2 +1,18 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package loadaware provides a load-aware scorer plugin for the epp.
 package loadaware

--- a/pkg/epp/framework/plugins/scheduling/scorer/loadaware/load_aware.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loadaware/load_aware.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package loadaware
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/scorer/loadaware/load_aware_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loadaware/load_aware_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package loadaware_test
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/doc.go
@@ -1,2 +1,18 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package nohitlru provides a no-hit LRU scorer plugin for the epp.
 package nohitlru

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package nohitlru
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package nohitlru_test
 
 import (

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/doc.go
@@ -1,2 +1,18 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package preciseprefixcache provides a precise prefix cache scorer plugin for the epp.
 package preciseprefixcache

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/multicluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/multicluster_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/multicluster_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/prefix/plugin_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/multicluster_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/queue.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/queue.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/queue_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/queuedepth/queue_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/runningrequests/running_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/runningrequests/running_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/runningrequests/runningrequest.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/runningrequests/runningrequest.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/encoded_endpoint_header.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/encoded_endpoint_header.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_id_header.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_id_header.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_id_header_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_id_header_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/test/filter/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/test/filter/filter_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/test/filter/request_header_based_filter.go
+++ b/pkg/epp/framework/plugins/scheduling/test/filter/request_header_based_filter.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/header.go
+++ b/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/header.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/session_id.go
+++ b/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/session_id.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/session_id_test.go
+++ b/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/session_id_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/util/topology/level.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/level.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/util/topology/level_test.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/level_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/util/topology/peer.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/peer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/framework/plugins/scheduling/util/topology/peer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/peer_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/handlers/parsers.go
+++ b/pkg/epp/handlers/parsers.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/handlers/parsers_test.go
+++ b/pkg/epp/handlers/parsers_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/handlers/request.go
+++ b/pkg/epp/handlers/request.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/handlers/request_test.go
+++ b/pkg/epp/handlers/request_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/handlers/response.go
+++ b/pkg/epp/handlers/response.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/handlers/response_test.go
+++ b/pkg/epp/handlers/response_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/handlers/server_abort_test.go
+++ b/pkg/epp/handlers/server_abort_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/metadata/consts.go
+++ b/pkg/epp/metadata/consts.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/metadata/consts_test.go
+++ b/pkg/epp/metadata/consts_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/metrics/cardinality.go
+++ b/pkg/epp/metrics/cardinality.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/metrics/cardinality_test.go
+++ b/pkg/epp/metrics/cardinality_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/metrics/collectors/inference_pool.go
+++ b/pkg/epp/metrics/collectors/inference_pool.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/metrics/collectors/inference_pool_test.go
+++ b/pkg/epp/metrics/collectors/inference_pool_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/requestcontrol/admission_integration_test.go
+++ b/pkg/epp/requestcontrol/admission_integration_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/requestcontrol/candidates_test.go
+++ b/pkg/epp/requestcontrol/candidates_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/requestcontrol/plugin_executor.go
+++ b/pkg/epp/requestcontrol/plugin_executor.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/requestcontrol/request_control_config.go
+++ b/pkg/epp/requestcontrol/request_control_config.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/requestcontrol/screener_test.go
+++ b/pkg/epp/requestcontrol/screener_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/scheduling/constants.go
+++ b/pkg/epp/scheduling/constants.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2025 The Kubernetes Authors.
 Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/scheduling/scheduler_bench_test.go
+++ b/pkg/epp/scheduling/scheduler_bench_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/scheduling/scheduler_config.go
+++ b/pkg/epp/scheduling/scheduler_config.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/scheduling/scheduler_profile.go
+++ b/pkg/epp/scheduling/scheduler_profile.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/scheduling/scheduler_profile_picker_tracing_test.go
+++ b/pkg/epp/scheduling/scheduler_profile_picker_tracing_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/scheduling/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/scheduler_profile_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/scheduling/scheduler_profile_tracing_test.go
+++ b/pkg/epp/scheduling/scheduler_profile_tracing_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/server/controller_config.go
+++ b/pkg/epp/server/controller_config.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/server/controller_config_test.go
+++ b/pkg/epp/server/controller_config_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/server/controller_manager.go
+++ b/pkg/epp/server/controller_manager.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/server/metrics_tls_test.go
+++ b/pkg/epp/server/metrics_tls_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package server
 
 import (

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/server/options_test.go
+++ b/pkg/epp/server/options_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/server/plugin_state_debug.go
+++ b/pkg/epp/server/plugin_state_debug.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/server/plugin_state_debug_test.go
+++ b/pkg/epp/server/plugin_state_debug_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/server/runserver_test.go
+++ b/pkg/epp/server/runserver_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/server/server_test.go
+++ b/pkg/epp/server/server_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/server/tls_test.go
+++ b/pkg/epp/server/tls_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/util/env/env_test.go
+++ b/pkg/epp/util/env/env_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package env
 
 import (

--- a/pkg/epp/util/pool/pool.go
+++ b/pkg/epp/util/pool/pool.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/util/request/headers.go
+++ b/pkg/epp/util/request/headers.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/util/request/headers_test.go
+++ b/pkg/epp/util/request/headers_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/util/testing/wrappers.go
+++ b/pkg/epp/util/testing/wrappers.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/epp/util/utils.go
+++ b/pkg/epp/util/utils.go
@@ -1,4 +1,20 @@
 /*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
 Copyright 2026 llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/generator/main.go
+++ b/pkg/generator/main.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kvevents/event_dedup_filter_test.go
+++ b/pkg/kvevents/event_dedup_filter_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kvevents //nolint:testpackage // tests use the unexported eventDedupFilter
 
 import (

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kvevents //nolint:testpackage // tests use unexported processEventBatch
 
 import (

--- a/pkg/sidecar/proxy/allowlist.go
+++ b/pkg/sidecar/proxy/allowlist.go
@@ -1,4 +1,20 @@
 /*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
 Copyright 2025 The llm-d Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/sidecar/proxy/allowlist_test.go
+++ b/pkg/sidecar/proxy/allowlist_test.go
@@ -1,4 +1,20 @@
 /*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
 Copyright 2025 The llm-d Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/sidecar/proxy/connector_ec_common.go
+++ b/pkg/sidecar/proxy/connector_ec_common.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // This file holds the encoder fan-out scaffolding shared by every EC
 // connector: deduplicated multimodal-item extraction and the parallel
 // per-item encoder dispatch loop. Each EC connector

--- a/pkg/sidecar/proxy/connector_ec_nixl.go
+++ b/pkg/sidecar/proxy/connector_ec_nixl.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package proxy
 
 import (

--- a/pkg/sidecar/proxy/connector_ec_nixl_test.go
+++ b/pkg/sidecar/proxy/connector_ec_nixl_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package proxy
 
 import (

--- a/pkg/sidecar/proxy/constants.go
+++ b/pkg/sidecar/proxy/constants.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2025 The Kubernetes Authors.
 Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/sidecar/proxy/data_parallel.go
+++ b/pkg/sidecar/proxy/data_parallel.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package proxy
 
 import (

--- a/pkg/sidecar/proxy/data_parallel_test.go
+++ b/pkg/sidecar/proxy/data_parallel_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package proxy
 
 import (

--- a/pkg/sidecar/proxy/doc.go
+++ b/pkg/sidecar/proxy/doc.go
@@ -1,2 +1,18 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package proxy contains the disaggregated prefilling routing proxy implementation
 package proxy

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package proxy
 
 import (

--- a/pkg/sidecar/version/version.go
+++ b/pkg/sidecar/version/version.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package version contains build version information
 package version
 

--- a/scripts/check-commits.sh
+++ b/scripts/check-commits.sh
@@ -1,5 +1,20 @@
 #!/usr/bin/env bash
 
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # Exit on error
 set -e
 

--- a/scripts/compare-coverage.sh
+++ b/scripts/compare-coverage.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
+
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # compare-coverage.sh <baseline-dir> <current-dir> [threshold] [label] [max-regression]
 #
 # Compares Go coverage profiles between a baseline and the current run.

--- a/scripts/istio/generate-cp.sh
+++ b/scripts/istio/generate-cp.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright 2025 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # python3 & pip install ruamel.yaml
 # istioctl https://gcsweb.istio.io/gcs/istio-build/dev/1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d  alpha pre release
 

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright 2025 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # This shell script deploys a kind cluster with an Istio-based Gateway API
 # implementation fully configured. It deploys the vllm simulator, which it
 # exposes with a Gateway -> HTTPRoute -> InferencePool. The Gateway is

--- a/scripts/kubernetes-dev-env.sh
+++ b/scripts/kubernetes-dev-env.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright 2025 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # This shell script deploys a Kubernetes  cluster with an
 # KGateway-based Gateway API implementation fully configured. It deploys the
 # vllm, which it exposes with a Gateway -> HTTPRoute -> InferencePool.

--- a/scripts/load_image.sh
+++ b/scripts/load_image.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # Use the CONTAINER_RUNTIME from the environment, or default to docker if it's not set.
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 echo "Using container tool: ${CONTAINER_RUNTIME}"

--- a/scripts/migrate-gaie-paths.sh
+++ b/scripts/migrate-gaie-paths.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
+
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Migrate one or more directories or files from the source repo into this repo,
 # rewriting Go import paths throughout.
 #

--- a/scripts/pull_images.sh
+++ b/scripts/pull_images.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright 2025 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # Use the CONTAINER_RUNTIME from the environment, or default to docker if it's not set.
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 echo "Using container tool: ${CONTAINER_RUNTIME}"

--- a/test/coordinator/scripts/run_e2e_coordinator.sh
+++ b/test/coordinator/scripts/run_e2e_coordinator.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright 2026 The llm-d Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 set -euo pipefail
 
 cleanup() {

--- a/test/e2e/configs_test.go
+++ b/test/e2e/configs_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import "fmt"

--- a/test/e2e/disruption_test.go
+++ b/test/e2e/disruption_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/test/e2e/generate_endpoint_test.go
+++ b/test/e2e/generate_endpoint_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/test/e2e/requests_test.go
+++ b/test/e2e/requests_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/test/framework/net/net_test.go
+++ b/test/framework/net/net_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/common_tests.go
+++ b/test/integration/epp/common_tests.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/datalayer_integration_test.go
+++ b/test/integration/epp/datalayer_integration_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/dynamic_attributes_test.go
+++ b/test/integration/epp/dynamic_attributes_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/e2e_config_smoke_test.go
+++ b/test/integration/epp/e2e_config_smoke_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/endpoint_scores_test.go
+++ b/test/integration/epp/endpoint_scores_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/grpc_test.go
+++ b/test/integration/epp/grpc_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/harness.go
+++ b/test/integration/epp/harness.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/hermetic_test.go
+++ b/test/integration/epp/hermetic_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/k8s_datasource_integration_test.go
+++ b/test/integration/epp/k8s_datasource_integration_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/request_attribute_reporter_streaming_test.go
+++ b/test/integration/epp/request_attribute_reporter_streaming_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/request_attribute_reporter_test.go
+++ b/test/integration/epp/request_attribute_reporter_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/runtime_notification_test.go
+++ b/test/integration/epp/runtime_notification_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/runtime_polling_test.go
+++ b/test/integration/epp/runtime_polling_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/session_affinity_test.go
+++ b/test/integration/epp/session_affinity_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp/wellknown_configs_test.go
+++ b/test/integration/epp/wellknown_configs_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/epp_test.go
+++ b/test/integration/epp_test.go
@@ -1,6 +1,22 @@
 //go:build integration_tests
 // +build integration_tests
 
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package integration_test
 
 import (

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -1,6 +1,22 @@
 //go:build integration_tests
 // +build integration_tests
 
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package integration_test
 
 import (

--- a/test/integration/util.go
+++ b/test/integration/util.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/util_test.go
+++ b/test/integration/util_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright 2025 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/utils/context.go
+++ b/test/utils/context.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package utils contains utilities for testing
 //
 //revive:disable:var-naming

--- a/test/utils/handle.go
+++ b/test/utils/handle.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2024 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/utils/server.go
+++ b/test/utils/server.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2024 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2025 The Kubernetes Authors.
+Copyright 2026 The llm-d Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Corrects copyright notice attribution across the repo based on local git history provenance:

- Adds `hack/copyright.sh` (verify/fix/classify modes) and wires `verify-boilerplate` into `make presubmit` so new files can't drift.
- Backfills the 92 `.go`/`.sh` files that had no notice at all.
- Adds the missing line to 6 GAIE-derived files that had only the llm-d notice, and to 283 GAIE-derived files that had only the Kubernetes notice, per the both-notice convention.
- Corrects 160 llm-d-origin files that carried only the Kubernetes notice (git history shows their creation commit predates and is   unrelated to any GAIE migration) to carry the llm-d notice instead.

**Which issue(s) this PR fixes**:
Fixes #2448

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
