### PR TITLE
feat(flowcontrol): attach Retry-After hint to
  capacity rejections

### DIFF
--- a/pkg/common/error/error.go
+++ b/pkg/common/error/error.go
@@ -29,6 +29,10 @@ import (
 // reason a request was dropped by flow control.
 const RequestDroppedReasonHeaderKey = "x-llm-d-request-dropped-reason"
 
+// RetryAfterHeaderKey is the HTTP response header carrying the advisory retry delay on capacity
+// rejections, in RFC 9110 delta-seconds.
+const RetryAfterHeaderKey = "retry-after"
+
 // RequestDroppedReason is the reason a request was rejected before dispatch or evicted after dispatch.
 type RequestDroppedReason string
 

--- a/pkg/epp/flowcontrol/controller/internal/drain.go
+++ b/pkg/epp/flowcontrol/controller/internal/drain.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"math"
+	"time"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/contracts"
+)
+
+const (
+	// drainFoldInterval is how often accumulated dispatch counts are folded into the rate EWMAs.
+	drainFoldInterval = time.Second
+
+	// drainEWMAAlpha weights the most recent fold window against the accumulated rate.
+	drainEWMAAlpha = 0.3
+
+	// retryAfterHintCap bounds the emitted hint. The value is advisory (RFC 9110) and consumers bound it independently;
+	// the cap keeps a decayed estimate from projecting arbitrarily far.
+	retryAfterHintCap = 30 * time.Second
+)
+
+// drainEstimator tracks dispatch completion rates per priority band and globally, and projects the wait until a slot
+// frees in a rejecting scope. It is owned by the Processor and accessed only from the Run goroutine, so it needs no
+// synchronization.
+type drainEstimator struct {
+	perBand  map[int]*drainRate
+	global   drainRate
+	lastFold time.Time
+}
+
+// drainRate is one scope's dispatch-rate state: the EWMA over completed fold windows and the count accumulated in the
+// current window.
+type drainRate struct {
+	count  uint64
+	rate   float64 // dispatches per second
+	folded bool
+}
+
+func newDrainEstimator(now time.Time) *drainEstimator {
+	return &drainEstimator{perBand: make(map[int]*drainRate), lastFold: now}
+}
+
+// recordDispatch counts one dispatch completion against the band and the global scope.
+func (e *drainEstimator) recordDispatch(priority int) {
+	b := e.perBand[priority]
+	if b == nil {
+		b = &drainRate{}
+		e.perBand[priority] = b
+	}
+	b.count++
+	e.global.count++
+}
+
+// maybeFold folds accumulated counts into the rate EWMAs once per drainFoldInterval.
+func (e *drainEstimator) maybeFold(now time.Time) {
+	elapsed := now.Sub(e.lastFold)
+	if elapsed < drainFoldInterval {
+		return
+	}
+	seconds := elapsed.Seconds()
+	e.global.fold(seconds)
+	for _, b := range e.perBand {
+		b.fold(seconds)
+	}
+	e.lastFold = now
+}
+
+func (r *drainRate) fold(elapsedSeconds float64) {
+	r.rate = drainEWMAAlpha*(float64(r.count)/elapsedSeconds) + (1-drainEWMAAlpha)*r.rate
+	r.count = 0
+	r.folded = true
+}
+
+// current returns the scope's dispatch rate in requests per second, and whether the scope has any measurement at all.
+// The rate is the EWMA, raised to the current window's instantaneous rate when that is higher, so a burst that resumes
+// dispatching after an idle stretch corrects a decayed estimate without waiting for the next fold.
+func (r *drainRate) current(sinceFold time.Duration) (float64, bool) {
+	rate := r.rate
+	if sec := sinceFold.Seconds(); sec > 0 && r.count > 0 {
+		if inst := float64(r.count) / sec; inst > rate {
+			rate = inst
+		}
+	}
+	return rate, r.folded || r.count > 0
+}
+
+// retryAfterHint projects the wait until one slot frees in the scope whose capacity check rejected the request: the
+// priority band, the global limit, or both (the longer projection wins). Byte-tripped scopes use the same request-rate
+// projection, on the approximation that one dispatch frees an average request's bytes. The hint is rounded up to whole
+// seconds and capped at retryAfterHintCap. It is zero, meaning no hint, when no tripped scope has a measured nonzero
+// rate or when the projection is under one second: a whole-second floor would over-throttle a fast-draining scope, and
+// absence tells the client to keep its own retry policy.
+func (e *drainEstimator) retryAfterHint(
+	stats contracts.AggregateStats,
+	priority int,
+	itemByteSize uint64,
+	now time.Time,
+) time.Duration {
+	sinceFold := now.Sub(e.lastFold)
+
+	var projection float64 // seconds
+	if globalTripped(stats, itemByteSize) {
+		if rate, ok := e.global.current(sinceFold); ok && rate > 0 {
+			projection = 1 / rate
+		}
+	}
+	if band, ok := stats.PerPriorityBandStats[priority]; ok && bandTripped(band, itemByteSize) {
+		if b := e.perBand[priority]; b != nil {
+			if rate, ok := b.current(sinceFold); ok && rate > 0 {
+				projection = math.Max(projection, 1/rate)
+			}
+		}
+	}
+	if projection < 1 {
+		return 0
+	}
+	hint := time.Duration(math.Ceil(projection)) * time.Second
+	if hint > retryAfterHintCap {
+		return retryAfterHintCap
+	}
+	return hint
+}
+
+// globalTripped mirrors hasCapacity's global comparisons.
+func globalTripped(stats contracts.AggregateStats, itemByteSize uint64) bool {
+	return (stats.TotalCapacityBytes > 0 && stats.TotalByteSize+itemByteSize > stats.TotalCapacityBytes) ||
+		(stats.TotalCapacityRequests > 0 && stats.TotalLen+1 > stats.TotalCapacityRequests)
+}
+
+// bandTripped mirrors hasCapacity's per-band comparisons.
+func bandTripped(band contracts.PriorityBandStats, itemByteSize uint64) bool {
+	return (band.CapacityBytes > 0 && band.ByteSize+itemByteSize > band.CapacityBytes) ||
+		(band.CapacityRequests > 0 && band.Len+1 > band.CapacityRequests)
+}

