### PR TITLE
Fix routing imbalance: deterministic tie-breaking for equal-score endpoints

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/picker/common.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/common.go
@@ -73,15 +73,20 @@ func (r *lockedRand) Shuffle(n int, swap func(i, j int)) {
 // overhead and ensure controlled randomization.
 var PickerRand = newLockedRand()
 
-// ShuffleScoredEndpoints provides deterministic round-robin tie-breaking for
+// ShuffleScoredEndpoints randomly shuffles the scored endpoints.
+func ShuffleScoredEndpoints(scoredEndpoints []*fwksched.ScoredEndpoint) {
+	PickerRand.Shuffle(len(scoredEndpoints), func(i, j int) {
+		scoredEndpoints[i], scoredEndpoints[j] = scoredEndpoints[j], scoredEndpoints[i]
+	})
+}
+
+// RotateScoredEndpoints provides deterministic round-robin rotation for
 // equal-score endpoints. Under concurrent load with prefix cache affinity,
 // multiple requests can see identical scores simultaneously. Pure random
 // shuffling causes them to converge on the same winner, creating severe
 // routing imbalance. The round-robin counter ensures each call rotates
 // through the endpoints evenly.
-//
-// This runs under the lockedRand mutex, so the counter is safe to reset.
-func ShuffleScoredEndpoints(scoredEndpoints []*fwksched.ScoredEndpoint) {
+func RotateScoredEndpoints(scoredEndpoints []*fwksched.ScoredEndpoint) {
 	n := len(scoredEndpoints)
 	if n <= 1 {
 		return
@@ -90,7 +95,6 @@ func ShuffleScoredEndpoints(scoredEndpoints []*fwksched.ScoredEndpoint) {
 	PickerRand.mu.Lock()
 	defer PickerRand.mu.Unlock()
 
-	// Rotate endpoints by the counter for deterministic round-robin tie-breaking
 	rotation := PickerRand.counter % n
 	PickerRand.counter++
 	if PickerRand.counter >= n {

--- a/pkg/epp/framework/plugins/scheduling/picker/common.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/common.go
@@ -42,8 +42,9 @@ type PickerParameters struct {
 }
 
 type lockedRand struct {
-	mu   sync.Mutex
-	rand *rand.Rand
+	mu      sync.Mutex
+	rand    *rand.Rand
+	counter int // round-robin counter for deterministic tie-breaking, reset when it reaches endpoint count
 }
 
 func newLockedRand() *lockedRand {
@@ -72,10 +73,34 @@ func (r *lockedRand) Shuffle(n int, swap func(i, j int)) {
 // overhead and ensure controlled randomization.
 var PickerRand = newLockedRand()
 
-// ShuffleScoredEndpoints randomizes the order of the given scored candidates in-place.
+// ShuffleScoredEndpoints provides deterministic round-robin tie-breaking for
+// equal-score endpoints. Under concurrent load with prefix cache affinity,
+// multiple requests can see identical scores simultaneously. Pure random
+// shuffling causes them to converge on the same winner, creating severe
+// routing imbalance. The round-robin counter ensures each call rotates
+// through the endpoints evenly.
+//
+// This runs under the lockedRand mutex, so the counter is safe to reset.
 func ShuffleScoredEndpoints(scoredEndpoints []*fwksched.ScoredEndpoint) {
-	// Shuffle in-place
-	PickerRand.Shuffle(len(scoredEndpoints), func(i, j int) {
-		scoredEndpoints[i], scoredEndpoints[j] = scoredEndpoints[j], scoredEndpoints[i]
-	})
+	n := len(scoredEndpoints)
+	if n <= 1 {
+		return
+	}
+
+	PickerRand.mu.Lock()
+	defer PickerRand.mu.Unlock()
+
+	// Rotate endpoints by the counter for deterministic round-robin tie-breaking
+	rotation := PickerRand.counter % n
+	PickerRand.counter++
+	if PickerRand.counter >= n {
+		PickerRand.counter = 0
+	}
+
+	if rotation > 0 {
+		rotated := make([]*fwksched.ScoredEndpoint, n)
+		copy(rotated, scoredEndpoints[rotation:])
+		copy(rotated[n-rotation:], scoredEndpoints[:rotation])
+		copy(scoredEndpoints, rotated)
+	}
 }

--- a/pkg/epp/framework/plugins/scheduling/picker/common.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/common.go
@@ -95,16 +95,12 @@ func RotateScoredEndpoints(scoredEndpoints []*fwksched.ScoredEndpoint) {
 	PickerRand.mu.Lock()
 	defer PickerRand.mu.Unlock()
 
-	rotation := PickerRand.counter % n
-	PickerRand.counter++
-	if PickerRand.counter >= n {
-		PickerRand.counter = 0
-	}
+	PickerRand.counter = (PickerRand.counter + 1) % n
 
-	if rotation > 0 {
+	if PickerRand.counter > 0 {
 		rotated := make([]*fwksched.ScoredEndpoint, n)
-		copy(rotated, scoredEndpoints[rotation:])
-		copy(rotated[n-rotation:], scoredEndpoints[:rotation])
+		copy(rotated, scoredEndpoints[PickerRand.counter:])
+		copy(rotated[n-PickerRand.counter:], scoredEndpoints[:PickerRand.counter])
 		copy(scoredEndpoints, rotated)
 	}
 }

--- a/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"sync/atomic"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -70,6 +71,11 @@ func NewMaxScorePicker(maxNumOfEndpoints int) *MaxScorePicker {
 type MaxScorePicker struct {
 	typedName         fwkplugin.TypedName
 	maxNumOfEndpoints int // maximum number of endpoints to pick
+	// requestCounter provides deterministic round-robin tie-breaking when multiple
+	// endpoints have equal scores. Without this, concurrent requests that see identical
+	// scores (e.g., when all pods have the same prefix cached) all pick the same
+	// random winner, causing severe routing imbalance.
+	requestCounter uint64
 }
 
 // WithName sets the picker's name
@@ -88,8 +94,12 @@ func (p *MaxScorePicker) Pick(ctx context.Context, scoredEndpoints []*fwksched.S
 	log.FromContext(ctx).V(logutil.DEBUG).Info("Selecting endpoints from candidates sorted by max score", "max-num-of-endpoints", p.maxNumOfEndpoints,
 		"num-of-candidates", len(scoredEndpoints), "scored-endpoints", scoredEndpoints)
 
-	// Shuffle in-place - needed for random tie break when scores are equal
-	picker.ShuffleScoredEndpoints(scoredEndpoints)
+	// Use an atomic counter for deterministic round-robin tie-breaking.
+	// When concurrent requests see identical scores (common with prefix cache
+	// affinity where all pods have the same prefix cached), random shuffle
+	// causes all requests to converge on the same winner. The counter ensures
+	// each request rotates through the equal-score group, spreading load evenly.
+	counter := atomic.AddUint64(&p.requestCounter, 1)
 
 	slices.SortStableFunc(scoredEndpoints, func(i, j *fwksched.ScoredEndpoint) int { // highest score first
 		if i.Score > j.Score {
@@ -100,6 +110,24 @@ func (p *MaxScorePicker) Pick(ctx context.Context, scoredEndpoints []*fwksched.S
 		}
 		return 0
 	})
+
+	// Rotate the top equal-score group by the counter to distribute ties
+	if len(scoredEndpoints) > 1 {
+		topScore := scoredEndpoints[0].Score
+		equalCount := 1
+		for equalCount < len(scoredEndpoints) && scoredEndpoints[equalCount].Score == topScore {
+			equalCount++
+		}
+		if equalCount > 1 {
+			rotation := int(counter % uint64(equalCount))
+			rotated := make([]*fwksched.ScoredEndpoint, len(scoredEndpoints))
+			for i := 0; i < equalCount; i++ {
+				rotated[i] = scoredEndpoints[(i+rotation)%equalCount]
+			}
+			copy(rotated[equalCount:], scoredEndpoints[equalCount:])
+			copy(scoredEndpoints, rotated)
+		}
+	}
 
 	// if we have enough endpoints to return keep only the "maxNumOfEndpoints" highest scored endpoints
 	if p.maxNumOfEndpoints < len(scoredEndpoints) {

--- a/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go
@@ -88,9 +88,9 @@ func (p *MaxScorePicker) Pick(ctx context.Context, scoredEndpoints []*fwksched.S
 	log.FromContext(ctx).V(logutil.DEBUG).Info("Selecting endpoints from candidates sorted by max score", "max-num-of-endpoints", p.maxNumOfEndpoints,
 		"num-of-candidates", len(scoredEndpoints), "scored-endpoints", scoredEndpoints)
 
-	// ShuffleScoredEndpoints now provides deterministic round-robin
+	// RotateScoredEndpoints provides deterministic round-robin
 	// tie-breaking instead of random shuffle (see picker/common.go)
-	picker.ShuffleScoredEndpoints(scoredEndpoints)
+	picker.RotateScoredEndpoints(scoredEndpoints)
 
 	slices.SortStableFunc(scoredEndpoints, func(i, j *fwksched.ScoredEndpoint) int { // highest score first
 		if i.Score > j.Score {

--- a/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
-	"sync/atomic"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -71,11 +70,6 @@ func NewMaxScorePicker(maxNumOfEndpoints int) *MaxScorePicker {
 type MaxScorePicker struct {
 	typedName         fwkplugin.TypedName
 	maxNumOfEndpoints int // maximum number of endpoints to pick
-	// requestCounter provides deterministic round-robin tie-breaking when multiple
-	// endpoints have equal scores. Without this, concurrent requests that see identical
-	// scores (e.g., when all pods have the same prefix cached) all pick the same
-	// random winner, causing severe routing imbalance.
-	requestCounter uint64
 }
 
 // WithName sets the picker's name
@@ -94,12 +88,9 @@ func (p *MaxScorePicker) Pick(ctx context.Context, scoredEndpoints []*fwksched.S
 	log.FromContext(ctx).V(logutil.DEBUG).Info("Selecting endpoints from candidates sorted by max score", "max-num-of-endpoints", p.maxNumOfEndpoints,
 		"num-of-candidates", len(scoredEndpoints), "scored-endpoints", scoredEndpoints)
 
-	// Use an atomic counter for deterministic round-robin tie-breaking.
-	// When concurrent requests see identical scores (common with prefix cache
-	// affinity where all pods have the same prefix cached), random shuffle
-	// causes all requests to converge on the same winner. The counter ensures
-	// each request rotates through the equal-score group, spreading load evenly.
-	counter := atomic.AddUint64(&p.requestCounter, 1)
+	// ShuffleScoredEndpoints now provides deterministic round-robin
+	// tie-breaking instead of random shuffle (see picker/common.go)
+	picker.ShuffleScoredEndpoints(scoredEndpoints)
 
 	slices.SortStableFunc(scoredEndpoints, func(i, j *fwksched.ScoredEndpoint) int { // highest score first
 		if i.Score > j.Score {
@@ -110,24 +101,6 @@ func (p *MaxScorePicker) Pick(ctx context.Context, scoredEndpoints []*fwksched.S
 		}
 		return 0
 	})
-
-	// Rotate the top equal-score group by the counter to distribute ties
-	if len(scoredEndpoints) > 1 {
-		topScore := scoredEndpoints[0].Score
-		equalCount := 1
-		for equalCount < len(scoredEndpoints) && scoredEndpoints[equalCount].Score == topScore {
-			equalCount++
-		}
-		if equalCount > 1 {
-			rotation := int(counter % uint64(equalCount))
-			rotated := make([]*fwksched.ScoredEndpoint, len(scoredEndpoints))
-			for i := 0; i < equalCount; i++ {
-				rotated[i] = scoredEndpoints[(i+rotation)%equalCount]
-			}
-			copy(rotated[equalCount:], scoredEndpoints[equalCount:])
-			copy(scoredEndpoints, rotated)
-		}
-	}
 
 	// if we have enough endpoints to return keep only the "maxNumOfEndpoints" highest scored endpoints
 	if p.maxNumOfEndpoints < len(scoredEndpoints) {

--- a/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker_test.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker_test.go
@@ -18,6 +18,7 @@ package maxscore
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -27,6 +28,46 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 )
+
+func TestEqualScoreDistribution(t *testing.T) {
+	// Verifies that concurrent requests with equal scores are distributed
+	// across endpoints via round-robin, not concentrated on one winner.
+	// This prevents routing imbalance when prefix cache affinity causes
+	// all endpoints to receive identical scores.
+	numPods := 8
+	endpoints := make([]fwksched.Endpoint, numPods)
+	for i := 0; i < numPods; i++ {
+		endpoints[i] = fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
+			ID: k8stypes.NamespacedName{Name: fmt.Sprintf("pod%d", i)},
+		}, nil, nil)
+	}
+
+	picker := NewMaxScorePicker(1)
+	picks := make(map[string]int)
+
+	// Simulate 80 concurrent requests all seeing the same scores
+	for i := 0; i < 80; i++ {
+		scored := make([]*fwksched.ScoredEndpoint, numPods)
+		for j := 0; j < numPods; j++ {
+			scored[j] = &fwksched.ScoredEndpoint{Endpoint: endpoints[j], Score: 50} // all equal
+		}
+		result := picker.Pick(context.Background(), scored)
+		winner := result.TargetEndpoints[0].String()
+		picks[winner]++
+	}
+
+	// Each pod should get exactly 10 requests (80/8)
+	for pod, count := range picks {
+		if count != 10 {
+			t.Errorf("Pod %s got %d requests, expected 10 (even distribution)", pod, count)
+		}
+	}
+
+	// All 8 pods should have been picked
+	if len(picks) != numPods {
+		t.Errorf("Only %d of %d pods were picked — routing imbalance", len(picks), numPods)
+	}
+}
 
 func TestPickMaxScorePicker(t *testing.T) {
 	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil)


### PR DESCRIPTION
## Problem

When multiple endpoints have identical scores, the `MaxScorePicker` uses `rand.Shuffle` for tie-breaking. Under concurrent load, all requests in a burst see the same stale scores and the same random shuffle seed — causing them all to pick the **same** endpoint. This creates severe routing imbalance where one pod handles all requests while others sit idle.

This is particularly severe with **prefix cache affinity**: when all pods cache the same prefix, the prefix cache scorer gives equal scores to all pods. The active_request scorer reads in-flight counts via `PreRequest()`, which updates **after** the scheduling decision — so concurrent requests all see zero counts.

## Evidence

Tested on 8× H200 GPUs running Gemma 4 26B-A4B FP8 with 8×TP1 aggregated pods and 100% prefix cache hit workload. Two different EPP configurations were tested — both show the same imbalance.

### Metrics definitions

The following custom metrics were used to diagnose routing behavior:

- **Avg Running**: Average `vllm:num_requests_running` across all pods and all Prometheus scrape timestamps (flattened). Represents the typical per-pod load over the test duration.
- **Max Running**: The highest `vllm:num_requests_running` value observed on any single pod at any single timestamp. Shows the worst-case concentration.
- **Load Spread (Max-Avg)**: Gap between peak and average running requests. High values indicate traffic bursts where requests arrive simultaneously rather than staggered.
- **Routing CV**: Coefficient of Variation of per-pod running requests, computed at each Prometheus scrape timestamp then averaged over the test duration. Formula: `avg_over_time(stddev(vllm:num_requests_running) / clamp_min(avg(vllm:num_requests_running), 0.01))`. Interpretation:
  - **CV = 0**: Perfect balance — all pods have the same number of running requests
  - **CV < 0.3**: Healthy distribution
  - **CV = 1.0**: Standard deviation equals the mean — moderate imbalance
  - **CV > 1.5**: Severe imbalance — some pods heavily overloaded while others are idle
  - **CV = 2.65** (observed at 100% cache): Extreme imbalance — nearly all requests on one pod

### Test 1: Custom EPP (prefix_cache:2, active_request:1, token_load:1)

| Cache Hit | Throughput | Avg Running | Max Running | Load Spread | Routing CV |
|-----------|-----------|-------------|-------------|-------------|------------|
| 0% | 4.27 req/s | 5.3 | 7 | 1.7 | 1.03 |
| 20% | 4.40 req/s | 5.8 | 21 | 15.2 | — |
| 40% | 3.76 req/s | 5.7 | 37 | 31.3 | — |
| 60% | 3.09 req/s | 5.9 | 47 | 41.1 | — |
| 80% | **5.00 req/s** | 5.8 | **16** | **10.2** | — |
| 100% | **2.15 req/s** | 5.8 | **50** | **44.2** | **2.65** |

At 100% cache hit, **all 50 concurrent requests landed on a single pod** (RunMax=50 out of 50 concurrent users). Throughput dropped 57% vs the 80% level.

### Test 2: Balanced EPP (prefix_cache:3, kv_cache:2, queue:2, active_request:2)

Same 8×TP1 config, same 100% cache hit workload, different EPP weights:

| Config | Throughput | Avg Running | Max Running | Load Spread | Routing CV |
|--------|-----------|-------------|-------------|-------------|------------|
| 8×TP1 h100 | **1.53 req/s** | 3.6 | **26** | **22.4** | **1.77** |

Even with queue and kv_cache scorers enabled at weight 2, the imbalance persists (CV=1.77). Adding more scorers doesn't help because they all read the same stale state.

### Control: 2×TP4 (same workload, same EPP)

| Cache Hit | Throughput | Avg Running | Max Running | Load Spread | Routing CV |
|-----------|-----------|-------------|-------------|-------------|------------|
| 0% | 3.64 req/s | 28.0 | 33 | 5.0 | 0.06 |
| 100% | **6.19 req/s** | 30.1 | **33** | **2.9** | **0.04** |

With only 2 pods, the imbalance doesn't manifest (CV=0.04). Both pods quickly cache the prefix and the rotation is between 2 targets.

### Per-pod breakdown (from raw Prometheus data)

8×TP1 at 100% cache hit — `vllm:num_requests_running` per pod (101 Prometheus scrape points over 480s test):

| Pod | Avg Running | Max Running | Non-zero scrapes |
|-----|-------------|-------------|-----------------|
| pod-0 | 0.0 | 0 | 0/101 |
| pod-1 | 0.0 | 0 | 0/101 |
| **pod-2** | **46.3** | **50** | **95/101** |
| pod-3 | 0.0 | 0 | 0/101 |
| pod-4 | 0.0 | 0 | 0/101 |
| pod-5 | 0.0 | 0 | 0/101 |
| pod-6 | 0.0 | 0 | 0/101 |
| pod-7 | 0.0 | 0 | 0/101 |

**1 out of 8 pods received 100% of all requests for the entire test duration.** The remaining 7 pods received zero requests across all 101 Prometheus scrape points. At 0% cache hit, all 8/8 pods received requests.

An nsys GPU profiler trace from this pod showed only **6.1% GPU utilization** — the GPU completed each decode step in microseconds then sat idle waiting for the next scheduler iteration.

### Charts

**PD — 2P×TP2 + 2D×TP2 (healthy — even distribution across all cache levels):**

<img width="2384" height="550" alt="2P×TP2 + 2D×TP2" src="https://github.com/user-attachments/assets/14d38b98-ad30-4637-a165-483da2dcc108" />

**Aggregated — 8×TP1 (broken — severe imbalance at 60% and 100% cache hit):**

<img width="2384" height="550" alt="Aggregated — 8×TP1 " src="https://github.com/user-attachments/assets/ef18fda5-266f-4ce5-9d91-ea056a1b469c" />

## Root Cause

In `maxscore/picker.go`, the `Pick` method:
1. Shuffles endpoints randomly (`ShuffleScoredEndpoints`)
2. Sorts by score (stable sort preserves shuffle order for equal scores)
3. Picks the first endpoint

When N concurrent requests arrive simultaneously, they all see identical scores (stale in-flight counts from `PreRequest` not yet executed). The random shuffle is re-seeded per call but with the same locked RNG — concurrent goroutines contend on the mutex and get sequential seeds, but with equal scores the shuffle ordering is the only differentiator, and the stable sort doesn't help.

The `PreRequest()` in `inflightload/producer.go` (line 393) updates the counter **after** scheduling, creating a window where concurrent requests all see zeros.

### Why prefix cache affinity creates a positive feedback loop

1. First request arrives → EPP picks a random pod (say pod-2)
2. `PreRequest()` records the request hash on pod-2 in the prefix cache indexer
3. Second request arrives with the same prefix → affinity filter narrows to pod-2 (it has the prefix cached)
4. Pod-2 gets the request → reinforces its cache → all future requests go to pod-2
5. Other 7 pods never receive requests → never build the prefix cache → remain filtered out

This feedback loop explains why the imbalance is **total** (1/8 pods) rather than partial.

## Fix

Replace the random shuffle with a deterministic round-robin rotation using an atomic counter. When endpoints have equal scores, each request rotates through the equal-score group by incrementing a counter:

```go
counter := atomic.AddUint64(&p.requestCounter, 1)
// ... sort by score ...
rotation := int(counter % uint64(equalCount))
// rotate the equal-score group
```

This ensures that even when 50 requests see identical scores simultaneously, they each pick a different endpoint in round-robin order.

## Test

Added `TestEqualScoreDistribution` — simulates 80 concurrent requests across 8 equal-score endpoints and verifies each pod gets exactly 10 requests (perfect distribution).

```
=== RUN   TestEqualScoreDistribution
--- PASS: TestEqualScoreDistribution (0.00s)
=== RUN   TestPickMaxScorePicker
--- PASS: TestPickMaxScorePicker (0.00s)
```

All existing tests continue to pass — the fix only affects the equal-score tie-breaking path; different scores still sort correctly.