### PR TITLE
refactor(flowcontrol): derive QueueOutcome from the finalization error

### DIFF
--- a/pkg/common/error/error.go
+++ b/pkg/common/error/error.go
@@ -39,6 +39,7 @@ const (
 	RequestDroppedReasonTTLExpired       RequestDroppedReason = "rejected-ttl-expired"
 	RequestDroppedReasonContextCancelled RequestDroppedReason = "rejected-context-cancelled"
 	RequestDroppedReasonShuttingDown     RequestDroppedReason = "rejected-shutting-down"
+	RequestDroppedReasonInternal         RequestDroppedReason = "rejected-internal"
 
 	// Evicted — request was dispatched to an inference server and then killed.
 	// The generic "evicted" reason is the current default used by ImmediateResponseEvictor.Evict().

--- a/pkg/epp/flowcontrol/controller/controller.go
+++ b/pkg/epp/flowcontrol/controller/controller.go
@@ -260,15 +260,12 @@ func (fc *FlowController) EnqueueAndWait(
 	reqCtx, cancel, enqueueTime, saturationTTL := fc.createRequestContext(ctx, req)
 	defer cancel()
 
-	var finalOutcome types.QueueOutcome
-
 	// 2. Acquire a lease for the Flow.
 	// We hold this lease for the entire duration of the request (Distribution + Queueing).
 	err := fc.withConnectionWithFallback(req, func(conn contracts.ActiveFlowConnection, effectiveReq flowcontrol.FlowControlRequest) error {
 
 		select { // Non-blocking check on controller lifecycle.
 		case <-fc.parentCtx.Done():
-			finalOutcome = types.QueueOutcomeRejectedOther
 			return fmt.Errorf("%w: %w", types.ErrRejected, types.ErrFlowControllerNotRunning)
 		default:
 		}
@@ -279,27 +276,21 @@ func (fc *FlowController) EnqueueAndWait(
 		item, err := fc.tryDistribution(reqCtx, effectiveReq, enqueueTime, saturationTTL, conn)
 		if err != nil {
 			// Distribution failed terminally (e.g., context cancelled during blocking submit).
-			// The item has already been finalized by tryDistribution.
-			finalState := item.FinalState()
-			finalOutcome = finalState.Outcome
-			return finalState.Err
+			// The item has already been finalized by tryDistribution, and err is its finalized error.
+			return err
 		}
 
 		// Distribution was successful; ownership of the item has been transferred to a processor.
 		// Now, we block here in awaitFinalization until the request is finalized by either the processor (e.g., dispatched,
 		// rejected) or the controller itself (e.g., caller's context cancelled/TTL expired).
-		outcome, err := fc.awaitFinalization(reqCtx, item)
-
-		// The outcome is terminal (Dispatched, Evicted, or another rejection).
-		finalOutcome = outcome
-		return err
+		return fc.awaitFinalization(reqCtx, item)
 	})
 
-	// If WithConnection returned an error (e.g. connection failure, context cancelled before lease), we must ensure we
-	// return a valid rejection outcome.
-	// In the success case (where the closure ran), finalOutcome is set inside the closure.
-	if err != nil && finalOutcome == types.QueueOutcomeNotYetFinalized {
-		finalOutcome = types.QueueOutcomeRejectedOther
+	// Every finalization path wraps a family sentinel. An error without one comes from the lease machinery
+	// (e.g. connection failure before the closure ran), which is pre-queue by definition; OutcomeFromError already
+	// classified it RejectedOther, so only the error needs the family wrap.
+	finalOutcome, ok := types.OutcomeFromError(err)
+	if !ok {
 		err = fmt.Errorf("%w: %w", types.ErrRejected, err)
 	}
 
@@ -361,7 +352,8 @@ func (fc *FlowController) withConnectionWithFallback(
 
 // tryDistribution handles a single attempt to submit a request to the processor.
 // It uses the provided `conn` to access the registry data plane.
-// If this function returns an error, it guarantees that the provided `item` has been finalized.
+// If this function returns an error, it guarantees that the provided `item` has been finalized and that the
+// returned error is the item's finalized error.
 func (fc *FlowController) tryDistribution(
 	reqCtx context.Context,
 	req flowcontrol.FlowControlRequest,
@@ -379,7 +371,7 @@ func (fc *FlowController) tryDistribution(
 	}
 
 	// We must create a fresh FlowItem on each attempt as finalization is per-lifecycle.
-	item := internal.NewItem(req, effectiveTTL, enqueueTime)
+	item := internal.NewItem(req, effectiveTTL, enqueueTime, fc.logger)
 
 	dp := conn.GetDataPlane()
 	_, err := dp.ManagedQueue(conn.FlowKey())
@@ -392,9 +384,9 @@ func (fc *FlowController) tryDistribution(
 		// flattened with %v because this finalized error is returned through the connection closure in
 		// EnqueueAndWait: a %w-preserved ErrPriorityBandNotFound would be misread by
 		// withConnectionWithFallback as a lease-acquisition failure and silently retried at priority 0.
-		item.FinalizeWithOutcome(types.QueueOutcomeRejectedOther,
+		item.FinalizeWithError(
 			fmt.Errorf("%w: failed to get ManagedQueue for leased flow: %v", types.ErrRejected, err))
-		return item, err
+		return item, item.FinalState().Err
 	}
 
 	// Distribution is bounded by the saturation budget, not by the request context's backstop. A request still waiting
@@ -407,30 +399,24 @@ func (fc *FlowController) tryDistribution(
 		defer cancel()
 	}
 
-	outcome, err := fc.distributeRequest(distributeCtx, item)
+	err = fc.distributeRequest(distributeCtx, item)
 	if err == nil {
 		// Success: Ownership of the item has been transferred to the processor.
 		return item, nil
 	}
 
 	// For any distribution error, the controller retains ownership and must finalize the item.
-	var finalErr error
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		// We propagate the original context error here, EnqueueAndWait will rely on item.FinalState().Err.
-		finalErr = err
 		item.Finalize(context.Cause(distributeCtx))
-	} else { // e.g.,
-		finalErr = fmt.Errorf("%w: request not accepted: %w", types.ErrRejected, err)
-		item.FinalizeWithOutcome(outcome, finalErr)
+	} else {
+		item.FinalizeWithError(err)
 	}
-	return item, finalErr
+	return item, item.FinalState().Err
 }
 
-func finalizeOnControllerShutdown(item *internal.FlowItem) (types.QueueOutcome, error) {
+func finalizeOnControllerShutdown(item *internal.FlowItem) error {
 	item.Finalize(types.ErrFlowControllerNotRunning)
-
-	finalState := item.FinalState()
-	return finalState.Outcome, finalState.Err
+	return item.FinalState().Err
 }
 
 // awaitFinalization blocks until an item is finalized, either by the processor (synchronously) or by the controller
@@ -438,7 +424,7 @@ func finalizeOnControllerShutdown(item *internal.FlowItem) (types.QueueOutcome, 
 func (fc *FlowController) awaitFinalization(
 	reqCtx context.Context,
 	item *internal.FlowItem,
-) (types.QueueOutcome, error) {
+) error {
 	select {
 	case <-reqCtx.Done():
 		// Asynchronous Finalization (Controller-initiated):
@@ -451,8 +437,7 @@ func (fc *FlowController) awaitFinalization(
 		item.Finalize(cause)
 
 		// The processor will eventually discard this "zombie" item during its cleanup sweep.
-		finalState := item.FinalState()
-		return finalState.Outcome, finalState.Err
+		return item.FinalState().Err
 
 	case <-fc.parentCtx.Done():
 		return finalizeOnControllerShutdown(item)
@@ -460,7 +445,7 @@ func (fc *FlowController) awaitFinalization(
 	case finalState := <-item.Done():
 		// Synchronous Finalization (Processor-initiated):
 		// The processor finalized the item (Dispatch, Reject, Shutdown).
-		return finalState.Outcome, finalState.Err
+		return finalState.Err
 	}
 }
 
@@ -515,17 +500,17 @@ func (fc *FlowController) createRequestContext(
 func (fc *FlowController) distributeRequest(
 	ctx context.Context,
 	item *internal.FlowItem,
-) (types.QueueOutcome, error) {
+) error {
 	reqID := item.OriginalRequest().ID()
 	if err := fc.processor.Submit(item); err == nil {
-		return types.QueueOutcomeNotYetFinalized, nil
+		return nil
 	}
 
 	// processor is busy. Attempt a single blocking submission to the candidate.
 	fc.logger.V(logutil.DEBUG).Info("Processor is busy, attempting blocking submit", "requestID", reqID)
 	err := fc.processor.SubmitOrBlock(ctx, item)
 	if err != nil {
-		return types.QueueOutcomeRejectedOther, fmt.Errorf("%w: request not accepted: %w", types.ErrRejected, err)
+		return fmt.Errorf("%w: request not accepted: %w", types.ErrRejected, err)
 	}
-	return types.QueueOutcomeNotYetFinalized, nil // Success, ownership transferred.
+	return nil // Success, ownership transferred.
 }

--- a/pkg/epp/flowcontrol/controller/controller_test.go
+++ b/pkg/epp/flowcontrol/controller/controller_test.go
@@ -364,27 +364,20 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(t.Context())
 			h := newUnitHarness(ctx, t, &Config{}, nil, nil)
-			item := internal.NewItem(newTestRequest(defaultFlowKey), 0, time.Now())
+			item := internal.NewItem(newTestRequest(defaultFlowKey), 0, time.Now(), logr.Discard())
 
-			result := make(chan struct {
-				outcome types.QueueOutcome
-				err     error
-			}, 1)
+			result := make(chan error, 1)
 			go func() {
-				outcome, err := h.fc.awaitFinalization(context.Background(), item)
-				result <- struct {
-					outcome types.QueueOutcome
-					err     error
-				}{outcome: outcome, err: err}
+				result <- h.fc.awaitFinalization(context.Background(), item)
 			}()
 
 			cancel()
 			select {
-			case r := <-result:
-				require.Error(t, r.err, "awaitFinalization must fail when controller shuts down")
-				assert.ErrorIs(t, r.err, types.ErrFlowControllerNotRunning,
+			case err := <-result:
+				require.Error(t, err, "awaitFinalization must fail when controller shuts down")
+				assert.ErrorIs(t, err, types.ErrFlowControllerNotRunning,
 					"error should wrap ErrFlowControllerNotRunning")
-				assert.Equal(t, types.QueueOutcomeRejectedOther, r.outcome,
+				assert.Equal(t, types.QueueOutcomeRejectedOther, item.FinalState().Outcome,
 					"outcome should be QueueOutcomeRejectedOther on shutdown")
 			case <-time.After(time.Second):
 				t.Fatal("awaitFinalization did not return after controller shutdown")
@@ -395,34 +388,34 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			h := newUnitHarness(ctx, t, &Config{}, nil, nil)
 			reqCtx, reqCancel := context.WithCancel(context.Background())
-			item := internal.NewItem(newTestRequest(defaultFlowKey), 0, time.Now())
+			item := internal.NewItem(newTestRequest(defaultFlowKey), 0, time.Now(), logr.Discard())
 
 			reqCancel()
 			cancel()
 
-			outcome, err := h.fc.awaitFinalization(reqCtx, item)
+			err := h.fc.awaitFinalization(reqCtx, item)
 			require.Error(t, err, "awaitFinalization must fail when controller shuts down")
 			assert.ErrorIs(t, err, types.ErrFlowControllerNotRunning,
 				"controller shutdown should take precedence over request cancellation")
-			assert.Equal(t, types.QueueOutcomeRejectedOther, outcome,
+			assert.Equal(t, types.QueueOutcomeRejectedOther, item.FinalState().Outcome,
 				"shutdown should return the rejected outcome")
 		})
 		t.Run("OnControllerShutdownPreservesQueuedOutcome", func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(t.Context())
 			h := newUnitHarness(ctx, t, &Config{}, nil, nil)
-			item := internal.NewItem(newTestRequest(defaultFlowKey), 0, time.Now())
+			item := internal.NewItem(newTestRequest(defaultFlowKey), 0, time.Now(), logr.Discard())
 			item.SetHandle(&fwkfcmocks.MockQueueItemHandle{})
 
 			cancel()
 
-			outcome, err := h.fc.awaitFinalization(context.Background(), item)
+			err := h.fc.awaitFinalization(context.Background(), item)
 			require.Error(t, err, "awaitFinalization must fail when controller shuts down")
 			assert.ErrorIs(t, err, types.ErrEvicted,
 				"a queued item should be evicted, not rejected, during shutdown")
 			assert.ErrorIs(t, err, types.ErrFlowControllerNotRunning,
 				"queued shutdown should preserve the shutdown cause")
-			assert.Equal(t, types.QueueOutcomeEvictedOther, outcome,
+			assert.Equal(t, types.QueueOutcomeEvictedOther, item.FinalState().Outcome,
 				"a queued item should return the evicted outcome")
 		})
 
@@ -512,7 +505,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 					return &mockProcessor{
 						SubmitFunc: func(item *internal.FlowItem) error {
 							// Simulate asynchronous processing and successful dispatch.
-							go item.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
+							go item.FinalizeWithError(nil)
 							return nil
 						},
 					}
@@ -874,7 +867,7 @@ func TestFlowController_EnqueueAndWait(t *testing.T) {
 					// Block until the test allows us to proceed.
 					select {
 					case <-unblockProcessor:
-						item.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
+						item.FinalizeWithError(nil)
 						return nil
 					case <-ctx.Done():
 						return ctx.Err()
@@ -1154,7 +1147,7 @@ func TestFlowController_EnqueueAndWait_FallbackRewritesItemPriority(t *testing.T
 	processor := &mockProcessor{
 		SubmitFunc: func(item *internal.FlowItem) error {
 			capturedKey = item.OriginalRequest().FlowKey()
-			go item.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
+			go item.FinalizeWithError(nil)
 			return nil
 		},
 	}

--- a/pkg/epp/flowcontrol/controller/internal/item.go
+++ b/pkg/epp/flowcontrol/controller/internal/item.go
@@ -25,6 +25,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/types"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
@@ -54,12 +56,13 @@ type FlowItem struct {
 	enqueueTime     time.Time
 	effectiveTTL    time.Duration
 	originalRequest flowcontrol.FlowControlRequest
+	logger          logr.Logger
 
 	// --- Synchronized State ---
 
 	// handle stores the types.QueueItemHandle atomically.
 	// Written by the Processor (SetHandle) when admitted.
-	// Read by inferOutcome (called by Finalize) to infer the outcome (Rejected vs. Evicted).
+	// Read by Finalize to select the error family (Rejected vs. Evicted).
 	// Distinguishing between pre-admission (Rejection) and post-admission (Eviction) during asynchronous finalization
 	// relies on whether this handle is nil or non-nil.
 	handle atomic.Pointer[flowcontrol.QueueItemHandle]
@@ -81,11 +84,17 @@ type FlowItem struct {
 var _ flowcontrol.QueueItemAccessor = &FlowItem{}
 
 // NewItem allocates and initializes a new FlowItem for a request lifecycle.
-func NewItem(req flowcontrol.FlowControlRequest, effectiveTTL time.Duration, enqueueTime time.Time) *FlowItem {
+func NewItem(
+	req flowcontrol.FlowControlRequest,
+	effectiveTTL time.Duration,
+	enqueueTime time.Time,
+	logger logr.Logger,
+) *FlowItem {
 	return &FlowItem{
 		enqueueTime:     enqueueTime,
 		effectiveTTL:    effectiveTTL,
 		originalRequest: req,
+		logger:          logger,
 		done:            make(chan *FinalState, 1),
 	}
 }
@@ -128,27 +137,33 @@ func (fi *FlowItem) SetHandle(handle flowcontrol.QueueItemHandle) { fi.handle.St
 func (fi *FlowItem) Finalize(cause error) {
 	fi.onceFinalize.Do(func() {
 		// Atomically load the handle to determine if the item was admitted to a queue.
-		// This synchronization is critical for correctly inferring the outcome across goroutines.
+		// This synchronization is critical for correctly classifying the outcome across goroutines.
 		isQueued := fi.Handle() != nil
-		outcome, finalErr := inferOutcome(cause, isQueued)
-		fi.finalizeInternal(outcome, finalErr)
+		fi.finalizeInternal(wrapCause(cause, isQueued))
 	})
 }
 
-// FinalizeWithOutcome sets the item's terminal state explicitly.
+// FinalizeWithError sets the item's terminal state from a pre-wrapped finalization error: nil for dispatch, otherwise
+// an error wrapping `types.ErrRejected` or `types.ErrEvicted`. The outcome is derived from the error.
 //
 // This method is intended for synchronous finalization by the Processor (Dispatch, Reject) or the Controller
 // (Distribution failure).
 // It is idempotent.
-func (fi *FlowItem) FinalizeWithOutcome(outcome types.QueueOutcome, err error) {
+func (fi *FlowItem) FinalizeWithError(err error) {
 	fi.onceFinalize.Do(func() {
-		fi.finalizeInternal(outcome, err)
+		fi.finalizeInternal(err)
 	})
 }
 
 // finalizeInternal is the core finalization logic. It must be called within the sync.Once.Do block.
-// It captures the state, stores it atomically, and signals the Done channel.
-func (fi *FlowItem) finalizeInternal(outcome types.QueueOutcome, err error) {
+// It derives the outcome from the error, captures the state, stores it atomically, and signals the Done channel.
+func (fi *FlowItem) finalizeInternal(err error) {
+	outcome, ok := types.OutcomeFromError(err)
+	if !ok {
+		fi.logger.Error(err, "Invariant violation: finalization error wraps neither ErrRejected nor ErrEvicted",
+			"requestID", fi.originalRequest.ID(), "flowKey", fi.originalRequest.FlowKey())
+	}
+
 	finalState := &FinalState{
 		Outcome: outcome,
 		Err:     err,
@@ -169,30 +184,26 @@ func (fi *FlowItem) finalizeInternal(outcome types.QueueOutcome, err error) {
 	close(fi.done)
 }
 
-// inferOutcome determines the correct QueueOutcome and Error based on the cause of finalization and whether the item
-// was already admitted to a queue.
-func inferOutcome(cause error, isQueued bool) (types.QueueOutcome, error) {
+// wrapCause normalizes a finalization cause (e.g., a Context error) into the canonical sentinel chain and wraps it
+// with the family sentinel that matches the item's admission status.
+func wrapCause(cause error, isQueued bool) error {
 	var specificErr error
-	var outcomeIfEvicted types.QueueOutcome
 	switch {
 	case errors.Is(cause, types.ErrTTLExpired) || errors.Is(cause, context.DeadlineExceeded):
 		specificErr = types.ErrTTLExpired
-		outcomeIfEvicted = types.QueueOutcomeEvictedTTL
 	case errors.Is(cause, context.Canceled):
 		specificErr = fmt.Errorf("%w: %w", types.ErrContextCancelled, cause)
-		outcomeIfEvicted = types.QueueOutcomeEvictedContextCancelled
 	default:
 		// Handle other potential causes (e.g., custom context errors).
 		specificErr = cause
-		outcomeIfEvicted = types.QueueOutcomeEvictedOther
 	}
 
 	if isQueued {
 		// The item was in the queue when it expired/cancelled.
-		return outcomeIfEvicted, fmt.Errorf("%w: %w", types.ErrEvicted, specificErr)
+		return fmt.Errorf("%w: %w", types.ErrEvicted, specificErr)
 	}
 
 	// The item was not yet in the queue (e.g., buffered in enqueueChan).
 	// We treat this as a rejection, as it never formally consumed queue capacity.
-	return types.QueueOutcomeRejectedOther, fmt.Errorf("%w: %w", types.ErrRejected, specificErr)
+	return fmt.Errorf("%w: %w", types.ErrRejected, specificErr)
 }

--- a/pkg/epp/flowcontrol/controller/internal/item.go
+++ b/pkg/epp/flowcontrol/controller/internal/item.go
@@ -189,8 +189,10 @@ func (fi *FlowItem) finalizeInternal(err error) {
 func wrapCause(cause error, isQueued bool) error {
 	var specificErr error
 	switch {
-	case errors.Is(cause, types.ErrTTLExpired) || errors.Is(cause, context.DeadlineExceeded):
-		specificErr = types.ErrTTLExpired
+	case errors.Is(cause, types.ErrTTLExpired):
+		specificErr = cause
+	case errors.Is(cause, context.DeadlineExceeded):
+		specificErr = fmt.Errorf("%w: %w", types.ErrTTLExpired, cause)
 	case errors.Is(cause, context.Canceled):
 		specificErr = fmt.Errorf("%w: %w", types.ErrContextCancelled, cause)
 	default:

--- a/pkg/epp/flowcontrol/controller/internal/item_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/item_test.go
@@ -19,9 +19,11 @@ package internal
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -35,7 +37,7 @@ func TestFlowItem_New(t *testing.T) {
 	req := mocks.NewMockFlowControlRequest(100, "req-1", flowcontrol.FlowKey{})
 
 	enqueueTime := time.Now()
-	item := NewItem(req, time.Minute, enqueueTime)
+	item := NewItem(req, time.Minute, enqueueTime, logr.Discard())
 
 	require.NotNil(t, item, "NewItem should not return a nil item")
 	assert.Equal(t, enqueueTime, item.EnqueueTime(), "EnqueueTime should be populated")
@@ -82,31 +84,31 @@ func TestFlowItem_Finalize_Idempotency(t *testing.T) {
 			expectedErrIs:   types.ErrTTLExpired,
 		},
 		{
-			name: "Finalize then FinalizeWithOutcome",
+			name: "Finalize then FinalizeWithError",
 			firstCall: func(item *FlowItem) {
 				item.Finalize(types.ErrTTLExpired)
 			},
 			secondCall: func(item *FlowItem) {
-				item.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
+				item.FinalizeWithError(nil)
 			},
 			expectedOutcome: types.QueueOutcomeRejectedOther,
 			expectedErrIs:   types.ErrTTLExpired,
 		},
 		{
-			name: "FinalizeWithOutcome then FinalizeWithOutcome",
+			name: "FinalizeWithError then FinalizeWithError",
 			firstCall: func(item *FlowItem) {
-				item.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
+				item.FinalizeWithError(nil)
 			},
 			secondCall: func(item *FlowItem) {
-				item.FinalizeWithOutcome(types.QueueOutcomeRejectedCapacity, errors.New("rejected"))
+				item.FinalizeWithError(fmt.Errorf("%w: %w", types.ErrRejected, types.ErrQueueAtCapacity))
 			},
 			expectedOutcome: types.QueueOutcomeDispatched,
 			expectedErrIs:   nil,
 		},
 		{
-			name: "FinalizeWithOutcome then Finalize",
+			name: "FinalizeWithError then Finalize",
 			firstCall: func(item *FlowItem) {
-				item.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
+				item.FinalizeWithError(nil)
 			},
 			secondCall: func(item *FlowItem) {
 				item.Finalize(types.ErrTTLExpired)
@@ -119,7 +121,7 @@ func TestFlowItem_Finalize_Idempotency(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			item := NewItem(req, time.Minute, now)
+			item := NewItem(req, time.Minute, now, logr.Discard())
 
 			// First call
 			tc.firstCall(item)
@@ -154,7 +156,7 @@ func TestFlowItem_Finalize_Idempotency(t *testing.T) {
 	}
 }
 
-func TestFlowItem_Finalize_InferOutcome(t *testing.T) {
+func TestFlowItem_Finalize_OutcomeClassification(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
 
@@ -220,7 +222,7 @@ func TestFlowItem_Finalize_InferOutcome(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			req := mocks.NewMockFlowControlRequest(100, "req-1", flowcontrol.FlowKey{})
-			item := NewItem(req, time.Minute, now)
+			item := NewItem(req, time.Minute, now, logr.Discard())
 			if tc.isQueued {
 				item.SetHandle(&mocks.MockQueueItemHandle{})
 			}

--- a/pkg/epp/flowcontrol/controller/internal/item_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/item_test.go
@@ -175,6 +175,13 @@ func TestFlowItem_Finalize_OutcomeClassification(t *testing.T) {
 			expectErrIs:   types.ErrTTLExpired,
 		},
 		{
+			name:          "queued deadline exceeded",
+			cause:         context.DeadlineExceeded,
+			isQueued:      true,
+			expectOutcome: types.QueueOutcomeEvictedTTL,
+			expectErrIs:   types.ErrTTLExpired,
+		},
+		{
 			name:          "queued context cancelled",
 			cause:         context.Canceled,
 			isQueued:      true,

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -56,7 +56,7 @@ var ErrProcessorBusy = errors.New("processor is busy")
 // The Processor takes ownership of a FlowItem only after it has been successfully sent to its internal enqueueChan
 // via Submit or SubmitOrBlock (i.e., when these methods return nil).
 // Once the Processor takes ownership, it is solely responsible for ensuring that item.Finalize() or
-// item.FinalizeWithOutcome() is called exactly once for that item, under all circumstances (dispatch, rejection, sweep,
+// item.FinalizeWithError() is called exactly once for that item, under all circumstances (dispatch, rejection, sweep,
 // or shutdown).
 //
 // If Submit or SubmitOrBlock return an error, ownership remains with the caller (the Controller), which must then
@@ -307,12 +307,13 @@ func (p *Processor) enqueue(item *FlowItem) {
 	}
 
 	// --- Configuration Validation ---
+	// Registry errors on both lookups are flattened with %v; see tryDistribution for why a finalized error must
+	// not preserve registry sentinels.
 	managedQ, err := p.registry.ManagedQueue(key)
 	if err != nil {
-		finalErr := fmt.Errorf("configuration error: failed to get queue for flow key %s: %w", key, err)
+		finalErr := fmt.Errorf("configuration error: failed to get queue for flow key %s: %v", key, err)
 		p.logger.Error(finalErr, "Rejecting request, queue lookup failed", "flowKey", key, "requestID", req.ID())
-		item.FinalizeWithOutcome(types.QueueOutcomeRejectedOther, fmt.Errorf("%w: %w", types.ErrRejected, finalErr))
-		p.recordDrop(types.QueueOutcomeRejectedOther)
+		p.finalizeAndRecordDrop(item, fmt.Errorf("%w: %w", types.ErrRejected, finalErr))
 		return
 	}
 
@@ -320,10 +321,9 @@ func (p *Processor) enqueue(item *FlowItem) {
 	// This check is safe because it is performed by the single-writer Run goroutine.
 	ok, stats, err := p.hasCapacity(key.Priority, req.ByteSize())
 	if err != nil {
-		finalErr := fmt.Errorf("configuration error: failed to read capacity for priority %d: %w", key.Priority, err)
+		finalErr := fmt.Errorf("configuration error: failed to read capacity for priority %d: %v", key.Priority, err)
 		p.logger.Error(finalErr, "Rejecting request, capacity lookup failed", "flowKey", key, "requestID", req.ID())
-		item.FinalizeWithOutcome(types.QueueOutcomeRejectedOther, fmt.Errorf("%w: %w", types.ErrRejected, finalErr))
-		p.recordDrop(types.QueueOutcomeRejectedOther)
+		p.finalizeAndRecordDrop(item, fmt.Errorf("%w: %w", types.ErrRejected, finalErr))
 		return
 	}
 	if !ok {
@@ -336,9 +336,7 @@ func (p *Processor) enqueue(item *FlowItem) {
 				"bandByteSize", stats.Band.ByteSize, "bandCapacityBytes", stats.Band.CapacityBytes,
 				"totalLen", stats.Global.Len, "totalCapacityRequests", stats.Global.CapacityRequests,
 				"totalByteSize", stats.Global.ByteSize, "totalCapacityBytes", stats.Global.CapacityBytes)
-			item.FinalizeWithOutcome(types.QueueOutcomeRejectedNoEndpoints, fmt.Errorf("%w: %w",
-				types.ErrRejected, types.ErrNoEndpoints))
-			p.recordDrop(types.QueueOutcomeRejectedNoEndpoints)
+			p.finalizeAndRecordDrop(item, fmt.Errorf("%w: %w", types.ErrRejected, types.ErrNoEndpoints))
 			return
 		}
 		p.logger.V(logutil.DEBUG).Info("Rejecting request, queue at capacity",
@@ -347,9 +345,7 @@ func (p *Processor) enqueue(item *FlowItem) {
 			"bandByteSize", stats.Band.ByteSize, "bandCapacityBytes", stats.Band.CapacityBytes,
 			"totalLen", stats.Global.Len, "totalCapacityRequests", stats.Global.CapacityRequests,
 			"totalByteSize", stats.Global.ByteSize, "totalCapacityBytes", stats.Global.CapacityBytes)
-		item.FinalizeWithOutcome(types.QueueOutcomeRejectedCapacity, fmt.Errorf("%w: %w",
-			types.ErrRejected, types.ErrQueueAtCapacity))
-		p.recordDrop(types.QueueOutcomeRejectedCapacity)
+		p.finalizeAndRecordDrop(item, fmt.Errorf("%w: %w", types.ErrRejected, types.ErrQueueAtCapacity))
 		return
 	}
 
@@ -359,8 +355,7 @@ func (p *Processor) enqueue(item *FlowItem) {
 		finalErr := fmt.Errorf("failed to add item to queue for flow key %s: %w", key, err)
 		p.logger.Error(finalErr, "Rejecting request, queue add failed",
 			"flowKey", key, "requestID", req.ID())
-		item.FinalizeWithOutcome(types.QueueOutcomeRejectedOther, fmt.Errorf("%w: %w", types.ErrRejected, finalErr))
-		p.recordDrop(types.QueueOutcomeRejectedOther)
+		p.finalizeAndRecordDrop(item, fmt.Errorf("%w: %w", types.ErrRejected, finalErr))
 		return
 	}
 	p.logger.V(logutil.TRACE).Info("Item enqueued.",
@@ -632,7 +627,7 @@ func (p *Processor) dispatchItem(itemAcc flowcontrol.QueueItemAccessor) error {
 		return fmt.Errorf("internal error: item %q for flow %s has unexpected type %T", req.ID(), key, removedItemAcc)
 	}
 	p.logger.V(logutil.TRACE).Info("Item dispatched.", "flowKey", req.FlowKey(), "requestID", req.ID())
-	removedItem.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
+	removedItem.FinalizeWithError(nil)
 	return nil
 }
 
@@ -668,6 +663,7 @@ func (p *Processor) runCleanupSweep(ctx context.Context) {
 func (p *Processor) sweepFinalizedItems() {
 	now := p.clock.Now()
 	regime := p.regime.Load()
+	expiryErr := expiryError(regime.empty)
 
 	processFn := func(managedQ contracts.ManagedQueue, logger logr.Logger) {
 		predicate := func(itemAcc flowcontrol.QueueItemAccessor) bool {
@@ -679,16 +675,16 @@ func (p *Processor) sweepFinalizedItems() {
 			if item.FinalState() != nil {
 				return true
 			}
-			outcome, expired := isExpired(item, now, regime, p.noEndpointRequestTTL)
-			if !expired {
+			if !isExpired(item, now, regime, p.noEndpointRequestTTL) {
 				return false
 			}
 			// Finalizing here rather than in a separate pass keeps expiry to a single scan. Finalization is
 			// idempotent, and an item finalized but not removed is the same zombie state the sweep already
 			// tolerates, so a queue that declines the removal costs nothing beyond a later sweep.
-			item.FinalizeWithOutcome(outcome, expiryError(outcome))
+			item.FinalizeWithError(expiryErr)
 			logger.V(logutil.TRACE).Info("Evicted item, queue-wait budget exhausted.",
-				"requestID", item.OriginalRequest().ID(), "outcome", outcome, "poolEmpty", regime.empty)
+				"requestID", item.OriginalRequest().ID(), "outcome", item.FinalState().Outcome,
+				"poolEmpty", regime.empty)
 			return true
 		}
 		removedItems := managedQ.Cleanup(predicate)
@@ -705,8 +701,8 @@ func (p *Processor) sweepFinalizedItems() {
 	p.processAllQueuesConcurrently("sweepFinalizedItems", processFn)
 }
 
-// isExpired reports whether item has exhausted the queue-wait budget in force, and the outcome that eviction would
-// carry. A zero budget disables eviction in that regime.
+// isExpired reports whether item has exhausted the queue-wait budget in force. A zero budget disables eviction in
+// that regime.
 //
 // Elapsed time is charged from the later of enqueue and the most recent regime change. Charging from enqueue alone
 // would shed a request the moment it becomes dispatchable: an endpoint appearing after the saturation budget has
@@ -717,25 +713,26 @@ func isExpired(
 	now time.Time,
 	regime *regimeSample,
 	noEndpointRequestTTL time.Duration,
-) (types.QueueOutcome, bool) {
-	budget, outcome := item.EffectiveTTL(), types.QueueOutcomeEvictedTTL
+) bool {
+	budget := item.EffectiveTTL()
 	if regime.empty {
-		budget, outcome = noEndpointRequestTTL, types.QueueOutcomeEvictedNoEndpoints
+		budget = noEndpointRequestTTL
 	}
 	if budget <= 0 {
-		return outcome, false
+		return false
 	}
 
 	chargeFrom := item.EnqueueTime()
 	if regime.since.After(chargeFrom) {
 		chargeFrom = regime.since
 	}
-	return outcome, !now.Before(chargeFrom.Add(budget))
+	return !now.Before(chargeFrom.Add(budget))
 }
 
-// expiryError builds the error accompanying an expiry eviction, wrapping the sentinels that callers match on.
-func expiryError(outcome types.QueueOutcome) error {
-	if outcome == types.QueueOutcomeEvictedNoEndpoints {
+// expiryError builds the error accompanying an expiry eviction, wrapping the sentinels that callers match on. The
+// no-endpoint regime adds `types.ErrNoEndpoints` so the eviction classifies as genuine unavailability.
+func expiryError(poolEmpty bool) error {
+	if poolEmpty {
 		return fmt.Errorf("%w: %w: %w", types.ErrEvicted, types.ErrTTLExpired, types.ErrNoEndpoints)
 	}
 	return fmt.Errorf("%w: %w", types.ErrEvicted, types.ErrTTLExpired)
@@ -756,9 +753,7 @@ func (p *Processor) shutdown() {
 					continue
 				}
 				// Finalize buffered items.
-				item.FinalizeWithOutcome(types.QueueOutcomeRejectedOther,
-					fmt.Errorf("%w: %w", types.ErrRejected, types.ErrFlowControllerNotRunning))
-				p.recordDrop(types.QueueOutcomeRejectedOther)
+				p.finalizeAndRecordDrop(item, fmt.Errorf("%w: %w", types.ErrRejected, types.ErrFlowControllerNotRunning))
 			default:
 				break DrainLoop
 			}
@@ -776,7 +771,6 @@ func (p *Processor) evictAll() {
 		key := managedQ.FlowQueueAccessor().FlowKey()
 		removedItems := managedQ.Drain()
 
-		outcome := types.QueueOutcomeEvictedOther
 		errShutdown := fmt.Errorf("%w: %w", types.ErrEvicted, types.ErrFlowControllerNotRunning)
 		for _, i := range removedItems {
 			item, ok := i.(*FlowItem)
@@ -786,17 +780,22 @@ func (p *Processor) evictAll() {
 				continue
 			}
 
-			// Finalization is idempotent; safe to call even if already finalized externally.
 			// The per-request log is emitted by EnqueueAndWait when it unblocks.
-			item.FinalizeWithOutcome(outcome, errShutdown)
-			p.recordDrop(item.FinalState().Outcome)
+			p.finalizeAndRecordDrop(item, errShutdown)
 		}
 	}
 	p.processAllQueuesConcurrently("evictAll", processFn)
 }
 
+// finalizeAndRecordDrop finalizes item with err and counts the outcome actually stored. Finalization is idempotent,
+// so under a race with an external finalization the winner's outcome is the one counted.
+func (p *Processor) finalizeAndRecordDrop(item *FlowItem, err error) {
+	item.FinalizeWithError(err)
+	p.recordDrop(item.FinalState().Outcome)
+}
+
 func (p *Processor) recordDrop(outcome types.QueueOutcome) {
-	if outcome == types.QueueOutcomeDispatched || outcome == types.QueueOutcomeNotYetFinalized {
+	if outcome == types.QueueOutcomeDispatched {
 		return
 	}
 	p.dropCounts[outcome].Add(1)

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -787,8 +787,9 @@ func (p *Processor) evictAll() {
 	p.processAllQueuesConcurrently("evictAll", processFn)
 }
 
-// finalizeAndRecordDrop finalizes item with err and counts the outcome actually stored. Finalization is idempotent,
-// so under a race with an external finalization the winner's outcome is the one counted.
+// finalizeAndRecordDrop finalizes item with err and counts the outcome actually stored. Finalization is idempotent
+// (sync.Once), so when the controller goroutine finalizes the same item concurrently (e.g. a TTL expiry racing the
+// processor's capacity rejection), the winner's outcome is the one counted.
 func (p *Processor) finalizeAndRecordDrop(item *FlowItem, err error) {
 	item.FinalizeWithError(err)
 	p.recordDrop(item.FinalState().Outcome)

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -197,7 +197,7 @@ func (h *testHarness) waitForFinalization(item *FlowItem) (types.QueueOutcome, e
 func (h *testHarness) newTestItem(id string, key flowcontrol.FlowKey, ttl time.Duration) *FlowItem {
 	h.t.Helper()
 	req := fwkfcmocks.NewMockFlowControlRequest(100, id, key)
-	return NewItem(req, ttl, h.clock.Now())
+	return NewItem(req, ttl, h.clock.Now(), logr.Discard())
 }
 
 // addQueue centrally registers a new mock queue for a given flow, ensuring all harness components are aware of it.
@@ -363,7 +363,9 @@ func TestProcessor(t *testing.T) {
 			outcome, err := h.waitForFinalization(item)
 			assert.Equal(t, types.QueueOutcomeRejectedOther, outcome, "The final outcome should be RejectedOther")
 			require.Error(t, err, "A rejection from a registry failure should produce an error")
-			assert.ErrorIs(t, err, registryErr, "The underlying registry error should be preserved")
+			assert.ErrorContains(t, err, registryErr.Error(),
+				"The registry error text should be preserved; the error itself is flattened so registry sentinels "+
+					"cannot be misread by the fallback retry")
 		})
 
 		t.Run("should reject item if enqueued during shutdown", func(t *testing.T) {
@@ -589,7 +591,8 @@ func TestProcessor(t *testing.T) {
 						assert.Equal(t, types.QueueOutcomeRejectedOther, item.FinalState().Outcome,
 							"Outcome should be RejectedOther")
 						require.Error(t, item.FinalState().Err, "An error should be returned")
-						assert.ErrorIs(t, item.FinalState().Err, testErr, "The underlying error should be preserved")
+						assert.ErrorContains(t, item.FinalState().Err, testErr.Error(),
+							"The registry error text should be preserved; the error itself is flattened")
 					},
 				},
 				{
@@ -604,7 +607,8 @@ func TestProcessor(t *testing.T) {
 						assert.Equal(t, types.QueueOutcomeRejectedOther, item.FinalState().Outcome,
 							"Outcome should be RejectedOther")
 						require.Error(t, item.FinalState().Err, "An error should be returned")
-						assert.ErrorIs(t, item.FinalState().Err, testErr, "The underlying error should be preserved")
+						assert.ErrorContains(t, item.FinalState().Err, testErr.Error(),
+							"The registry error text should be preserved; the error itself is flattened")
 					},
 				},
 				{
@@ -679,7 +683,7 @@ func TestProcessor(t *testing.T) {
 					item: func() *FlowItem {
 						// Create a pre-finalized item.
 						item := newTestHarness(t, 0).newTestItem("req-finalized", testFlow, testTTL)
-						item.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
+						item.FinalizeWithError(nil)
 						return item
 					}(),
 					assert: func(t *testing.T, h *testHarness, item *FlowItem) {
@@ -1333,7 +1337,7 @@ func TestProcessor(t *testing.T) {
 				// --- ARRANGE ---
 				h := newTestHarness(t, testCleanupTick)
 				item := h.newTestItem("req-already-finalized", testFlow, testTTL)
-				item.FinalizeWithOutcome(types.QueueOutcomeRejectedOther, errors.New("already done"))
+				item.FinalizeWithError(fmt.Errorf("%w: already done", types.ErrRejected))
 
 				h.ManagedQueueFunc = func(flowcontrol.FlowKey) (contracts.ManagedQueue, error) {
 					return &mocks.MockManagedQueue{
@@ -1776,33 +1780,28 @@ func TestProcessor_QueueWaitBudget(t *testing.T) {
 			// regimeAfter is how long after enqueue the regime last changed; zero means it never has.
 			regimeAfter time.Duration
 			elapsed     time.Duration
-			wantOutcome types.QueueOutcome
 			wantExpired bool
 		}{
 			{
 				name:        "SaturatedPool_HoldsWithinSaturationBudget",
 				elapsed:     saturationTTL - time.Millisecond,
-				wantOutcome: types.QueueOutcomeEvictedTTL,
 				wantExpired: false,
 			},
 			{
 				name:        "SaturatedPool_ShedsAtSaturationBudget",
 				elapsed:     saturationTTL,
-				wantOutcome: types.QueueOutcomeEvictedTTL,
 				wantExpired: true,
 			},
 			{
 				name:        "EmptyPool_HoldsPastSaturationBudget",
 				poolEmpty:   true,
 				elapsed:     noEndpointTTL - time.Millisecond,
-				wantOutcome: types.QueueOutcomeEvictedNoEndpoints,
 				wantExpired: false,
 			},
 			{
 				name:        "EmptyPool_ShedsAtNoEndpointBudget",
 				poolEmpty:   true,
 				elapsed:     noEndpointTTL,
-				wantOutcome: types.QueueOutcomeEvictedNoEndpoints,
 				wantExpired: true,
 			},
 			{
@@ -1810,14 +1809,12 @@ func TestProcessor_QueueWaitBudget(t *testing.T) {
 				noEndpointTTL: -1, // Sentinel for an explicit zero; see the field comment.
 				poolEmpty:     true,
 				elapsed:       time.Hour,
-				wantOutcome:   types.QueueOutcomeEvictedNoEndpoints,
 				wantExpired:   false,
 			},
 			{
 				name:        "SaturatedPool_ZeroBudgetWaitsIndefinitely",
 				itemTTL:     -1, // Sentinel for an explicit zero; see the field comment.
 				elapsed:     time.Hour,
-				wantOutcome: types.QueueOutcomeEvictedTTL,
 				wantExpired: false,
 			},
 			{
@@ -1826,14 +1823,12 @@ func TestProcessor_QueueWaitBudget(t *testing.T) {
 				name:        "PoolCameUp_StartsFreshSaturationBudget",
 				regimeAfter: noEndpointTTL / 2,
 				elapsed:     noEndpointTTL/2 + saturationTTL - time.Millisecond,
-				wantOutcome: types.QueueOutcomeEvictedTTL,
 				wantExpired: false,
 			},
 			{
 				name:        "PoolCameUp_ShedsAfterFreshSaturationBudget",
 				regimeAfter: noEndpointTTL / 2,
 				elapsed:     noEndpointTTL/2 + saturationTTL,
-				wantOutcome: types.QueueOutcomeEvictedTTL,
 				wantExpired: true,
 			},
 			{
@@ -1841,7 +1836,6 @@ func TestProcessor_QueueWaitBudget(t *testing.T) {
 				name:        "RegimeChangeBeforeEnqueue_DoesNotExtendBudget",
 				regimeAfter: -saturationTTL,
 				elapsed:     saturationTTL,
-				wantOutcome: types.QueueOutcomeEvictedTTL,
 				wantExpired: true,
 			},
 		}
@@ -1863,14 +1857,27 @@ func TestProcessor_QueueWaitBudget(t *testing.T) {
 					regimeSince = base.Add(tc.regimeAfter)
 				}
 
-				item := NewItem(fwkfcmocks.NewMockFlowControlRequest(100, "req-budget", testFlow), itemTTL, base)
+				item := NewItem(fwkfcmocks.NewMockFlowControlRequest(100, "req-budget", testFlow), itemTTL, base, logr.Discard())
 				regime := &regimeSample{empty: tc.poolEmpty, since: regimeSince}
-				outcome, expired := isExpired(item, base.Add(tc.elapsed), regime, noEndpoint)
+				expired := isExpired(item, base.Add(tc.elapsed), regime, noEndpoint)
 
-				assert.Equal(t, tc.wantOutcome, outcome, "expiry should be attributed to the regime in force")
 				assert.Equal(t, tc.wantExpired, expired, "the budget in force decides whether the request is shed")
 			})
 		}
+	})
+
+	t.Run("expiry error carries the regime sentinels", func(t *testing.T) {
+		t.Parallel()
+
+		saturated := expiryError(false)
+		assert.ErrorIs(t, saturated, types.ErrEvicted, "saturation expiry should classify as an eviction")
+		assert.ErrorIs(t, saturated, types.ErrTTLExpired, "saturation expiry should carry the TTL sentinel")
+		assert.NotErrorIs(t, saturated, types.ErrNoEndpoints, "saturation expiry must not claim unavailability")
+
+		empty := expiryError(true)
+		assert.ErrorIs(t, empty, types.ErrEvicted, "no-endpoint expiry should classify as an eviction")
+		assert.ErrorIs(t, empty, types.ErrTTLExpired, "no-endpoint expiry should carry the TTL sentinel")
+		assert.ErrorIs(t, empty, types.ErrNoEndpoints, "no-endpoint expiry should carry the no-endpoints sentinel")
 	})
 
 	t.Run("sweep holds a queued request across a scale-from-zero", func(t *testing.T) {

--- a/pkg/epp/flowcontrol/types/outcomes.go
+++ b/pkg/epp/flowcontrol/types/outcomes.go
@@ -16,12 +16,18 @@ limitations under the License.
 
 package types
 
-import "strconv"
+import (
+	"errors"
+	"strconv"
+)
 
 // QueueOutcome represents the high-level final state of a request's lifecycle within the `controller.FlowController`.
 //
 // It is returned by `FlowController.EnqueueAndWait()` along with a corresponding error. This enum is designed to be a
 // low-cardinality label ideal for metrics, while the error provides fine-grained details for non-dispatched outcomes.
+//
+// The error is the authoritative representation of a final state; the outcome is derived from it via
+// `OutcomeFromError`. The per-constant documentation below describes which sentinels each outcome corresponds to.
 type QueueOutcome int
 
 const (
@@ -51,6 +57,9 @@ const (
 	// enqueued.
 	// The specific underlying cause can be determined from the associated error (e.g., a nil request, an unregistered
 	// flow ID, or controller shutdown), which will be wrapped by `ErrRejected`.
+	// A pre-admission TTL expiry or context cancellation (`ErrRejected` wrapping `ErrTTLExpired` or
+	// `ErrContextCancelled`) lands here by design: no dedicated rejection outcome exists for them because rejected
+	// items never consumed queue capacity, and the Rejected/Evicted metrics split accounts for exactly that.
 	QueueOutcomeRejectedOther
 
 	// --- Post-Enqueue Eviction Outcomes (request was in a SafeQueue but not dispatched) ---
@@ -109,5 +118,43 @@ func (o QueueOutcome) String() string {
 	default:
 		// Return the integer value for unknown outcomes to aid in debugging.
 		return "UnknownOutcome(" + strconv.Itoa(int(o)) + ")"
+	}
+}
+
+// OutcomeFromError derives the QueueOutcome corresponding to a finalization error. A nil error means
+// `QueueOutcomeDispatched`. ok is false when a non-nil error wraps neither `ErrRejected` nor `ErrEvicted`, which is
+// an internal invariant violation; callers should log it and use the returned `QueueOutcomeRejectedOther`.
+//
+// Within the `ErrEvicted` family, `ErrNoEndpoints` is matched before `ErrTTLExpired` because a no-endpoint budget
+// expiry wraps both sentinels. The `ErrEvicted` family is matched before `ErrRejected`: no error carries both, but
+// if one ever did, eviction is the safer classification because it implies queue capacity was consumed, which is
+// what the Rejected/Evicted metrics split accounts for.
+func OutcomeFromError(err error) (QueueOutcome, bool) {
+	switch {
+	case err == nil:
+		return QueueOutcomeDispatched, true
+	case errors.Is(err, ErrEvicted):
+		switch {
+		case errors.Is(err, ErrNoEndpoints):
+			return QueueOutcomeEvictedNoEndpoints, true
+		case errors.Is(err, ErrTTLExpired):
+			return QueueOutcomeEvictedTTL, true
+		case errors.Is(err, ErrContextCancelled):
+			return QueueOutcomeEvictedContextCancelled, true
+		default:
+			return QueueOutcomeEvictedOther, true
+		}
+	case errors.Is(err, ErrRejected):
+		switch {
+		case errors.Is(err, ErrNoEndpoints):
+			return QueueOutcomeRejectedNoEndpoints, true
+		case errors.Is(err, ErrQueueAtCapacity):
+			return QueueOutcomeRejectedCapacity, true
+		default:
+			// Intentionally includes `ErrTTLExpired` and `ErrContextCancelled`: see `QueueOutcomeRejectedOther`.
+			return QueueOutcomeRejectedOther, true
+		}
+	default:
+		return QueueOutcomeRejectedOther, false
 	}
 }

--- a/pkg/epp/flowcontrol/types/outcomes_test.go
+++ b/pkg/epp/flowcontrol/types/outcomes_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestOutcomeFromError pins the outcome derived for every error shape a finalization site produces. Most rows are
+// the literal expression a producer builds, and the expected outcome is the constant that producer's final state
+// carries; a mapping change that would silently reclassify a producer fails here. Rows marked defensive pin shapes
+// no producer currently emits, so the mapping stays stable if one appears.
+func TestOutcomeFromError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		err           error
+		expectOutcome QueueOutcome
+		expectOK      bool
+	}{
+		{
+			name:          "nil means dispatched",
+			err:           nil,
+			expectOutcome: QueueOutcomeDispatched,
+			expectOK:      true,
+		},
+		{
+			name:          "rejected at capacity",
+			err:           fmt.Errorf("%w: %w", ErrRejected, ErrQueueAtCapacity),
+			expectOutcome: QueueOutcomeRejectedCapacity,
+			expectOK:      true,
+		},
+		{
+			name:          "rejected at capacity with empty pool",
+			err:           fmt.Errorf("%w: %w", ErrRejected, ErrNoEndpoints),
+			expectOutcome: QueueOutcomeRejectedNoEndpoints,
+			expectOK:      true,
+		},
+		{
+			name:          "rejected on registry failure",
+			err:           fmt.Errorf("%w: %w", ErrRejected, errors.New("failed to resolve queue")),
+			expectOutcome: QueueOutcomeRejectedOther,
+			expectOK:      true,
+		},
+		{
+			name:          "rejected on shutdown",
+			err:           fmt.Errorf("%w: %w", ErrRejected, ErrFlowControllerNotRunning),
+			expectOutcome: QueueOutcomeRejectedOther,
+			expectOK:      true,
+		},
+		{
+			// See QueueOutcomeRejectedOther: pre-admission expiries stay in the Rejected family.
+			name:          "pre-admission TTL expiry",
+			err:           fmt.Errorf("%w: %w", ErrRejected, ErrTTLExpired),
+			expectOutcome: QueueOutcomeRejectedOther,
+			expectOK:      true,
+		},
+		{
+			name:          "pre-admission context cancellation",
+			err:           fmt.Errorf("%w: %w", ErrRejected, fmt.Errorf("%w: %w", ErrContextCancelled, context.Canceled)),
+			expectOutcome: QueueOutcomeRejectedOther,
+			expectOK:      true,
+		},
+		{
+			// The registry error is flattened with %v at its producer, so only the family sentinel survives.
+			name:          "rejected with flattened inner error",
+			err:           fmt.Errorf("%w: failed to get ManagedQueue for leased flow: %v", ErrRejected, ErrQueueAtCapacity),
+			expectOutcome: QueueOutcomeRejectedOther,
+			expectOK:      true,
+		},
+		{
+			// Defensive: no producer double-wraps, but a repeated family sentinel must stay harmless.
+			name:          "double-wrapped rejection",
+			err:           fmt.Errorf("%w: %w", ErrRejected, fmt.Errorf("%w: %w", ErrRejected, ErrFlowControllerNotRunning)),
+			expectOutcome: QueueOutcomeRejectedOther,
+			expectOK:      true,
+		},
+		{
+			name:          "evicted on TTL expiry",
+			err:           fmt.Errorf("%w: %w", ErrEvicted, ErrTTLExpired),
+			expectOutcome: QueueOutcomeEvictedTTL,
+			expectOK:      true,
+		},
+		{
+			// The no-endpoint budget expiry wraps both inner sentinels; ErrNoEndpoints takes precedence.
+			name:          "evicted on no-endpoint budget expiry",
+			err:           fmt.Errorf("%w: %w: %w", ErrEvicted, ErrTTLExpired, ErrNoEndpoints),
+			expectOutcome: QueueOutcomeEvictedNoEndpoints,
+			expectOK:      true,
+		},
+		{
+			// Defensive: every current no-endpoint eviction also carries ErrTTLExpired.
+			name:          "evicted with no endpoints and no TTL sentinel",
+			err:           fmt.Errorf("%w: %w", ErrEvicted, ErrNoEndpoints),
+			expectOutcome: QueueOutcomeEvictedNoEndpoints,
+			expectOK:      true,
+		},
+		{
+			name:          "evicted on context cancellation",
+			err:           fmt.Errorf("%w: %w", ErrEvicted, fmt.Errorf("%w: %w", ErrContextCancelled, context.Canceled)),
+			expectOutcome: QueueOutcomeEvictedContextCancelled,
+			expectOK:      true,
+		},
+		{
+			name:          "evicted on shutdown",
+			err:           fmt.Errorf("%w: %w", ErrEvicted, ErrFlowControllerNotRunning),
+			expectOutcome: QueueOutcomeEvictedOther,
+			expectOK:      true,
+		},
+		{
+			name:          "evicted with unrecognized cause",
+			err:           fmt.Errorf("%w: %w", ErrEvicted, errors.New("custom context cause")),
+			expectOutcome: QueueOutcomeEvictedOther,
+			expectOK:      true,
+		},
+		{
+			name:          "missing family sentinel is an invariant violation",
+			err:           errors.New("no family sentinel"),
+			expectOutcome: QueueOutcomeRejectedOther,
+			expectOK:      false,
+		},
+	}
+
+	covered := make(map[QueueOutcome]bool)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			outcome, ok := OutcomeFromError(tc.err)
+			assert.Equal(t, tc.expectOutcome, outcome, "unexpected outcome")
+			assert.Equal(t, tc.expectOK, ok, "unexpected ok")
+		})
+		covered[tc.expectOutcome] = true
+	}
+
+	// Every reachable outcome must have a producer row, so a new outcome added without extending this table (and the
+	// mapping) fails loudly.
+	for o := QueueOutcomeNotYetFinalized + 1; o < NumQueueOutcomes; o++ {
+		assert.True(t, covered[o], "no test row covers outcome %s", o)
+	}
+}

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -275,6 +275,6 @@ func translateFlowControlError(err error, poolEmpty func() bool) error {
 	case errors.Is(err, types.ErrContextCancelled):
 		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "client disconnected: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonContextCancelled)}}
 	default:
-		return errcommon.Error{Code: errcommon.Internal, Msg: "internal flow control error: " + msg}
+		return errcommon.Error{Code: errcommon.Internal, Msg: "internal flow control error: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonInternal)}}
 	}
 }

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -187,17 +187,10 @@ func (fcac *FlowControlAdmissionController) Admit(
 	}
 	logger.V(logutil.DEBUG).Info("Flow control outcome",
 		"requestID", reqCtx.SchedulingRequest.RequestID, "outcome", outcome, "error", err)
-	// A TTL expiry signals backpressure (429) when serving capacity exists, but genuine unavailability (503) when
-	// the pool is empty. This covers the queued eviction outcome and a pre-admission expiry, which surfaces as
-	// RejectedOther or EvictedOther wrapping ErrTTLExpired. Probe pool emptiness (nil metadata = whole pool) only
-	// on those paths.
-	ttlPoolEmpty := false
-	if outcome == types.QueueOutcomeEvictedTTL ||
-		((outcome == types.QueueOutcomeRejectedOther || outcome == types.QueueOutcomeEvictedOther) &&
-			errors.Is(err, types.ErrTTLExpired)) {
-		ttlPoolEmpty = len(fcac.endpointCandidates.Locate(ctx, nil)) == 0
-	}
-	return translateFlowControlOutcome(outcome, err, ttlPoolEmpty)
+	// Pool emptiness (nil metadata = whole pool) is a live probe, so it is passed lazily and runs only when the
+	// mapping consults it: a TTL expiry whose regime is not already established by ErrNoEndpoints.
+	poolEmpty := func() bool { return len(fcac.endpointCandidates.Locate(ctx, nil)) == 0 }
+	return translateFlowControlError(err, poolEmpty)
 }
 
 // flowControlRequest is an adapter that implements the FlowControlRequest interface.
@@ -247,53 +240,41 @@ func (r *flowControlRequest) FlowKey() flowcontrol.FlowKey {
 	return flowcontrol.FlowKey{ID: r.fairnessID, Priority: r.priority}
 }
 
-// translateFlowControlOutcome maps the context-rich outcome of the Flow Control layer to the public errcommon.Error
-// contract used by the Director.
+// translateFlowControlError maps the finalization error of the Flow Control layer to the public errcommon.Error
+// contract used by the Director. The error is the authoritative encoding of the final state, so the mapping switches
+// on its sentinels; the Rejected/Evicted family only refines the message text. Pre- and post-admission terminations
+// with the same cause (e.g. a TTL expiry while buffered vs. while queued) therefore agree by construction.
 //
 // Error codes encode availability: ResourceExhausted (429) means capacity exists but is contended (backpressure),
-// ServiceUnavailable (503) means no serving capacity exists right now. A queue-wait TTL eviction is therefore 429
-// when the pool has endpoints and 503 (ttlPoolEmpty) when it does not.
-func translateFlowControlOutcome(outcome types.QueueOutcome, err error, ttlPoolEmpty bool) error {
-	msg := "request rejected by flow control"
-	if err != nil {
-		msg = err.Error()
-	}
-
-	switch outcome {
-	case types.QueueOutcomeDispatched:
+// ServiceUnavailable (503) means no serving capacity exists right now. A queue-wait TTL expiry is therefore 429
+// when the pool has endpoints and 503 when it does not; poolEmpty is the live probe deciding that split, invoked
+// only when the TTL case is reached.
+func translateFlowControlError(err error, poolEmpty func() bool) error {
+	if err == nil {
 		return nil
-	case types.QueueOutcomeRejectedCapacity:
-		return errcommon.Error{Code: errcommon.ResourceExhausted, Msg: msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonSaturated)}}
-	case types.QueueOutcomeRejectedNoEndpoints:
+	}
+	msg := err.Error()
+
+	switch {
+	case errors.Is(err, types.ErrFlowControllerNotRunning):
+		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "flow controller shutting down: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonShuttingDown)}}
+	case errors.Is(err, types.ErrNoEndpoints):
 		// No serving capacity exists (e.g. pool scaled to zero): signal genuine unavailability rather than backpressure.
+		// An eviction additionally spent its queue-wait budget waiting for an endpoint to appear.
+		if errors.Is(err, types.ErrEvicted) {
+			return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "request timed out in queue and no endpoints are available: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonNoEndpoints)}}
+		}
 		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "no endpoints available: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonNoEndpoints)}}
-	case types.QueueOutcomeEvictedNoEndpoints:
-		// The queue-wait budget was exhausted while the pool had no endpoints, so the regime is already established and
-		// needs no probe: waiting failed because nothing came up to serve the request.
-		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "request timed out in queue and no endpoints are available: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonNoEndpoints)}}
-	case types.QueueOutcomeEvictedTTL:
-		if ttlPoolEmpty {
+	case errors.Is(err, types.ErrQueueAtCapacity):
+		return errcommon.Error{Code: errcommon.ResourceExhausted, Msg: msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonSaturated)}}
+	case errors.Is(err, types.ErrTTLExpired):
+		if poolEmpty() {
 			return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "request timed out in queue and no endpoints are available: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonNoEndpoints)}}
 		}
 		return errcommon.Error{Code: errcommon.ResourceExhausted, Msg: "request timed out in queue: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonTTLExpired)}}
-	case types.QueueOutcomeEvictedContextCancelled:
+	case errors.Is(err, types.ErrContextCancelled):
 		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "client disconnected: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonContextCancelled)}}
-	case types.QueueOutcomeRejectedOther, types.QueueOutcomeEvictedOther:
-		switch {
-		case errors.Is(err, types.ErrFlowControllerNotRunning):
-			return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "flow controller shutting down: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonShuttingDown)}}
-		// A TTL expiry or client disconnect that fires before the item is admitted to a queue (e.g. while
-		// buffered in the enqueue channel or blocked in submission) surfaces as RejectedOther/EvictedOther
-		// rather than as a dedicated eviction outcome. These are client-caused terminations, so delegate
-		// to the mapping of the post-admission equivalent; the two paths then agree by construction.
-		case errors.Is(err, types.ErrTTLExpired):
-			return translateFlowControlOutcome(types.QueueOutcomeEvictedTTL, err, ttlPoolEmpty)
-		case errors.Is(err, types.ErrContextCancelled):
-			return translateFlowControlOutcome(types.QueueOutcomeEvictedContextCancelled, err, ttlPoolEmpty)
-		default:
-			return errcommon.Error{Code: errcommon.Internal, Msg: "internal flow control error: " + msg}
-		}
 	default:
-		return errcommon.Error{Code: errcommon.Internal, Msg: "unhandled flow control outcome: " + msg}
+		return errcommon.Error{Code: errcommon.Internal, Msg: "internal flow control error: " + msg}
 	}
 }

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -289,6 +289,7 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 			expectErr:       true,
 			expectErrCode:   errcommon.Internal,
 			expectErrSubstr: "internal flow control error",
+			expectHeaders:   map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonInternal)},
 		},
 		{
 			name:            "fc_reject_other_preadmission_ttl",
@@ -320,6 +321,7 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 			expectErr:       true,
 			expectErrCode:   errcommon.Internal,
 			expectErrSubstr: "internal flow control error",
+			expectHeaders:   map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonInternal)},
 		},
 		{
 			name:            "fc_missing_family_sentinel",
@@ -329,6 +331,7 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 			expectErr:       true,
 			expectErrCode:   errcommon.Internal,
 			expectErrSubstr: "internal flow control error",
+			expectHeaders:   map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonInternal)},
 		},
 	}
 
@@ -496,14 +499,16 @@ func TestTranslateFlowControlError(t *testing.T) {
 			wantReason: string(errcommon.RequestDroppedReasonShuttingDown),
 		},
 		{
-			name:     "family sentinel without a recognized cause returns 500",
-			err:      fmt.Errorf("%w: unexpected failure", fctypes.ErrRejected),
-			wantCode: errcommon.Internal,
+			name:       "family sentinel without a recognized cause returns 500",
+			err:        fmt.Errorf("%w: unexpected failure", fctypes.ErrRejected),
+			wantCode:   errcommon.Internal,
+			wantReason: string(errcommon.RequestDroppedReasonInternal),
 		},
 		{
-			name:     "missing family sentinel returns 500",
-			err:      errors.New("unexpected failure"),
-			wantCode: errcommon.Internal,
+			name:       "missing family sentinel returns 500",
+			err:        errors.New("unexpected failure"),
+			wantCode:   errcommon.Internal,
+			wantReason: string(errcommon.RequestDroppedReasonInternal),
 		},
 	}
 

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -233,16 +233,17 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 			name:            "fc_reject_capacity",
 			priority:        0,
 			fcOutcome:       fctypes.QueueOutcomeRejectedCapacity,
+			fcErr:           fmt.Errorf("%w: %w", fctypes.ErrRejected, fctypes.ErrQueueAtCapacity),
 			expectErr:       true,
 			expectErrCode:   errcommon.ResourceExhausted,
-			expectErrSubstr: "request rejected by flow control",
+			expectErrSubstr: "queue at capacity",
 			expectHeaders:   map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonSaturated)},
 		},
 		{
 			name:            "fc_reject_no_endpoints",
 			priority:        0,
 			fcOutcome:       fctypes.QueueOutcomeRejectedNoEndpoints,
-			fcErr:           fctypes.ErrNoEndpoints,
+			fcErr:           fmt.Errorf("%w: %w", fctypes.ErrRejected, fctypes.ErrNoEndpoints),
 			expectErr:       true,
 			expectErrCode:   errcommon.ServiceUnavailable,
 			expectErrSubstr: "no endpoints available",
@@ -252,28 +253,29 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 			name:            "fc_evict_ttl",
 			priority:        0,
 			fcOutcome:       fctypes.QueueOutcomeEvictedTTL,
-			fcErr:           errors.New("timeout"),
+			fcErr:           fmt.Errorf("%w: %w", fctypes.ErrEvicted, fctypes.ErrTTLExpired),
 			locatorPods:     []fwkdl.Endpoint{fwkdl.NewEndpoint(nil, nil)},
 			expectErr:       true,
 			expectErrCode:   errcommon.ResourceExhausted,
-			expectErrSubstr: "request timed out in queue: timeout",
+			expectErrSubstr: "request timed out in queue",
 			expectHeaders:   map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonTTLExpired)},
 		},
 		{
 			name:            "fc_evict_ttl_empty_pool",
 			priority:        0,
 			fcOutcome:       fctypes.QueueOutcomeEvictedTTL,
-			fcErr:           errors.New("timeout"),
+			fcErr:           fmt.Errorf("%w: %w", fctypes.ErrEvicted, fctypes.ErrTTLExpired),
 			locatorPods:     []fwkdl.Endpoint{},
 			expectErr:       true,
 			expectErrCode:   errcommon.ServiceUnavailable,
-			expectErrSubstr: "request timed out in queue and no endpoints are available: timeout",
+			expectErrSubstr: "request timed out in queue and no endpoints are available",
 			expectHeaders:   map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonNoEndpoints)},
 		},
 		{
 			name:            "fc_evict_context_cancelled",
 			priority:        0,
 			fcOutcome:       fctypes.QueueOutcomeEvictedContextCancelled,
+			fcErr:           fmt.Errorf("%w: %w", fctypes.ErrEvicted, fctypes.ErrContextCancelled),
 			expectErr:       true,
 			expectErrCode:   errcommon.ServiceUnavailable,
 			expectErrSubstr: "client disconnected",
@@ -283,6 +285,7 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 			name:            "fc_reject_other",
 			priority:        0,
 			fcOutcome:       fctypes.QueueOutcomeRejectedOther,
+			fcErr:           fmt.Errorf("%w: configuration error", fctypes.ErrRejected),
 			expectErr:       true,
 			expectErrCode:   errcommon.Internal,
 			expectErrSubstr: "internal flow control error",
@@ -313,18 +316,19 @@ func TestFlowControlAdmissionController_Admit(t *testing.T) {
 			name:            "fc_evict_other",
 			priority:        0,
 			fcOutcome:       fctypes.QueueOutcomeEvictedOther,
-			fcErr:           errors.New("internal error"),
+			fcErr:           fmt.Errorf("%w: internal error", fctypes.ErrEvicted),
 			expectErr:       true,
 			expectErrCode:   errcommon.Internal,
-			expectErrSubstr: "internal flow control error: internal error",
+			expectErrSubstr: "internal flow control error",
 		},
 		{
-			name:            "fc_unhandled_outcome",
+			name:            "fc_missing_family_sentinel",
 			priority:        0,
-			fcOutcome:       fctypes.QueueOutcomeNotYetFinalized,
+			fcOutcome:       fctypes.QueueOutcomeRejectedOther,
+			fcErr:           errors.New("no family sentinel"),
 			expectErr:       true,
 			expectErrCode:   errcommon.Internal,
-			expectErrSubstr: "unhandled flow control outcome",
+			expectErrSubstr: "internal flow control error",
 		},
 	}
 
@@ -378,7 +382,11 @@ func TestFlowControlAdmissionController_StampsQueueDuration(t *testing.T) {
 	t.Run("flow control leaves fields unset on rejection", func(t *testing.T) {
 		t.Parallel()
 		reqCtx := newReqCtx()
-		fc := &mockFlowController{outcome: fctypes.QueueOutcomeRejectedCapacity, delay: 5 * time.Millisecond}
+		fc := &mockFlowController{
+			outcome: fctypes.QueueOutcomeRejectedCapacity,
+			err:     fmt.Errorf("%w: %w", fctypes.ErrRejected, fctypes.ErrQueueAtCapacity),
+			delay:   5 * time.Millisecond,
+		}
 		ac := NewFlowControlAdmissionController(fc, "pool", &mocks.MockEndpointCandidates{})
 
 		require.Error(t, ac.Admit(ctx, reqCtx, 0))
@@ -396,12 +404,11 @@ func TestFlowControlAdmissionController_StampsQueueDuration(t *testing.T) {
 	})
 }
 
-func TestTranslateFlowControlOutcome(t *testing.T) {
+func TestTranslateFlowControlError(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name         string
-		outcome      fctypes.QueueOutcome
 		err          error
 		ttlPoolEmpty bool
 		wantCode     string
@@ -409,72 +416,68 @@ func TestTranslateFlowControlOutcome(t *testing.T) {
 		wantNil      bool
 	}{
 		{
-			name:    "dispatched returns nil",
-			outcome: fctypes.QueueOutcomeDispatched,
+			name:    "nil means dispatched and returns nil",
 			err:     nil,
 			wantNil: true,
 		},
 		{
 			name:       "capacity rejection returns 429",
-			outcome:    fctypes.QueueOutcomeRejectedCapacity,
-			err:        fctypes.ErrQueueAtCapacity,
+			err:        fmt.Errorf("%w: %w", fctypes.ErrRejected, fctypes.ErrQueueAtCapacity),
 			wantCode:   errcommon.ResourceExhausted,
 			wantReason: string(errcommon.RequestDroppedReasonSaturated),
 		},
 		{
+			name:       "no-endpoints rejection returns 503",
+			err:        fmt.Errorf("%w: %w", fctypes.ErrRejected, fctypes.ErrNoEndpoints),
+			wantCode:   errcommon.ServiceUnavailable,
+			wantReason: string(errcommon.RequestDroppedReasonNoEndpoints),
+		},
+		{
 			name:       "TTL expiry with endpoints returns 429",
-			outcome:    fctypes.QueueOutcomeEvictedTTL,
-			err:        fctypes.ErrTTLExpired,
+			err:        fmt.Errorf("%w: %w", fctypes.ErrEvicted, fctypes.ErrTTLExpired),
 			wantCode:   errcommon.ResourceExhausted,
 			wantReason: string(errcommon.RequestDroppedReasonTTLExpired),
 		},
 		{
 			name:         "TTL expiry with empty pool returns 503",
-			outcome:      fctypes.QueueOutcomeEvictedTTL,
-			err:          fctypes.ErrTTLExpired,
+			err:          fmt.Errorf("%w: %w", fctypes.ErrEvicted, fctypes.ErrTTLExpired),
 			ttlPoolEmpty: true,
 			wantCode:     errcommon.ServiceUnavailable,
 			wantReason:   string(errcommon.RequestDroppedReasonNoEndpoints),
 		},
 		{
-			// The regime is carried by the outcome itself, so the mapping must not depend on a pool probe.
+			// The regime is carried by the error itself, so the mapping must not depend on a pool probe.
 			name:       "no-endpoint budget expiry returns 503",
-			outcome:    fctypes.QueueOutcomeEvictedNoEndpoints,
-			err:        fmt.Errorf("%w: %w", fctypes.ErrTTLExpired, fctypes.ErrNoEndpoints),
+			err:        fmt.Errorf("%w: %w: %w", fctypes.ErrEvicted, fctypes.ErrTTLExpired, fctypes.ErrNoEndpoints),
 			wantCode:   errcommon.ServiceUnavailable,
 			wantReason: string(errcommon.RequestDroppedReasonNoEndpoints),
 		},
 		{
 			name:       "context cancellation returns 503",
-			outcome:    fctypes.QueueOutcomeEvictedContextCancelled,
-			err:        fctypes.ErrContextCancelled,
+			err:        fmt.Errorf("%w: %w", fctypes.ErrEvicted, fctypes.ErrContextCancelled),
 			wantCode:   errcommon.ServiceUnavailable,
 			wantReason: string(errcommon.RequestDroppedReasonContextCancelled),
 		},
 		{
 			name:       "shutdown eviction returns 503",
-			outcome:    fctypes.QueueOutcomeEvictedOther,
-			err:        fctypes.ErrFlowControllerNotRunning,
+			err:        fmt.Errorf("%w: %w", fctypes.ErrEvicted, fctypes.ErrFlowControllerNotRunning),
 			wantCode:   errcommon.ServiceUnavailable,
 			wantReason: string(errcommon.RequestDroppedReasonShuttingDown),
 		},
 		{
 			name:       "shutdown rejection returns 503",
-			outcome:    fctypes.QueueOutcomeRejectedOther,
-			err:        fctypes.ErrFlowControllerNotRunning,
+			err:        fmt.Errorf("%w: %w", fctypes.ErrRejected, fctypes.ErrFlowControllerNotRunning),
 			wantCode:   errcommon.ServiceUnavailable,
 			wantReason: string(errcommon.RequestDroppedReasonShuttingDown),
 		},
 		{
 			name:       "pre-admission TTL rejection maps like TTL eviction",
-			outcome:    fctypes.QueueOutcomeRejectedOther,
 			err:        fmt.Errorf("%w: %w", fctypes.ErrRejected, fctypes.ErrTTLExpired),
 			wantCode:   errcommon.ResourceExhausted,
 			wantReason: string(errcommon.RequestDroppedReasonTTLExpired),
 		},
 		{
 			name:         "pre-admission TTL rejection with empty pool maps like TTL eviction",
-			outcome:      fctypes.QueueOutcomeRejectedOther,
 			err:          fmt.Errorf("%w: %w", fctypes.ErrRejected, fctypes.ErrTTLExpired),
 			ttlPoolEmpty: true,
 			wantCode:     errcommon.ServiceUnavailable,
@@ -482,35 +485,23 @@ func TestTranslateFlowControlOutcome(t *testing.T) {
 		},
 		{
 			name:       "pre-admission cancellation rejection maps like cancellation eviction",
-			outcome:    fctypes.QueueOutcomeRejectedOther,
 			err:        fmt.Errorf("%w: %w", fctypes.ErrRejected, fctypes.ErrContextCancelled),
 			wantCode:   errcommon.ServiceUnavailable,
 			wantReason: string(errcommon.RequestDroppedReasonContextCancelled),
 		},
 		{
-			name:       "other TTL eviction maps like TTL eviction",
-			outcome:    fctypes.QueueOutcomeEvictedOther,
-			err:        fmt.Errorf("%w: %w", fctypes.ErrEvicted, fctypes.ErrTTLExpired),
-			wantCode:   errcommon.ResourceExhausted,
-			wantReason: string(errcommon.RequestDroppedReasonTTLExpired),
-		},
-		{
-			name:       "other cancellation eviction maps like cancellation eviction",
-			outcome:    fctypes.QueueOutcomeEvictedOther,
-			err:        fmt.Errorf("%w: %w", fctypes.ErrEvicted, fctypes.ErrContextCancelled),
-			wantCode:   errcommon.ServiceUnavailable,
-			wantReason: string(errcommon.RequestDroppedReasonContextCancelled),
-		},
-		{
 			name:       "shutdown takes precedence over TTL",
-			outcome:    fctypes.QueueOutcomeRejectedOther,
-			err:        fmt.Errorf("%w: %w", fctypes.ErrFlowControllerNotRunning, fctypes.ErrTTLExpired),
+			err:        fmt.Errorf("%w: %w: %w", fctypes.ErrRejected, fctypes.ErrFlowControllerNotRunning, fctypes.ErrTTLExpired),
 			wantCode:   errcommon.ServiceUnavailable,
 			wantReason: string(errcommon.RequestDroppedReasonShuttingDown),
 		},
 		{
-			name:     "internal error returns 500",
-			outcome:  fctypes.QueueOutcomeRejectedOther,
+			name:     "family sentinel without a recognized cause returns 500",
+			err:      fmt.Errorf("%w: unexpected failure", fctypes.ErrRejected),
+			wantCode: errcommon.Internal,
+		},
+		{
+			name:     "missing family sentinel returns 500",
 			err:      errors.New("unexpected failure"),
 			wantCode: errcommon.Internal,
 		},
@@ -519,7 +510,7 @@ func TestTranslateFlowControlOutcome(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := translateFlowControlOutcome(tt.outcome, tt.err, tt.ttlPoolEmpty)
+			result := translateFlowControlError(tt.err, func() bool { return tt.ttlPoolEmpty })
 			if tt.wantNil {
 				require.NoError(t, result)
 				return


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Makes `QueueOutcome` a pure function of the finalization error instead of a second, independently chosen value.

Every finalization site picked an (outcome, error) pair by hand, and the pair encodes one fact twice: the outer sentinel (`ErrRejected` vs `ErrEvicted`) carries the pre/post-admission split and the inner sentinel carries the cause. #2097 came from the pairing drifting out of agreement. The mapping also existed twice in helper form, in opposite directions: the queue-wait sweep derived the error from an outcome (`expiryError(outcome)`) while `inferOutcome` derived an outcome from an error.

- `types.OutcomeFromError(err)` is the single mapping. `finalizeInternal` derives the outcome from the error; an error missing a family sentinel is logged as an invariant violation and classified `RejectedOther`.
- `FlowItem.FinalizeWithOutcome(outcome, err)` becomes `FinalizeWithError(err)`, nil meaning dispatched. `inferOutcome` splits into `wrapCause` plus the shared mapping. The sweep builds the error and the outcome is derived, so the inverse helper is gone.
- `translateFlowControlOutcome` becomes `translateFlowControlError(err, poolEmpty)` and switches on error sentinels, removing the recursion that re-entered `RejectedOther` wrapping `ErrTTLExpired` as `EvictedTTL`. Pre-admission TTL/cancel still finalizes in the `ErrRejected` family (#2162), since the metrics split relies on rejected items never having consumed queue capacity; the single `ErrTTLExpired` arm covers both families. Pool emptiness is a live state the error cannot carry, so it is passed as a `poolEmpty func() bool` and called only in the TTL arm.
- `EnqueueAndWait`'s signature and the metrics label vocabulary are unchanged. `TestOutcomeFromError` pins the derived outcome for every producer error expression and fails when a `QueueOutcome` value has no producer row. The integration suite is untouched and asserts observed (outcome, error) pairs end to end.

Behavior changes:

- The blocking-submit failure path wraps `ErrRejected` once: `distributeRequest` wraps, and `tryDistribution` returns the finalized error unchanged.
- Processor drop counts record the outcome stored on the item (`finalizeAndRecordDrop`) instead of a literal at the call site. Under a finalization race the summary counts the winner's outcome, matching `flow_control_requests_total`, which already recorded the winner.
- The enqueue path's two registry-lookup rejections flatten the registry error with `%v`, matching the existing convention in `tryDistribution`: a `%w`-preserved `ErrPriorityBandNotFound` returned through the connection closure would be misread by `withConnectionWithFallback` as a lease-acquisition failure and retried at priority 0.
- Flow control errors that map to HTTP 500 carry `x-llm-d-request-dropped-reason: rejected-internal`, so every flow control drop response now carries the reason header.
- A bare `context.DeadlineExceeded` finalization cause is wrapped as `ErrTTLExpired: <cause>`, preserving the original error in the chain like the cancellation arm.

**Which issue(s) this PR fixes**:

Fixes #2168

**Release note** _(write `NONE` if no user-facing change)_:

```release-note
Flow control drop responses that map to HTTP 500 now carry the header `x-llm-d-request-dropped-reason: rejected-internal`.
```

**Test plan**:

- [x] Derived outcome matches the stored outcome for every producer error expression, and every `QueueOutcome` value has a producer row
- [x] Expiry errors carry the regime sentinels for the saturation and no-endpoint regimes
- [x] Pre- and post-admission TTL and cancellation map to the same HTTP statuses from the error alone, and errors without a family sentinel map to 500 with the `rejected-internal` reason header
- [x] A bare deadline-exceeded cause classifies as a TTL outcome with the original error preserved in the chain