--- a/pkg/epp/flowcontrol/controller/internal/drain_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/drain_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/contracts"
+)
+
+const drainTestPriority = 10
+
+// fullBandStats returns stats whose band capacity check fails for any request size, leaving the global scope untripped.
+func fullBandStats() contracts.AggregateStats {
+	return contracts.AggregateStats{
+		PerPriorityBandStats: map[int]contracts.PriorityBandStats{
+			drainTestPriority: {Priority: drainTestPriority, CapacityRequests: 5, Len: 5},
+		},
+	}
+}
+
+func TestDrainEstimator(t *testing.T) {
+	t.Parallel()
+	base := time.Unix(1000, 0)
+
+	t.Run("omits the hint before any measurement", func(t *testing.T) {
+		t.Parallel()
+		e := newDrainEstimator(base)
+		assert.Zero(t, e.retryAfterHint(fullBandStats(), drainTestPriority, 100, base),
+			"a scope with no observed dispatches has no basis for a projection")
+	})
+
+	t.Run("omits the hint on a measured-zero rate", func(t *testing.T) {
+		t.Parallel()
+		e := newDrainEstimator(base)
+		e.maybeFold(base.Add(2 * time.Second))
+		e.maybeFold(base.Add(4 * time.Second))
+		assert.Zero(t, e.retryAfterHint(fullBandStats(), drainTestPriority, 100, base.Add(4*time.Second)),
+			"zero drain gives no bound on the wait, so no hint is emitted")
+	})
+
+	t.Run("projects one slot from the band rate, rounded up", func(t *testing.T) {
+		t.Parallel()
+		e := newDrainEstimator(base)
+		e.recordDispatch(drainTestPriority)
+		e.recordDispatch(drainTestPriority)
+		now := base.Add(2 * time.Second)
+		e.maybeFold(now) // rate = 0.3 * (2/2) = 0.3/s; projection = 3.33s.
+		assert.Equal(t, 4*time.Second, e.retryAfterHint(fullBandStats(), drainTestPriority, 100, now))
+	})
+
+	t.Run("omits sub-second projections", func(t *testing.T) {
+		t.Parallel()
+		e := newDrainEstimator(base)
+		for range 10 {
+			e.recordDispatch(drainTestPriority)
+		}
+		now := base.Add(2 * time.Second)
+		e.maybeFold(now) // rate = 0.3 * (10/2) = 1.5/s; projection = 0.67s.
+		assert.Zero(t, e.retryAfterHint(fullBandStats(), drainTestPriority, 100, now),
+			"a whole-second floor would over-throttle a fast-draining band")
+	})
+
+	t.Run("caps long projections", func(t *testing.T) {
+		t.Parallel()
+		e := newDrainEstimator(base)
+		e.recordDispatch(drainTestPriority)
+		now := base.Add(100 * time.Second)
+		e.maybeFold(now) // rate = 0.3 * (1/100) = 0.003/s; projection = 333s.
+		assert.Equal(t, retryAfterHintCap, e.retryAfterHint(fullBandStats(), drainTestPriority, 100, now))
+	})
+
+	t.Run("current-window dispatches correct a decayed rate", func(t *testing.T) {
+		t.Parallel()
+		e := newDrainEstimator(base)
+		e.recordDispatch(drainTestPriority)
+		e.recordDispatch(drainTestPriority)
+		e.maybeFold(base.Add(2 * time.Second)) // rate = 0.3/s.
+		e.maybeFold(base.Add(4 * time.Second)) // idle folds decay the EWMA toward zero.
+		e.maybeFold(base.Add(6 * time.Second))
+		now := base.Add(6*time.Second + 500*time.Millisecond)
+		withoutBurst := e.retryAfterHint(fullBandStats(), drainTestPriority, 100, now)
+		assert.Equal(t, 7*time.Second, withoutBurst, "decayed rate 0.147/s projects 6.8s")
+
+		for range 5 {
+			e.recordDispatch(drainTestPriority)
+		}
+		assert.Zero(t, e.retryAfterHint(fullBandStats(), drainTestPriority, 100, now),
+			"5 dispatches in the open 500ms window prove a 10/s drain, under the one-second floor")
+	})
+
+	t.Run("uses the global rate when only the global limit tripped", func(t *testing.T) {
+		t.Parallel()
+		e := newDrainEstimator(base)
+		e.recordDispatch(drainTestPriority)
+		now := base.Add(2 * time.Second)
+		e.maybeFold(now) // global rate = 0.3 * (1/2) = 0.15/s; projection = 6.67s.
+		stats := contracts.AggregateStats{
+			TotalCapacityRequests: 5,
+			TotalLen:              5,
+			PerPriorityBandStats: map[int]contracts.PriorityBandStats{
+				drainTestPriority: {Priority: drainTestPriority, CapacityRequests: 100},
+			},
+		}
+		assert.Equal(t, 7*time.Second, e.retryAfterHint(stats, drainTestPriority, 100, now))
+	})
+
+	t.Run("takes the longer projection when both scopes tripped", func(t *testing.T) {
+		t.Parallel()
+		e := newDrainEstimator(base)
+		const fastPriority = 20
+		for range 10 {
+			e.recordDispatch(fastPriority)
+		}
+		e.recordDispatch(drainTestPriority)
+		now := base.Add(2 * time.Second)
+		e.maybeFold(now) // band rate = 0.15/s (6.67s); global rate = 1.65/s (0.61s).
+		stats := contracts.AggregateStats{
+			TotalCapacityRequests: 5,
+			TotalLen:              5,
+			PerPriorityBandStats: map[int]contracts.PriorityBandStats{
+				drainTestPriority: {Priority: drainTestPriority, CapacityRequests: 5, Len: 5},
+			},
+		}
+		assert.Equal(t, 7*time.Second, e.retryAfterHint(stats, drainTestPriority, 100, now),
+			"the slower tripped scope bounds the wait")
+	})
+}

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -99,6 +99,10 @@ type Processor struct {
 	// synchronization.
 	ceilings []float64
 
+	// drain tracks dispatch completion rates for the Retry-After hint attached to capacity rejections.
+	// Only accessed from the Run goroutine, so it needs no synchronization.
+	drain *drainEstimator
+
 	// wg is used to wait for background tasks (cleanup sweep) to complete on shutdown.
 	wg             sync.WaitGroup
 	isShuttingDown atomic.Bool
@@ -149,6 +153,7 @@ func NewProcessor(
 		lifecycleCtx:         ctx,
 		enqueueChan:          make(chan *FlowItem, enqueueChannelBufferSize),
 		reclamation:          reclamation,
+		drain:                newDrainEstimator(clock.Now()),
 	}
 	// Seeded so readers never handle a nil sample. The pool reads as non-empty until the first dispatch cycle observes
 	// otherwise, which keeps a request that arrives before that cycle on the saturation budget.
@@ -342,8 +347,10 @@ func (p *Processor) enqueue(item *FlowItem) {
 			"flowKey", key, "requestID", req.ID(), "reqByteSize", req.ByteSize(),
 			"totalLen", stats.TotalLen, "totalCapacityRequests", stats.TotalCapacityRequests,
 			"totalByteSize", stats.TotalByteSize, "totalCapacityBytes", stats.TotalCapacityBytes)
-		item.FinalizeWithOutcome(types.QueueOutcomeRejectedCapacity, fmt.Errorf("%w: %w",
-			types.ErrRejected, types.ErrQueueAtCapacity))
+		item.FinalizeWithOutcome(types.QueueOutcomeRejectedCapacity, fmt.Errorf("%w: %w", types.ErrRejected,
+			&types.QueueCapacityError{
+				RetryAfterHint: p.drain.retryAfterHint(stats, key.Priority, req.ByteSize(), p.clock.Now()),
+			}))
 		p.recordDrop(types.QueueOutcomeRejectedCapacity)
 		return
 	}
