### PR TITLE
feat(epp): make the fairness_id metric label cap configurable

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -385,6 +385,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 	setupLog.Info("EPP config after phase two", "config", eppConfig)
 
 	// --- Setup Metrics Server ---
+	metrics.SetFairnessIDLabelLimit(opts.FairnessIDMetricLabelLimit)
 	r.customCollectors = append(r.customCollectors, collectors.NewInferencePoolMetricsCollector(ds))
 	metrics.Register(r.customCollectors...)
 	metrics.RecordInferenceExtensionInfo(version.CommitSHA, version.BuildRef)

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -61,6 +61,7 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkfc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/observability/cardinality"
 	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 	attrgpu "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/gpu"
 	attrlatency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/latency"
@@ -385,7 +386,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 	setupLog.Info("EPP config after phase two", "config", eppConfig)
 
 	// --- Setup Metrics Server ---
-	metrics.SetFairnessIDLabelLimit(opts.FairnessIDMetricLabelLimit)
+	cardinality.SetFairnessIDLabelLimit(opts.FairnessIDMetricLabelLimit)
 	r.customCollectors = append(r.customCollectors, collectors.NewInferencePoolMetricsCollector(ds))
 	metrics.Register(r.customCollectors...)
 	metrics.RecordInferenceExtensionInfo(version.CommitSHA, version.BuildRef)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -64,10 +64,11 @@ and the release stage is ALPHA. Request and latency metrics share the label set
 
 Client-derived label values are cardinality-bounded: `model_name` and `target_model_name` (from the
 request body) share a cap of 1000 distinct values, and `fairness_id` (from the
-`x-llm-d-inference-fairness-id` header) is capped at 1000 distinct values. Caps apply over the
-lifetime of the process; once a cap is reached, new values are reported as `other`. Model names
-configured through InferenceModelRewrite rules never fold to `other`. Flow control series for a
-`fairness_id` are removed when its flow is garbage collected.
+`x-llm-d-inference-fairness-id` header) has a cap that defaults to 1000 distinct values and is
+configurable with `--fairness-id-metric-label-limit`; setting it to 0 collapses every `fairness_id`
+to `other`. Caps apply over the lifetime of the process; once a cap is reached, new values are
+reported as `other`. Model names configured through InferenceModelRewrite rules never fold to
+`other`. Flow control series for a `fairness_id` are removed when its flow is garbage collected.
 
 ### Request and latency
 

