### PR TITLE
feat(flowcontrol): make stale-metrics scoring configurable

### DIFF
--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/README.md
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/README.md
@@ -23,18 +23,26 @@ The global pool saturation is then evaluated across all candidate endpoints as a
     PoolSaturation = Average(EndpointScore)
 
 **Heterogeneous Deployments:** Because this detector calculates saturation as an unweighted average of individual endpoint scores, it treats all endpoints equally regardless of their physical capacity. In deployments with heterogeneous compute (e.g., mixing H100 and L4 nodes), a small, saturated endpoint has the exact same impact on global backpressure as a massive, saturated endpoint. Contrast this with the Concurrency Detector, which evaluates saturation as a single aggregate fraction, biasing toward larger endpoints.
-*Note: Endpoints with missing or stale metrics are aggressively scored as 100% saturated (fail-closed).*
+*Note: Endpoints with missing or stale metrics are scored according to `stalenessPolicy`: as 100% saturated under `saturated` (default), or excluded from the pool average under `ignore`. An empty candidate list reads 1.0 under both policies.*
 
-**Operational dependency:** because stale endpoints score as saturated, Flow Control dispatch depends on the
-health of model-server metrics collection (scrape path, port, TLS, auth). A fleet-wide scrape outage pins
+**Operational dependency:** under `saturated`, a fleet-wide scrape outage pins
 `flow_control_pool_saturation` at 1.0 and halts dispatch entirely. The `flow_control_stale_endpoints` gauge and a
 rate-limited detector log distinguish this from genuine overload: stale endpoints read exactly 1.0, while genuine
-oversubscription typically reads above 1.0. This fail-closed posture is deliberate — admitting blind on missing
+oversubscription typically reads above 1.0. `saturated` is the default because admitting blind on missing
 data risks overloading model servers with no backpressure signal at all. Staleness also tends to correlate with
-overload: a server too busy to serve its metrics endpoint is often the one that is saturated, so failing open
-would hide exactly the wrong endpoints. The posture is not configurable; if field evidence shows a need, a
-staleness policy (for example, holding the last known score for a bounded window) can be added later without
-changing this default.
+overload: a server too busy to serve its metrics endpoint is often the one that is saturated, so `ignore`
+discounts the endpoints most likely to be overloaded from the backpressure signal. Deployments whose availability budget cannot absorb a dispatch halt
+during a metrics collection outage can select `ignore`, which excludes stale endpoints from the saturation
+average and scores an all-stale pool at 0.0, consistent with the Filter's fail-open fallback. Under `ignore`,
+a fleet-wide scrape outage means dispatching with no backpressure signal at all; the stale-endpoints gauge and
+detector log are the primary operational signal in that posture.
+
+`stalenessPolicy` governs the `SaturationDetector` role only. The `Filter` role always drops stale candidates
+and falls back to the original list when every candidate is stale, independent of this setting. Slow scrape
+cadences should be tuned with `metricsStalenessThreshold` rather than `ignore`: if the poll interval is
+longer than the staleness threshold, every sample reads stale between polls and `saturated` will block
+dispatch almost continuously. The policy field is an enum so additional degradations (for example, holding
+the last known score for a bounded window) can be added later.
 
 ### Role in Scheduling (The Traffic Shaper)
 The detector implements the `Filter` interface to protect individual endpoints. It removes endpoints from candidate lists if their telemetry is stale, or if they exceed specific safety limits:
@@ -59,7 +67,8 @@ The plugin accepts JSON parameters decoding to the following fields:
 
 - `queueDepthThreshold` (`int`): Target waiting queue depth limit. Serves as the "ideal" queue capacity for a single endpoint. Must be > 0. (Default: `5`)
 - `kvCacheUtilThreshold` (`float64`): Target KV cache memory utilization limit, expressed as a fraction. Must be in `(0.0, 1.0]`. (Default: `0.8`)