@@ -443,6 +450,7 @@ func (p *Processor) dispatchCycle(ctx context.Context) bool {
 	if empty := len(pool) == 0; empty != p.regime.Load().empty {
 		p.regime.Store(&regimeSample{empty: empty, since: p.clock.Now()})
 	}
+	p.drain.maybeFold(p.clock.Now())
 	saturation := p.saturationDetector.Saturation(ctx, pool)
 
 	// Record pool saturation metric
@@ -559,6 +567,7 @@ func (p *Processor) dispatchItem(itemAcc flowcontrol.QueueItemAccessor) error {
 	}
 	p.logger.V(logutil.TRACE).Info("Item dispatched.", "flowKey", req.FlowKey(), "requestID", req.ID())
 	removedItem.FinalizeWithOutcome(types.QueueOutcomeDispatched, nil)
+	p.drain.recordDispatch(key.Priority)
 	return nil
 }
 

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -342,6 +342,53 @@ func TestProcessor(t *testing.T) {
 			assert.Equal(t, types.QueueOutcomeRejectedCapacity, outcome, "The final outcome should be RejectedCapacity")
 			require.Error(t, err, "A capacity rejection should produce an error")
 			assert.ErrorIs(t, err, types.ErrQueueAtCapacity, "The error should be of type ErrQueueAtCapacity")
+			var capErr *types.QueueCapacityError
+			require.ErrorAs(t, err, &capErr, "The error should carry the typed capacity cause")
+			assert.Zero(t, capErr.RetryAfterHint, "No dispatches have been observed, so the rejection carries no hint")
+		})
+
+		t.Run("should attach a Retry-After hint to a capacity rejection after observed drain", func(t *testing.T) {
+			t.Parallel()
+			// --- ARRANGE ---
+			h := newTestHarness(t, testCleanupTick)
+			h.addQueue(testFlow)
+
+			// --- ACT ---
+			h.Start()
+			h.Go()
+			// Dispatch six items, then advance the fake clock so the next dispatch cycle folds them into the drain
+			// estimate: rate = 0.3 * (6 / 2s) = 0.9/s.
+			for i := range 6 {
+				item := h.newTestItem(fmt.Sprintf("req-drain-%d", i), testFlow, testTTL)
+				require.NoError(t, h.processor.Submit(item), "precondition: Submit should not fail")
+				outcome, err := h.waitForFinalization(item)
+				require.Equal(t, types.QueueOutcomeDispatched, outcome, "precondition: item should dispatch")
+				require.NoError(t, err)
+			}
+			h.clock.Step(2 * time.Second)
+			// A dispatch cycle at the stepped time performs the fold before this item dispatches, whether triggered by
+			// the ticker or by the item's own arrival.
+			foldItem := h.newTestItem("req-drain-fold", testFlow, testTTL)
+			require.NoError(t, h.processor.Submit(foldItem), "precondition: Submit should not fail")
+			outcome, err := h.waitForFinalization(foldItem)
+			require.Equal(t, types.QueueOutcomeDispatched, outcome, "precondition: item should dispatch")
+			require.NoError(t, err)
+
+			h.StatsFunc = func() contracts.AggregateStats {
+				return contracts.AggregateStats{PerPriorityBandStats: map[int]contracts.PriorityBandStats{
+					testFlow.Priority: {CapacityBytes: 50}, // 50 is less than item size of 100
+				}}
+			}
+			rejected := h.newTestItem("req-drain-reject", testFlow, testTTL)
+			require.NoError(t, h.processor.Submit(rejected), "precondition: Submit should not fail")
+
+			// --- ASSERT ---
+			outcome, err = h.waitForFinalization(rejected)
+			assert.Equal(t, types.QueueOutcomeRejectedCapacity, outcome, "The final outcome should be RejectedCapacity")
+			var capErr *types.QueueCapacityError
+			require.ErrorAs(t, err, &capErr, "The error should carry the typed capacity cause")
+			assert.Equal(t, 2*time.Second, capErr.RetryAfterHint,
+				"A 0.9/s band drain projects a 1.11s wait for one slot, rounded up to 2s")
 		})
 
 		t.Run("should reject item on registry lookup failure", func(t *testing.T) {

--- a/pkg/epp/flowcontrol/types/errors.go
+++ b/pkg/epp/flowcontrol/types/errors.go
@@ -18,6 +18,8 @@ package types
 
 import (
 	"errors"
+	"fmt"
+	"time"
 )
 
 // --- High-Level Outcome Errors ---
@@ -51,6 +53,24 @@ var (
 	// rejection reflects genuine unavailability rather than backpressure against a contended pool.
 	ErrNoEndpoints = errors.New("no endpoints available")
 )
+
+// QueueCapacityError is the cause carried by a QueueOutcomeRejectedCapacity finalization. It unwraps to
+// ErrQueueAtCapacity, so sentinel matching via `errors.Is` is unaffected, and additionally carries the controller's
+// advisory estimate of when the rejecting scope next has a free slot, for use as an HTTP Retry-After value.
+type QueueCapacityError struct {
+	// RetryAfterHint is the projected wait until one slot frees in the scope whose capacity check failed, in whole
+	// seconds. Zero means no estimate is available and no hint should be emitted.
+	RetryAfterHint time.Duration
+}
+
+func (e *QueueCapacityError) Error() string {
+	if e.RetryAfterHint > 0 {
+		return fmt.Sprintf("%s (projected wait %s)", ErrQueueAtCapacity.Error(), e.RetryAfterHint)
+	}
+	return ErrQueueAtCapacity.Error()
+}
+
+func (e *QueueCapacityError) Unwrap() error { return ErrQueueAtCapacity }
 
 // --- Post-Enqueue Eviction Errors ---
 

--- a/pkg/epp/flowcontrol/types/errors_test.go
+++ b/pkg/epp/flowcontrol/types/errors_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueueCapacityError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unwraps to the capacity sentinel", func(t *testing.T) {
+		t.Parallel()
+		err := fmt.Errorf("%w: %w", ErrRejected, &QueueCapacityError{RetryAfterHint: 5 * time.Second})
+		assert.ErrorIs(t, err, ErrQueueAtCapacity, "sentinel matching must survive the typed wrapper")
+		assert.ErrorIs(t, err, ErrRejected, "the outer rejection sentinel must remain matchable")
+	})
+
+	t.Run("carries the hint through the chain", func(t *testing.T) {
+		t.Parallel()
+		err := fmt.Errorf("%w: %w", ErrRejected, &QueueCapacityError{RetryAfterHint: 5 * time.Second})
+		var capErr *QueueCapacityError
+		require.ErrorAs(t, err, &capErr)
+		assert.Equal(t, 5*time.Second, capErr.RetryAfterHint)
+	})
+
+	t.Run("message includes the projected wait only when set", func(t *testing.T) {
+		t.Parallel()
+		withHint := &QueueCapacityError{RetryAfterHint: 5 * time.Second}
+		assert.Contains(t, withHint.Error(), ErrQueueAtCapacity.Error())
+		assert.Contains(t, withHint.Error(), "5s")
+		withoutHint := &QueueCapacityError{}
+		assert.Equal(t, ErrQueueAtCapacity.Error(), withoutHint.Error())
+	})
+}

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -19,6 +19,7 @@ package requestcontrol
 import (
 	"context"
 	"errors"
+	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -253,7 +254,13 @@ func translateFlowControlOutcome(outcome types.QueueOutcome, err error, ttlPoolE
 	case types.QueueOutcomeDispatched:
 		return nil
 	case types.QueueOutcomeRejectedCapacity:
-		return errcommon.Error{Code: errcommon.ResourceExhausted, Msg: msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonSaturated)}}
+		headers := map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonSaturated)}
+		// The hint arrives pre-rounded to whole seconds; zero means the controller had no estimate.
+		var capErr *types.QueueCapacityError
+		if errors.As(err, &capErr) && capErr.RetryAfterHint > 0 {
+			headers[errcommon.RetryAfterHeaderKey] = strconv.FormatInt(int64(capErr.RetryAfterHint/time.Second), 10)
+		}
+		return errcommon.Error{Code: errcommon.ResourceExhausted, Msg: msg, Headers: headers}
 	case types.QueueOutcomeRejectedNoEndpoints:
 		// No serving capacity exists (e.g. pool scaled to zero): signal genuine unavailability rather than backpressure.
 		return errcommon.Error{Code: errcommon.ServiceUnavailable, Msg: "no endpoints available: " + msg, Headers: map[string]string{errcommon.RequestDroppedReasonHeaderKey: string(errcommon.RequestDroppedReasonNoEndpoints)}}

