### PR TITLE
(WIP) feat: add compatibility-screener plugin and string metric label extraction

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -105,6 +105,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestattributereporter"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestheader/outlenbucket"
+	compatibilityfilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/screener/compatibilityfilter"
 	disaggregatedsetrollout "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout"
 	testresponsereceived "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/test/responsereceived"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/anthropic"
@@ -575,6 +576,7 @@ func (r *Runner) registerInTreePlugins() {
 	// request control screeners
 	// Alpha
 	fwkplugin.Register(disaggregatedsetrollout.PluginType, fwkplugin.StabilityAlpha, disaggregatedsetrollout.Factory)
+	fwkplugin.Register(compatibilityfilter.PluginType, fwkplugin.StabilityAlpha, compatibilityfilter.Factory)
 
 	// bylabel role filters
 	// Beta

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -103,6 +103,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestattributereporter"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity"
+	compatibilityfilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/screener/compatibilityfilter"
 	disaggregatedsetrollout "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/screener/disaggregatedsetrollout"
 	testresponsereceived "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/test/responsereceived"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/anthropic"
@@ -567,6 +568,7 @@ func (r *Runner) registerInTreePlugins() {
 	// request control screeners
 	// Alpha
 	fwkplugin.Register(disaggregatedsetrollout.PluginType, fwkplugin.StabilityAlpha, disaggregatedsetrollout.Factory)
+	fwkplugin.Register(compatibilityfilter.PluginType, fwkplugin.StabilityAlpha, compatibilityfilter.Factory)
 
 	// bylabel role filters
 	// Beta

--- a/pkg/epp/framework/plugins/datalayer/attribute/metrics/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/metrics/data_types.go
@@ -37,6 +37,14 @@ func (v ScalarMetricValue) Clone() fwkdl.Cloneable {
 	return v
 }
 
+// StringMetricValue is a string endpoint attribute extracted from a Prometheus
+// metric label on an info-style gauge (e.g. a compatibility hash).
+type StringMetricValue string
+
+func (v StringMetricValue) Clone() fwkdl.Cloneable {
+	return v
+}
+
 // ScalarMetricDataKey returns the key under which the core metrics extractor
 // publishes the custom scalar metric configured as attributeKey. The data type
 // of a custom metric is chosen in configuration rather than in code, so the key
@@ -45,8 +53,18 @@ func ScalarMetricDataKey(attributeKey string) plugin.DataKey {
 	return plugin.NewDataKey(attributeKey, MetricsExtractorType)
 }
 
+// StringMetricDataKey returns the key under which the core metrics extractor
+// publishes a string metric label value configured as attributeKey.
+func StringMetricDataKey(attributeKey string) plugin.DataKey {
+	return plugin.NewDataKey(attributeKey, MetricsExtractorType)
+}
+
 func ReadScalarMetricValue(attrs fwkdl.AttributeMap, key plugin.DataKey) (ScalarMetricValue, bool) {
 	return fwkdl.ReadAttribute[ScalarMetricValue](attrs, key)
+}
+
+func ReadStringMetricValue(attrs fwkdl.AttributeMap, key plugin.DataKey) (StringMetricValue, bool) {
+	return fwkdl.ReadAttribute[StringMetricValue](attrs, key)
 }
 
 // ResolveConfiguredKey builds the key a plugin reads from an attribute name and

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -88,14 +88,18 @@ func (ext *Extractor) TypedName() fwkplugin.TypedName {
 
 var _ fwkplugin.ProducerPlugin = &Extractor{}
 
-// Produces declares the custom scalar metric attributes, whose names come from
+// Produces declares the custom metric attributes, whose names come from
 // the per-engine mappings in configuration. Core metrics land on the Metrics
 // struct rather than the attribute map and so are not declared here.
 func (ext *Extractor) Produces() map[fwkplugin.DataKey]any {
 	produced := map[fwkplugin.DataKey]any{}
 	for _, mapping := range ext.registry.Mappings() {
 		for _, custom := range mapping.CustomMetrics {
-			produced[attrmetrics.ScalarMetricDataKey(custom.AttributeKey)] = attrmetrics.ScalarMetricValue(0)
+			if custom.LabelName != "" {
+				produced[attrmetrics.StringMetricDataKey(custom.AttributeKey)] = attrmetrics.StringMetricValue("")
+			} else {
+				produced[attrmetrics.ScalarMetricDataKey(custom.AttributeKey)] = attrmetrics.ScalarMetricValue(0)
+			}
 		}
 	}
 	return produced
@@ -193,8 +197,17 @@ func (ext *Extractor) Extract(ctx context.Context, in fwkdl.PollInput[sourcemetr
 			errs = append(errs, fmt.Errorf("custom metric %q: %w", custom.AttributeKey, err))
 			continue
 		}
-		ep.GetAttributes().Put(attrmetrics.ScalarMetricDataKey(custom.AttributeKey), attrmetrics.ScalarMetricValue(extractValue(metric)))
-		updated = true
+		if custom.LabelName != "" {
+			if val, ok := extractLabelValue(metric, custom.LabelName); ok {
+				ep.GetAttributes().Put(attrmetrics.StringMetricDataKey(custom.AttributeKey), attrmetrics.StringMetricValue(val))
+				updated = true
+			} else {
+				errs = append(errs, fmt.Errorf("custom metric %q: label %q not found", custom.AttributeKey, custom.LabelName))
+			}
+		} else {
+			ep.GetAttributes().Put(attrmetrics.ScalarMetricDataKey(custom.AttributeKey), attrmetrics.ScalarMetricValue(extractValue(metric)))
+			updated = true
+		}
 	}
 
 	logger := log.FromContext(ctx).WithValues("endpoint", ep.GetMetadata().ID)

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -87,7 +87,7 @@ func (ext *Extractor) TypedName() fwkplugin.TypedName {
 
 var _ fwkplugin.ProducerPlugin = &Extractor{}
 
-// Produces declares the custom scalar metric attributes, whose names come from
+// Produces declares the custom metric attributes, whose names come from
 // the per-engine mappings in configuration, plus the per-pod metric fields this
 // extractor writes into the endpoint's Metrics struct that a scorer or filter
 // declares as a Consumes() dependency. Declaring both lets the data-attribute
@@ -104,7 +104,11 @@ func (ext *Extractor) Produces() map[fwkplugin.DataKey]any {
 	}
 	for _, mapping := range ext.registry.Mappings() {
 		for _, custom := range mapping.CustomMetrics {
-			produced[attrmetrics.ScalarMetricDataKey(custom.AttributeKey)] = attrmetrics.ScalarMetricValue(0)
+			if custom.LabelName != "" {
+				produced[attrmetrics.StringMetricDataKey(custom.AttributeKey)] = attrmetrics.StringMetricValue("")
+			} else {
+				produced[attrmetrics.ScalarMetricDataKey(custom.AttributeKey)] = attrmetrics.ScalarMetricValue(0)
+			}
 		}
 	}
 	return produced
@@ -202,7 +206,26 @@ func (ext *Extractor) Extract(ctx context.Context, in fwkdl.PollInput[sourcemetr
 			errs = append(errs, fmt.Errorf("custom metric %q: %w", custom.AttributeKey, err))
 			continue
 		}
-		ep.GetAttributes().Put(attrmetrics.ScalarMetricDataKey(custom.AttributeKey), attrmetrics.ScalarMetricValue(extractValue(metric)))
+		if custom.LabelName != "" {
+			value, ok := extractLabelValue(metric, custom.LabelName)
+			if !ok {
+				errs = append(errs, fmt.Errorf(
+					"custom metric %q: label %q not found",
+					custom.AttributeKey,
+					custom.LabelName,
+				))
+				continue
+			}
+			ep.GetAttributes().Put(
+				attrmetrics.StringMetricDataKey(custom.AttributeKey),
+				attrmetrics.StringMetricValue(value),
+			)
+		} else {
+			ep.GetAttributes().Put(
+				attrmetrics.ScalarMetricDataKey(custom.AttributeKey),
+				attrmetrics.ScalarMetricValue(extractValue(metric)),
+			)
+		}
 		updated = true
 	}
 

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
@@ -66,10 +66,14 @@ type (
 	}
 
 	customMetricConfigParams struct {
-		// AttributeKey is the endpoint attribute key where the scalar value is stored.
+		// AttributeKey is the endpoint attribute key where the extracted value is stored.
 		AttributeKey string `json:"attributeKey"`
 		// MetricSpec defines the source metric specification string.
 		MetricSpec string `json:"metricSpec"`
+		// LabelName, when set, extracts the named Prometheus label's string value
+		// instead of the metric's numeric gauge/counter value. The result is stored
+		// as a StringMetricValue attribute.
+		LabelName string `json:"labelName,omitempty"`
 	}
 
 	// modelServerExtractorParams holds the configuration parameters for the core metrics extractor plugin.
@@ -269,6 +273,7 @@ func customMetricConfigs(configs []customMetricConfigParams) ([]CustomMetric, []
 		custom = append(custom, CustomMetric{
 			AttributeKey: cfg.AttributeKey,
 			Spec:         spec,
+			LabelName:    cfg.LabelName,
 		})
 	}
 	return custom, errs

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
@@ -61,6 +61,10 @@ type MappingConfig struct {
 type CustomMetric struct {
 	AttributeKey string
 	Spec         *Spec
+	// LabelName, when set, extracts the named Prometheus label's string value
+	// instead of the metric's numeric value. The result is stored as a
+	// StringMetricValue attribute rather than a ScalarMetricValue.
+	LabelName string
 }
 
 type namedSpec struct {
@@ -201,6 +205,7 @@ func parseCustomMetrics(configs []CustomMetric) ([]CustomMetric, []error) {
 		metrics = append(metrics, CustomMetric{
 			AttributeKey: cfg.AttributeKey,
 			Spec:         cfg.Spec,
+			LabelName:    cfg.LabelName,
 		})
 	}
 	return metrics, errs

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
@@ -62,6 +62,10 @@ type MappingConfig struct {
 type CustomMetric struct {
 	AttributeKey string
 	Spec         *Spec
+	// LabelName, when set, extracts the named Prometheus label's string value
+	// instead of the metric's numeric value. The result is stored as a
+	// StringMetricValue attribute rather than a ScalarMetricValue.
+	LabelName string
 }
 
 type namedSpec struct {
@@ -202,6 +206,7 @@ func parseCustomMetrics(configs []CustomMetric) ([]CustomMetric, []error) {
 		metrics = append(metrics, CustomMetric{
 			AttributeKey: cfg.AttributeKey,
 			Spec:         cfg.Spec,
+			LabelName:    cfg.LabelName,
 		})
 	}
 	return metrics, errs

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
@@ -386,6 +386,50 @@ func TestMetricsExtractionCustomScalarFromConfig(t *testing.T) {
 	assert.Zero(t, ep.GetMetrics().KVCacheUsagePercent)
 }
 
+func TestMetricsExtractionCustomStringLabelFromConfig(t *testing.T) {
+	const attributeKey = "vllm.io/nixl-compat-hash"
+
+	srv := createMockServer([]MetricMock{
+		{
+			Name:  "vllm:nixl_config_info",
+			Value: 1,
+			Labels: map[string]string{
+				"compatibility_hash": "sha256:abc123",
+			},
+		},
+	})
+	defer srv.Close()
+
+	params := &modelServerExtractorParams{
+		EngineConfigs: []engineConfigParams{
+			{
+				Name: "vllm",
+				CustomMetrics: []customMetricConfigParams{
+					{
+						AttributeKey: attributeKey,
+						MetricSpec:   "vllm:nixl_config_info",
+						LabelName:    "compatibility_hash",
+					},
+				},
+			},
+		},
+	}
+
+	p, err := buildPipeline(t, srv.URL, params)
+	require.NoError(t, err)
+	ep := newEndpointAt(mustHost(t, srv.URL), map[string]string{
+		DefaultEngineTypeLabelKey: "vllm",
+	})
+
+	require.NoError(t, p.Poll(context.Background(), ep))
+	got, ok := attrmetrics.ReadStringMetricValue(
+		ep.GetAttributes(),
+		attrmetrics.StringMetricDataKey(attributeKey),
+	)
+	require.True(t, ok)
+	assert.Equal(t, attrmetrics.StringMetricValue("sha256:abc123"), got)
+}
+
 func TestMetricsExtractionCustomCounterFromConfig(t *testing.T) {
 	const attributeKey = "custom.total_requests"
 

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec.go
@@ -159,3 +159,17 @@ func extractValue(metric *dto.Metric) float64 {
 	}
 	return 0
 }
+
+// extractLabelValue returns the value of the named Prometheus label on the
+// given metric, or ("", false) if the label is not present.
+func extractLabelValue(metric *dto.Metric, labelName string) (string, bool) {
+	if metric == nil {
+		return "", false
+	}
+	for _, lp := range metric.GetLabel() {
+		if lp.GetName() == labelName {
+			return lp.GetValue(), true
+		}
+	}
+	return "", false
+}

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/spec.go
@@ -161,3 +161,17 @@ func extractValue(metric *dto.Metric) float64 {
 	}
 	return 0
 }
+
+// extractLabelValue returns the value of the named Prometheus label on the
+// given metric, or ("", false) if the label is not present.
+func extractLabelValue(metric *dto.Metric, labelName string) (string, bool) {
+	if metric == nil {
+		return "", false
+	}
+	for _, lp := range metric.GetLabel() {
+		if lp.GetName() == labelName {
+			return lp.GetValue(), true
+		}
+	}
+	return "", false
+}

--- a/pkg/epp/framework/plugins/requestcontrol/screener/compatibilityfilter/config.go
+++ b/pkg/epp/framework/plugins/requestcontrol/screener/compatibilityfilter/config.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package compatibilityfilter provides a request-control Screener that groups
+// endpoints by a metrics-derived compatibility value (e.g. a NIXL config hash)
+// and ensures that only mutually compatible endpoints survive screening.
+//
+// This is useful during rolling upgrades of disaggregated prefill/decode
+// deployments: pods running different model configs produce different hashes,
+// and KV transfer between incompatible pods will fail. The screener picks one
+// compatible group per request so the scheduler only sees endpoints that can
+// exchange KV cache data.
+package compatibilityfilter
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Config is the parameters block of a compatibility-screener plugin.
+type Config struct {
+	// AttributeKey is the endpoint attribute key that holds the compatibility
+	// value (e.g. a hash extracted from a Prometheus metric label via the
+	// customMetrics extractor with labelName).
+	AttributeKey string `json:"attributeKey"`
+
+	// HeaderName is the HTTP header used to propagate the chosen compatibility
+	// value. On prefill responses it is stamped; on decode requests, if present,
+	// it pins the screener to a specific value (strict matching).
+	HeaderName string `json:"headerName"`
+
+	// RoleLabelKey is the pod label key that identifies an endpoint's role
+	// (e.g. "prefill", "decode"). Used to verify that a compatibility group
+	// has coverage across all required roles before selecting it.
+	// Optional: if empty, role coverage checking is skipped.
+	RoleLabelKey string `json:"roleLabelKey,omitempty"`
+
+	// RequireRoles lists the roles that must each have at least one endpoint
+	// in a compatibility group for that group to be eligible. Ignored when
+	// RoleLabelKey is empty.
+	RequireRoles []string `json:"requireRoles,omitempty"`
+}
+
+// Validate performs static config checks.
+func (c *Config) Validate() error {
+	if c.AttributeKey == "" {
+		return errors.New("attributeKey is required")
+	}
+	if c.HeaderName == "" {
+		return errors.New("headerName is required")
+	}
+	c.HeaderName = strings.ToLower(c.HeaderName)
+
+	if c.RoleLabelKey != "" && len(c.RequireRoles) == 0 {
+		return errors.New("requireRoles must contain at least one role when roleLabelKey is set")
+	}
+	if c.RoleLabelKey == "" && len(c.RequireRoles) > 0 {
+		return errors.New("roleLabelKey is required when requireRoles is set")
+	}
+
+	seen := make(map[string]struct{}, len(c.RequireRoles))
+	for i, role := range c.RequireRoles {
+		if role == "" {
+			return fmt.Errorf("requireRoles[%d] must not be empty", i)
+		}
+		if _, exists := seen[role]; exists {
+			return fmt.Errorf("requireRoles contains duplicate role %q", role)
+		}
+		seen[role] = struct{}{}
+	}
+	return nil
+}

--- a/pkg/epp/framework/plugins/requestcontrol/screener/compatibilityfilter/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/screener/compatibilityfilter/plugin.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compatibilityfilter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+)
+
+const (
+	PluginType = "compatibility-screener"
+)
+
+// Screener groups endpoints by a metrics-derived compatibility value and
+// filters to one compatible group per request.
+type Screener struct {
+	typedName fwkplugin.TypedName
+	config    Config
+	dataKey   fwkplugin.DataKey
+
+	// chosenValues caches the compatibility value chosen during Screen() so
+	// that ResponseHeader() can stamp it. Keyed by request ID.
+	mu           sync.Mutex
+	chosenValues map[string]string
+}
+
+var (
+	_ fwkplugin.Plugin              = (*Screener)(nil)
+	_ fwkplugin.ConsumerPlugin      = (*Screener)(nil)
+	_ fwkrc.Screener                = (*Screener)(nil)
+	_ fwkrc.ResponseHeaderProcessor = (*Screener)(nil)
+)
+
+// Factory creates a compatibility-screener from plugin parameters.
+func Factory(name string, parameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	if name == "" {
+		name = PluginType
+	}
+	config := Config{}
+	if parameters == nil {
+		return nil, errors.New("compatibility-screener requires parameters")
+	}
+	if err := parameters.Decode(&config); err != nil {
+		return nil, fmt.Errorf("decode compatibility-screener parameters: %w", err)
+	}
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	dataKey := attrmetrics.StringMetricDataKey(config.AttributeKey)
+	return newScreener(name, config, dataKey), nil
+}
+
+func newScreener(
+	name string,
+	config Config,
+	dataKey fwkplugin.DataKey,
+) *Screener {
+	return &Screener{
+		typedName:    fwkplugin.TypedName{Type: PluginType, Name: name},
+		config:       config,
+		dataKey:      dataKey,
+		chosenValues: make(map[string]string),
+	}
+}
+
+func (s *Screener) TypedName() fwkplugin.TypedName { return s.typedName }
+
+func (s *Screener) Consumes() fwkplugin.DataDependencies {
+	return fwkplugin.DataDependencies{
+		Required: map[fwkplugin.DataKey]any{
+			s.dataKey: attrmetrics.StringMetricValue(""),
+		},
+	}
+}
+
+// ResponseHeader stamps the chosen compatibility value into the response so
+// downstream consumers (e.g. a coordinator forwarding to a decode EPP) can pin
+// their request to the same value.
+func (s *Screener) ResponseHeader(_ context.Context, request *fwksched.InferenceRequest, response *fwkrc.Response, _ *fwkdl.EndpointMetadata) {
+	if request == nil || response == nil || response.Headers == nil {
+		return
+	}
+	s.mu.Lock()
+	value, ok := s.chosenValues[request.RequestID]
+	if ok {
+		delete(s.chosenValues, request.RequestID)
+	}
+	s.mu.Unlock()
+
+	if ok && value != "" {
+		response.Headers[s.config.HeaderName] = value
+	}
+}
+
+// getCompatValue reads the compatibility value from an endpoint's attributes.
+func (s *Screener) getCompatValue(endpoint fwksched.Endpoint) string {
+	val, ok := endpoint.Get(s.dataKey)
+	if !ok {
+		return ""
+	}
+	if v, isStr := val.(attrmetrics.StringMetricValue); isStr {
+		return string(v)
+	}
+	return ""
+}

--- a/pkg/epp/framework/plugins/requestcontrol/screener/compatibilityfilter/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/screener/compatibilityfilter/plugin.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compatibilityfilter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+)
+
+const (
+	PluginType = "compatibility-screener"
+)
+
+// Screener groups endpoints by a metrics-derived compatibility value and
+// filters to one compatible group per request.
+type Screener struct {
+	typedName fwkplugin.TypedName
+	config    Config
+	dataKey   fwkplugin.DataKey
+
+	// chosenValues caches the compatibility value chosen during Screen() so
+	// that ResponseHeader() can stamp it. Keyed by request ID.
+	mu           sync.Mutex
+	chosenValues map[string]string
+}
+
+var (
+	_ fwkplugin.Plugin              = (*Screener)(nil)
+	_ fwkrc.Screener                = (*Screener)(nil)
+	_ fwkrc.ResponseHeaderProcessor = (*Screener)(nil)
+)
+
+// Factory creates a compatibility-screener from plugin parameters.
+func Factory(name string, parameters *json.Decoder, _ fwkplugin.Handle) (fwkplugin.Plugin, error) {
+	if name == "" {
+		name = PluginType
+	}
+	config := Config{}
+	if parameters == nil {
+		return nil, errors.New("compatibility-screener requires parameters")
+	}
+	if err := parameters.Decode(&config); err != nil {
+		return nil, fmt.Errorf("decode compatibility-screener parameters: %w", err)
+	}
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	return newScreener(name, config), nil
+}
+
+func newScreener(name string, config Config) *Screener {
+	return &Screener{
+		typedName:    fwkplugin.TypedName{Type: PluginType, Name: name},
+		config:       config,
+		dataKey:      fwkplugin.NewDataKey(config.AttributeKey, "core-metrics-extractor"),
+		chosenValues: make(map[string]string),
+	}
+}
+
+func (s *Screener) TypedName() fwkplugin.TypedName { return s.typedName }
+
+// ResponseHeader stamps the chosen compatibility value into the response so
+// downstream consumers (e.g. a coordinator forwarding to a decode EPP) can pin
+// their request to the same value.
+func (s *Screener) ResponseHeader(_ context.Context, request *fwksched.InferenceRequest, response *fwkrc.Response, _ *fwkdl.EndpointMetadata) {
+	if request == nil || response == nil || response.Headers == nil {
+		return
+	}
+	s.mu.Lock()
+	value, ok := s.chosenValues[request.RequestID]
+	if ok {
+		delete(s.chosenValues, request.RequestID)
+	}
+	s.mu.Unlock()
+
+	if ok && value != "" {
+		response.Headers[s.config.HeaderName] = value
+	}
+}
+
+// getCompatValue reads the compatibility value from an endpoint's attributes.
+func (s *Screener) getCompatValue(endpoint fwksched.Endpoint) string {
+	val, ok := endpoint.Get(s.dataKey)
+	if !ok {
+		return ""
+	}
+	if v, isStr := val.(attrmetrics.StringMetricValue); isStr {
+		return string(v)
+	}
+	return ""
+}

--- a/pkg/epp/framework/plugins/requestcontrol/screener/compatibilityfilter/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/screener/compatibilityfilter/plugin_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compatibilityfilter
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+)
+
+const (
+	testAttribute = "vllm.io/nixl-compat-hash"
+	testHeader    = "x-compat-hash"
+	testRoleLabel = "llm-d.ai/role"
+)
+
+func testScreener(t *testing.T) *Screener {
+	t.Helper()
+	config := Config{
+		AttributeKey: testAttribute,
+		HeaderName:   testHeader,
+		RoleLabelKey: testRoleLabel,
+		RequireRoles: []string{"prefill", "decode"},
+	}
+	require.NoError(t, config.Validate())
+	return newScreener(
+		"test-screener",
+		config,
+		attrmetrics.StringMetricDataKey(testAttribute),
+	)
+}
+
+func testEndpoint(name, role, hash string) fwksched.Endpoint {
+	attributes := fwkdl.NewAttributes()
+	if hash != "" {
+		attributes.Put(
+			attrmetrics.StringMetricDataKey(testAttribute),
+			attrmetrics.StringMetricValue(hash),
+		)
+	}
+	return fwksched.NewEndpoint(
+		&fwkdl.EndpointMetadata{
+			Name: name,
+			Labels: map[string]string{
+				testRoleLabel: role,
+			},
+		},
+		&fwkdl.Metrics{},
+		attributes,
+	)
+}
+
+func TestScreenerConsumesCompatibilityAttribute(t *testing.T) {
+	screener := testScreener(t)
+	dependencies := screener.Consumes()
+	require.Contains(t, dependencies.Required, screener.dataKey)
+	assert.IsType(
+		t,
+		attrmetrics.StringMetricValue(""),
+		dependencies.Required[screener.dataKey],
+	)
+}
+
+func TestScreenPinnedValue(t *testing.T) {
+	screener := testScreener(t)
+	endpoints := []fwksched.Endpoint{
+		testEndpoint("a-prefill", "prefill", "a"),
+		testEndpoint("a-decode", "decode", "a"),
+		testEndpoint("b-prefill", "prefill", "b"),
+		testEndpoint("b-decode", "decode", "b"),
+	}
+	request := &fwksched.InferenceRequest{
+		Headers: map[string]string{testHeader: "b"},
+	}
+
+	got := screener.Screen(context.Background(), request, endpoints)
+	require.Len(t, got, 2)
+	assert.Equal(t, "b-prefill", got[0].GetMetadata().Name)
+	assert.Equal(t, "b-decode", got[1].GetMetadata().Name)
+}
+
+func TestScreenRequiresRoleCoverage(t *testing.T) {
+	screener := testScreener(t)
+	endpoints := []fwksched.Endpoint{
+		testEndpoint("a-prefill", "prefill", "a"),
+		testEndpoint("a-decode", "decode", "a"),
+		testEndpoint("b-prefill", "prefill", "b"),
+	}
+	request := &fwksched.InferenceRequest{
+		RequestID: "request-1",
+		Headers:   map[string]string{},
+	}
+
+	got := screener.Screen(context.Background(), request, endpoints)
+	require.Len(t, got, 2)
+	assert.Equal(t, "a-prefill", got[0].GetMetadata().Name)
+	assert.Equal(t, "a-decode", got[1].GetMetadata().Name)
+}
+
+func TestResponseHeaderStampsChosenCompatibility(t *testing.T) {
+	screener := testScreener(t)
+	request := &fwksched.InferenceRequest{
+		RequestID: "request-1",
+		Headers:   map[string]string{},
+	}
+	endpoints := []fwksched.Endpoint{
+		testEndpoint("a-prefill", "prefill", "a"),
+		testEndpoint("a-decode", "decode", "a"),
+	}
+	require.Len(
+		t,
+		screener.Screen(context.Background(), request, endpoints),
+		2,
+	)
+
+	response := &fwkrc.Response{Headers: map[string]string{}}
+	screener.ResponseHeader(context.Background(), request, response, nil)
+	assert.Equal(t, "a", response.Headers[testHeader])
+	assert.NotContains(t, screener.chosenValues, request.RequestID)
+}
+
+func TestScreenFailsClosedWithoutCompatibilityData(t *testing.T) {
+	screener := testScreener(t)
+	request := &fwksched.InferenceRequest{Headers: map[string]string{}}
+	endpoints := []fwksched.Endpoint{
+		testEndpoint("prefill", "prefill", ""),
+		testEndpoint("decode", "decode", ""),
+	}
+
+	assert.Empty(t, screener.Screen(context.Background(), request, endpoints))
+}
+
+func TestFactoryAcceptsSlashInAttributeKey(t *testing.T) {
+	config := Config{
+		AttributeKey: testAttribute,
+		HeaderName:   testHeader,
+	}
+	raw, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	plugin, err := Factory(
+		"test-screener",
+		fwkplugin.StrictDecoder(raw),
+		nil,
+	)
+	require.NoError(t, err)
+	screener, ok := plugin.(*Screener)
+	require.True(t, ok)
+
+	assert.Equal(
+		t,
+		attrmetrics.StringMetricDataKey(testAttribute),
+		screener.dataKey,
+	)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/screener/compatibilityfilter/screener.go
+++ b/pkg/epp/framework/plugins/requestcontrol/screener/compatibilityfilter/screener.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compatibilityfilter
+
+import (
+	"context"
+	"math/rand/v2"
+	"sort"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+// Screen filters endpoints to a single compatibility group.
+//
+// If the request carries the configured header (e.g. forwarded from a prefill
+// response), only endpoints matching that value survive (strict pinning).
+// Otherwise, endpoints are grouped by compatibility value, groups missing any
+// required role are dropped, and one surviving group is chosen at random
+// weighted by endpoint count.
+func (s *Screener) Screen(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+	if request == nil || len(endpoints) == 0 {
+		return endpoints
+	}
+
+	// Strict pinning: if the request already carries a compatibility value
+	// (e.g. decode request forwarded from a prefill response), filter to
+	// endpoints with that exact value.
+	if pinned := request.Headers[s.config.HeaderName]; pinned != "" {
+		return s.filterByValue(endpoints, pinned)
+	}
+
+	// Group endpoints by compatibility value.
+	groups := s.groupEndpoints(endpoints)
+	if len(groups) == 0 {
+		return nil
+	}
+
+	// Drop groups missing required roles.
+	eligible := s.filterCoveredGroups(groups)
+	if len(eligible) == 0 {
+		logger := log.FromContext(ctx)
+		logger.V(4).Info("No compatibility group covers all required roles",
+			"plugin", s.typedName.Name,
+			"groups", len(groups),
+			"requireRoles", s.config.RequireRoles,
+		)
+		return nil
+	}
+
+	// Pick one group, weighted by endpoint count.
+	chosen := pickGroup(eligible, rand.Float64())
+
+	// Cache the chosen value for ResponseHeader().
+	s.mu.Lock()
+	s.chosenValues[request.RequestID] = chosen
+	s.mu.Unlock()
+
+	return s.filterByValue(endpoints, chosen)
+}
+
+type compatGroup struct {
+	value    string
+	count    int
+	roleSeen map[string]bool
+}
+
+func (s *Screener) groupEndpoints(endpoints []fwksched.Endpoint) map[string]*compatGroup {
+	groups := make(map[string]*compatGroup)
+	for _, ep := range endpoints {
+		if ep == nil || ep.GetMetadata() == nil {
+			continue
+		}
+		value := s.getCompatValue(ep)
+		if value == "" {
+			continue
+		}
+		g, ok := groups[value]
+		if !ok {
+			g = &compatGroup{value: value, roleSeen: make(map[string]bool)}
+			groups[value] = g
+		}
+		g.count++
+		if s.config.RoleLabelKey != "" {
+			if role := ep.GetMetadata().Labels[s.config.RoleLabelKey]; role != "" {
+				g.roleSeen[role] = true
+			}
+		}
+	}
+	return groups
+}
+
+func (s *Screener) filterCoveredGroups(groups map[string]*compatGroup) map[string]*compatGroup {
+	if len(s.config.RequireRoles) == 0 {
+		return groups
+	}
+	covered := make(map[string]*compatGroup, len(groups))
+	for value, g := range groups {
+		if hasCoverage(g, s.config.RequireRoles) {
+			covered[value] = g
+		}
+	}
+	return covered
+}
+
+func hasCoverage(g *compatGroup, requiredRoles []string) bool {
+	for _, role := range requiredRoles {
+		if !g.roleSeen[role] {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Screener) filterByValue(endpoints []fwksched.Endpoint, value string) []fwksched.Endpoint {
+	result := make([]fwksched.Endpoint, 0, len(endpoints))
+	for _, ep := range endpoints {
+		if ep == nil || ep.GetMetadata() == nil {
+			continue
+		}
+		if s.getCompatValue(ep) == value {
+			result = append(result, ep)
+		}
+	}
+	return result
+}
+
+// pickGroup selects one compatibility value from the eligible groups, weighted
+// by endpoint count. Deterministic for a given draw value.
+func pickGroup(groups map[string]*compatGroup, draw float64) string {
+	values := make([]string, 0, len(groups))
+	total := 0
+	for value, g := range groups {
+		values = append(values, value)
+		total += g.count
+	}
+	if total == 0 {
+		return ""
+	}
+	sort.Strings(values)
+	if len(values) == 1 {
+		return values[0]
+	}
+	x := draw * float64(total)
+	cumulative := 0.0
+	for _, value := range values {
+		cumulative += float64(groups[value].count)
+		if x < cumulative {
+			return value
+		}
+	}
+	return values[len(values)-1]
+}

--- a/pkg/epp/framework/plugins/requestcontrol/screener/compatibilityfilter/screener.go
+++ b/pkg/epp/framework/plugins/requestcontrol/screener/compatibilityfilter/screener.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compatibilityfilter
+
+import (
+	"context"
+	"math/rand/v2"
+	"sort"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+// Screen filters endpoints to a single compatibility group.
+//
+// If the request carries the configured header (e.g. forwarded from a prefill
+// response), only endpoints matching that value survive (strict pinning).
+// Otherwise, endpoints are grouped by compatibility value, groups missing any
+// required role are dropped, and one surviving group is chosen at random
+// weighted by endpoint count.
+func (s *Screener) Screen(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+	if request == nil || len(endpoints) == 0 {
+		return endpoints
+	}
+
+	// Strict pinning: if the request already carries a compatibility value
+	// (e.g. decode request forwarded from a prefill response), filter to
+	// endpoints with that exact value.
+	if pinned := request.Headers[s.config.HeaderName]; pinned != "" {
+		return s.filterByValue(endpoints, pinned)
+	}
+
+	// Group endpoints by compatibility value.
+	groups := s.groupEndpoints(endpoints)
+	if len(groups) == 0 {
+		return nil
+	}
+
+	// Drop groups missing required roles.
+	eligible := s.filterCoveredGroups(groups)
+	if len(eligible) == 0 {
+		logger := log.FromContext(ctx)
+		logger.V(logutil.DEBUG).Info("No compatibility group covers all required roles",
+			"plugin", s.typedName.Name,
+			"groups", len(groups),
+			"requireRoles", s.config.RequireRoles,
+		)
+		return nil
+	}
+
+	// Pick one group, weighted by endpoint count.
+	chosen := pickGroup(eligible, rand.Float64())
+
+	// Cache the chosen value for ResponseHeader().
+	s.mu.Lock()
+	s.chosenValues[request.RequestID] = chosen
+	s.mu.Unlock()
+
+	return s.filterByValue(endpoints, chosen)
+}
+
+type compatGroup struct {
+	value    string
+	count    int
+	roleSeen map[string]bool
+}
+
+func (s *Screener) groupEndpoints(endpoints []fwksched.Endpoint) map[string]*compatGroup {
+	groups := make(map[string]*compatGroup)
+	for _, ep := range endpoints {
+		if ep == nil || ep.GetMetadata() == nil {
+			continue
+		}
+		value := s.getCompatValue(ep)
+		if value == "" {
+			continue
+		}
+		g, ok := groups[value]
+		if !ok {
+			g = &compatGroup{value: value, roleSeen: make(map[string]bool)}
+			groups[value] = g
+		}
+		g.count++
+		if s.config.RoleLabelKey != "" {
+			if role := ep.GetMetadata().Labels[s.config.RoleLabelKey]; role != "" {
+				g.roleSeen[role] = true
+			}
+		}
+	}
+	return groups
+}
+
+func (s *Screener) filterCoveredGroups(groups map[string]*compatGroup) map[string]*compatGroup {
+	if len(s.config.RequireRoles) == 0 {
+		return groups
+	}
+	covered := make(map[string]*compatGroup, len(groups))
+	for value, g := range groups {
+		if hasCoverage(g, s.config.RequireRoles) {
+			covered[value] = g
+		}
+	}
+	return covered
+}
+
+func hasCoverage(g *compatGroup, requiredRoles []string) bool {
+	for _, role := range requiredRoles {
+		if !g.roleSeen[role] {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Screener) filterByValue(endpoints []fwksched.Endpoint, value string) []fwksched.Endpoint {
+	result := make([]fwksched.Endpoint, 0, len(endpoints))
+	for _, ep := range endpoints {
+		if ep == nil || ep.GetMetadata() == nil {
+			continue
+		}
+		if s.getCompatValue(ep) == value {
+			result = append(result, ep)
+		}
+	}
+	return result
+}
+
+// pickGroup selects one compatibility value from the eligible groups, weighted
+// by endpoint count. Deterministic for a given draw value.
+func pickGroup(groups map[string]*compatGroup, draw float64) string {
+	values := make([]string, 0, len(groups))
+	total := 0
+	for value, g := range groups {
+		values = append(values, value)
+		total += g.count
+	}
+	if total == 0 {
+		return ""
+	}
+	sort.Strings(values)
+	if len(values) == 1 {
+		return values[0]
+	}
+	x := draw * float64(total)
+	cumulative := 0.0
+	for _, value := range values {
+		cumulative += float64(groups[value].count)
+		if x < cumulative {
+			return value
+		}
+	}
+	return values[len(values)-1]
+}


### PR DESCRIPTION
Add a new `compatibility-screener` plugin that groups endpoints by a metrics-derived compatibility value (e.g. NIXL config hash) and filters to one compatible group per request, preventing KV transfer failures during rolling upgrades of disaggregated P/D deployments. Also extends the custom metrics extractor to support extracting string label values from info-style Prometheus gauges (via new `labelName` config field) to enable this.

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds a `compatibility-screener` plugin that prevents KV transfer failures during rolling upgrades of disaggregated P/D deployments. The screener groups endpoints by a compatibility value (e.g. NIXL config hash scraped from a vLLM Prometheus metric), drops groups missing required roles, and picks one compatible group per request — so prefill and decode always land on pods that can exchange KV cache data.

To support this, the `core-metrics-extractor` is extended with a `labelName` field on `customMetrics` that extracts string label values from info-style gauges (stored as a new `StringMetricValue` attribute type). 

**Example configuration:**
```yaml
plugins:
- parameters:
    engineConfigs:
    - name: vllm
      customMetrics:
      - attributeKey: "vllm.io/nixl-compat-hash"
        metricSpec: "vllm:nixl_config_info"
        labelName: "compatibility_hash"
  type: core-metrics-extractor
- parameters:
    attributeKey: "vllm.io/nixl-compat-hash"
    headerName: "x-compat-hash"
    roleLabelKey: llm-d.ai/role
    requireRoles: [prefill, decode]
  type: compatibility-screener
```

**Test results:**

16,000-request benchmark during a rolling dtype change on a live P/D cluster (3 prefill + 3 decode, Qwen3-0.6B, NIXL `kv_both`):
- **Without screener:** 14,593 errors (91%)
- **With screener:** 0 errors

Depends on vLLM PR exposing `vllm:nixl_config_info` metric: https://github.com/vllm-project/vllm/pull/52999

**Which issue(s) this PR fixes**:

Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Add compatibility-screener plugin for filtering endpoints by NIXL config hash during rolling upgrades of disaggregated P/D deployments.
```