-- `metricsStalenessThreshold` (`string` / duration): Maximum age of metrics before an endpoint is considered stale. Stale endpoints are treated as 100% saturated. Must be > 0. (Default: `"200ms"`)
+- `metricsStalenessThreshold` (`string` / duration): Maximum age of metrics before an endpoint is considered stale. How stale endpoints are scored is controlled by `stalenessPolicy`. Must be > 0. (Default: `"200ms"`)
+- `stalenessPolicy` (`string`): How endpoints with missing or stale metrics contribute to pool saturation: `"saturated"` scores them as fully saturated; `"ignore"` excludes them from the saturation average. (Default: `"saturated"`)
 - `headroom` (`float64`): Allowed burst capacity above the ideal thresholds, expressed as a fraction (e.g., `0.2` for 20%). Must be >= 0.0. (Default: `0.0`)
 
 ## Trade-offs

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/config.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/config.go
@@ -38,6 +38,23 @@ const (
 	defaultHeadroom float64 = 0.0
 )
 
+// StalenessPolicy selects how endpoints with missing or stale metrics contribute to pool
+// saturation in Saturation().
+type StalenessPolicy string
+
+const (
+	// StalenessSaturated scores endpoints with missing or stale metrics as fully saturated
+	// (1.0). A fleet-wide metrics collection failure therefore halts dispatch entirely rather than
+	// admitting blind.
+	StalenessSaturated StalenessPolicy = "saturated"
+	// StalenessIgnore excludes endpoints with missing or stale metrics from the saturation
+	// average. When every candidate endpoint is stale, the pool scores 0.0 and dispatch continues,
+	// consistent with the Filter's fail-open fallback. Deployments choose this posture when the
+	// availability cost of a metrics collection outage outweighs the risk of driving stale,
+	// possibly overloaded endpoints.
+	StalenessIgnore StalenessPolicy = "ignore"
+)
+
 // apiConfig represents the external configuration schema for the utilization detector.
 // It dictates how the plugin calculates pool-level saturation (to trigger backpressure) and
 // endpoint-level limits (to filter out overloaded candidates during routing).
@@ -65,8 +82,8 @@ type apiConfig struct {
 	KVCacheUtilThreshold *float64 `json:"kvCacheUtilThreshold,omitempty"`
 
 	// MetricsStalenessThreshold defines how old an endpoint's metrics can be before they are
-	// considered stale. Stale endpoints are treated as 100% saturated to prevent routing traffic into
-	// unobservable black holes.
+	// considered stale. How stale endpoints affect pool saturation is controlled by
+	// StalenessPolicy.
 	//
 	// WARNING: In continuous batching architectures, the KV cache grows rapidly during the decode
 	// phase. A high staleness threshold combined with a high KV cache utilization limit can lead to
@@ -75,6 +92,13 @@ type apiConfig struct {
 	//
 	// Defaults to 200ms if unset.
 	MetricsStalenessThreshold *metav1.Duration `json:"metricsStalenessThreshold,omitempty"`
+
+	// StalenessPolicy selects how endpoints with missing or stale metrics contribute to pool
+	// saturation: "saturated" scores them as fully saturated, and "ignore" excludes them from
+	// the saturation average.
+	//
+	// Defaults to "saturated" if unset.
+	StalenessPolicy *StalenessPolicy `json:"stalenessPolicy,omitempty"`
 
 	// Headroom defines the allowed burst capacity above the ideal thresholds, expressed as a
 	// multiplier (e.g., 0.2 for 20%).
@@ -101,6 +125,7 @@ type Config struct {
 	KVCacheUtilThreshold      float64
 	MetricsStalenessThreshold time.Duration
 	Headroom                  float64
+	StalenessPolicy           StalenessPolicy
 }
 
 // buildConfig applies the configuration lifecycle (defaulting and validation) and translates the
@@ -123,6 +148,7 @@ func buildConfig(apiCfg *apiConfig) (*Config, error) {
 		KVCacheUtilThreshold:      *safeCfg.KVCacheUtilThreshold,
 		MetricsStalenessThreshold: safeCfg.MetricsStalenessThreshold.Duration,
 		Headroom:                  *safeCfg.Headroom,
+		StalenessPolicy:           *safeCfg.StalenessPolicy,
 	}, nil
 }
 
@@ -139,6 +165,9 @@ func applyDefaults(cfg *apiConfig) {
 	}
 	if cfg.Headroom == nil {
 		cfg.Headroom = ptr.To(defaultHeadroom)
+	}
+	if cfg.StalenessPolicy == nil {
+		cfg.StalenessPolicy = ptr.To(StalenessSaturated)
 	}
 }
 