--- a/pkg/epp/framework/observability/cardinality/cardinality.go
+++ b/pkg/epp/framework/observability/cardinality/cardinality.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cardinality bounds the distinct values a metric label may take, so
+// client-derived labels cannot grow the Prometheus time series set without
+// limit. Both core code and plugins share the same limiter for a given label.
+package cardinality
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// OverflowValue is the label value that admitted-out (capped) values collapse to.
+const OverflowValue = "other"
+
+// BoundedLabel caps the number of distinct values a label may take; values
+// beyond the cap collapse to OverflowValue. Pinned values always emit their real
+// value and do not count against the cap.
+type BoundedLabel struct {
+	mu     sync.RWMutex
+	seen   map[string]struct{}
+	pinned map[string]struct{}
+	max    int
+}
+
+// NewBoundedLabel returns a BoundedLabel that admits at most max distinct values.
+func NewBoundedLabel(max int) *BoundedLabel {
+	return &BoundedLabel{
+		seen:   make(map[string]struct{}),
+		pinned: make(map[string]struct{}),
+		max:    max,
+	}
+}
+
+// Bound returns v if it is pinned, already admitted, or there is room to admit
+// it, otherwise OverflowValue. A value, once admitted, always returns itself, so
+// paired calls (e.g. running-request increment and decrement) stay balanced. The
+// one exception is a value that folded to OverflowValue and is later pinned: pairs
+// in flight across that instant can leave a small, bounded residue on the
+// overflow series.
+func (b *BoundedLabel) Bound(v string) string {
+	if v == "" {
+		return v
+	}
+	b.mu.RLock()
+	_, pin := b.pinned[v]
+	_, ok := b.seen[v]
+	full := len(b.seen) >= b.max
+	b.mu.RUnlock()
+	if pin || ok {
+		return v
+	}
+	if full {
+		return OverflowValue
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.seen[v]; ok {
+		return v
+	}
+	if len(b.seen) >= b.max {
+		return OverflowValue
+	}
+	b.seen[v] = struct{}{}
+	return v
+}
+
+// Pin marks v as always admitted without consuming a cap slot. Pins are never
+// removed: a value deconfigured at runtime keeps emitting its real label, which
+// matches Prometheus semantics (its existing series persist regardless) and
+// keeps paired gauge calls balanced.
+func (b *BoundedLabel) Pin(v string) {
+	if v == "" {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.pinned[v] = struct{}{}
+}
+
+// Fairness IDs are populated from a client request header (or an agent-identity attribute), so
+// their cardinality is not operator-bounded. They label per-request, flow-control, and plugin
+// metrics; without a cap, every distinct fairness ID ever observed permanently grows the time
+// series set. The cap defaults to DefaultFairnessIDLabelLimit and collapses excess values to
+// OverflowValue. A cap of 0 folds every ID onto the single overflow series.
+const DefaultFairnessIDLabelLimit = 1000
+
+var fairnessLimiter atomic.Pointer[BoundedLabel]
+
+func init() {
+	fairnessLimiter.Store(NewBoundedLabel(DefaultFairnessIDLabelLimit))
+}
+
+// SetFairnessIDLabelLimit configures the cap on distinct fairness_id label values from startup
+// configuration.
+func SetFairnessIDLabelLimit(limit int) {
+	fairnessLimiter.Store(NewBoundedLabel(limit))
+}
+
+// BoundFairnessID caps the request-derived fairness_id label. Core code and plugins that emit a
+// fairness_id label call this so they share one cap.
+func BoundFairnessID(fairnessID string) string {
+	return fairnessLimiter.Load().Bound(fairnessID)
+}

--- a/pkg/epp/framework/observability/cardinality/cardinality_test.go
+++ b/pkg/epp/framework/observability/cardinality/cardinality_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cardinality
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoundedLabel(t *testing.T) {
+	b := NewBoundedLabel(2)
+
+	require.Equal(t, "a", b.Bound("a"), "first value admitted")
+	require.Equal(t, "b", b.Bound("b"), "second value admitted")
+	require.Equal(t, OverflowValue, b.Bound("c"), "value beyond cap collapses to overflow")
+	require.Equal(t, "a", b.Bound("a"), "already-admitted value still returns itself after cap")
+	require.Equal(t, OverflowValue, b.Bound("d"), "further unseen values keep collapsing")
+	require.Equal(t, "", b.Bound(""), "empty value passes through without consuming a slot")
+}
+
+// Pinned values must emit their real label even when the cap is exhausted by
+// unpinned values, and must not consume cap slots themselves.
+func TestBoundedLabelPin(t *testing.T) {
+	b := NewBoundedLabel(2)
+
+	b.Pin("configured")
+	b.Pin("configured") // idempotent
+	require.Equal(t, "a", b.Bound("a"), "pin does not consume a cap slot")
+	require.Equal(t, "b", b.Bound("b"), "cap still has room for a second unpinned value")
+	require.Equal(t, OverflowValue, b.Bound("c"), "cap full for unpinned values")
+	require.Equal(t, "configured", b.Bound("configured"), "pinned value survives a full cap")
+
+	b.Pin("late")
+	require.Equal(t, "late", b.Bound("late"), "value pinned after the cap fills still emits its real label")
+}
+
+// SetFairnessIDLabelLimit replaces the shared fairness limiter, so the cap
+// applies and previously admitted values are cleared.
+func TestSetFairnessIDLabelLimit(t *testing.T) {
+	t.Cleanup(func() { SetFairnessIDLabelLimit(DefaultFairnessIDLabelLimit) })
+
+	SetFairnessIDLabelLimit(2)
+	require.Equal(t, "a", BoundFairnessID("a"))
+	require.Equal(t, "b", BoundFairnessID("b"))
+	require.Equal(t, OverflowValue, BoundFairnessID("c"), "value beyond the cap collapses to overflow")
+
+	SetFairnessIDLabelLimit(0)
+	require.Equal(t, OverflowValue, BoundFairnessID("a"), "a zero cap collapses every value to overflow")
+
+	SetFairnessIDLabelLimit(10)
+	for i := 0; i < 5; i++ {
+		require.NotEqual(t, OverflowValue, BoundFairnessID(fmt.Sprintf("tenant-%d", i)),
+			"raising the cap admits new values again")
+	}
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/metrics_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/metrics_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/observability/cardinality"
 	testutils "github.com/llm-d/llm-d-router/test/utils"
 )
 
@@ -313,4 +314,33 @@ func TestAddedTokensEntry_Clone(t *testing.T) {
 	require.Equal(t, entry.priority, cloned.priority)
 	require.Equal(t, int64(15), cloned.tokens.Load())
 	require.Equal(t, int32(1), cloned.requests.Load())
+}
+
+// The plugin's fairness_id label shares the cardinality cap, so a flood of distinct client IDs
+// collapses to the bounded set plus one overflow series instead of one series per ID.
+func TestInflightGauges_FairnessIDCardinalityBounded(t *testing.T) {
+	const testCap = 3
+	inflightRequests.Reset()
+	inflightTokens.Reset()
+	cardinality.SetFairnessIDLabelLimit(testCap)
+	t.Cleanup(func() {
+		cardinality.SetFairnessIDLabelLimit(cardinality.DefaultFairnessIDLabelLimit)
+		inflightRequests.Reset()
+		inflightTokens.Reset()
+	})
+
+	producer := newTestProducer(t)
+	ctx := context.Background()
+
+	// All requests target the same endpoint, so fairness_id is the only varying label.
+	for i := 0; i < 100; i++ {
+		req := makeTokenRequest(fmt.Sprintf("req-%d", i), 4)
+		req.FairnessID = fmt.Sprintf("tenant-%d", i)
+		require.NoError(t, producer.PreRequest(ctx, req, makeSchedulingResult("ep1")))
+	}
+
+	require.Equal(t, testCap+1, promtestutil.CollectAndCount(inflightRequests),
+		"100 distinct fairness IDs must collapse to cap+overflow series")
+	require.Equal(t, testCap+1, promtestutil.CollectAndCount(inflightTokens),
+		"the tokens gauge must be bounded identically")
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -33,6 +33,7 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/observability/cardinality"
 	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	sourcenotifications "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
@@ -407,7 +408,10 @@ func (p *InFlightLoadProducer) PreRequest(ctx context.Context, request *fwksched
 	}
 
 	inputTokens := p.tokenEstimator.EstimateInput(request)
-	fairnessID := request.FairnessID
+	// Bound the fairness_id label so a large number of distinct client IDs cannot grow this
+	// plugin's series set. The bounded value is stored on the entry, so the eviction-time
+	// decrement uses the same label as the increment here.
+	fairnessID := cardinality.BoundFairnessID(request.FairnessID)
 	priority := strconv.Itoa(request.Objectives.Priority)
 
 	if request.Body != nil {

--- a/pkg/epp/metrics/cardinality.go
+++ b/pkg/epp/metrics/cardinality.go
@@ -95,16 +95,30 @@ func (b *boundedLabel) pin(v string) {
 	b.pinned[v] = struct{}{}
 }
 
+// setMax sets the cap on the number of distinct admitted values.
+func (b *boundedLabel) setMax(max int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.max = max
+}
+
 var modelLabelLimiter = newBoundedLabel(maxModelLabelValues)
 
 // Fairness IDs are populated from a client request header (or an agent-identity attribute), so
 // like model names their cardinality is not operator-bounded. They label per-request and
 // flow-control metrics; without a cap, every distinct fairness ID ever observed permanently
-// grows the time series set. maxFairnessLabelValues bounds the distinct fairness_id label
-// values; values beyond the cap collapse to overflowValue.
-const maxFairnessLabelValues = 1000
+// grows the time series set. The limiter bounds the distinct fairness_id label values; values
+// beyond the cap collapse to overflowValue. A cap of 0 folds every ID onto the single overflow
+// series.
+const DefaultFairnessIDMetricLabelLimit = 1000
 
-var fairnessLabelLimiter = newBoundedLabel(maxFairnessLabelValues)
+var fairnessLabelLimiter = newBoundedLabel(DefaultFairnessIDMetricLabelLimit)
+
+// SetFairnessIDLabelLimit configures the cap on distinct fairness_id label values from startup
+// configuration.
+func SetFairnessIDLabelLimit(limit int) {
+	fairnessLabelLimiter.setMax(limit)
+}
 
 // boundFairnessID caps the request-derived fairness_id label.
 func boundFairnessID(fairnessID string) string {

--- a/pkg/epp/metrics/cardinality.go
+++ b/pkg/epp/metrics/cardinality.go
@@ -16,113 +16,23 @@ limitations under the License.
 
 package metrics
 
-import "sync"
+import "github.com/llm-d/llm-d-router/pkg/epp/framework/observability/cardinality"
 
 // Model name labels are populated from the request body, which is not validated
-// against a closed set of served models. Prometheus *Vec types never evict label
-// combinations, so an unbounded number of distinct model names would grow the time
-// series set without limit and exhaust memory. boundedLabel caps the number of
-// distinct values a label may take; values beyond the cap collapse to overflowValue.
+// against a closed set of served models. An unbounded number of distinct model
+// names would grow the time series set without limit, so they share a fixed cap.
 //
 // Names configured through InferenceModelRewrite rules (exact-match sources and
 // rewrite targets) are pinned: they always emit their real label and do not count
 // against the cap, so a flood of unconfigured names cannot displace a configured
 // model into the overflow bucket.
-const (
-	maxModelLabelValues = 1000
-	overflowValue       = "other"
-)
+const maxModelLabelValues = 1000
 
-type boundedLabel struct {
-	mu     sync.RWMutex
-	seen   map[string]struct{}
-	pinned map[string]struct{}
-	max    int
-}
-
-func newBoundedLabel(max int) *boundedLabel {
-	return &boundedLabel{
-		seen:   make(map[string]struct{}),
-		pinned: make(map[string]struct{}),
-		max:    max,
-	}
-}
-
-// bound returns v if it is pinned, already admitted, or there is room to admit
-// it, otherwise overflowValue. A value, once admitted, always returns itself, so
-// paired calls (e.g. running-request increment and decrement) stay balanced. The
-// one exception is a value that folded to overflowValue and is later pinned by a
-// new rewrite rule: pairs in flight across that instant can leave a small,
-// bounded residue on the overflow series.
-func (b *boundedLabel) bound(v string) string {
-	if v == "" {
-		return v
-	}
-	b.mu.RLock()
-	_, pin := b.pinned[v]
-	_, ok := b.seen[v]
-	full := len(b.seen) >= b.max
-	b.mu.RUnlock()
-	if pin || ok {
-		return v
-	}
-	if full {
-		return overflowValue
-	}
-
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if _, ok := b.seen[v]; ok {
-		return v
-	}
-	if len(b.seen) >= b.max {
-		return overflowValue
-	}
-	b.seen[v] = struct{}{}
-	return v
-}
-
-// pin marks v as always admitted without consuming a cap slot. Pins are never
-// removed: a model deconfigured at runtime keeps emitting its real label, which
-// matches Prometheus semantics (its existing series persist regardless) and
-// keeps paired gauge calls balanced.
-func (b *boundedLabel) pin(v string) {
-	if v == "" {
-		return
-	}
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.pinned[v] = struct{}{}
-}
-
-// setMax sets the cap on the number of distinct admitted values.
-func (b *boundedLabel) setMax(max int) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.max = max
-}
-
-var modelLabelLimiter = newBoundedLabel(maxModelLabelValues)
-
-// Fairness IDs are populated from a client request header (or an agent-identity attribute), so
-// like model names their cardinality is not operator-bounded. They label per-request and
-// flow-control metrics; without a cap, every distinct fairness ID ever observed permanently
-// grows the time series set. The limiter bounds the distinct fairness_id label values; values
-// beyond the cap collapse to overflowValue. A cap of 0 folds every ID onto the single overflow
-// series.
-const DefaultFairnessIDMetricLabelLimit = 1000
-
-var fairnessLabelLimiter = newBoundedLabel(DefaultFairnessIDMetricLabelLimit)
-
-// SetFairnessIDLabelLimit configures the cap on distinct fairness_id label values from startup
-// configuration.
-func SetFairnessIDLabelLimit(limit int) {
-	fairnessLabelLimiter.setMax(limit)
-}
+var modelLabelLimiter = cardinality.NewBoundedLabel(maxModelLabelValues)
 
 // boundFairnessID caps the request-derived fairness_id label.
 func boundFairnessID(fairnessID string) string {
-	return fairnessLabelLimiter.bound(fairnessID)
+	return cardinality.BoundFairnessID(fairnessID)
 }
 
 // PreAdmitModelLabels pins the given model names so they always emit their real
@@ -131,16 +41,16 @@ func boundFairnessID(fairnessID string) string {
 // rules are loaded or updated.
 func PreAdmitModelLabels(names ...string) {
 	for _, n := range names {
-		modelLabelLimiter.pin(n)
+		modelLabelLimiter.Pin(n)
 	}
 }
 
 // boundModel caps a single request-derived model-name label.
 func boundModel(modelName string) string {
-	return modelLabelLimiter.bound(modelName)
+	return modelLabelLimiter.Bound(modelName)
 }
 
 // boundModels caps the model-name labels shared by request metrics.
 func boundModels(modelName, targetModelName string) (string, string) {
-	return modelLabelLimiter.bound(modelName), modelLabelLimiter.bound(targetModelName)
+	return modelLabelLimiter.Bound(modelName), modelLabelLimiter.Bound(targetModelName)
 }

--- a/pkg/epp/metrics/cardinality_test.go
+++ b/pkg/epp/metrics/cardinality_test.go
@@ -235,3 +235,39 @@ func TestDeleteFlowControlFlowSeriesPreservesOverflowSeries(t *testing.T) {
 	require.Equal(t, 2, promtestutil.CollectAndCount(llmdFlowControlRequestEnqueueDuration),
 		"the llm_d_epp family must be preserved identically")
 }
+
+// SetFairnessIDLabelLimit changes the cap on distinct fairness_id label values.
+func TestSetFairnessIDLabelLimit(t *testing.T) {
+	t.Cleanup(func() {
+		fairnessLabelLimiter = newBoundedLabel(DefaultFairnessIDMetricLabelLimit)
+		flowControlRequestEnqueueDuration.Reset()
+		llmdFlowControlRequestEnqueueDuration.Reset()
+	})
+
+	tests := []struct {
+		name       string
+		limit      int
+		wantSeries int
+	}{
+		// cap distinct IDs to the limit plus one overflow series.
+		{name: "low cap", limit: 3, wantSeries: 4},
+		// a zero cap folds every ID onto the single overflow series.
+		{name: "zero disables per-id recording", limit: 0, wantSeries: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fairnessLabelLimiter = newBoundedLabel(DefaultFairnessIDMetricLabelLimit)
+			flowControlRequestEnqueueDuration.Reset()
+			llmdFlowControlRequestEnqueueDuration.Reset()
+
+			SetFairnessIDLabelLimit(test.limit)
+
+			for i := 0; i < 100; i++ {
+				RecordFlowControlRequestEnqueueDuration(fmt.Sprintf("tenant-%d", i), "0", "Dispatched", time.Millisecond)
+			}
+
+			require.Equal(t, test.wantSeries, promtestutil.CollectAndCount(llmdFlowControlRequestEnqueueDuration))
+		})
+	}
+}

--- a/pkg/epp/metrics/cardinality_test.go
+++ b/pkg/epp/metrics/cardinality_test.go
@@ -23,34 +23,14 @@ import (
 
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/observability/cardinality"
 )
 
-func TestBoundedLabel(t *testing.T) {
-	b := newBoundedLabel(2)
-
-	require.Equal(t, "a", b.bound("a"), "first value admitted")
-	require.Equal(t, "b", b.bound("b"), "second value admitted")
-	require.Equal(t, overflowValue, b.bound("c"), "value beyond cap collapses to overflow")
-	require.Equal(t, "a", b.bound("a"), "already-admitted value still returns itself after cap")
-	require.Equal(t, overflowValue, b.bound("d"), "further unseen values keep collapsing")
-	require.Equal(t, "", b.bound(""), "empty value passes through without consuming a slot")
-}
-
-// Pinned names model operator-configured models (InferenceModelRewrite sources
-// and targets): they must emit their real label even when the cap is exhausted
-// by unconfigured names, and must not consume cap slots themselves.
-func TestBoundedLabelPin(t *testing.T) {
-	b := newBoundedLabel(2)
-
-	b.pin("configured")
-	b.pin("configured") // idempotent
-	require.Equal(t, "a", b.bound("a"), "pin does not consume a cap slot")
-	require.Equal(t, "b", b.bound("b"), "cap still has room for a second unconfigured name")
-	require.Equal(t, overflowValue, b.bound("c"), "cap full for unconfigured names")
-	require.Equal(t, "configured", b.bound("configured"), "pinned name survives a full cap")
-
-	b.pin("late")
-	require.Equal(t, "late", b.bound("late"), "name pinned after the cap fills still emits its real label")
+// resetFairnessLabelLimit restores the shared fairness cap to its default after a test.
+func resetFairnessLabelLimit(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { cardinality.SetFairnessIDLabelLimit(cardinality.DefaultFairnessIDLabelLimit) })
 }
 
 // PreAdmitModelLabels feeds the package-level limiter used by the record
@@ -58,7 +38,7 @@ func TestBoundedLabelPin(t *testing.T) {
 func TestPreAdmitModelLabelsSurvivesFlood(t *testing.T) {
 	const testCap = 5
 	old := modelLabelLimiter
-	modelLabelLimiter = newBoundedLabel(testCap)
+	modelLabelLimiter = cardinality.NewBoundedLabel(testCap)
 	requestCounter.Reset()
 	t.Cleanup(func() {
 		modelLabelLimiter = old
@@ -84,7 +64,7 @@ func TestPreAdmitModelLabelsSurvivesFlood(t *testing.T) {
 func TestRecordRequestCounterBoundsModelCardinality(t *testing.T) {
 	const testCap = 5
 	old := modelLabelLimiter
-	modelLabelLimiter = newBoundedLabel(testCap)
+	modelLabelLimiter = cardinality.NewBoundedLabel(testCap)
 	requestCounter.Reset()
 	t.Cleanup(func() {
 		modelLabelLimiter = old
@@ -100,17 +80,16 @@ func TestRecordRequestCounterBoundsModelCardinality(t *testing.T) {
 		"model_name cardinality must stay bounded by the cap, got %d series", count)
 }
 
-// The fairness_id label is populated from a client request header, so the package-level limiter
-// must collapse an unbounded flood of distinct IDs into the overflow bucket instead of minting a
-// series per ID.
+// The fairness_id label is populated from a client request header, so the shared limiter must
+// collapse an unbounded flood of distinct IDs into the overflow bucket instead of minting a series
+// per ID.
 func TestFairnessLabelFloodCollapsesToOverflow(t *testing.T) {
 	const testCap = 5
-	old := fairnessLabelLimiter
-	fairnessLabelLimiter = newBoundedLabel(testCap)
+	resetFairnessLabelLimit(t)
+	cardinality.SetFairnessIDLabelLimit(testCap)
 	flowControlRequestEnqueueDuration.Reset()
 	llmdFlowControlRequestEnqueueDuration.Reset()
 	t.Cleanup(func() {
-		fairnessLabelLimiter = old
 		flowControlRequestEnqueueDuration.Reset()
 		llmdFlowControlRequestEnqueueDuration.Reset()
 	})
@@ -129,12 +108,11 @@ func TestFairnessLabelFloodCollapsesToOverflow(t *testing.T) {
 // DeleteFlowControlFlowSeries backs the flow registry's GC hook: once a flow is collected, its
 // series must not linger for the lifetime of the process.
 func TestDeleteFlowControlFlowSeries(t *testing.T) {
-	old := fairnessLabelLimiter
-	fairnessLabelLimiter = newBoundedLabel(10)
+	resetFairnessLabelLimit(t)
+	cardinality.SetFairnessIDLabelLimit(10)
 	flowControlRequestEnqueueDuration.Reset()
 	llmdFlowControlRequestEnqueueDuration.Reset()
 	t.Cleanup(func() {
-		fairnessLabelLimiter = old
 		flowControlRequestEnqueueDuration.Reset()
 		llmdFlowControlRequestEnqueueDuration.Reset()
 	})
@@ -158,14 +136,13 @@ func TestDeleteFlowControlFlowSeries(t *testing.T) {
 // pattern regressing there.
 func TestFairnessLabelBoundOnRequestMetrics(t *testing.T) {
 	const testCap = 3
-	oldFairness := fairnessLabelLimiter
-	fairnessLabelLimiter = newBoundedLabel(testCap)
+	resetFairnessLabelLimit(t)
+	cardinality.SetFairnessIDLabelLimit(testCap)
 	oldModels := modelLabelLimiter
-	modelLabelLimiter = newBoundedLabel(10)
+	modelLabelLimiter = cardinality.NewBoundedLabel(10)
 	requestCounter.Reset()
 	llmdRequestCounter.Reset()
 	t.Cleanup(func() {
-		fairnessLabelLimiter = oldFairness
 		modelLabelLimiter = oldModels
 		requestCounter.Reset()
 		llmdRequestCounter.Reset()
@@ -186,14 +163,13 @@ func TestFairnessLabelBoundOnRequestMetrics(t *testing.T) {
 func TestQueueDurationBoundsModelLabels(t *testing.T) {
 	const testCap = 3
 	oldModels := modelLabelLimiter
-	modelLabelLimiter = newBoundedLabel(testCap)
-	oldFairness := fairnessLabelLimiter
-	fairnessLabelLimiter = newBoundedLabel(10)
+	modelLabelLimiter = cardinality.NewBoundedLabel(testCap)
+	resetFairnessLabelLimit(t)
+	cardinality.SetFairnessIDLabelLimit(10)
 	flowControlRequestQueueDuration.Reset()
 	llmdFlowControlRequestQueueDuration.Reset()
 	t.Cleanup(func() {
 		modelLabelLimiter = oldModels
-		fairnessLabelLimiter = oldFairness
 		flowControlRequestQueueDuration.Reset()
 		llmdFlowControlRequestQueueDuration.Reset()
 	})
@@ -212,12 +188,11 @@ func TestQueueDurationBoundsModelLabels(t *testing.T) {
 // A client can choose the overflow value itself as its fairness ID; GC of that flow must not
 // delete the shared overflow series that aggregates every capped-out tenant.
 func TestDeleteFlowControlFlowSeriesPreservesOverflowSeries(t *testing.T) {
-	old := fairnessLabelLimiter
-	fairnessLabelLimiter = newBoundedLabel(1)
+	resetFairnessLabelLimit(t)
+	cardinality.SetFairnessIDLabelLimit(1)
 	flowControlRequestEnqueueDuration.Reset()
 	llmdFlowControlRequestEnqueueDuration.Reset()
 	t.Cleanup(func() {
-		fairnessLabelLimiter = old
 		flowControlRequestEnqueueDuration.Reset()
 		llmdFlowControlRequestEnqueueDuration.Reset()
 	})
@@ -228,7 +203,7 @@ func TestDeleteFlowControlFlowSeriesPreservesOverflowSeries(t *testing.T) {
 	require.Equal(t, 2, promtestutil.CollectAndCount(flowControlRequestEnqueueDuration),
 		"setup: expected the admitted series plus the overflow series")
 
-	DeleteFlowControlFlowSeries(overflowValue, "0")
+	DeleteFlowControlFlowSeries(cardinality.OverflowValue, "0")
 
 	require.Equal(t, 2, promtestutil.CollectAndCount(flowControlRequestEnqueueDuration),
 		"deleting the overflow value must be a no-op; the shared overflow series must survive")
@@ -236,10 +211,10 @@ func TestDeleteFlowControlFlowSeriesPreservesOverflowSeries(t *testing.T) {
 		"the llm_d_epp family must be preserved identically")
 }
 
-// SetFairnessIDLabelLimit changes the cap on distinct fairness_id label values.
-func TestSetFairnessIDLabelLimit(t *testing.T) {
+// The configured cap propagates through the record functions to the emitted series.
+func TestFairnessIDLabelLimitAppliesToRecordedMetrics(t *testing.T) {
+	resetFairnessLabelLimit(t)
 	t.Cleanup(func() {
-		fairnessLabelLimiter = newBoundedLabel(DefaultFairnessIDMetricLabelLimit)
 		flowControlRequestEnqueueDuration.Reset()
 		llmdFlowControlRequestEnqueueDuration.Reset()
 	})
@@ -257,11 +232,9 @@ func TestSetFairnessIDLabelLimit(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fairnessLabelLimiter = newBoundedLabel(DefaultFairnessIDMetricLabelLimit)
+			cardinality.SetFairnessIDLabelLimit(test.limit)
 			flowControlRequestEnqueueDuration.Reset()
 			llmdFlowControlRequestEnqueueDuration.Reset()
-
-			SetFairnessIDLabelLimit(test.limit)
 
 			for i := 0; i < 100; i++ {
 				RecordFlowControlRequestEnqueueDuration(fmt.Sprintf("tenant-%d", i), "0", "Dispatched", time.Millisecond)

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -30,6 +30,7 @@ import (
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	metricsutil "github.com/llm-d/llm-d-router/pkg/common/observability/metrics"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/observability/cardinality"
 )
 
 const (
@@ -1049,7 +1050,7 @@ func RecordFlowControlRevocationConfirmationDuration(inferencePool string, durat
 func DeleteFlowControlFlowSeries(fairnessID, priority string) {
 	// The overflow value aggregates every capped-out fairness ID, so a flow whose client-chosen ID
 	// equals it must not delete the shared series.
-	if fairnessID == overflowValue {
+	if fairnessID == cardinality.OverflowValue {
 		return
 	}
 	labels := prometheus.Labels{"fairness_id": fairnessID, "priority": priority}

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -37,6 +37,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/common/routing"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
 )
 
 const (
@@ -122,6 +123,10 @@ type Options struct {
 	MetricsClientCAFile     string   // PEM CA that requires a verified client cert on the metrics endpoint.
 	MetricsCertDir          string   // Directory with the metrics server certificates that enables metrics TLS.
 	EnableGRPCStreamMetrics bool     // Enables ext_proc gRPC stream metrics (in-flight gauge, hold duration, completions counter by code).
+	// FairnessIDMetricLabelLimit caps the number of distinct fairness_id label values recorded on metrics; values
+	// beyond the cap collapse to a single overflow series, and 0 collapses all of them. Bounds metric cardinality in
+	// deployments with many distinct fairness IDs.
+	FairnessIDMetricLabelLimit int
 	//
 	// Configuration.
 	//
@@ -157,6 +162,7 @@ func NewOptions() *Options {
 		LoggingOptions:                   *logging.NewOptions(),
 		Tracing:                          true,
 		MetricsPort:                      9090,
+		FairnessIDMetricLabelLimit:       metrics.DefaultFairnessIDMetricLabelLimit,
 		GRPCHealthPort:                   9003,
 		EnablePprof:                      true,
 		SecureServing:                    true,
@@ -236,6 +242,9 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 		"Enables certificate reloading of the certificates specified in --cert-path.")
 	fs.BoolVar(&opts.EnableGRPCStreamMetrics, "enable-grpc-stream-metrics", opts.EnableGRPCStreamMetrics,
 		"Enables ext_proc gRPC stream metrics (in-flight gauge, hold-duration histogram, completions counter by code).")
+	fs.IntVar(&opts.FairnessIDMetricLabelLimit, "fairness-id-metric-label-limit", opts.FairnessIDMetricLabelLimit,
+		"Caps the number of distinct fairness_id label values recorded on metrics; values beyond the cap collapse to a "+
+			"single overflow series, and 0 collapses all of them. Bounds metric cardinality with many distinct fairness IDs.")
 	fs.BoolVar(&opts.SecureServing, "secure-serving", opts.SecureServing, "Enables secure serving.")
 	fs.StringVar(&opts.TLSMinVersion, "tls-min-version", opts.TLSMinVersion,
 		"Minimum TLS version for secure serving (e.g., VersionTLS12, VersionTLS13).")
@@ -412,6 +421,9 @@ func (opts *Options) Validate() error {
 	}
 	if opts.GRPCMaxSendMsgSize < 0 {
 		return fmt.Errorf("grpc-max-send-msg-size must be non-negative, got %d", opts.GRPCMaxSendMsgSize)
+	}
+	if opts.FairnessIDMetricLabelLimit < 0 {
+		return fmt.Errorf("fairness-id-metric-label-limit must be non-negative, got %d", opts.FairnessIDMetricLabelLimit)
 	}
 
 	if opts.PluginStateStalenessThreshold <= 0 {

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -37,7 +37,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/common/routing"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
-	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/observability/cardinality"
 )
 
 const (
@@ -162,7 +162,7 @@ func NewOptions() *Options {
 		LoggingOptions:                   *logging.NewOptions(),
 		Tracing:                          true,
 		MetricsPort:                      9090,
-		FairnessIDMetricLabelLimit:       metrics.DefaultFairnessIDMetricLabelLimit,
+		FairnessIDMetricLabelLimit:       cardinality.DefaultFairnessIDLabelLimit,
 		GRPCHealthPort:                   9003,
 		EnablePprof:                      true,
 		SecureServing:                    true,

--- a/pkg/epp/server/options_test.go
+++ b/pkg/epp/server/options_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
 )
 
 const (
@@ -255,6 +257,27 @@ func TestValidateDirectValues(t *testing.T) {
 	opts.GRPCMaxSendMsgSize = -5
 	if err := opts.Validate(); err == nil {
 		t.Errorf("Expected Validate() to fail for negative GRPCMaxSendMsgSize, but it succeeded")
+	}
+
+	opts = NewOptions()
+	opts.PoolName = testPoolName
+	opts.FairnessIDMetricLabelLimit = -1
+	if err := opts.Validate(); err == nil {
+		t.Errorf("Expected Validate() to fail for negative FairnessIDMetricLabelLimit, but it succeeded")
+	}
+
+	opts = NewOptions()
+	opts.AddFlags(pflag.NewFlagSet("test", pflag.ContinueOnError))
+	opts.PoolName = testPoolName
+	opts.FairnessIDMetricLabelLimit = 0
+	if err := opts.Validate(); err != nil {
+		t.Errorf("Expected Validate() to allow a zero FairnessIDMetricLabelLimit, got %v", err)
+	}
+}
+
+func TestFairnessIDMetricLabelLimitDefault(t *testing.T) {
+	if got := NewOptions().FairnessIDMetricLabelLimit; got != metrics.DefaultFairnessIDMetricLabelLimit {
+		t.Errorf("default FairnessIDMetricLabelLimit: got %d, want %d", got, metrics.DefaultFairnessIDMetricLabelLimit)
 	}
 }
 

--- a/pkg/epp/server/options_test.go
+++ b/pkg/epp/server/options_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 
-	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/observability/cardinality"
 )
 
 const (
@@ -276,8 +276,8 @@ func TestValidateDirectValues(t *testing.T) {
 }
 
 func TestFairnessIDMetricLabelLimitDefault(t *testing.T) {
-	if got := NewOptions().FairnessIDMetricLabelLimit; got != metrics.DefaultFairnessIDMetricLabelLimit {
-		t.Errorf("default FairnessIDMetricLabelLimit: got %d, want %d", got, metrics.DefaultFairnessIDMetricLabelLimit)
+	if got := NewOptions().FairnessIDMetricLabelLimit; got != cardinality.DefaultFairnessIDLabelLimit {
+		t.Errorf("default FairnessIDMetricLabelLimit: got %d, want %d", got, cardinality.DefaultFairnessIDLabelLimit)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The fairness_id metric label is capped at a fixed 1000 distinct values to bound cardinality. In large deployments (several active EPP + many different models) this can lead to a huge cardinality. This PR exposes the cap as a new `--fairness-id-metric-label-limit` flag to allow lowering the cardinality (down to retain only the `other` label).

**Which issue(s) this PR fixes**:

None

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Add the `--fairness-id-metric-label-limit` flag to lower the cardinality of fairness related metrics.
```
