### PR TITLE
perf(sidecar): skip usage rewrite parsing for frames without usage

### DIFF
--- a/pkg/sidecar/proxy/cached_tokens_usage_rewriter.go
+++ b/pkg/sidecar/proxy/cached_tokens_usage_rewriter.go
@@ -39,6 +39,11 @@ type cachedTokensUsageRewriter struct {
 // See: https://platform.openai.com/docs/guides/prompt-caching
 const promptTokensDetailsField = "prompt_tokens_details"
 
+// usageKey is the JSON key that must be present before a frame can carry usage.
+// Streamed responses send one frame per token and only the final frame has usage,
+// so scanning for this is much cheaper than unmarshalling every frame to find out.
+var usageKey = []byte(`"usage"`)
+
 func newCachedTokensResponseWriter(w http.ResponseWriter, cachedTokens int) http.ResponseWriter {
 	writer, _ := newCachedTokensResponseWriterWithFinalize(w, cachedTokens)
 	return writer
@@ -278,6 +283,10 @@ func replaceCachedTokensSSELine(line []byte, cachedTokens int) ([]byte, bool) {
 		return line, false
 	}
 	if bytes.Equal(bytes.TrimSpace(data), []byte("[DONE]")) {
+		return line, true
+	}
+	if !bytes.Contains(data, usageKey) {
+		// No usage in this frame, so unmarshalling it could not change anything.
 		return line, true
 	}
 	// Only JSON data frames can carry usage; other SSE frames pass through.

--- a/pkg/sidecar/proxy/cached_tokens_usage_rewriter_test.go
+++ b/pkg/sidecar/proxy/cached_tokens_usage_rewriter_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2" // nolint:revive
 	. "github.com/onsi/gomega"    // nolint:revive
@@ -215,3 +216,24 @@ var _ = Describe("Cached token usage rewriter", func() {
 		Expect(recorder.Body.String()).To(ContainSubstring(`"cached_tokens":7`))
 	})
 })
+
+// Streamed responses send one SSE frame per token and only the final frame carries
+// usage, so these two benchmarks bracket the per-frame cost of the rewrite.
+var (
+	benchContentFrame = []byte(`data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1730000000,"model":"meta-llama/Llama-3.1-8B-Instruct","choices":[{"index":0,"delta":{"content":" the"},"logprobs":null,"finish_reason":null}]}` + "\n")
+	benchUsageFrame   = []byte(`data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1730000000,"model":"meta-llama/Llama-3.1-8B-Instruct","choices":[],"usage":{"prompt_tokens":1024,"completion_tokens":256,"total_tokens":1280,"prompt_tokens_details":{"cached_tokens":1024}}}` + "\n")
+)
+
+func BenchmarkReplaceCachedTokensSSELineContentFrame(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		replaceCachedTokensSSELine(benchContentFrame, 512)
+	}
+}
+
+func BenchmarkReplaceCachedTokensSSELineUsageFrame(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		replaceCachedTokensSSELine(benchUsageFrame, 512)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

replaceCachedTokensSSELine unmarshals every sse frame looking for usage, but only the last frame in a stream has usage in it. so a 500 token response does ~500 full json.Unmarshal calls to end up rewriting one field once.

put a bytes.Contains check for "usage" in front of the parse. frames without it already came out unchanged, they just paid for the unmarshal first, so the output is the same. if the model writes the word usage in its own text the check passes and the parse runs and finds nothing, same as now.

numbers from the benchmarks in this PR:

content frame: 3689 ns/op 1816 B/op 40 allocs/op -> 224 ns/op 0 B/op 0 allocs
usage frame: unchanged

added benchmarks for both frame shapes to the existing test file. existing tests pass, race clean, vet and gofmt clean.

the openai streaming parser already does the same strings.Contains(content, "usage") check before unmarshalling, and its the same idea as the guarded log sites in #2470. came across this while looking at #2447 but its unrelated to that discussion, this path already runs today on the nixl connector.

**Which issue(s) this PR fixes**:

Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```