@@ -159,6 +188,11 @@ func validateConfig(cfg *apiConfig) error {
 	}
 	if cfg.Headroom != nil && *cfg.Headroom < 0.0 {
 		errs = append(errs, fmt.Errorf("headroom must be a non-negative value, got %f", *cfg.Headroom))
+	}
+	if cfg.StalenessPolicy != nil && *cfg.StalenessPolicy != StalenessSaturated &&
+		*cfg.StalenessPolicy != StalenessIgnore {
+		errs = append(errs, fmt.Errorf("stalenessPolicy must be %q or %q, got %q",
+			StalenessSaturated, StalenessIgnore, *cfg.StalenessPolicy))
 	}
 
 	return errors.Join(errs...)

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector.go
@@ -96,6 +96,7 @@ func NewDetector(name string, cfg Config, logger logr.Logger) *Detector {
 		"queueDepthThreshold", cfg.QueueDepthThreshold,
 		"kvCacheUtilThreshold", cfg.KVCacheUtilThreshold,
 		"metricsStalenessThreshold", cfg.MetricsStalenessThreshold.String(),
+		"stalenessPolicy", cfg.StalenessPolicy,
 		"headroom", cfg.Headroom)
 
 	if cfg.Headroom > 1.0 {
@@ -125,6 +126,9 @@ func (d *Detector) TypedName() fwkplugin.TypedName {
 // For each pod, the score is determined by the most constrained resource (Compute or Memory):
 //
 //	PodScore = Max(WaitingQueue / QueueThreshold, KVCacheUsage / KVCacheThreshold)
+//
+// Pods with missing or stale metrics contribute 1.0 under the saturated policy, or are excluded
+// from the average under the ignore policy.
 func (d *Detector) Saturation(_ context.Context, candidates []datalayer.Endpoint) float64 {
 	if len(candidates) == 0 {
 		// No candidates means no stale endpoints. Keeping the gauge current here prevents a stale
@@ -140,11 +144,14 @@ func (d *Detector) Saturation(_ context.Context, candidates []datalayer.Endpoint
 		podMetrics := e.GetMetrics()
 
 		if podMetrics == nil || time.Since(podMetrics.UpdateTime) > d.config.MetricsStalenessThreshold {
-			// Fail closed: an endpoint whose metrics are missing or stale scores as fully saturated. A
-			// fleet-wide metrics collection failure therefore halts dispatch entirely rather than
-			// admitting blind; the gauge and the rate-limited log below exist so operators can tell that
-			// stall apart from genuine overload (which typically scores above 1.0).
-			totalScore += 1.0
+			if d.config.StalenessPolicy != StalenessIgnore {
+				// Saturated: an endpoint whose metrics are missing or stale scores as fully
+				// saturated. A fleet-wide metrics collection failure therefore halts dispatch
+				// entirely rather than admitting blind; the gauge and the rate-limited log below
+				// exist so operators can tell that stall apart from genuine overload (which
+				// typically scores above 1.0).
+				totalScore += 1.0
+			}
 			staleCount++
 			continue
 		}
@@ -161,6 +168,16 @@ func (d *Detector) Saturation(_ context.Context, candidates []datalayer.Endpoint
 		d.maybeLogStaleEndpoints(staleCount, len(candidates))
 	}
 
+	// Under ignore, stale endpoints are out of the average; if every candidate is stale the pool
+	// scores 0.0 and dispatch continues, consistent with Filter's fail-open fallback.
+	if d.config.StalenessPolicy == StalenessIgnore {
+		fresh := len(candidates) - staleCount
+		if fresh == 0 {
+			return 0.0
+		}
+		return totalScore / float64(fresh)
+	}
+
 	return totalScore / float64(len(candidates))
 }
 
@@ -175,10 +192,11 @@ func (d *Detector) maybeLogStaleEndpoints(staleCount, total int) {
 		return // Another goroutine logged concurrently.
 	}
 	d.logger.V(logutil.DEFAULT).Info(
-		"Endpoints with missing or stale metrics are scored as fully saturated (fail-closed); "+
+		"Endpoints with missing or stale metrics observed; "+
 			"if dispatch is stalled, check model-server metrics collection (scrape path, port, TLS, auth)",
 		"staleEndpoints", staleCount,
 		"totalEndpoints", total,
+		"stalenessPolicy", d.config.StalenessPolicy,
 		"metricsStalenessThreshold", d.config.MetricsStalenessThreshold.String())
 }
 

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
@@ -114,6 +114,21 @@ func TestUtilizationDetectorFactory(t *testing.T) {
 			configJSON: []byte(`{"headroom": 2.0}`),
 			wantError:  false,
 		},
+		{
+			name:       "valid staleness policy: ignore",
+			configJSON: []byte(`{"stalenessPolicy": "ignore"}`),
+			wantError:  false,
+		},
+		{
+			name:       "valid staleness policy: saturated",
+			configJSON: []byte(`{"stalenessPolicy": "saturated"}`),
+			wantError:  false,
+		},
+		{
+			name:       "invalid staleness policy",
+			configJSON: []byte(`{"stalenessPolicy": "bogus"}`),
+			wantError:  true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -130,6 +145,14 @@ func TestUtilizationDetectorFactory(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildConfigDefaultsStalenessPolicy(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := buildConfig(&apiConfig{})
+	require.NoError(t, err)
+	require.Equal(t, StalenessSaturated, cfg.StalenessPolicy)
 }
 
 // TestDetector_TypedName provides structural assurance that initialization assigns proper types.
@@ -153,7 +176,8 @@ func TestDetector_Saturation(t *testing.T) {
 	config := &Config{
 		QueueDepthThreshold:       5,
 		KVCacheUtilThreshold:      0.90,
-		MetricsStalenessThreshold: 100 * time.Millisecond,
+		MetricsStalenessThreshold: time.Hour,
+		StalenessPolicy:           StalenessSaturated,
 	}
 
 	tests := []struct {
@@ -164,7 +188,7 @@ func TestDetector_Saturation(t *testing.T) {
 		{
 			name:           "No candidate pods",
 			pods:           []fwkdl.Endpoint{},
-			wantSaturation: 1.0, // Fail closed
+			wantSaturation: 1.0, // An empty pool remains saturated.
 		},
 		{
 			name: "Single pod with good capacity",
@@ -179,7 +203,7 @@ func TestDetector_Saturation(t *testing.T) {
 			name: "Single pod with stale metrics",
 			pods: []fwkdl.Endpoint{
 				// Stale = 1.0
-				makePodMetric("pod1", 1, 0.1, baseTime.Add(-200*time.Millisecond)),
+				makePodMetric("pod1", 1, 0.1, baseTime.Add(-2*time.Hour)),
 			},
 			wantSaturation: 1.0,
 		},
@@ -227,7 +251,7 @@ func TestDetector_Saturation(t *testing.T) {
 				// Pod1 (Good): Q=1/5(0.2), KV=0.1/0.9(0.11). Max=0.2.
 				makePodMetric("pod1", 1, 0.1, baseTime),
 				// Pod2 (Stale): 1.0.
-				makePodMetric("pod2", 0, 0.2, baseTime.Add(-300*time.Millisecond)),
+				makePodMetric("pod2", 0, 0.2, baseTime.Add(-3*time.Hour)),
 			},
 			// Avg(0.2, 1.0) = 0.6
 			wantSaturation: 0.6,
@@ -247,7 +271,7 @@ func TestDetector_Saturation(t *testing.T) {
 			name: "Multiple pods, all bad capacity",
 			pods: []fwkdl.Endpoint{
 				// Pod1 (Stale): 1.0
-				makePodMetric("pod1", 1, 0.1, baseTime.Add(-200*time.Millisecond)),
+				makePodMetric("pod1", 1, 0.1, baseTime.Add(-2*time.Hour)),
 				// Pod2 (High Q): 20/5 = 4.0
 				makePodMetric("pod2", 20, 0.2, baseTime),
 				// Pod3 (High KV): 0.99/0.90 = 1.1
@@ -268,9 +292,83 @@ func TestDetector_Saturation(t *testing.T) {
 		{
 			name: "Metrics age just over staleness threshold",
 			pods: []fwkdl.Endpoint{
-				makePodMetric("pod1", 1, 0.1, baseTime.Add(-101*time.Millisecond)),
+				makePodMetric("pod1", 1, 0.1, baseTime.Add(-time.Hour-time.Millisecond)),
 			},
 			wantSaturation: 1.0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			detector := NewDetector("test-detector", *config, logr.Discard())
+
+			got := detector.Saturation(context.Background(), tc.pods)
+			require.InDelta(t, tc.wantSaturation, got, 1e-4, "Saturation mismatch")
+		})
+	}
+}
+
+func TestDetector_SaturationIgnorePolicy(t *testing.T) {
+	t.Parallel()
+
+	baseTime := time.Now()
+
+	// Config: Queue=5, KV=0.9
+	config := &Config{
+		QueueDepthThreshold:       5,
+		KVCacheUtilThreshold:      0.90,
+		MetricsStalenessThreshold: time.Hour,
+		StalenessPolicy:           StalenessIgnore,
+	}
+
+	tests := []struct {
+		name           string
+		pods           []fwkdl.Endpoint
+		wantSaturation float64
+	}{
+		{
+			name:           "No candidate pods",
+			pods:           []fwkdl.Endpoint{},
+			wantSaturation: 1.0, // Fail closed
+		},
+		{
+			name: "Single pod with good capacity",
+			pods: []fwkdl.Endpoint{
+				makePodMetric("pod1", 2, 0.5, baseTime),
+			},
+			wantSaturation: 0.5 / 0.9,
+		},
+		{
+			name: "Single stale pod excluded; all-stale pool scores 0.0",
+			pods: []fwkdl.Endpoint{
+				makePodMetric("pod1", 1, 0.1, baseTime.Add(-2*time.Hour)),
+			},
+			wantSaturation: 0.0,
+		},
+		{
+			name: "Single pod with nil metrics scores zero",
+			pods: []fwkdl.Endpoint{
+				fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+					ID: types.NamespacedName{Name: "pod1", Namespace: "ns1"},
+				}, nil),
+			},
+			wantSaturation: 0.0,
+		},
+		{
+			name: "Multiple pods, one good, one stale",
+			pods: []fwkdl.Endpoint{
+				makePodMetric("pod1", 1, 0.1, baseTime),
+				makePodMetric("pod2", 0, 0.2, baseTime.Add(-3*time.Hour)),
+			},
+			wantSaturation: 0.2,
+		},
+		{
+			name: "All pods stale",
+			pods: []fwkdl.Endpoint{
+				makePodMetric("pod1", 1, 0.1, baseTime.Add(-2*time.Hour)),
+				makePodMetric("pod2", 1, 0.1, baseTime.Add(-2*time.Hour)),
+			},
+			wantSaturation: 0.0,
 		},
 	}
 
@@ -292,7 +390,7 @@ func TestDetector_Filter(t *testing.T) {
 	config := &Config{
 		QueueDepthThreshold:       5,
 		KVCacheUtilThreshold:      0.80,
-		MetricsStalenessThreshold: 100 * time.Millisecond,
+		MetricsStalenessThreshold: time.Hour,
 		Headroom:                  0.2, // 20% burst
 	}
 
@@ -349,8 +447,8 @@ func TestDetector_Filter(t *testing.T) {
 		{
 			name: "Pass - all stale (Fail open at pool level)",
 			endpoints: []fwksched.Endpoint{
-				makeSchedulingEndpoint("pod1", 1, 0.1, baseTime.Add(-200*time.Millisecond)),
-				makeSchedulingEndpoint("pod2", 1, 0.1, baseTime.Add(-200*time.Millisecond)),
+				makeSchedulingEndpoint("pod1", 1, 0.1, baseTime.Add(-2*time.Hour)),
+				makeSchedulingEndpoint("pod2", 1, 0.1, baseTime.Add(-2*time.Hour)),
 			},
 			wantLen: 2,
 		},
@@ -373,6 +471,27 @@ func TestDetector_Filter(t *testing.T) {
 	}
 }
 
+// staleGaugeValue reads the llm_d_epp_flow_control_stale_endpoints series for the given detector.
+// It returns -1 when the series is absent.
+func staleGaugeValue(t *testing.T, detectorName string) float64 {
+	t.Helper()
+	families, err := ctrlmetrics.Registry.Gather()
+	require.NoError(t, err)
+	for _, f := range families {
+		if f.GetName() != "llm_d_epp_flow_control_stale_endpoints" {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "detector" && l.GetValue() == detectorName {
+					return m.GetGauge().GetValue()
+				}
+			}
+		}
+	}
+	return -1 // Series absent.
+}
+
 // TestDetector_StaleEndpointObservability verifies that Saturation records the stale-endpoint
 // gauge (keyed by detector name) and that the stale-metrics log is time-bounded.
 func TestDetector_StaleEndpointObservability(t *testing.T) {
@@ -391,24 +510,6 @@ func TestDetector_StaleEndpointObservability(t *testing.T) {
 	detectorName := "stale-observability-test"
 	detector := NewDetector(detectorName, config, logr.Discard())
 
-	staleGaugeValue := func() float64 {
-		families, err := ctrlmetrics.Registry.Gather()
-		require.NoError(t, err)
-		for _, f := range families {
-			if f.GetName() != "llm_d_epp_flow_control_stale_endpoints" {
-				continue
-			}
-			for _, m := range f.GetMetric() {
-				for _, l := range m.GetLabel() {
-					if l.GetName() == "detector" && l.GetValue() == detectorName {
-						return m.GetGauge().GetValue()
-					}
-				}
-			}
-		}
-		return -1 // Series absent.
-	}
-
 	baseTime := time.Now()
 	pods := []fwkdl.Endpoint{
 		makePodMetric("fresh", 1, 0.1, baseTime),
@@ -419,7 +520,7 @@ func TestDetector_StaleEndpointObservability(t *testing.T) {
 	}
 
 	detector.Saturation(context.Background(), pods)
-	require.Equal(t, 2.0, staleGaugeValue(), "stale and nil-metrics endpoints should both be counted")
+	require.Equal(t, 2.0, staleGaugeValue(t, detectorName), "stale and nil-metrics endpoints should both be counted")
 	firstWarn := detector.lastStaleWarnNanos.Load()
 	require.NotZero(t, firstWarn, "first stale observation should record a log timestamp")
 
@@ -431,11 +532,31 @@ func TestDetector_StaleEndpointObservability(t *testing.T) {
 	// An empty candidate list has no stale endpoints; the gauge must not stay pinned at its last
 	// value, or an empty-pool stall reads as a metrics collection failure.
 	detector.Saturation(context.Background(), []fwkdl.Endpoint{})
-	require.Equal(t, 0.0, staleGaugeValue(), "gauge should read zero for an empty candidate list")
+	require.Equal(t, 0.0, staleGaugeValue(t, detectorName), "gauge should read zero for an empty candidate list")
 
 	// Re-observe staleness, then confirm fresh metrics clear it.
 	detector.Saturation(context.Background(), pods)
-	require.Equal(t, 2.0, staleGaugeValue(), "staleness should be re-observed after the empty list")
+	require.Equal(t, 2.0, staleGaugeValue(t, detectorName), "staleness should be re-observed after the empty list")
 	detector.Saturation(context.Background(), []fwkdl.Endpoint{makePodMetric("fresh", 1, 0.1, time.Now())})
-	require.Equal(t, 0.0, staleGaugeValue(), "gauge should return to zero when staleness clears")
+	require.Equal(t, 0.0, staleGaugeValue(t, detectorName), "gauge should return to zero when staleness clears")
+}
+
+func TestDetector_StaleEndpointObservabilityIgnore(t *testing.T) {
+	t.Parallel()
+
+	eppmetrics.Register()
+	detectorName := "stale-observability-ignore-test"
+	detector := NewDetector(detectorName, Config{
+		QueueDepthThreshold:       5,
+		KVCacheUtilThreshold:      0.90,
+		MetricsStalenessThreshold: time.Hour,
+		StalenessPolicy:           StalenessIgnore,
+	}, logr.Discard())
+
+	detector.Saturation(context.Background(), []fwkdl.Endpoint{
+		makePodMetric("stale", 1, 0.1, time.Now().Add(-2*time.Hour)),
+	})
+
+	require.Equal(t, 1.0, staleGaugeValue(t, detectorName),
+		"the stale endpoint gauge must record under the ignore policy too")
 }

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -393,7 +393,7 @@ var (
 					"value used for gating. 1.0 is the gating set point; values above 1.0 indicate the magnitude of "+
 					"oversubscription past it. An empty pool reads as 1.0. With the default utilization detector, "+
 					"endpoints with missing or stale metrics score as fully saturated "+
-					"(fail-closed; see flow_control_stale_endpoints).",
+					"under stalenessPolicy=saturated; see flow_control_stale_endpoints.",
 				compbasemetrics.ALPHA),
 		},
 		[]string{"inference_pool", "stage"},
@@ -406,8 +406,8 @@ var (
 			Help: metricsutil.HelpMsgWithStability(
 				"Number of candidate endpoints whose metrics are missing or older than the staleness threshold, as of "+
 					"the most recent saturation evaluation. Recorded by the utilization saturation detector, which scores "+
-					"these endpoints as fully saturated in flow_control_pool_saturation (fail-closed): a nonzero value "+
-					"during a dispatch stall indicates a metrics collection problem rather than genuine overload. "+
+					"these endpoints according to stalenessPolicy: saturated by default or excluded under ignore. A nonzero "+
+					"value during a dispatch stall indicates a metrics collection problem rather than genuine overload. "+
 					"This gauge carries no stage label and is written on every detector call, so it reflects the most "+
 					"recently evaluated stage; a reading of 0 does not rule out stale metrics in another stage. "+
 					"Per-stage stale accounting is tracked in #2475.",

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -374,8 +374,8 @@ var (
 					"signals, 'effective' is max(prefill, decode) and is the value used for gating. "+
 					"1.0 is the gating set point; values above 1.0 indicate the magnitude of oversubscription "+
 					"past it. An empty pool reads as 1.0. With the default utilization detector, endpoints with missing "+
-					"or stale metrics score as fully saturated (fail-closed; see "+
-					"llm_d_epp_flow_control_stale_endpoints).",
+					"or stale metrics score as fully saturated under stalenessPolicy=saturated; see "+
+					"llm_d_epp_flow_control_stale_endpoints.",
 				compbasemetrics.ALPHA),
 		},
 		[]string{"inference_pool", "stage"},


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds a configurable `stalenessPolicy` to the utilization saturation detector:

- `saturated` (default) preserves the current fail-closed behavior and scores missing/stale endpoint metrics as `1.0`.
- `ignore` excludes missing/stale endpoints from the pool saturation average; an all-stale pool evaluates to `0.0` and continues dispatching.

The stale endpoint gauge and rate-limited detector log remain active under both policies. Documentation and metric help text describe the configured posture and the operational trade-off. The scheduling `Filter` behavior is unchanged. Tests cover defaults, validation, mixed/all-stale pools, empty pools, and stale-endpoint observability.

**Which issue(s) this PR fixes**:
Fixes #2408

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The utilization saturation detector now supports `stalenessPolicy: saturated|ignore`, defaulting to `saturated`.
```

**Test plan**:
- `go test ./pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/... -count=3`
- `git show --check`