### PR TITLE
fix(charts): roll the EPP pod when its ConfigMaps change

### DIFF
--- a/config/charts/routerlib/templates/_deployment.yaml
+++ b/config/charts/routerlib/templates/_deployment.yaml
@@ -317,10 +317,8 @@ spec:
       labels:
         {{- include "llm-d-router.selectorLabels" . | nindent 8 }}
         {{- include "llm-d-router.modeLabels" . | nindent 8 }}
-      {{- with .Values.router.epp.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "llm-d-epp.podAnnotations" . | nindent 8 }}
     spec:
 {{ include "llm-d-epp.deployment-pod-spec" . }}
 ---
@@ -351,10 +349,8 @@ spec:
       labels:
         {{- include "llm-d-router.selectorLabels" . | nindent 8 }}
         {{- include "llm-d-router.modeLabels" . | nindent 8 }}
-      {{- with .Values.router.epp.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "llm-d-epp.podAnnotations" . | nindent 8 }}
     spec:
 {{ include "llm-d-epp.deployment-pod-spec" . }}
 ---

--- a/config/charts/routerlib/templates/_helpers.tpl
+++ b/config/charts/routerlib/templates/_helpers.tpl
@@ -516,3 +516,19 @@ Deprecation validations
 {{- fail "Top-level 'inferenceObjectives' is deprecated. Please migrate your values to 'router.inferenceObjectives'." }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Annotations for the EPP pod template.
+
+The EPP parses its plugin configuration once at startup and never re-reads the
+mounted file, so a helm upgrade that touches only a ConfigMap has to change the
+pod template or the running pod keeps its old configuration. Hash the whole
+config partial rather than one ConfigMap: it renders the plugins, proxy and
+latency-predictor ConfigMaps, and all of them are mounted into this pod.
+*/}}
+{{- define "llm-d-epp.podAnnotations" -}}
+checksum/config: {{ include "llm-d-epp.config" . | sha256sum }}
+{{- with .Values.router.epp.podAnnotations }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
+{{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:

The EPP pod template carries no annotation derived from the ConfigMaps it mounts, so a
`helm upgrade` that changes only plugin configuration leaves the pod template byte-identical
and Kubernetes correctly declines to create a new ReplicaSet. `cmd/epp/runner/runner.go`
reads the config file once and caches it in `r.rawConfig`, and nothing watches that path, so
the running pod keeps the configuration it parsed at startup.

What makes this worth fixing rather than documenting is that every signal reports success:
`helm upgrade` bumps the revision, `kubectl get cm` shows the new config (the kubelet syncs
the mounted file regardless of whether anything re-reads it), and `kubectl rollout status`
returns `successfully rolled out` immediately, because the Deployment genuinely is at its
desired state. That last one is the command you would reach for to check exactly this, and on
an unchanged pod template it cannot distinguish "rolled out with the new config" from "never
rolled, because there was nothing to roll".

This adds the conventional checksum annotation to both the `Deployment` and `StatefulSet` pod
templates, through a shared `llm-d-epp.podAnnotations` helper so the two branches cannot drift.

The hash is taken over the whole `llm-d-epp.config` partial rather than a single ConfigMap.
That partial renders four ConfigMaps — EPP plugins, the proxy config, and the two
latency-predictor ones — and all of them are mounted into this same pod, so hashing the
partial covers them in one annotation. The proxy ConfigMap has the same defect today:
changing `router.proxy.configMap.data` currently leaves the pod template untouched.

User-supplied `router.epp.podAnnotations` are still emitted, after the checksum.

**Verification**

Rendered `llm-d-router-standalone` and `llm-d-router-gateway` from this branch, comparing the
sha1 of the pod template:

| change | before this PR | after |
|---|---|---|
| `pluginsCustomConfig` `featureGates: []` → `[flowControl]` | identical | differs |
| `proxy.configMap.data.extra.txt` `one` → `two` | identical | differs |
| nothing (same values rendered twice) | identical | identical |

Also swept the 32-combination cross product of `monitoring.prometheus.enabled` ×
`monitoring.provider.name` (`PrometheusOperator`/`GMP`) × `monitoring.prometheus.auth.enabled`
× `inferencePool.create` × `epp.replicas` (1/2) on both charts:

| | combos | pod templates carrying `checksum/config` | fused YAML documents |
|---|---|---|---|
| `main` | 32 | 0 | 0 |
| this branch | 32 | 32 | 0 |

`helm lint` passes on both charts. The `StatefulSet` branch
(`gkePreferredBackends.enabled=true`) and `podAnnotations` merging were checked separately.

**Which issue(s) this PR fixes**:

Fixes #2459

**Release note**:
```release-note
The EPP pod now restarts when its ConfigMaps change. A `helm upgrade` that modifies only plugin, proxy or latency-predictor configuration previously left the running EPP on its old configuration while reporting success.
```
