### PR TITLE
fix(tokenizer): match Anthropic prefix tokens to vLLM rendering

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -702,8 +702,17 @@ type MessagesRequest struct {
 	System AnthropicContent `json:"system,omitempty"`
 	// Tools field for tool use capabilities.
 	Tools []AnthropicTool `json:"tools,omitempty"`
+	// ChatTemplateKWArgs are forwarded by vLLM to the model chat template.
+	ChatTemplateKWArgs map[string]any `json:"chat_template_kwargs,omitempty"`
+	// OutputConfig carries prompt-affecting output controls.
+	OutputConfig *AnthropicOutputConfig `json:"output_config,omitempty"`
 	// CacheSalt isolates prefix caches for security.
 	CacheSalt string `json:"cache_salt,omitempty"`
+}
+
+// AnthropicOutputConfig is the prompt-affecting subset of Anthropic output_config.
+type AnthropicOutputConfig struct {
+	Effort string `json:"effort,omitempty"`
 }
 
 // AnthropicTool is a tool definition in the Anthropic schema. InputSchema keeps

--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -707,7 +707,8 @@ type MessagesRequest struct {
 }
 
 // AnthropicTool is a tool definition in the Anthropic schema. InputSchema keeps
-// the raw JSON bytes so the wire key order survives downstream re-serialization.
+// the raw JSON bytes for token-faithful canonicalization against the forwarded
+// request body.
 type AnthropicTool struct {
 	Name         string          `json:"name"`
 	Description  string          `json:"description,omitempty"`
@@ -779,8 +780,8 @@ func (ac AnthropicContent) textLen() int {
 }
 
 // AnthropicContentBlock is one block of an Anthropic content array. Field sets
-// are disjoint per Type; Input and InputSchema keep raw JSON bytes to preserve
-// the wire key order for token-faithful re-serialization.
+// are disjoint per Type; Input keeps raw JSON bytes for token-faithful
+// canonicalization against the forwarded request body.
 type AnthropicContentBlock struct {
 	Type string `json:"type"`
 	Text string `json:"text,omitempty"`

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -52,7 +52,7 @@ Backend selection:
 | `vllm.url`       | `http://localhost:8000` | Base URL of the vLLM render endpoint (no trailing slash).         |
 | `vllm.timeout`   | `5s`                    | Per-request timeout for text-only requests.                       |
 | `vllm.mmTimeout` | `30s`                   | Per-request timeout for multimodal requests.                      |
-| `vllm.mergeAnthropicInlineSystem` | `false` | Merge inline Anthropic system messages into the leading system message. Set this to match vLLM when its chat template requires system-first ordering. |
+| `vllm.mergeAnthropicInlineSystem` | automatic | Override detection of whether vLLM merges inline Anthropic system messages into the leading system message. Set this only when the vLLM server does not provide `/v1/messages/count_tokens`; `true` is the common setting for servers without an explicit chat-template override. |
 
 The `estimate` backend tunes multimodal image placeholder estimation (empty uses
 the defaults below):
@@ -128,7 +128,6 @@ Plugin config — sidecar (loopback):
     modelName: "${MODEL_NAME}"
     vllm:
       url: "http://localhost:8000"       # optional; this is the default
-      mergeAnthropicInlineSystem: true   # when vLLM merges inline system messages
 ```
 
 Plugin config — dedicated render Service:

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -52,6 +52,7 @@ Backend selection:
 | `vllm.url`       | `http://localhost:8000` | Base URL of the vLLM render endpoint (no trailing slash).         |
 | `vllm.timeout`   | `5s`                    | Per-request timeout for text-only requests.                       |
 | `vllm.mmTimeout` | `30s`                   | Per-request timeout for multimodal requests.                      |
+| `vllm.mergeAnthropicInlineSystem` | `false` | Merge inline Anthropic system messages into the leading system message. Set this to match vLLM when its chat template requires system-first ordering. |
 
 The `estimate` backend tunes multimodal image placeholder estimation (empty uses
 the defaults below):
@@ -127,6 +128,7 @@ Plugin config — sidecar (loopback):
     modelName: "${MODEL_NAME}"
     vllm:
       url: "http://localhost:8000"       # optional; this is the default
+      mergeAnthropicInlineSystem: true   # when vLLM merges inline system messages
 ```
 
 Plugin config — dedicated render Service:

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
@@ -106,7 +106,7 @@ type renderBackend struct {
 }
 
 type anthropicRenderer interface {
-	RenderAnthropic(ctx context.Context, request *fwkrh.MessagesRequest) ([]uint32, *tokenization.MultiModalFeatures, error)
+	RenderAnthropic(ctx context.Context, request *fwkrh.MessagesRequest, canonicalizeJSON bool) ([]uint32, *tokenization.MultiModalFeatures, error)
 }
 
 func (b renderBackend) produce(ctx context.Context, body *fwkrh.InferenceRequestBody) (*fwkrh.TokenizedRequest, error) {
@@ -132,7 +132,7 @@ func (b renderBackend) produce(ctx context.Context, body *fwkrh.InferenceRequest
 			err        error
 		)
 		if renderer, ok := b.tk.(anthropicRenderer); ok {
-			tokenIDs, mmFeatures, err = renderer.RenderAnthropic(ctx, body.Messages)
+			tokenIDs, mmFeatures, err = renderer.RenderAnthropic(ctx, body.Messages, body.Mutated)
 		} else {
 			tokenIDs, mmFeatures, err = b.tk.RenderChat(ctx, messagesPayload(body))
 		}
@@ -190,10 +190,10 @@ func chatPayload(body *fwkrh.InferenceRequestBody) fwkrh.RequestPayload {
 // blocks), which vLLM /render does not accept, so the payload is always rebuilt
 // from the typed struct into the /render chat schema regardless of body.Payload.
 // Messages and tools are embedded as raw JSON to avoid another untyped
-// decode-and-encode cycle. Arbitrary Anthropic JSON fields are canonicalized
-// during conversion to the same order as the forwarded PayloadMap body.
+// decode-and-encode cycle. Their object order follows the bytes the director
+// forwards: client order for unchanged bodies, PayloadMap order after mutation.
 func messagesPayload(body *fwkrh.InferenceRequestBody) fwkrh.RequestPayload {
-	rr := buildChatRenderRequest(MessagesToRenderChatRequest(body.Messages))
+	rr := buildChatRenderRequest(messagesToRenderChatRequest(body.Messages, false, body.Mutated))
 	msgs := make([]any, len(rr.Messages))
 	for i, m := range rr.Messages {
 		data, _ := json.Marshal(m)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
@@ -28,7 +28,6 @@ import (
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/kvcache/tokenization"
-	tokenizerTypes "github.com/llm-d/llm-d-router/pkg/kvcache/tokenization/types"
 )
 
 // tokenInputProducer turns a request body into a TokenizedRequest. Backends vary
@@ -103,15 +102,11 @@ func warmupChat(imageURLs ...string) *fwkrh.InferenceRequestBody {
 // renderBackend produces real token IDs and owns protocol dispatch, including
 // the pre-tokenized (Generate) passthrough.
 type renderBackend struct {
-	tk                         tokenizer
-	mergeAnthropicInlineSystem bool
+	tk tokenizer
 }
 
-// typedChatRenderer accepts the already-converted render request. The vLLM
-// backend implements this to avoid converting large Anthropic requests through
-// JSON into a generic map only to marshal that map again for HTTP.
-type typedChatRenderer interface {
-	RenderChatRequest(ctx context.Context, request *tokenizerTypes.RenderChatRequest) ([]uint32, *tokenization.MultiModalFeatures, error)
+type anthropicRenderer interface {
+	RenderAnthropic(ctx context.Context, request *fwkrh.MessagesRequest) ([]uint32, *tokenization.MultiModalFeatures, error)
 }
 
 func (b renderBackend) produce(ctx context.Context, body *fwkrh.InferenceRequestBody) (*fwkrh.TokenizedRequest, error) {
@@ -136,8 +131,8 @@ func (b renderBackend) produce(ctx context.Context, body *fwkrh.InferenceRequest
 			mmFeatures *tokenization.MultiModalFeatures
 			err        error
 		)
-		if renderer, ok := b.tk.(typedChatRenderer); ok {
-			tokenIDs, mmFeatures, err = renderer.RenderChatRequest(ctx, messagesToRenderChatRequest(body.Messages, b.mergeAnthropicInlineSystem))
+		if renderer, ok := b.tk.(anthropicRenderer); ok {
+			tokenIDs, mmFeatures, err = renderer.RenderAnthropic(ctx, body.Messages)
 		} else {
 			tokenIDs, mmFeatures, err = b.tk.RenderChat(ctx, messagesPayload(body))
 		}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
@@ -194,9 +194,9 @@ func chatPayload(body *fwkrh.InferenceRequestBody) fwkrh.RequestPayload {
 // body uses the Anthropic Messages schema (top-level system, source-based image
 // blocks), which vLLM /render does not accept, so the payload is always rebuilt
 // from the typed struct into the /render chat schema regardless of body.Payload.
-// Messages and tools are embedded as raw JSON rather than decoded maps: Go maps
-// re-serialize with sorted keys, which would reorder tool schemas and break
-// token parity with what vLLM renders server-side.
+// Messages and tools are embedded as raw JSON to avoid another untyped
+// decode-and-encode cycle. Arbitrary Anthropic JSON fields are canonicalized
+// during conversion to the same order as the forwarded PayloadMap body.
 func messagesPayload(body *fwkrh.InferenceRequestBody) fwkrh.RequestPayload {
 	rr := buildChatRenderRequest(MessagesToRenderChatRequest(body.Messages))
 	msgs := make([]any, len(rr.Messages))

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
@@ -27,6 +27,8 @@ import (
 
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	"github.com/llm-d/llm-d-router/pkg/kvcache/tokenization"
+	tokenizerTypes "github.com/llm-d/llm-d-router/pkg/kvcache/tokenization/types"
 )
 
 // tokenInputProducer turns a request body into a TokenizedRequest. Backends vary
@@ -101,7 +103,15 @@ func warmupChat(imageURLs ...string) *fwkrh.InferenceRequestBody {
 // renderBackend produces real token IDs and owns protocol dispatch, including
 // the pre-tokenized (Generate) passthrough.
 type renderBackend struct {
-	tk tokenizer
+	tk                         tokenizer
+	mergeAnthropicInlineSystem bool
+}
+
+// typedChatRenderer accepts the already-converted render request. The vLLM
+// backend implements this to avoid converting large Anthropic requests through
+// JSON into a generic map only to marshal that map again for HTTP.
+type typedChatRenderer interface {
+	RenderChatRequest(ctx context.Context, request *tokenizerTypes.RenderChatRequest) ([]uint32, *tokenization.MultiModalFeatures, error)
 }
 
 func (b renderBackend) produce(ctx context.Context, body *fwkrh.InferenceRequestBody) (*fwkrh.TokenizedRequest, error) {
@@ -121,7 +131,16 @@ func (b renderBackend) produce(ctx context.Context, body *fwkrh.InferenceRequest
 			MultiModalFeatures: convertMMFeaturesToUpstream(mmFeatures),
 		}}}, nil
 	case body.Messages != nil:
-		tokenIDs, mmFeatures, err := b.tk.RenderChat(ctx, messagesPayload(body))
+		var (
+			tokenIDs   []uint32
+			mmFeatures *tokenization.MultiModalFeatures
+			err        error
+		)
+		if renderer, ok := b.tk.(typedChatRenderer); ok {
+			tokenIDs, mmFeatures, err = renderer.RenderChatRequest(ctx, messagesToRenderChatRequest(body.Messages, b.mergeAnthropicInlineSystem))
+		} else {
+			tokenIDs, mmFeatures, err = b.tk.RenderChat(ctx, messagesPayload(body))
+		}
 		if err != nil {
 			return nil, fmt.Errorf("tokenization failed: %w", err)
 		}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -569,7 +569,8 @@ func appendImageBlock(blocks []tokenizerTypes.ContentBlock, src *fwkrh.Anthropic
 
 // anthropicToolCall converts a tool_use block into an OpenAI function tool
 // call. Arguments are CPython json.dumps formatted (separators, ASCII
-// escaping, wire key order) - the exact string vLLM renders into the prompt.
+// escaping, forwarded key order) - the exact string vLLM renders into the
+// prompt after EPP repackage.
 func anthropicToolCall(b fwkrh.AnthropicContentBlock) map[string]any {
 	id := b.ID
 	if id == "" {
@@ -594,6 +595,7 @@ func pythonArguments(raw json.RawMessage) string {
 	case "", "null", "{}":
 		return "{}"
 	}
+	raw = canonicalizeRepackagedJSON(raw)
 	if out, err := pythonDumps(raw); err == nil {
 		return out
 	}
@@ -638,8 +640,7 @@ func anthropicToolResultContent(b fwkrh.AnthropicContentBlock) (string, []tokeni
 }
 
 // convertAnthropicTools rewrites Anthropic tool definitions into OpenAI
-// function tools. input_schema passes through as raw JSON so the template's
-// re-serialization keeps the wire key order.
+// function tools.
 func convertAnthropicTools(tools []fwkrh.AnthropicTool) []any {
 	if len(tools) == 0 {
 		return nil
@@ -650,6 +651,11 @@ func convertAnthropicTools(tools []fwkrh.AnthropicTool) []any {
 		if len(schema) == 0 || bytes.Equal(schema, []byte("null")) {
 			schema = json.RawMessage(`{"type":"object"}`)
 		}
+		// Anthropic requests are forwarded from PayloadMap, whose Marshal uses
+		// encoding/json and therefore sorts every object key. Canonicalize the
+		// schema the same way before tokenization so the lookup blocks match the
+		// prompt vLLM actually receives after EPP repackage.
+		schema = canonicalizeAnthropicInputSchema(schema)
 		fn := map[string]any{
 			"name":       t.Name,
 			"parameters": schema,
@@ -666,6 +672,48 @@ func convertAnthropicTools(tools []fwkrh.AnthropicTool) []any {
 		out = append(out, map[string]any{"type": "function", "function": fn})
 	}
 	return out
+}
+
+// canonicalizeRepackagedJSON applies the same decode-and-encode cycle used by
+// PayloadMap.Marshal. encoding/json sorts object keys, including nested ones.
+func canonicalizeRepackagedJSON(raw json.RawMessage) json.RawMessage {
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return raw
+	}
+	canonical, err := json.Marshal(decoded)
+	if err != nil {
+		return raw
+	}
+	return canonical
+}
+
+// canonicalizeAnthropicInputSchema also mirrors vLLM's AnthropicTool
+// validator, which supplies an object type when input_schema omits it.
+func canonicalizeAnthropicInputSchema(raw json.RawMessage) json.RawMessage {
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return raw
+	}
+	canonical, err := json.Marshal(decoded)
+	if err != nil {
+		return raw
+	}
+	schema, ok := decoded.(map[string]any)
+	if !ok {
+		return canonical
+	}
+	if _, exists := schema["type"]; exists {
+		return canonical
+	}
+	// vLLM validates the already-decoded schema and appends the default type
+	// to that Python dict. Keep the same insertion order after the existing
+	// canonical keys instead of re-sorting the added member with encoding/json.
+	if len(schema) == 0 {
+		return json.RawMessage(`{"type":"object"}`)
+	}
+	canonical = append(canonical[:len(canonical)-1], []byte(`,"type":"object"}`)...)
+	return canonical
 }
 
 // anthropicImageToURL converts an Anthropic image source to an OpenAI-shaped

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -305,7 +305,10 @@ func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) 
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize vLLM HTTP renderer for '%s' plugin - %w", PluginType, err)
 		}
-		backend = renderBackend{tk: renderer}
+		backend = renderBackend{
+			tk:                         renderer,
+			mergeAnthropicInlineSystem: cfg.MergeAnthropicInlineSystem,
+		}
 	default:
 		backend = estimateBackend{img: newImageEstimator(config.Estimate), vid: newVideoEstimator(config.Estimate)}
 	}
@@ -421,19 +424,35 @@ func ChatCompletionsToRenderChatRequest(chat *fwkrh.ChatCompletionsRequest) *tok
 // backend and the server apply the identical chat-template pipeline to the
 // same request and prefix-cache blocks line up.
 func MessagesToRenderChatRequest(msg *fwkrh.MessagesRequest) *tokenizerTypes.RenderChatRequest {
+	return messagesToRenderChatRequest(msg, false)
+}
+
+func messagesToRenderChatRequest(msg *fwkrh.MessagesRequest, mergeInlineSystem bool) *tokenizerTypes.RenderChatRequest {
 	conversation := make([]tokenizerTypes.Conversation, 0, 1+len(msg.Messages))
 
-	if sys := anthropicSystemText(msg.System); sys != "" {
+	var system strings.Builder
+	system.WriteString(anthropicSystemText(msg.System))
+	if mergeInlineSystem {
+		for _, m := range msg.Messages {
+			if m.Role == "system" {
+				system.WriteString(anthropicInlineSystemText(m.Content))
+			}
+		}
+	}
+	if system.Len() > 0 {
 		conversation = append(conversation, tokenizerTypes.Conversation{
 			Role:    "system",
-			Content: &tokenizerTypes.Content{Raw: sys},
+			Content: &tokenizerTypes.Content{Raw: system.String()},
 		})
 	}
 
 	for _, m := range msg.Messages {
 		if m.Role == "system" {
+			if mergeInlineSystem {
+				continue
+			}
 			// Not valid Anthropic input; tolerated the way vLLM does.
-			if text := anthropicSystemText(m.Content); text != "" {
+			if text := anthropicInlineSystemText(m.Content); text != "" {
 				conversation = append(conversation, tokenizerTypes.Conversation{
 					Role:    "system",
 					Content: &tokenizerTypes.Content{Raw: text},
@@ -464,6 +483,16 @@ func anthropicSystemText(ac fwkrh.AnthropicContent) string {
 		}
 	}
 	return sb.String()
+}
+
+func anthropicInlineSystemText(ac fwkrh.AnthropicContent) string {
+	if ac.Raw != "" {
+		if strings.HasPrefix(ac.Raw, anthropicBillingHeaderPrefix) {
+			return ""
+		}
+		return ac.Raw
+	}
+	return anthropicSystemText(ac)
 }
 
 // appendAnthropicMessage appends the conversations for one message. User

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -421,10 +421,10 @@ func ChatCompletionsToRenderChatRequest(chat *fwkrh.ChatCompletionsRequest) *tok
 // backend and the server apply the identical chat-template pipeline to the
 // same request and prefix-cache blocks line up.
 func MessagesToRenderChatRequest(msg *fwkrh.MessagesRequest) *tokenizerTypes.RenderChatRequest {
-	return messagesToRenderChatRequest(msg, false)
+	return messagesToRenderChatRequest(msg, false, false)
 }
 
-func messagesToRenderChatRequest(msg *fwkrh.MessagesRequest, mergeInlineSystem bool) *tokenizerTypes.RenderChatRequest {
+func messagesToRenderChatRequest(msg *fwkrh.MessagesRequest, mergeInlineSystem, canonicalizeJSON bool) *tokenizerTypes.RenderChatRequest {
 	conversation := make([]tokenizerTypes.Conversation, 0, 1+len(msg.Messages))
 
 	var system strings.Builder
@@ -457,12 +457,12 @@ func messagesToRenderChatRequest(msg *fwkrh.MessagesRequest, mergeInlineSystem b
 			}
 			continue
 		}
-		conversation = appendAnthropicMessage(conversation, m)
+		conversation = appendAnthropicMessage(conversation, m, canonicalizeJSON)
 	}
 
 	return &tokenizerTypes.RenderChatRequest{
 		Conversation:       conversation,
-		Tools:              convertAnthropicTools(msg.Tools),
+		Tools:              convertAnthropicTools(msg.Tools, canonicalizeJSON),
 		ChatTemplateKWArgs: anthropicChatTemplateKWArgs(msg),
 	}
 }
@@ -518,7 +518,7 @@ func anthropicInlineSystemText(ac fwkrh.AnthropicContent) string {
 // appendAnthropicMessage appends the conversations for one message. User
 // tool_result blocks append their tool messages immediately, so those precede
 // the user message that carried them - the order vLLM emits.
-func appendAnthropicMessage(conversation []tokenizerTypes.Conversation, m fwkrh.AnthropicMessage) []tokenizerTypes.Conversation {
+func appendAnthropicMessage(conversation []tokenizerTypes.Conversation, m fwkrh.AnthropicMessage, canonicalizeJSON bool) []tokenizerTypes.Conversation {
 	if m.Content.Raw != "" {
 		return append(conversation, tokenizerTypes.Conversation{
 			Role:    m.Role,
@@ -542,7 +542,7 @@ func appendAnthropicMessage(conversation []tokenizerTypes.Conversation, m fwkrh.
 		case blockTypeRedactedThinking:
 			// Opaque safety-filtered reasoning; parses but contributes no tokens.
 		case blockTypeToolUse:
-			toolCalls = append(toolCalls, anthropicToolCall(b))
+			toolCalls = append(toolCalls, anthropicToolCall(b, canonicalizeJSON))
 		case blockTypeToolResult:
 			if m.Role == "user" {
 				conversation = appendAnthropicToolResult(conversation, b)
@@ -590,8 +590,8 @@ func appendImageBlock(blocks []tokenizerTypes.ContentBlock, src *fwkrh.Anthropic
 // anthropicToolCall converts a tool_use block into an OpenAI function tool
 // call. Arguments are CPython json.dumps formatted (separators, ASCII
 // escaping, forwarded key order) - the exact string vLLM renders into the
-// prompt after EPP repackage.
-func anthropicToolCall(b fwkrh.AnthropicContentBlock) map[string]any {
+// prompt.
+func anthropicToolCall(b fwkrh.AnthropicContentBlock, canonicalizeJSON bool) map[string]any {
 	id := b.ID
 	if id == "" {
 		// vLLM falls back to call_<unix-time>; a fixed stand-in only keeps the
@@ -603,19 +603,21 @@ func anthropicToolCall(b fwkrh.AnthropicContentBlock) map[string]any {
 		"type": "function",
 		"function": map[string]any{
 			"name":      b.Name,
-			"arguments": pythonArguments(b.Input),
+			"arguments": pythonArguments(b.Input, canonicalizeJSON),
 		},
 	}
 }
 
 // pythonArguments renders tool_use input as json.dumps(input or {}): absent,
 // null, and empty-object inputs all render as "{}".
-func pythonArguments(raw json.RawMessage) string {
+func pythonArguments(raw json.RawMessage, canonicalizeJSON bool) string {
 	switch string(bytes.TrimSpace(raw)) {
 	case "", "null", "{}":
 		return "{}"
 	}
-	raw = canonicalizeRepackagedJSON(raw)
+	if canonicalizeJSON {
+		raw = canonicalizeRepackagedJSON(raw)
+	}
 	if out, err := pythonDumps(raw); err == nil {
 		return out
 	}
@@ -661,7 +663,7 @@ func anthropicToolResultContent(b fwkrh.AnthropicContentBlock) (string, []tokeni
 
 // convertAnthropicTools rewrites Anthropic tool definitions into OpenAI
 // function tools.
-func convertAnthropicTools(tools []fwkrh.AnthropicTool) []any {
+func convertAnthropicTools(tools []fwkrh.AnthropicTool, canonicalizeJSON bool) []any {
 	if len(tools) == 0 {
 		return nil
 	}
@@ -671,11 +673,7 @@ func convertAnthropicTools(tools []fwkrh.AnthropicTool) []any {
 		if len(schema) == 0 || bytes.Equal(schema, []byte("null")) {
 			schema = json.RawMessage(`{"type":"object"}`)
 		}
-		// Anthropic requests are forwarded from PayloadMap, whose Marshal uses
-		// encoding/json and therefore sorts every object key. Canonicalize the
-		// schema the same way before tokenization so the lookup blocks match the
-		// prompt vLLM actually receives after EPP repackage.
-		schema = canonicalizeAnthropicInputSchema(schema)
+		schema = prepareAnthropicInputSchema(schema, canonicalizeJSON)
 		fn := map[string]any{
 			"name":       t.Name,
 			"parameters": schema,
@@ -708,23 +706,29 @@ func canonicalizeRepackagedJSON(raw json.RawMessage) json.RawMessage {
 	return canonical
 }
 
-// canonicalizeAnthropicInputSchema also mirrors vLLM's AnthropicTool
-// validator, which supplies an object type when input_schema omits it.
-func canonicalizeAnthropicInputSchema(raw json.RawMessage) json.RawMessage {
+// prepareAnthropicInputSchema mirrors the JSON object order vLLM receives. An
+// unchanged request keeps client key order; a body already marked Mutated will
+// be repackaged through PayloadMap.Marshal and therefore uses sorted keys.
+// vLLM then appends an object type when input_schema omits it.
+func prepareAnthropicInputSchema(raw json.RawMessage, canonicalizeJSON bool) json.RawMessage {
 	var decoded any
 	if err := json.Unmarshal(raw, &decoded); err != nil {
 		return raw
 	}
-	canonical, err := json.Marshal(decoded)
-	if err != nil {
-		return raw
+	prepared := bytes.TrimSpace(raw)
+	if canonicalizeJSON {
+		canonical, err := json.Marshal(decoded)
+		if err != nil {
+			return raw
+		}
+		prepared = canonical
 	}
 	schema, ok := decoded.(map[string]any)
 	if !ok {
-		return canonical
+		return prepared
 	}
 	if _, exists := schema["type"]; exists {
-		return canonical
+		return prepared
 	}
 	// vLLM validates the already-decoded schema and appends the default type
 	// to that Python dict. Keep the same insertion order after the existing
@@ -732,8 +736,8 @@ func canonicalizeAnthropicInputSchema(raw json.RawMessage) json.RawMessage {
 	if len(schema) == 0 {
 		return json.RawMessage(`{"type":"object"}`)
 	}
-	canonical = append(canonical[:len(canonical)-1], []byte(`,"type":"object"}`)...)
-	return canonical
+	prepared = append(prepared[:len(prepared)-1], []byte(`,"type":"object"}`)...)
+	return prepared
 }
 
 // anthropicImageToURL converts an Anthropic image source to an OpenAI-shaped

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -461,9 +461,32 @@ func messagesToRenderChatRequest(msg *fwkrh.MessagesRequest, mergeInlineSystem b
 	}
 
 	return &tokenizerTypes.RenderChatRequest{
-		Conversation: conversation,
-		Tools:        convertAnthropicTools(msg.Tools),
+		Conversation:       conversation,
+		Tools:              convertAnthropicTools(msg.Tools),
+		ChatTemplateKWArgs: anthropicChatTemplateKWArgs(msg),
 	}
+}
+
+// anthropicChatTemplateKWArgs mirrors ChatCompletionRequest.build_chat_params
+// after vLLM converts /v1/messages to an OpenAI chat request. Anthropic
+// output_config.effort becomes reasoning_effort and also enables thinking
+// unless the caller explicitly supplied enable_thinking.
+func anthropicChatTemplateKWArgs(msg *fwkrh.MessagesRequest) map[string]any {
+	if len(msg.ChatTemplateKWArgs) == 0 && (msg.OutputConfig == nil || msg.OutputConfig.Effort == "") {
+		return nil
+	}
+
+	kwargs := make(map[string]any, len(msg.ChatTemplateKWArgs)+2)
+	for key, value := range msg.ChatTemplateKWArgs {
+		kwargs[key] = value
+	}
+	if msg.OutputConfig != nil && msg.OutputConfig.Effort != "" {
+		kwargs["reasoning_effort"] = msg.OutputConfig.Effort
+		if _, exists := kwargs["enable_thinking"]; !exists {
+			kwargs["enable_thinking"] = true
+		}
+	}
+	return kwargs
 }
 
 // anthropicSystemText joins the system prompt's text blocks with no

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -305,10 +305,7 @@ func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) 
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize vLLM HTTP renderer for '%s' plugin - %w", PluginType, err)
 		}
-		backend = renderBackend{
-			tk:                         renderer,
-			mergeAnthropicInlineSystem: cfg.MergeAnthropicInlineSystem,
-		}
+		backend = renderBackend{tk: renderer}
 	default:
 		backend = estimateBackend{img: newImageEstimator(config.Estimate), vid: newVideoEstimator(config.Estimate)}
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -79,17 +79,21 @@ func TestProduceTimeout(t *testing.T) {
 }
 
 func TestNewPlugin_MergeAnthropicInlineSystem(t *testing.T) {
+	mergeInlineSystem := true
 	p, err := NewPlugin(context.Background(), "tok", &tokenizerPluginConfig{
 		ModelName: "m",
 		VLLM: &vllmConfig{
-			MergeAnthropicInlineSystem: true,
+			MergeAnthropicInlineSystem: &mergeInlineSystem,
 		},
 	})
 	require.NoError(t, err)
 
 	backend, ok := p.backend.(renderBackend)
 	require.True(t, ok)
-	assert.True(t, backend.mergeAnthropicInlineSystem)
+	renderer, ok := backend.tk.(*vllmHTTPRenderer)
+	require.True(t, ok)
+	require.NotNil(t, renderer.mergeAnthropicInlineSystem)
+	assert.True(t, *renderer.mergeAnthropicInlineSystem)
 }
 
 func TestPluginFactory_Validation(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	anthropicparser "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/anthropic"
 	"github.com/llm-d/llm-d-router/test/utils"
 )
 
@@ -709,7 +710,7 @@ func TestMessagesToRenderChatRequest_Tools(t *testing.T) {
 		"function": map[string]any{
 			"name":        "get_weather",
 			"description": "Get the weather",
-			"parameters":  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+			"parameters":  json.RawMessage(`{"properties":{"city":{"type":"string"}},"type":"object"}`),
 		},
 	}, result.Tools[0])
 }
@@ -721,12 +722,13 @@ func TestMessagesToRenderChatRequest_ToolDefaults(t *testing.T) {
 		Tools: []fwkrh.AnthropicTool{
 			{Name: "no_schema"},
 			{Name: "flags", InputSchema: json.RawMessage(`null`), Strict: &strict, DeferLoading: &deferLoading},
+			{Name: "implicit_type", InputSchema: json.RawMessage(`{"z":0,"a":1}`)},
 		},
 	}
 
 	result := MessagesToRenderChatRequest(msg)
 
-	require.Len(t, result.Tools, 2)
+	require.Len(t, result.Tools, 3)
 	assert.Equal(t, map[string]any{
 		"type": "function",
 		"function": map[string]any{
@@ -743,6 +745,13 @@ func TestMessagesToRenderChatRequest_ToolDefaults(t *testing.T) {
 			"defer_loading": false,
 		},
 	}, result.Tools[1])
+	assert.Equal(t, map[string]any{
+		"type": "function",
+		"function": map[string]any{
+			"name":       "implicit_type",
+			"parameters": json.RawMessage(`{"a":1,"z":0,"type":"object"}`),
+		},
+	}, result.Tools[2])
 }
 
 func TestMessagesToRenderChatRequest_StructuredSystem(t *testing.T) {
@@ -990,6 +999,7 @@ func TestPythonArguments(t *testing.T) {
 	assert.Equal(t, "{}", pythonArguments(json.RawMessage(`null`)))
 	assert.Equal(t, "{}", pythonArguments(json.RawMessage(`{}`)))
 	assert.Equal(t, `{"a": 1}`, pythonArguments(json.RawMessage(`{"a":1}`)))
+	assert.Equal(t, `{"a": 1, "b": 2}`, pythonArguments(json.RawMessage(`{"b":2,"a":1}`)))
 }
 
 // TestMessagesToRenderChatRequest_ToolUseAndThinking covers an assistant
@@ -1166,8 +1176,8 @@ func TestMessagesToRenderChatRequest_FullAgenticTurn(t *testing.T) {
 }
 
 // TestProduce_MessagesRequestToolSchemaOrder asserts that tool input_schema
-// key order survives the trip to the render payload: Go maps would
-// alphabetize the keys and desynchronize prefix hashes from the engine's.
+// uses the same encoding/json key order as the PayloadMap body forwarded to
+// vLLM after EPP repackage.
 func TestProduce_MessagesRequestToolSchemaOrder(t *testing.T) {
 	var gotPayload fwkrh.RequestPayload
 	tok := &mockTokenizer{
@@ -1194,6 +1204,81 @@ func TestProduce_MessagesRequestToolSchemaOrder(t *testing.T) {
 	rendered, err := json.Marshal(gotPayload)
 	require.NoError(t, err)
 	assert.Contains(t, string(rendered),
-		`"parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`,
-		"input_schema key order must be preserved verbatim")
+		`"parameters":{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"}`,
+		"input_schema key order must match the forwarded request body")
+}
+
+func TestMessagesRenderMatchesRepackagedAnthropicJSON(t *testing.T) {
+	raw := []byte(`{
+		"model":"zai-org/GLM-5.2-FP8",
+		"tools":[{
+			"name":"run",
+			"input_schema":{"z":0,"nested":{"b":2,"a":1},"a":3}
+		}],
+		"messages":[
+			{"role":"user","content":"Run it"},
+			{"role":"assistant","content":[{
+				"type":"tool_use","id":"toolu_01","name":"run",
+				"input":{"z":0,"nested":{"b":2,"a":1},"a":3}
+			}]}
+		]
+	}`)
+	parsed, err := anthropicparser.NewAnthropicParser().ParseRequest(
+		context.Background(), raw, map[string]string{":path": "/v1/messages"})
+	require.NoError(t, err)
+
+	marshaler, ok := parsed.Body.Payload.(fwkrh.Marshaler)
+	require.True(t, ok)
+	forwardedJSON, err := marshaler.Marshal()
+	require.NoError(t, err)
+	var forwarded struct {
+		Tools []struct {
+			InputSchema json.RawMessage `json:"input_schema"`
+		} `json:"tools"`
+		Messages []struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	require.NoError(t, json.Unmarshal(forwardedJSON, &forwarded))
+	var forwardedToolUse []struct {
+		Input json.RawMessage `json:"input"`
+	}
+	require.NoError(t, json.Unmarshal(forwarded.Messages[1].Content, &forwardedToolUse))
+
+	renderJSON, err := json.Marshal(buildChatRenderRequest(
+		MessagesToRenderChatRequest(parsed.Body.Messages)))
+	require.NoError(t, err)
+	var rendered struct {
+		Tools []struct {
+			Function struct {
+				Parameters json.RawMessage `json:"parameters"`
+			} `json:"function"`
+		} `json:"tools"`
+		Messages []struct {
+			ToolCalls []struct {
+				Function struct {
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
+		} `json:"messages"`
+	}
+	require.NoError(t, json.Unmarshal(renderJSON, &rendered))
+
+	require.Len(t, forwarded.Tools, 1)
+	require.Len(t, forwarded.Messages, 2)
+	require.Len(t, forwardedToolUse, 1)
+	require.Len(t, rendered.Tools, 1)
+	require.Len(t, rendered.Messages, 2)
+	require.Len(t, rendered.Messages[1].ToolCalls, 1)
+
+	assert.Equal(t,
+		`{"a":3,"nested":{"a":1,"b":2},"z":0}`,
+		string(forwarded.Tools[0].InputSchema))
+	assert.Equal(t,
+		`{"a":3,"nested":{"a":1,"b":2},"z":0,"type":"object"}`,
+		string(rendered.Tools[0].Function.Parameters))
+
+	expectedArguments, err := pythonDumps(forwardedToolUse[0].Input)
+	require.NoError(t, err)
+	assert.Equal(t, expectedArguments, rendered.Messages[1].ToolCalls[0].Function.Arguments)
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -660,6 +660,27 @@ func TestMessagesToRenderChatRequest_RawSystem(t *testing.T) {
 	assert.Equal(t, &tokenizerTypes.Content{Raw: "Hello"}, result.Conversation[1].Content)
 }
 
+func TestMessagesToRenderChatRequest_PreservesTemplateControls(t *testing.T) {
+	msg := &fwkrh.MessagesRequest{
+		Messages: []fwkrh.AnthropicMessage{{
+			Role:    "user",
+			Content: fwkrh.AnthropicContent{Raw: "Hello"},
+		}},
+		ChatTemplateKWArgs: map[string]any{
+			"enable_thinking":  false,
+			"reasoning_effort": "low",
+		},
+		OutputConfig: &fwkrh.AnthropicOutputConfig{Effort: "high"},
+	}
+
+	result := MessagesToRenderChatRequest(msg)
+
+	assert.Equal(t, map[string]any{
+		"enable_thinking":  false,
+		"reasoning_effort": "high",
+	}, result.ChatTemplateKWArgs)
+}
+
 func TestMessagesToRenderChatRequest_MergesInlineSystemForDefaultVLLMTemplate(t *testing.T) {
 	msg := &fwkrh.MessagesRequest{
 		System: fwkrh.AnthropicContent{Raw: "Top-level system."},
@@ -1215,6 +1236,8 @@ func TestProduce_MessagesRequestToolSchemaOrder(t *testing.T) {
 func TestMessagesRenderMatchesRepackagedAnthropicJSON(t *testing.T) {
 	raw := []byte(`{
 		"model":"zai-org/GLM-5.2-FP8",
+		"chat_template_kwargs":{"enable_thinking":false,"custom":"value"},
+		"output_config":{"effort":"high"},
 		"tools":[{
 			"name":"run",
 			"input_schema":{"z":0,"nested":{"b":2,"a":1},"a":3}
@@ -1253,7 +1276,8 @@ func TestMessagesRenderMatchesRepackagedAnthropicJSON(t *testing.T) {
 		MessagesToRenderChatRequest(parsed.Body.Messages)))
 	require.NoError(t, err)
 	var rendered struct {
-		Tools []struct {
+		ChatTemplateKWArgs map[string]any `json:"chat_template_kwargs"`
+		Tools              []struct {
 			Function struct {
 				Parameters json.RawMessage `json:"parameters"`
 			} `json:"function"`
@@ -1274,6 +1298,11 @@ func TestMessagesRenderMatchesRepackagedAnthropicJSON(t *testing.T) {
 	require.Len(t, rendered.Tools, 1)
 	require.Len(t, rendered.Messages, 2)
 	require.Len(t, rendered.Messages[1].ToolCalls, 1)
+	assert.Equal(t, map[string]any{
+		"enable_thinking":  false,
+		"custom":           "value",
+		"reasoning_effort": "high",
+	}, rendered.ChatTemplateKWArgs)
 
 	assert.Equal(t,
 		`{"a":3,"nested":{"a":1,"b":2},"z":0}`,

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -691,7 +691,7 @@ func TestMessagesToRenderChatRequest_MergesInlineSystemForDefaultVLLMTemplate(t 
 		},
 	}
 
-	result := messagesToRenderChatRequest(msg, true)
+	result := messagesToRenderChatRequest(msg, true, false)
 
 	// AnthropicServingMessages enables merge_inline_system when vLLM starts
 	// without an explicit --chat-template, which is the production GLM shape.
@@ -735,7 +735,7 @@ func TestMessagesToRenderChatRequest_Tools(t *testing.T) {
 		"function": map[string]any{
 			"name":        "get_weather",
 			"description": "Get the weather",
-			"parameters":  json.RawMessage(`{"properties":{"city":{"type":"string"}},"type":"object"}`),
+			"parameters":  json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
 		},
 	}, result.Tools[0])
 }
@@ -774,7 +774,7 @@ func TestMessagesToRenderChatRequest_ToolDefaults(t *testing.T) {
 		"type": "function",
 		"function": map[string]any{
 			"name":       "implicit_type",
-			"parameters": json.RawMessage(`{"a":1,"z":0,"type":"object"}`),
+			"parameters": json.RawMessage(`{"z":0,"a":1,"type":"object"}`),
 		},
 	}, result.Tools[2])
 }
@@ -1020,11 +1020,12 @@ func TestPythonDumpsNonASCIIEscaped(t *testing.T) {
 }
 
 func TestPythonArguments(t *testing.T) {
-	assert.Equal(t, "{}", pythonArguments(nil))
-	assert.Equal(t, "{}", pythonArguments(json.RawMessage(`null`)))
-	assert.Equal(t, "{}", pythonArguments(json.RawMessage(`{}`)))
-	assert.Equal(t, `{"a": 1}`, pythonArguments(json.RawMessage(`{"a":1}`)))
-	assert.Equal(t, `{"a": 1, "b": 2}`, pythonArguments(json.RawMessage(`{"b":2,"a":1}`)))
+	assert.Equal(t, "{}", pythonArguments(nil, false))
+	assert.Equal(t, "{}", pythonArguments(json.RawMessage(`null`), false))
+	assert.Equal(t, "{}", pythonArguments(json.RawMessage(`{}`), false))
+	assert.Equal(t, `{"a": 1}`, pythonArguments(json.RawMessage(`{"a":1}`), false))
+	assert.Equal(t, `{"b": 2, "a": 1}`, pythonArguments(json.RawMessage(`{"b":2,"a":1}`), false))
+	assert.Equal(t, `{"a": 1, "b": 2}`, pythonArguments(json.RawMessage(`{"b":2,"a":1}`), true))
 }
 
 // TestMessagesToRenderChatRequest_ToolUseAndThinking covers an assistant
@@ -1200,9 +1201,8 @@ func TestMessagesToRenderChatRequest_FullAgenticTurn(t *testing.T) {
 	require.Len(t, result.Tools, 1)
 }
 
-// TestProduce_MessagesRequestToolSchemaOrder asserts that tool input_schema
-// uses the same encoding/json key order as the PayloadMap body forwarded to
-// vLLM after EPP repackage.
+// TestProduce_MessagesRequestToolSchemaOrder asserts that an unchanged body
+// preserves the client key order that the director forwards to vLLM.
 func TestProduce_MessagesRequestToolSchemaOrder(t *testing.T) {
 	var gotPayload fwkrh.RequestPayload
 	tok := &mockTokenizer{
@@ -1229,11 +1229,11 @@ func TestProduce_MessagesRequestToolSchemaOrder(t *testing.T) {
 	rendered, err := json.Marshal(gotPayload)
 	require.NoError(t, err)
 	assert.Contains(t, string(rendered),
-		`"parameters":{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"}`,
+		`"parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`,
 		"input_schema key order must match the forwarded request body")
 }
 
-func TestMessagesRenderMatchesRepackagedAnthropicJSON(t *testing.T) {
+func TestMessagesRenderMatchesForwardedAnthropicJSON(t *testing.T) {
 	raw := []byte(`{
 		"model":"zai-org/GLM-5.2-FP8",
 		"chat_template_kwargs":{"enable_thinking":false,"custom":"value"},
@@ -1254,11 +1254,7 @@ func TestMessagesRenderMatchesRepackagedAnthropicJSON(t *testing.T) {
 		context.Background(), raw, map[string]string{":path": "/v1/messages"})
 	require.NoError(t, err)
 
-	marshaler, ok := parsed.Body.Payload.(fwkrh.Marshaler)
-	require.True(t, ok)
-	forwardedJSON, err := marshaler.Marshal()
-	require.NoError(t, err)
-	var forwarded struct {
+	type forwardedRequest struct {
 		Tools []struct {
 			InputSchema json.RawMessage `json:"input_schema"`
 		} `json:"tools"`
@@ -1266,16 +1262,7 @@ func TestMessagesRenderMatchesRepackagedAnthropicJSON(t *testing.T) {
 			Content json.RawMessage `json:"content"`
 		} `json:"messages"`
 	}
-	require.NoError(t, json.Unmarshal(forwardedJSON, &forwarded))
-	var forwardedToolUse []struct {
-		Input json.RawMessage `json:"input"`
-	}
-	require.NoError(t, json.Unmarshal(forwarded.Messages[1].Content, &forwardedToolUse))
-
-	renderJSON, err := json.Marshal(buildChatRenderRequest(
-		MessagesToRenderChatRequest(parsed.Body.Messages)))
-	require.NoError(t, err)
-	var rendered struct {
+	type renderedRequest struct {
 		ChatTemplateKWArgs map[string]any `json:"chat_template_kwargs"`
 		Tools              []struct {
 			Function struct {
@@ -1290,28 +1277,64 @@ func TestMessagesRenderMatchesRepackagedAnthropicJSON(t *testing.T) {
 			} `json:"tool_calls"`
 		} `json:"messages"`
 	}
-	require.NoError(t, json.Unmarshal(renderJSON, &rendered))
 
-	require.Len(t, forwarded.Tools, 1)
-	require.Len(t, forwarded.Messages, 2)
-	require.Len(t, forwardedToolUse, 1)
-	require.Len(t, rendered.Tools, 1)
-	require.Len(t, rendered.Messages, 2)
-	require.Len(t, rendered.Messages[1].ToolCalls, 1)
-	assert.Equal(t, map[string]any{
-		"enable_thinking":  false,
-		"custom":           "value",
-		"reasoning_effort": "high",
-	}, rendered.ChatTemplateKWArgs)
+	tests := []struct {
+		name            string
+		mutated         bool
+		forwardedJSON   []byte
+		wantSchemaOrder string
+	}{
+		{
+			name:            "unchanged body preserves wire order",
+			forwardedJSON:   raw,
+			wantSchemaOrder: `{"z":0,"nested":{"b":2,"a":1},"a":3,"type":"object"}`,
+		},
+		{
+			name:            "mutated body matches PayloadMap repackage",
+			mutated:         true,
+			wantSchemaOrder: `{"a":3,"nested":{"a":1,"b":2},"z":0,"type":"object"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			forwardedJSON := tt.forwardedJSON
+			if tt.mutated {
+				marshaler, ok := parsed.Body.Payload.(fwkrh.Marshaler)
+				require.True(t, ok)
+				var err error
+				forwardedJSON, err = marshaler.Marshal()
+				require.NoError(t, err)
+			}
 
-	assert.Equal(t,
-		`{"a":3,"nested":{"a":1,"b":2},"z":0}`,
-		string(forwarded.Tools[0].InputSchema))
-	assert.Equal(t,
-		`{"a":3,"nested":{"a":1,"b":2},"z":0,"type":"object"}`,
-		string(rendered.Tools[0].Function.Parameters))
+			var forwarded forwardedRequest
+			require.NoError(t, json.Unmarshal(forwardedJSON, &forwarded))
+			var forwardedToolUse []struct {
+				Input json.RawMessage `json:"input"`
+			}
+			require.NoError(t, json.Unmarshal(forwarded.Messages[1].Content, &forwardedToolUse))
 
-	expectedArguments, err := pythonDumps(forwardedToolUse[0].Input)
-	require.NoError(t, err)
-	assert.Equal(t, expectedArguments, rendered.Messages[1].ToolCalls[0].Function.Arguments)
+			renderJSON, err := json.Marshal(buildChatRenderRequest(
+				messagesToRenderChatRequest(parsed.Body.Messages, false, tt.mutated)))
+			require.NoError(t, err)
+			var rendered renderedRequest
+			require.NoError(t, json.Unmarshal(renderJSON, &rendered))
+
+			require.Len(t, forwarded.Tools, 1)
+			require.Len(t, forwarded.Messages, 2)
+			require.Len(t, forwardedToolUse, 1)
+			require.Len(t, rendered.Tools, 1)
+			require.Len(t, rendered.Messages, 2)
+			require.Len(t, rendered.Messages[1].ToolCalls, 1)
+			assert.Equal(t, map[string]any{
+				"enable_thinking":  false,
+				"custom":           "value",
+				"reasoning_effort": "high",
+			}, rendered.ChatTemplateKWArgs)
+			assert.Equal(t, tt.wantSchemaOrder, string(rendered.Tools[0].Function.Parameters))
+
+			expectedArguments, err := pythonDumps(forwardedToolUse[0].Input)
+			require.NoError(t, err)
+			assert.Equal(t, expectedArguments, rendered.Messages[1].ToolCalls[0].Function.Arguments)
+		})
+	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -77,6 +77,20 @@ func TestProduceTimeout(t *testing.T) {
 	assert.Zero(t, newTestPlugin(&mockTokenizer{}).ProduceTimeout())
 }
 
+func TestNewPlugin_MergeAnthropicInlineSystem(t *testing.T) {
+	p, err := NewPlugin(context.Background(), "tok", &tokenizerPluginConfig{
+		ModelName: "m",
+		VLLM: &vllmConfig{
+			MergeAnthropicInlineSystem: true,
+		},
+	})
+	require.NoError(t, err)
+
+	backend, ok := p.backend.(renderBackend)
+	require.True(t, ok)
+	assert.True(t, backend.mergeAnthropicInlineSystem)
+}
+
 func TestPluginFactory_Validation(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	handle := plugin.NewEppHandle(ctx, nil)
@@ -639,6 +653,43 @@ func TestMessagesToRenderChatRequest_RawSystem(t *testing.T) {
 	assert.Equal(t, &tokenizerTypes.Content{Raw: "You are helpful."}, result.Conversation[0].Content)
 	assert.Equal(t, "user", result.Conversation[1].Role)
 	assert.Equal(t, &tokenizerTypes.Content{Raw: "Hello"}, result.Conversation[1].Content)
+}
+
+func TestMessagesToRenderChatRequest_MergesInlineSystemForDefaultVLLMTemplate(t *testing.T) {
+	msg := &fwkrh.MessagesRequest{
+		System: fwkrh.AnthropicContent{Raw: "Top-level system."},
+		Messages: []fwkrh.AnthropicMessage{
+			{Role: "user", Content: fwkrh.AnthropicContent{Raw: "First turn."}},
+			{Role: "system", Content: fwkrh.AnthropicContent{Raw: "Inline system."}},
+			{Role: "user", Content: fwkrh.AnthropicContent{Raw: "Second turn."}},
+		},
+	}
+
+	result := messagesToRenderChatRequest(msg, true)
+
+	// AnthropicServingMessages enables merge_inline_system when vLLM starts
+	// without an explicit --chat-template, which is the production GLM shape.
+	require.Len(t, result.Conversation, 3)
+	assert.Equal(t, "system", result.Conversation[0].Role)
+	assert.Equal(t, &tokenizerTypes.Content{Raw: "Top-level system.Inline system."}, result.Conversation[0].Content)
+	assert.Equal(t, "user", result.Conversation[1].Role)
+	assert.Equal(t, "user", result.Conversation[2].Role)
+}
+
+func TestMessagesToRenderChatRequest_RawInlineBillingHeaderStripped(t *testing.T) {
+	msg := &fwkrh.MessagesRequest{
+		Messages: []fwkrh.AnthropicMessage{
+			{Role: "user", Content: fwkrh.AnthropicContent{Raw: "Hello"}},
+			{Role: "system", Content: fwkrh.AnthropicContent{Raw: "x-anthropic-billing-header: cc_version=2.1.160"}},
+			{Role: "assistant", Content: fwkrh.AnthropicContent{Raw: "Hi"}},
+		},
+	}
+
+	result := MessagesToRenderChatRequest(msg)
+
+	require.Len(t, result.Conversation, 2)
+	assert.Equal(t, "user", result.Conversation[0].Role)
+	assert.Equal(t, "assistant", result.Conversation[1].Role)
 }
 
 func TestMessagesToRenderChatRequest_Tools(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -183,12 +183,12 @@ func (r *vllmHTTPRenderer) RenderChat(ctx context.Context, payload fwkrh.Request
 
 // RenderAnthropic converts an Anthropic request using the same inline-system
 // mode as the serving vLLM process and renders the resulting chat request.
-func (r *vllmHTTPRenderer) RenderAnthropic(ctx context.Context, request *fwkrh.MessagesRequest) ([]uint32, *tokenization.MultiModalFeatures, error) {
+func (r *vllmHTTPRenderer) RenderAnthropic(ctx context.Context, request *fwkrh.MessagesRequest, canonicalizeJSON bool) ([]uint32, *tokenization.MultiModalFeatures, error) {
 	mergeInlineSystem, err := r.anthropicInlineSystemMode(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
-	return r.renderChatRequest(ctx, messagesToRenderChatRequest(request, mergeInlineSystem))
+	return r.renderChatRequest(ctx, messagesToRenderChatRequest(request, mergeInlineSystem, canonicalizeJSON))
 }
 
 func (r *vllmHTTPRenderer) renderChatRequest(ctx context.Context, request *tokenizerTypes.RenderChatRequest) ([]uint32, *tokenization.MultiModalFeatures, error) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -27,6 +27,7 @@ import (
 	"maps"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
@@ -69,9 +70,9 @@ type vllmConfig struct {
 	// MMTimeout is the per-request timeout for multimodal requests
 	// (image download/processing). Defaults to 30s.
 	MMTimeout string `json:"mmTimeout,omitempty"`
-	// MergeAnthropicInlineSystem matches vLLM's Anthropic conversion when its
-	// chat template requires system messages to precede the conversation.
-	MergeAnthropicInlineSystem bool `json:"mergeAnthropicInlineSystem,omitempty"`
+	// MergeAnthropicInlineSystem overrides automatic detection of vLLM's
+	// Anthropic inline-system conversion.
+	MergeAnthropicInlineSystem *bool `json:"mergeAnthropicInlineSystem,omitempty"`
 }
 
 // vllmHTTPRenderer implements the tokenizer interface by calling vLLM's
@@ -82,6 +83,10 @@ type vllmHTTPRenderer struct {
 	modelName string
 	timeout   time.Duration
 	mmTimeout time.Duration
+
+	mergeAnthropicInlineSystem *bool
+	anthropicModeMu            sync.Mutex
+	detectedAnthropicMode      *bool
 }
 
 func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, error) {
@@ -103,10 +108,11 @@ func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, 
 			// transport's default "HTTP POST" so traces identify render calls.
 			func(_ string, r *http.Request) string { return "tokenize_render " + r.URL.Path },
 		))},
-		baseURL:   url,
-		modelName: modelName,
-		timeout:   timeout,
-		mmTimeout: mmTimeout,
+		baseURL:                    url,
+		modelName:                  modelName,
+		timeout:                    timeout,
+		mmTimeout:                  mmTimeout,
+		mergeAnthropicInlineSystem: cfg.MergeAnthropicInlineSystem,
 	}, nil
 }
 
@@ -175,6 +181,29 @@ func (r *vllmHTTPRenderer) RenderChat(ctx context.Context, payload fwkrh.Request
 	return r.postChatRender(ctx, body, r.chatTimeout(pm))
 }
 
+// RenderAnthropic converts an Anthropic request using the same inline-system
+// mode as the serving vLLM process and renders the resulting chat request.
+func (r *vllmHTTPRenderer) RenderAnthropic(ctx context.Context, request *fwkrh.MessagesRequest) ([]uint32, *tokenization.MultiModalFeatures, error) {
+	mergeInlineSystem, err := r.anthropicInlineSystemMode(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return r.renderChatRequest(ctx, messagesToRenderChatRequest(request, mergeInlineSystem))
+}
+
+func (r *vllmHTTPRenderer) renderChatRequest(ctx context.Context, request *tokenizerTypes.RenderChatRequest) ([]uint32, *tokenization.MultiModalFeatures, error) {
+	body := buildChatRenderRequest(request)
+	body.Model = r.modelName
+	timeout := r.timeout
+	for _, message := range request.Conversation {
+		if message.Content != nil && len(message.Content.Structured) > 0 {
+			timeout = r.mmTimeout
+			break
+		}
+	}
+	return r.postChatRender(ctx, body, timeout)
+}
+
 func (r *vllmHTTPRenderer) postChatRender(ctx context.Context, body any, timeout time.Duration) ([]uint32, *tokenization.MultiModalFeatures, error) {
 	var resp renderResponse
 	if err := r.postJSON(ctx, chatRenderPath, body, timeout, &resp); err != nil {
@@ -219,6 +248,7 @@ func (r *vllmHTTPRenderer) produceTimeout() time.Duration {
 // Used by the non-PayloadMap fallback path (gRPC, warmup). The model is
 // stamped in by the renderer, not carried here.
 type chatRenderRequest struct {
+	Model                string         `json:"model,omitempty"`
 	Messages             []chatMessage  `json:"messages"`
 	Tools                []any          `json:"tools,omitempty"`
 	Documents            []any          `json:"documents,omitempty"`

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -69,6 +69,9 @@ type vllmConfig struct {
 	// MMTimeout is the per-request timeout for multimodal requests
 	// (image download/processing). Defaults to 30s.
 	MMTimeout string `json:"mmTimeout,omitempty"`
+	// MergeAnthropicInlineSystem matches vLLM's Anthropic conversion when its
+	// chat template requires system messages to precede the conversation.
+	MergeAnthropicInlineSystem bool `json:"mergeAnthropicInlineSystem,omitempty"`
 }
 
 // vllmHTTPRenderer implements the tokenizer interface by calling vLLM's

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_anthropic_mode.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_anthropic_mode.go
@@ -65,8 +65,8 @@ func (r *vllmHTTPRenderer) detectAnthropicInlineSystem(ctx context.Context) (boo
 		return false, fmt.Errorf("detect Anthropic inline-system mode: %w", err)
 	}
 
-	unmergedIDs, _, unmergedErr := r.renderChatRequest(ctx, messagesToRenderChatRequest(probe, false))
-	mergedIDs, _, mergedErr := r.renderChatRequest(ctx, messagesToRenderChatRequest(probe, true))
+	unmergedIDs, _, unmergedErr := r.renderChatRequest(ctx, messagesToRenderChatRequest(probe, false, false))
+	mergedIDs, _, mergedErr := r.renderChatRequest(ctx, messagesToRenderChatRequest(probe, true, false))
 	unmergedMatches := unmergedErr == nil && len(unmergedIDs) == countResponse.InputTokens
 	mergedMatches := mergedErr == nil && len(mergedIDs) == countResponse.InputTokens
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_anthropic_mode.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_anthropic_mode.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenizer
+
+import (
+	"context"
+	"fmt"
+
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+)
+
+const anthropicCountPath = "/v1/messages/count_tokens"
+
+func (r *vllmHTTPRenderer) anthropicInlineSystemMode(ctx context.Context) (bool, error) {
+	if r.mergeAnthropicInlineSystem != nil {
+		return *r.mergeAnthropicInlineSystem, nil
+	}
+
+	r.anthropicModeMu.Lock()
+	defer r.anthropicModeMu.Unlock()
+	if r.detectedAnthropicMode != nil {
+		return *r.detectedAnthropicMode, nil
+	}
+
+	mode, err := r.detectAnthropicInlineSystem(ctx)
+	if err != nil {
+		return false, err
+	}
+	r.detectedAnthropicMode = &mode
+	return mode, nil
+}
+
+// TODO: Remove this detector and its configuration override when vLLM exposes
+// an Anthropic render endpoint that returns the token IDs used for generation.
+func (r *vllmHTTPRenderer) detectAnthropicInlineSystem(ctx context.Context) (bool, error) {
+	probe := &fwkrh.MessagesRequest{
+		System: fwkrh.AnthropicContent{Raw: "router-system-probe"},
+		Messages: []fwkrh.AnthropicMessage{
+			{Role: "user", Content: fwkrh.AnthropicContent{Raw: "router-user-probe-one"}},
+			{Role: "system", Content: fwkrh.AnthropicContent{Raw: "router-inline-system-probe"}},
+			{Role: "user", Content: fwkrh.AnthropicContent{Raw: "router-user-probe-two"}},
+		},
+	}
+	countRequest := anthropicCountTokensRequest{
+		Model:    r.modelName,
+		System:   probe.System,
+		Messages: probe.Messages,
+	}
+	var countResponse anthropicCountTokensResponse
+	if err := r.postJSON(ctx, anthropicCountPath, countRequest, r.timeout, &countResponse); err != nil {
+		return false, fmt.Errorf("detect Anthropic inline-system mode: %w", err)
+	}
+
+	unmergedIDs, _, unmergedErr := r.renderChatRequest(ctx, messagesToRenderChatRequest(probe, false))
+	mergedIDs, _, mergedErr := r.renderChatRequest(ctx, messagesToRenderChatRequest(probe, true))
+	unmergedMatches := unmergedErr == nil && len(unmergedIDs) == countResponse.InputTokens
+	mergedMatches := mergedErr == nil && len(mergedIDs) == countResponse.InputTokens
+
+	switch {
+	case unmergedMatches && !mergedMatches:
+		return false, nil
+	case mergedMatches && !unmergedMatches:
+		return true, nil
+	default:
+		return false, fmt.Errorf(
+			"detect Anthropic inline-system mode: token count %d did not uniquely match unmerged (tokens=%d, err=%v) or merged (tokens=%d, err=%v) rendering",
+			countResponse.InputTokens, len(unmergedIDs), unmergedErr, len(mergedIDs), mergedErr,
+		)
+	}
+}
+
+type anthropicCountTokensRequest struct {
+	Model    string                   `json:"model"`
+	System   fwkrh.AnthropicContent   `json:"system,omitempty"`
+	Messages []fwkrh.AnthropicMessage `json:"messages"`
+}
+
+type anthropicCountTokensResponse struct {
+	InputTokens int `json:"input_tokens"`
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
@@ -158,6 +158,76 @@ func TestProduce_MessagesVLLMHTTPMergesInlineSystem(t *testing.T) {
 	assert.Equal(t, "user", sent.Messages[2].Role)
 }
 
+func TestProduce_MessagesVLLMHTTPMatchesForwardedJSONOrder(t *testing.T) {
+	tests := []struct {
+		name          string
+		mutated       bool
+		wantSchema    string
+		wantArguments string
+	}{
+		{
+			name:          "unchanged body preserves wire order",
+			wantSchema:    `{"z":0,"nested":{"b":2,"a":1},"a":3,"type":"object"}`,
+			wantArguments: `{"z": 0, "nested": {"b": 2, "a": 1}, "a": 3}`,
+		},
+		{
+			name:          "mutated body matches repackage order",
+			mutated:       true,
+			wantSchema:    `{"a":3,"nested":{"a":1,"b":2},"z":0,"type":"object"}`,
+			wantArguments: `{"a": 3, "nested": {"a": 1, "b": 2}, "z": 0}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, cap := httpFixture(t, nil, renderResponse{TokenIDs: []uint32{1}})
+			defer srv.Close()
+
+			req := &scheduling.InferenceRequest{Body: &fwkrh.InferenceRequestBody{
+				Mutated: tt.mutated,
+				Messages: &fwkrh.MessagesRequest{
+					Tools: []fwkrh.AnthropicTool{{
+						Name:        "run",
+						InputSchema: json.RawMessage(`{"z":0,"nested":{"b":2,"a":1},"a":3}`),
+					}},
+					Messages: []fwkrh.AnthropicMessage{
+						{Role: "user", Content: fwkrh.AnthropicContent{Raw: "Run it"}},
+						{Role: "assistant", Content: fwkrh.AnthropicContent{Structured: []fwkrh.AnthropicContentBlock{{
+							Type:  blockTypeToolUse,
+							ID:    "toolu_01",
+							Name:  "run",
+							Input: json.RawMessage(`{"z":0,"nested":{"b":2,"a":1},"a":3}`),
+						}}}},
+					},
+				},
+			}}
+
+			p := newTestPlugin(newHTTPRenderer(t, srv))
+			require.NoError(t, p.Produce(context.Background(), req, nil))
+
+			var sent struct {
+				Tools []struct {
+					Function struct {
+						Parameters json.RawMessage `json:"parameters"`
+					} `json:"function"`
+				} `json:"tools"`
+				Messages []struct {
+					ToolCalls []struct {
+						Function struct {
+							Arguments string `json:"arguments"`
+						} `json:"function"`
+					} `json:"tool_calls"`
+				} `json:"messages"`
+			}
+			require.NoError(t, json.Unmarshal(cap.chat, &sent))
+			require.Len(t, sent.Tools, 1)
+			require.Len(t, sent.Messages, 2)
+			require.Len(t, sent.Messages[1].ToolCalls, 1)
+			assert.Equal(t, tt.wantSchema, string(sent.Tools[0].Function.Parameters))
+			assert.Equal(t, tt.wantArguments, sent.Messages[1].ToolCalls[0].Function.Arguments)
+		})
+	}
+}
+
 func TestProduce_MessagesVLLMHTTPDetectsAndCachesInlineSystemMode(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
@@ -46,7 +46,11 @@ const testHTTPModel = "test-model"
 
 func newHTTPRenderer(t *testing.T, srv *httptest.Server) *vllmHTTPRenderer {
 	t.Helper()
-	r, err := newVLLMHTTPRenderer(&vllmConfig{URL: srv.URL}, testHTTPModel)
+	mergeInlineSystem := false
+	r, err := newVLLMHTTPRenderer(&vllmConfig{
+		URL:                        srv.URL,
+		MergeAnthropicInlineSystem: &mergeInlineSystem,
+	}, testHTTPModel)
 	require.NoError(t, err)
 	return r
 }
@@ -112,6 +116,145 @@ func TestProduce_CompletionsVLLMHTTPUsesRawPayload(t *testing.T) {
 	require.NoError(t, json.Unmarshal(cap.completions, &sent))
 	assert.Equal(t, "kept", sent["dummy_field"])
 	assert.Equal(t, testHTTPModel, sent["model"])
+}
+
+func TestProduce_MessagesVLLMHTTPMergesInlineSystem(t *testing.T) {
+	srv, cap := httpFixture(t, nil, renderResponse{TokenIDs: []uint32{1, 2, 3}})
+	defer srv.Close()
+
+	req := &scheduling.InferenceRequest{
+		Body: &fwkrh.InferenceRequestBody{
+			Messages: &fwkrh.MessagesRequest{
+				System: fwkrh.AnthropicContent{Raw: "root"},
+				Messages: []fwkrh.AnthropicMessage{
+					{Role: "user", Content: fwkrh.AnthropicContent{Raw: "first"}},
+					{Role: "system", Content: fwkrh.AnthropicContent{Raw: "inline"}},
+					{Role: "user", Content: fwkrh.AnthropicContent{Raw: "second"}},
+				},
+			},
+		},
+	}
+
+	mergeInlineSystem := true
+	renderer, err := newVLLMHTTPRenderer(&vllmConfig{
+		URL:                        srv.URL,
+		MergeAnthropicInlineSystem: &mergeInlineSystem,
+	}, testHTTPModel)
+	require.NoError(t, err)
+	p := newTestPlugin(renderer)
+	require.NoError(t, p.Produce(context.Background(), req, nil))
+
+	var sent struct {
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	require.NoError(t, json.Unmarshal(cap.chat, &sent))
+	require.Len(t, sent.Messages, 3)
+	assert.Equal(t, "system", sent.Messages[0].Role)
+	assert.Equal(t, "rootinline", sent.Messages[0].Content)
+	assert.Equal(t, "user", sent.Messages[1].Role)
+	assert.Equal(t, "user", sent.Messages[2].Role)
+}
+
+func TestProduce_MessagesVLLMHTTPDetectsAndCachesInlineSystemMode(t *testing.T) {
+	tests := []struct {
+		name           string
+		countTokens    int
+		rejectUnmerged bool
+		expectMerged   bool
+	}{
+		{name: "merged", countTokens: 3, expectMerged: true},
+		{name: "merged when unmerged render is rejected", countTokens: 3, rejectUnmerged: true, expectMerged: true},
+		{name: "unmerged", countTokens: 4, expectMerged: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			countCalls := 0
+			chatCalls := 0
+			lastMessageCount := 0
+			mux := http.NewServeMux()
+			mux.HandleFunc(anthropicCountPath, func(w http.ResponseWriter, _ *http.Request) {
+				countCalls++
+				_ = json.NewEncoder(w).Encode(anthropicCountTokensResponse{InputTokens: tt.countTokens})
+			})
+			mux.HandleFunc(chatRenderPath, func(w http.ResponseWriter, r *http.Request) {
+				chatCalls++
+				var body struct {
+					Messages []json.RawMessage `json:"messages"`
+				}
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+				lastMessageCount = len(body.Messages)
+				if tt.rejectUnmerged && lastMessageCount == 4 {
+					http.Error(w, "system message must be first", http.StatusBadRequest)
+					return
+				}
+				tokenIDs := make([]uint32, lastMessageCount)
+				_ = json.NewEncoder(w).Encode(renderResponse{TokenIDs: tokenIDs})
+			})
+			srv := httptest.NewServer(mux)
+			defer srv.Close()
+
+			renderer, err := newVLLMHTTPRenderer(&vllmConfig{URL: srv.URL}, testHTTPModel)
+			require.NoError(t, err)
+			p := newTestPlugin(renderer)
+
+			require.NoError(t, p.Produce(context.Background(), anthropicSystemTestRequest(), nil))
+			assert.Equal(t, 1, countCalls)
+			assert.Equal(t, 3, chatCalls, "detection renders two candidates and the request once")
+			if tt.expectMerged {
+				assert.Equal(t, 3, lastMessageCount)
+			} else {
+				assert.Equal(t, 4, lastMessageCount)
+			}
+
+			require.NoError(t, p.Produce(context.Background(), anthropicSystemTestRequest(), nil))
+			assert.Equal(t, 1, countCalls, "detected mode is cached")
+			assert.Equal(t, 4, chatCalls, "subsequent requests render once")
+		})
+	}
+}
+
+func TestProduce_MessagesVLLMHTTPRejectsAmbiguousInlineSystemMode(t *testing.T) {
+	countCalls := 0
+	chatCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc(anthropicCountPath, func(w http.ResponseWriter, _ *http.Request) {
+		countCalls++
+		_ = json.NewEncoder(w).Encode(anthropicCountTokensResponse{InputTokens: 3})
+	})
+	mux.HandleFunc(chatRenderPath, func(w http.ResponseWriter, _ *http.Request) {
+		chatCalls++
+		_ = json.NewEncoder(w).Encode(renderResponse{TokenIDs: []uint32{1, 2, 3}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	renderer, err := newVLLMHTTPRenderer(&vllmConfig{URL: srv.URL}, testHTTPModel)
+	require.NoError(t, err)
+	p := newTestPlugin(renderer)
+
+	err = p.Produce(context.Background(), anthropicSystemTestRequest(), nil)
+	require.ErrorContains(t, err, "did not uniquely match")
+	assert.Equal(t, 1, countCalls)
+	assert.Equal(t, 2, chatCalls)
+}
+
+func anthropicSystemTestRequest() *scheduling.InferenceRequest {
+	return &scheduling.InferenceRequest{
+		Body: &fwkrh.InferenceRequestBody{
+			Messages: &fwkrh.MessagesRequest{
+				System: fwkrh.AnthropicContent{Raw: "root"},
+				Messages: []fwkrh.AnthropicMessage{
+					{Role: "user", Content: fwkrh.AnthropicContent{Raw: "first"}},
+					{Role: "system", Content: fwkrh.AnthropicContent{Raw: "inline"}},
+					{Role: "user", Content: fwkrh.AnthropicContent{Raw: "second"}},
+				},
+			},
+		},
+	}
 }
 
 // TestVLLMHTTPRenderer_RenderChat_Multimodal covers the chat endpoint: the raw

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
@@ -44,6 +44,29 @@ func TestNewAnthropicParser(t *testing.T) {
 	}
 }
 
+func TestAnthropicParser_PreservesTemplateControls(t *testing.T) {
+	parsed, err := NewAnthropicParser().ParseRequest(
+		context.Background(),
+		[]byte(`{
+			"model":"zai-org/GLM-5.2-FP8",
+			"max_tokens":512,
+			"messages":[{"role":"user","content":"Hello"}],
+			"chat_template_kwargs":{"enable_thinking":false,"custom":"value"},
+			"output_config":{"effort":"high"}
+		}`),
+		map[string]string{":path": "/v1/messages"},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, parsed.Body.Messages)
+
+	assert.Equal(t, map[string]any{
+		"enable_thinking": false,
+		"custom":          "value",
+	}, parsed.Body.Messages.ChatTemplateKWArgs)
+	require.NotNil(t, parsed.Body.Messages.OutputConfig)
+	assert.Equal(t, "high", parsed.Body.Messages.OutputConfig.Effort)
+}
+
 func TestAnthropicParser_ParseRequest(t *testing.T) {
 	parser := NewAnthropicParser()
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Precise prefix-cache routing can miss reusable blocks for Anthropic `/v1/messages` requests when the router and vLLM derive different prompt tokens from the same request. Because several Anthropic controls affect the beginning of the rendered prompt, these differences can make the block identity diverge from block zero even while KV-event ingestion is healthy.

The Anthropic render path added by [#1896](https://github.com/llm-d/llm-d-router/pull/1896) still had three sources of divergence:

- vLLM reparses nested JSON in `tools[].input_schema` and assistant `tool_use.input`, which canonicalizes object-key order. The router retained the incoming wire order.
- vLLM's handling of inline system messages depends on its Anthropic conversion and model chat template. The router could therefore merge or preserve those messages differently from vLLM. Claude Code billing headers introduce another request-varying prefix unless both sides remove them.
- The parsed Messages request dropped `chat_template_kwargs` and `output_config.effort`. vLLM passes the former to the chat template and maps the latter to `reasoning_effort`, enabling thinking only when the caller did not explicitly set `enable_thinking`.

This PR aligns the router with the request vLLM renders:

- Canonicalizes nested Anthropic JSON after request reparsing.
- Matches vLLM's missing `input_schema.type` insertion order.
- Removes Claude Code billing headers.
- Routes Anthropic requests through the typed vLLM HTTP renderer.
- Automatically detects whether vLLM merges or preserves inline system messages by comparing `/v1/messages/count_tokens` with merged and unmerged render candidates.
- Caches detection once per renderer and fails fast when detection is unavailable or ambiguous instead of producing incorrect cache keys.
- Preserves caller-provided `chat_template_kwargs` without hardcoding model-specific values.
- Maps `output_config.effort` with vLLM's precedence: it overwrites `reasoning_effort`, while an explicit caller-provided `enable_thinking` wins over the derived default.
- Retains `vllm.mergeAnthropicInlineSystem` only as a compatibility override.

The inline-system detector is isolated and marked for deletion once vLLM provides a native Anthropic render endpoint.

Related work:

- [llm-d-router #1896](https://github.com/llm-d/llm-d-router/pull/1896) - merged; added Anthropic support to the render tokenizer.
- [vLLM #44602](https://github.com/vllm-project/vllm/pull/44602) - merged; preserved inline system-message position for prefix caching.
- [vLLM #46025](https://github.com/vllm-project/vllm/pull/46025) - merged; introduced chat-template-based inline-system detection.
- [vLLM #46196](https://github.com/vllm-project/vllm/pull/46196) - open; resolves the model chat template before applying that detection.
- [vLLM #47681](https://github.com/vllm-project/vllm/pull/47681) - open; proposes a shared inline-system policy for OpenAI and Anthropic requests.
- [vLLM #52978](https://github.com/vllm-project/vllm/pull/52978) - open; handles trailing Anthropic system messages without undoing mid-conversation prefix reuse.
- [vLLM #45803](https://github.com/vllm-project/vllm/pull/45803) - open; adds native `/v1/messages/render`, which would replace the router-side conversion and detector.

Verification:

- Parser-to-forwarded-payload parity for nested and reverse-ordered Anthropic JSON.
- Missing `input_schema.type` insertion-order parity.
- Tool-use input, inline-system, billing-header, `chat_template_kwargs`, and `output_config.effort` conversion.
- Merged and preserved automatic detection.
- Explicit override, cached detection, strict-template rejection, and ambiguous-result failure.
- Focused package tests, race tests for the tokenizer and Anthropic parser, and `go vet`.
- A controlled integration reproducer showed zero matches for prompt-affecting Anthropic controls before the fix and full reusable-prefix matches after the fix.
- The patched build restored routing matches in live validation without transport failures, restarts, or request-path errors.

**Which issue(s) this PR fixes**:

Follow-up to [#1861](https://github.com/llm-d/llm-d-router/issues/1861) and [#1896](https://github.com/llm-d/llm-d-router/pull/1896).

**Release note** _(write `NONE` if no user-facing change)_:

```release-note
Anthropic `/v1/messages` prefix-cache routing preserves prompt-affecting template controls and matches vLLM's request rendering.
```