--- a/pkg/epp/requestcontrol/admission_test.go
+++ b/pkg/epp/requestcontrol/admission_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -352,13 +353,14 @@ func TestTranslateFlowControlOutcome(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		outcome      fctypes.QueueOutcome
-		err          error
-		ttlPoolEmpty bool
-		wantCode     string
-		wantReason   string
-		wantNil      bool
+		name           string
+		outcome        fctypes.QueueOutcome
+		err            error
+		ttlPoolEmpty   bool
+		wantCode       string
+		wantReason     string
+		wantRetryAfter string
+		wantNil        bool
 	}{
 		{
 			name:    "dispatched returns nil",
@@ -370,6 +372,21 @@ func TestTranslateFlowControlOutcome(t *testing.T) {
 			name:       "capacity rejection returns 429",
 			outcome:    fctypes.QueueOutcomeRejectedCapacity,
 			err:        fctypes.ErrQueueAtCapacity,
+			wantCode:   errcommon.ResourceExhausted,
+			wantReason: string(errcommon.RequestDroppedReasonSaturated),
+		},
+		{
+			name:           "capacity rejection with a drain hint adds Retry-After",
+			outcome:        fctypes.QueueOutcomeRejectedCapacity,
+			err:            fmt.Errorf("%w: %w", fctypes.ErrRejected, &fctypes.QueueCapacityError{RetryAfterHint: 7 * time.Second}),
+			wantCode:       errcommon.ResourceExhausted,
+			wantReason:     string(errcommon.RequestDroppedReasonSaturated),
+			wantRetryAfter: "7",
+		},
+		{
+			name:       "capacity rejection with a zero hint omits Retry-After",
+			outcome:    fctypes.QueueOutcomeRejectedCapacity,
+			err:        fmt.Errorf("%w: %w", fctypes.ErrRejected, &fctypes.QueueCapacityError{}),
 			wantCode:   errcommon.ResourceExhausted,
 			wantReason: string(errcommon.RequestDroppedReasonSaturated),
 		},
@@ -483,6 +500,13 @@ func TestTranslateFlowControlOutcome(t *testing.T) {
 			if tt.wantReason != "" {
 				assert.Equal(t, tt.wantReason, e.Headers[errcommon.RequestDroppedReasonHeaderKey],
 					"drop reason header should match")
+			}
+			if tt.wantRetryAfter == "" {
+				assert.NotContains(t, e.Headers, errcommon.RetryAfterHeaderKey,
+					"retry-after header should be absent without a capacity drain hint")
+			} else {
+				assert.Equal(t, tt.wantRetryAfter, e.Headers[errcommon.RetryAfterHeaderKey],
+					"retry-after header should carry the hint in delta-seconds")
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Flow control returns a capacity rejection as HTTP 429 with `x-llm-d-request-dropped-reason: rejected-saturated`. The response identifies the rejection cause and carries no estimate of when capacity returns. This PR adds a `Retry-After` header: an advisory projection of when the rejecting scope next has a free slot.

- The processor tracks dispatch completion rates per priority band and globally: counters incremented at dispatch finalization, folded into an EWMA about once per second by the dispatch cycle. Both sites run on the single-writer Run goroutine, so the estimator needs no synchronization.
- On a capacity rejection, the projection is `1 / rate` for the scope whose capacity check tripped (the band, the global limit, or the longer of the two). The current window's instantaneous rate raises a decayed EWMA, so a burst that resumes dispatching after an idle stretch corrects the estimate without waiting for the next fold.
- Emission policy: RFC 9110 delta-seconds, rounded up, capped at 30 seconds. The header is omitted when the projection is under one second, because a whole-second floor would over-throttle a fast-draining scope, and when no tripped scope has a measured nonzero rate (startup, or measured-zero drain). An absent header means no estimate; clients apply their own retry policy.
- The hint travels inside the rejection error as `types.QueueCapacityError`, which unwraps to `ErrQueueAtCapacity`; the `EnqueueAndWait` signature and existing sentinel matching are unchanged. The admission translation reads it with `errors.As` and adds the header beside the drop reason.
- Scope: capacity rejections only. A queue-TTL 429 reports an exhausted latency budget, and a drain estimate carries no information about whether a retry would fit the next budget; TTL 429s, 503s, and post-dispatch eviction 429s carry no Retry-After.

The value is advisory and per-replica. The async processor's feedback-based dispatch gate (llm-d/llm-d-async#379, llm-d/llm-d-async#382) consumes it as a bounded window-close instruction and clamps it independently.

The contract, including the model behind the projection and the open question on zero-drain emission, is specified in #2487. This PR rebases onto #2456 when that lands (`hasCapacity` returns `contracts.CapacitySnapshot` there; the adaptation is mechanical).

**Which issue(s) this PR fixes**:

Fixes #2487

Part of #2485.

**Release note**

```release-note
Flow control capacity rejections (HTTP 429 with reason `rejected-saturated`) now carry a `Retry-After` header projecting when the rejecting scope next has a free slot, derived from observed dispatch rates. The header is omitted when no estimate is available or the projected wait is under one second, and is capped at 30 seconds.
```

Test plan (functionality verified by new tests):
- [x] Drain estimator: warmup and measured-zero omission, one-slot projection with round-up, sub-second omission, 30s cap, burst correction of a decayed rate, global-scope and both-scopes-tripped projections
- [x] Processor integration: cold-start capacity rejection carries the typed cause with no hint; rejection after observed drain carries the projected hint
- [x] Outcome translation: hint renders as `retry-after` delta-seconds beside the drop reason; absent on zero hint and on TTL-expiry 429s
- [x] Typed error: `errors.Is` compatibility with `ErrQueueAtCapacity` and `errors.As` round-trip
