### PR TITLE
perf(epp): optimize HTTP token ID request parsing

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/token_ids.go
+++ b/pkg/epp/framework/interface/requesthandling/token_ids.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requesthandling
+
+import "math"
+
+func parseCanonicalTokenIDArrays(data []byte) ([][]uint32, bool) {
+	i := skipJSONSpace(data, 0)
+	if i >= len(data) || data[i] != '[' {
+		return nil, false
+	}
+	i = skipJSONSpace(data, i+1)
+	if i >= len(data) || data[i] == ']' {
+		return nil, false
+	}
+
+	if data[i] != '[' {
+		tokenIDs, ok := ParseCanonicalTokenIDs(data)
+		if !ok {
+			return nil, false
+		}
+		return [][]uint32{tokenIDs}, true
+	}
+
+	tokenCapacity, arrayCapacity := 1, 0
+	for _, c := range data {
+		switch c {
+		case ',':
+			tokenCapacity++
+		case '[':
+			arrayCapacity++
+		}
+	}
+
+	tokenIDs := make([]uint32, 0, tokenCapacity)
+	arrays := make([][]uint32, 0, arrayCapacity-1)
+	for {
+		i = skipJSONSpace(data, i)
+		if i >= len(data) || data[i] != '[' {
+			return nil, false
+		}
+
+		start := len(tokenIDs)
+		var ok bool
+		tokenIDs, i, ok = parseCanonicalTokenIDArray(data, i+1, tokenIDs)
+		if !ok {
+			return nil, false
+		}
+		end := len(tokenIDs)
+		arrays = append(arrays, tokenIDs[start:end:end])
+
+		i = skipJSONSpace(data, i)
+		switch {
+		case i >= len(data):
+			return nil, false
+		case data[i] == ']':
+			i = skipJSONSpace(data, i+1)
+			if i != len(data) {
+				return nil, false
+			}
+			return arrays, true
+		case data[i] == ',':
+			i++
+		default:
+			return nil, false
+		}
+	}
+}
+
+// ParseCanonicalTokenIDs parses a non-empty JSON array of canonical uint32 values.
+func ParseCanonicalTokenIDs(data []byte) ([]uint32, bool) {
+	i := skipJSONSpace(data, 0)
+	if i >= len(data) || data[i] != '[' {
+		return nil, false
+	}
+	i = skipJSONSpace(data, i+1)
+	if i >= len(data) || data[i] == ']' || data[i] == '[' {
+		return nil, false
+	}
+
+	capacity := 1
+	for _, c := range data {
+		if c == ',' {
+			capacity++
+		}
+	}
+	tokenIDs, i, ok := parseCanonicalTokenIDArray(data, i, make([]uint32, 0, capacity))
+	if !ok || skipJSONSpace(data, i) != len(data) {
+		return nil, false
+	}
+	return tokenIDs, true
+}
+
+func parseCanonicalTokenIDArray(data []byte, i int, tokenIDs []uint32) ([]uint32, int, bool) {
+	i = skipJSONSpace(data, i)
+	if i >= len(data) || data[i] < '0' || data[i] > '9' {
+		return nil, 0, false
+	}
+
+	for {
+		start := i
+		value := uint64(0)
+		for i < len(data) && data[i] >= '0' && data[i] <= '9' {
+			value = value*10 + uint64(data[i]-'0')
+			if value > math.MaxUint32 {
+				return nil, 0, false
+			}
+			i++
+		}
+		if data[start] == '0' && i-start > 1 {
+			return nil, 0, false
+		}
+		tokenIDs = append(tokenIDs, uint32(value))
+
+		i = skipJSONSpace(data, i)
+		switch {
+		case i >= len(data):
+			return nil, 0, false
+		case data[i] == ']':
+			return tokenIDs, i + 1, true
+		case data[i] == ',':
+			i = skipJSONSpace(data, i+1)
+			if i >= len(data) || data[i] < '0' || data[i] > '9' {
+				return nil, 0, false
+			}
+		default:
+			return nil, 0, false
+		}
+	}
+}
+
+func skipJSONSpace(data []byte, i int) int {
+	for i < len(data) {
+		switch data[i] {
+		case ' ', '\t', '\n', '\r':
+			i++
+		default:
+			return i
+		}
+	}
+	return i
+}

--- a/pkg/epp/framework/interface/requesthandling/token_ids_test.go
+++ b/pkg/epp/framework/interface/requesthandling/token_ids_test.go
@@ -1,0 +1,334 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requesthandling
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCanonicalTokenIDArrays(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		canonical bool
+		want      [][]uint32
+	}{
+		{
+			name:      "flat integers",
+			input:     `[1,2,3]`,
+			canonical: true,
+			want:      [][]uint32{{1, 2, 3}},
+		},
+		{
+			name:      "zero",
+			input:     `[0]`,
+			canonical: true,
+			want:      [][]uint32{{0}},
+		},
+		{
+			name:      "max uint32",
+			input:     `[4294967295]`,
+			canonical: true,
+			want:      [][]uint32{{4294967295}},
+		},
+		{
+			name:      "whitespace",
+			input:     "[ 1,\n\t2 ]",
+			canonical: true,
+			want:      [][]uint32{{1, 2}},
+		},
+		{
+			name:      "nested integers",
+			input:     `[[1,2],[3]]`,
+			canonical: true,
+			want:      [][]uint32{{1, 2}, {3}},
+		},
+		{
+			name:  "empty array falls through",
+			input: `[]`,
+		},
+		{
+			name:  "whole decimal falls through",
+			input: `[1.0]`,
+		},
+		{
+			name:  "exponent falls through",
+			input: `[1e0]`,
+		},
+		{
+			name:  "negative falls through",
+			input: `[-1]`,
+		},
+		{
+			name:  "above MaxUint32 falls through",
+			input: `[4294967296]`,
+		},
+		{
+			name:  "leading zeros fall through",
+			input: `[01]`,
+		},
+		{
+			name:  "trailing junk falls through",
+			input: `[1,2]true`,
+		},
+		{
+			name:  "numeric strings stay strings",
+			input: `["1","2"]`,
+		},
+		{
+			name:  "empty nested array falls through",
+			input: `[[]]`,
+		},
+		{
+			name:  "triple nesting falls through",
+			input: `[[[1]]]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := []byte(tt.input)
+			got, ok := parseCanonicalTokenIDArrays(data)
+			assert.Equal(t, tt.canonical, ok)
+			if ok {
+				require.True(t, json.Valid(data), "fast path must only accept valid JSON")
+				assert.Equal(t, tt.want, got)
+			} else {
+				assert.Nil(t, got)
+			}
+		})
+	}
+}
+
+func TestParseCanonicalTokenIDArraysMatchesLegacyPath(t *testing.T) {
+	flat := make([]uint32, 1024)
+	for i := range flat {
+		flat[i] = uint32(i * 7919)
+	}
+	flat[len(flat)-1] = ^uint32(0)
+
+	nested := make([][]uint32, 32)
+	for row := range nested {
+		nested[row] = make([]uint32, row+1)
+		for column := range nested[row] {
+			nested[row][column] = uint32((row+1)*100000 + column)
+		}
+	}
+
+	for name, input := range map[string]any{
+		"flat":   flat,
+		"nested": nested,
+	} {
+		t.Run(name, func(t *testing.T) {
+			data, err := json.Marshal(input)
+			require.NoError(t, err)
+
+			got, ok := parseCanonicalTokenIDArrays(data)
+			require.True(t, ok)
+
+			var raw any
+			require.NoError(t, json.Unmarshal(data, &raw))
+			legacy, err := parseArrayInput(raw.([]any), "prompt")
+			require.NoError(t, err)
+			assert.Equal(t, legacy.TokenIDs, got)
+		})
+	}
+}
+
+func TestParseCanonicalTokenIDArraysUsesContiguousBackingStorage(t *testing.T) {
+	got, ok := parseCanonicalTokenIDArrays([]byte(`[[1,2],[3,4,5],[6]]`))
+	require.True(t, ok)
+	require.Len(t, got, 3)
+
+	const totalTokens = 6
+	base := reflect.ValueOf(&got[0][0]).Pointer()
+	elementSize := reflect.TypeOf(uint32(0)).Size()
+	offset := 0
+	for _, row := range got {
+		require.NotEmpty(t, row)
+		assert.Equal(t, len(row), cap(row))
+		if gotAddress := reflect.ValueOf(&row[0]).Pointer(); gotAddress != base+uintptr(offset)*elementSize {
+			t.Fatalf("row at offset %d does not share the contiguous backing storage", offset)
+		}
+		offset += len(row)
+	}
+	assert.Equal(t, totalTokens, offset)
+
+	got[0] = append(got[0], 99)
+	assert.Equal(t, []uint32{1, 2, 99}, got[0])
+	assert.Equal(t, []uint32{3, 4, 5}, got[1])
+}
+
+// referencePromptUnmarshal is Prompt.UnmarshalJSON without the canonical token-ID
+// fast path: it decodes through encoding/json only. The fast path is correct iff
+// it never changes the observable result of this reference.
+func referencePromptUnmarshal(data []byte) (Prompt, error) {
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return Prompt{}, err
+	}
+	switch v := raw.(type) {
+	case string:
+		return Prompt{Raw: v}, nil
+	case []any:
+		res, err := parseArrayInput(v, "prompt")
+		if err != nil {
+			return Prompt{}, err
+		}
+		return Prompt{Strings: res.Strings, TokenIDs: res.TokenIDs}, nil
+	default:
+		return Prompt{}, errors.New("prompt: must be a string or an array")
+	}
+}
+
+// FuzzParseCanonicalTokenIDArrays cross-checks the hand-written parser against
+// encoding/json for arbitrary bytes. It guards two properties:
+//   - safety: the parser never panics and never reports success for input that
+//     encoding/json rejects (accepting invalid JSON would be an injection vector);
+//   - correctness: the fast path never changes what Prompt.UnmarshalJSON produces
+//     versus decoding through encoding/json alone.
+func FuzzParseCanonicalTokenIDArrays(f *testing.F) {
+	seeds := []string{
+		`[1,2,3]`, `[[1,2],[3]]`, `[0]`, `[4294967295]`, `[4294967296]`,
+		`[1.0]`, `[1e0]`, `[1e10]`, `[-1]`, `[01]`, `[1,2,]`, `[1,,2]`,
+		`["a","b"]`, `"hello"`, `"123"`, `123`, `true`, `null`, `{}`, `[]`,
+		`[[]]`, `[[1],,[2]]`, `[1,2]/*x*/`, `foo([1,2])`, "[1,2]\x00",
+		`[1,2] [3]`, "[ 1,\n\t2 ]", `[[1,2],"x"]`, `[[[1]]]`, `[{}]`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		got, ok := parseCanonicalTokenIDArrays(data)
+
+		if ok {
+			if !json.Valid(data) {
+				t.Fatalf("fast path accepted invalid JSON: %q", data)
+			}
+			var raw any
+			if err := json.Unmarshal(data, &raw); err != nil {
+				t.Fatalf("fast path accepted but json.Unmarshal failed: %q: %v", data, err)
+			}
+			arr, isArr := raw.([]any)
+			if !isArr {
+				t.Fatalf("fast path accepted non-array %q", data)
+			}
+			legacy, err := parseArrayInput(arr, "prompt")
+			if err != nil {
+				t.Fatalf("fast path accepted but legacy path rejected %q: %v", data, err)
+			}
+			if !reflect.DeepEqual(legacy.TokenIDs, got) {
+				t.Fatalf("fast path %v != legacy path %v for %q", got, legacy.TokenIDs, data)
+			}
+		}
+
+		var p Prompt
+		gotErr := p.UnmarshalJSON(data)
+		refP, refErr := referencePromptUnmarshal(data)
+		if (gotErr == nil) != (refErr == nil) {
+			t.Fatalf("error mismatch for %q: fast=%v ref=%v", data, gotErr, refErr)
+		}
+		if gotErr == nil && !reflect.DeepEqual(refP, p) {
+			t.Fatalf("UnmarshalJSON diverges from reference for %q: fast=%#v ref=%#v", data, p, refP)
+		}
+	})
+}
+
+var benchmarkPrompt Prompt
+
+func benchmarkTokenArray(count int, nonCanonicalLast bool) string {
+	var body strings.Builder
+	body.Grow(count*6 + 2)
+	body.WriteByte('[')
+	for i := 0; i < count; i++ {
+		if i > 0 {
+			body.WriteByte(',')
+		}
+		if nonCanonicalLast && i == count-1 {
+			body.WriteString("12345.0")
+		} else {
+			body.WriteString("12345")
+		}
+	}
+	body.WriteByte(']')
+	return body.String()
+}
+
+func benchmarkNestedTokenArray(rows, columns int) string {
+	var body strings.Builder
+	body.Grow(rows*columns*6 + rows*2 + 2)
+	body.WriteByte('[')
+	for row := 0; row < rows; row++ {
+		if row > 0 {
+			body.WriteByte(',')
+		}
+		body.WriteByte('[')
+		for column := 0; column < columns; column++ {
+			if column > 0 {
+				body.WriteByte(',')
+			}
+			body.WriteString("12345")
+		}
+		body.WriteByte(']')
+	}
+	body.WriteByte(']')
+	return body.String()
+}
+
+func benchmarkPromptUnmarshalJSON(b *testing.B, tokens string) {
+	data := []byte(tokens)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for b.Loop() {
+		var p Prompt
+		if err := p.UnmarshalJSON(data); err != nil {
+			b.Fatal(err)
+		}
+		benchmarkPrompt = p
+	}
+}
+
+func BenchmarkPromptUnmarshalJSONTokenIDs(b *testing.B) {
+	for _, count := range []int{4 * 1024, 32 * 1024, 256 * 1024, 1_000_000} {
+		name := map[int]string{
+			4 * 1024:   "4K",
+			32 * 1024:  "32K",
+			256 * 1024: "256K",
+			1_000_000:  "1M",
+		}[count]
+		tokens := benchmarkTokenArray(count, false)
+		b.Run("Flat/"+name, func(b *testing.B) {
+			benchmarkPromptUnmarshalJSON(b, tokens)
+		})
+	}
+
+	b.Run("Nested/1M", func(b *testing.B) {
+		benchmarkPromptUnmarshalJSON(b, benchmarkNestedTokenArray(1000, 1000))
+	})
+	b.Run("Fallback/1M", func(b *testing.B) {
+		benchmarkPromptUnmarshalJSON(b, benchmarkTokenArray(1_000_000, true))
+	})
+}

--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -323,6 +323,12 @@ func parseArrayInput(v []any, errorPrefix string) (arrayInputResult, error) {
 }
 
 func (p *Prompt) UnmarshalJSON(data []byte) error {
+	if tokenIDs, ok := parseCanonicalTokenIDArrays(data); ok {
+		p.Strings = nil
+		p.TokenIDs = tokenIDs
+		return nil
+	}
+
 	var raw any
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -476,6 +482,12 @@ type EmbeddingsInput struct {
 }
 
 func (e *EmbeddingsInput) UnmarshalJSON(data []byte) error {
+	if tokenIDs, ok := parseCanonicalTokenIDArrays(data); ok {
+		e.Strings = nil
+		e.TokenIDs = tokenIDs
+		return nil
+	}
+
 	var raw any
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -572,6 +584,39 @@ type GenerateRequest struct {
 	CacheSalt string `json:"cache_salt,omitempty"`
 }
 
+type wirePlaceholder struct {
+	Offset int `json:"offset"`
+	Length int `json:"length"`
+}
+
+type wireFeatures struct {
+	MMHashes       map[string][]string          `json:"mm_hashes"`
+	MMPlaceholders map[string][]wirePlaceholder `json:"mm_placeholders"`
+}
+
+var errNonCanonicalTokenIDs = errors.New("non-canonical token IDs")
+
+type generateRequestCanonicalTokenIDs struct {
+	Values []uint32
+	Seen   bool
+}
+
+func (t *generateRequestCanonicalTokenIDs) UnmarshalJSON(data []byte) error {
+	t.Seen = true
+	tokenIDs, ok := ParseCanonicalTokenIDs(data)
+	if !ok {
+		return errNonCanonicalTokenIDs
+	}
+	t.Values = tokenIDs
+	return nil
+}
+
+type generateRequestFastWire struct {
+	TokenIDs  generateRequestCanonicalTokenIDs `json:"token_ids"`
+	CacheSalt string                           `json:"cache_salt,omitempty"`
+	Features  *wireFeatures                    `json:"features,omitempty"`
+}
+
 func (r *GenerateRequest) String() string {
 	if r == nil {
 		return nilStr
@@ -598,17 +643,21 @@ func (r *GenerateRequest) String() string {
 }
 
 func (r *GenerateRequest) UnmarshalJSON(data []byte) error {
-	type wirePlaceholder struct {
-		Offset int `json:"offset"`
-		Length int `json:"length"`
+	var raw generateRequestFastWire
+	if err := json.Unmarshal(data, &raw); err == nil && raw.TokenIDs.Seen {
+		r.CacheSalt = raw.CacheSalt
+		r.TokenIDs = raw.TokenIDs.Values
+		r.setGenerateRequestFeatures(raw.Features)
+		return nil
 	}
+	return r.unmarshalJSONFallback(data)
+}
+
+func (r *GenerateRequest) unmarshalJSONFallback(data []byte) error {
 	var raw struct {
-		TokenIDs  []float64 `json:"token_ids"`
-		CacheSalt string    `json:"cache_salt,omitempty"`
-		Features  *struct {
-			MMHashes       map[string][]string          `json:"mm_hashes"`
-			MMPlaceholders map[string][]wirePlaceholder `json:"mm_placeholders"`
-		} `json:"features,omitempty"`
+		TokenIDs  []float64     `json:"token_ids"`
+		CacheSalt string        `json:"cache_salt,omitempty"`
+		Features  *wireFeatures `json:"features,omitempty"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -621,21 +670,26 @@ func (r *GenerateRequest) UnmarshalJSON(data []byte) error {
 		}
 		r.TokenIDs[i] = uint32(v)
 	}
-	if raw.Features != nil {
-		ranges := make(map[string][]kvblock.PlaceholderRange, len(raw.Features.MMPlaceholders))
-		for modality, ws := range raw.Features.MMPlaceholders {
-			out := make([]kvblock.PlaceholderRange, len(ws))
-			for i, w := range ws {
-				out[i] = kvblock.PlaceholderRange{Offset: w.Offset, Length: w.Length}
-			}
-			ranges[modality] = out
-		}
-		r.Features = &tokenization.MultiModalFeatures{
-			MMHashes:       raw.Features.MMHashes,
-			MMPlaceholders: ranges,
-		}
-	}
+	r.setGenerateRequestFeatures(raw.Features)
 	return nil
+}
+
+func (r *GenerateRequest) setGenerateRequestFeatures(features *wireFeatures) {
+	if features == nil {
+		return
+	}
+	ranges := make(map[string][]kvblock.PlaceholderRange, len(features.MMPlaceholders))
+	for modality, placeholders := range features.MMPlaceholders {
+		out := make([]kvblock.PlaceholderRange, len(placeholders))
+		for i, placeholder := range placeholders {
+			out[i] = kvblock.PlaceholderRange{Offset: placeholder.Offset, Length: placeholder.Length}
+		}
+		ranges[modality] = out
+	}
+	r.Features = &tokenization.MultiModalFeatures{
+		MMHashes:       features.MMHashes,
+		MMPlaceholders: ranges,
+	}
 }
 
 // ConversationItem represents a single item in a conversation

--- a/pkg/epp/framework/interface/requesthandling/types_test.go
+++ b/pkg/epp/framework/interface/requesthandling/types_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
+
+	"github.com/llm-d/llm-d-router/pkg/kvcache/tokenization"
 )
 
 func TestPrompt_UnmarshalJSON(t *testing.T) {
@@ -57,7 +59,11 @@ func TestPrompt_UnmarshalJSON(t *testing.T) {
 			input:   `[1.5,2.7]`,
 			wantErr: true,
 		},
-
+		{
+			name:  "whole decimal token IDs",
+			input: `[1.0]`,
+			want:  Prompt{TokenIDs: [][]uint32{{1}}},
+		},
 		{
 			name:  "array of arrays of integers prompt",
 			input: `[[1,2],[3,4]]`,
@@ -112,12 +118,33 @@ func TestPrompt_UnmarshalJSON(t *testing.T) {
 			err := p.UnmarshalJSON([]byte(tt.input))
 			if tt.wantErr {
 				assert.Error(t, err)
+				assert.Equal(t, Prompt{}, p)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.want, p)
 			}
 		})
 	}
+}
+
+func TestPrompt_UnmarshalJSONPreservesReceiverBehavior(t *testing.T) {
+	stale := Prompt{
+		Raw:      "stale",
+		Strings:  []string{"stale"},
+		TokenIDs: [][]uint32{{99}},
+	}
+
+	p := stale
+	require.NoError(t, p.UnmarshalJSON([]byte(`[1,2,3]`)))
+	assert.Equal(t, Prompt{Raw: "stale", TokenIDs: [][]uint32{{1, 2, 3}}}, p)
+
+	p = stale
+	require.NoError(t, p.UnmarshalJSON([]byte(`[1.0]`)))
+	assert.Equal(t, Prompt{Raw: "stale", TokenIDs: [][]uint32{{1}}}, p)
+
+	p = stale
+	require.NoError(t, p.UnmarshalJSON([]byte(`"hello"`)))
+	assert.Equal(t, Prompt{Raw: "hello", Strings: []string{"stale"}, TokenIDs: [][]uint32{{99}}}, p)
 }
 
 func TestEmbeddingsInput_UnmarshalJSON(t *testing.T) {
@@ -148,6 +175,11 @@ func TestEmbeddingsInput_UnmarshalJSON(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:  "exponent token IDs",
+			input: `[1e0]`,
+			want:  EmbeddingsInput{TokenIDs: [][]uint32{{1}}},
+		},
+		{
 			name:  "array of arrays of integers input",
 			input: `[[1,2],[3,4]]`,
 			want:  EmbeddingsInput{TokenIDs: [][]uint32{{1, 2}, {3, 4}}},
@@ -172,6 +204,26 @@ func TestEmbeddingsInput_UnmarshalJSON(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEmbeddingsInput_UnmarshalJSONPreservesReceiverBehavior(t *testing.T) {
+	stale := EmbeddingsInput{
+		Raw:      "stale",
+		Strings:  []string{"stale"},
+		TokenIDs: [][]uint32{{99}},
+	}
+
+	e := stale
+	require.NoError(t, e.UnmarshalJSON([]byte(`[1,2,3]`)))
+	assert.Equal(t, EmbeddingsInput{Raw: "stale", TokenIDs: [][]uint32{{1, 2, 3}}}, e)
+
+	e = stale
+	require.NoError(t, e.UnmarshalJSON([]byte(`[1e0]`)))
+	assert.Equal(t, EmbeddingsInput{Raw: "stale", TokenIDs: [][]uint32{{1}}}, e)
+
+	e = stale
+	require.NoError(t, e.UnmarshalJSON([]byte(`"hello"`)))
+	assert.Equal(t, EmbeddingsInput{Raw: "hello", Strings: []string{"stale"}, TokenIDs: [][]uint32{{99}}}, e)
 }
 
 func TestPrompt_PlainText(t *testing.T) {
@@ -229,9 +281,29 @@ func TestGenerateRequest_UnmarshalJSON(t *testing.T) {
 			want:  []uint32{1, 2, 3},
 		},
 		{
+			name:  "valid token ids with whitespace",
+			input: "{\n\t\"token_ids\": [ 1,\r\n2, 3 ]\n}",
+			want:  []uint32{1, 2, 3},
+		},
+		{
 			name:  "max uint32 boundary accepted",
 			input: `{"token_ids":[4294967295]}`,
 			want:  []uint32{4294967295},
+		},
+		{
+			name:  "whole decimal accepted",
+			input: `{"token_ids":[1.0]}`,
+			want:  []uint32{1},
+		},
+		{
+			name:  "whole exponent accepted",
+			input: `{"token_ids":[1e0]}`,
+			want:  []uint32{1},
+		},
+		{
+			name:  "negative zero accepted",
+			input: `{"token_ids":[-0]}`,
+			want:  []uint32{0},
 		},
 		{
 			name:        "negative token id rejected",
@@ -263,6 +335,18 @@ func TestGenerateRequest_UnmarshalJSON(t *testing.T) {
 			wantErr:     true,
 			errContains: "unexpected end of JSON",
 		},
+		{
+			name:        "invalid cache salt preserves error field",
+			input:       `{"token_ids":[1,2,3],"cache_salt":1}`,
+			wantErr:     true,
+			errContains: "Go struct field .cache_salt",
+		},
+		{
+			name:        "invalid placeholder preserves error field",
+			input:       `{"token_ids":[1,2,3],"features":{"mm_placeholders":{"image":[{"offset":"x","length":1}]}}}`,
+			wantErr:     true,
+			errContains: "Go struct field wirePlaceholder.features.mm_placeholders.offset",
+		},
 	}
 
 	for _, tt := range tests {
@@ -280,6 +364,43 @@ func TestGenerateRequest_UnmarshalJSON(t *testing.T) {
 			assert.Equal(t, tt.want, g.TokenIDs)
 		})
 	}
+}
+
+func TestGenerateRequest_UnmarshalJSONPreservesReceiverBehavior(t *testing.T) {
+	g := GenerateRequest{
+		TokenIDs:  []uint32{99},
+		CacheSalt: "stale",
+		Features: &tokenization.MultiModalFeatures{
+			MMHashes: map[string][]string{"image": {"stale"}},
+		},
+	}
+
+	err := g.UnmarshalJSON([]byte(`{"token_ids":[1,2.5,3],"cache_salt":"updated"}`))
+	require.EqualError(t, err, "token_ids[1]: invalid value 2.5")
+	assert.Equal(t, []uint32{1, 0, 0}, g.TokenIDs)
+	assert.Equal(t, "updated", g.CacheSalt)
+	assert.Equal(t, []string{"stale"}, g.Features.MMHashes["image"])
+
+	require.NoError(t, g.UnmarshalJSON([]byte(`{}`)))
+	assert.NotNil(t, g.TokenIDs)
+	assert.Empty(t, g.TokenIDs)
+	assert.Empty(t, g.CacheSalt)
+	assert.Equal(t, []string{"stale"}, g.Features.MMHashes["image"])
+}
+
+func TestGenerateRequest_UnmarshalJSONCanonicalPreservesAbsentFeatures(t *testing.T) {
+	g := GenerateRequest{
+		TokenIDs:  []uint32{99},
+		CacheSalt: "stale",
+		Features: &tokenization.MultiModalFeatures{
+			MMHashes: map[string][]string{"image": {"stale"}},
+		},
+	}
+
+	require.NoError(t, g.UnmarshalJSON([]byte(`{"token_ids":[1,2,3],"cache_salt":"updated"}`)))
+	assert.Equal(t, []uint32{1, 2, 3}, g.TokenIDs)
+	assert.Equal(t, "updated", g.CacheSalt)
+	assert.Equal(t, []string{"stale"}, g.Features.MMHashes["image"])
 }
 
 func TestMaxOutputTokensFromPayload(t *testing.T) {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -127,15 +127,26 @@ func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers ma
 	if apiType == imagesEditsAPI {
 		return parseImagesEditsRequest(body, headers)
 	}
-	bodyMap := make(map[string]any)
-	if err := parserutil.Unmarshal(body, &bodyMap); err != nil {
-		return nil, fmt.Errorf("error unmarshaling request bodyMap: %w", err)
-	}
 	extractedBody, err := extractRequestBody(apiType, body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error extracting request body: %w", err)
 	}
-	extractedBody.Payload = fwkrh.PayloadMap(bodyMap)
+
+	rawField := tokenInputField(extractedBody)
+	var bodyMap fwkrh.PayloadMap
+	if rawField == "" {
+		bodyMap = make(fwkrh.PayloadMap)
+		err = parserutil.Unmarshal(body, &bodyMap)
+	} else {
+		var payload map[string]any
+		payload, err = parserutil.UnmarshalMapWithRawField(body, rawField)
+		bodyMap = fwkrh.PayloadMap(payload)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling request bodyMap: %w", err)
+	}
+
+	extractedBody.Payload = bodyMap
 	if model, ok := bodyMap["model"].(string); ok {
 		extractedBody.Model = model
 	}
@@ -144,6 +155,17 @@ func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers ma
 		extractedBody.Stream = true
 	}
 	return &fwkrh.ParseResult{Body: extractedBody, SkipResponseProcessing: false}, nil
+}
+
+func tokenInputField(body *fwkrh.InferenceRequestBody) string {
+	switch {
+	case body.Completions != nil && len(body.Completions.Prompt.TokenIDs) > 0:
+		return "prompt"
+	case body.Embeddings != nil && len(body.Embeddings.Input.TokenIDs) > 0:
+		return "input"
+	default:
+		return ""
+	}
 }
 
 // RewriteModelName writes the resolved model into the request payload map.
@@ -265,48 +287,70 @@ func determineAPITypeFromPath(path string) string {
 func extractRequestBody(apiType string, rawBody []byte) (*fwkrh.InferenceRequestBody, error) {
 	switch apiType {
 	case conversationsAPI:
+		validationErr := errors.New("invalid conversations request: must have items field")
 		var conversations fwkrh.ConversationsRequest
-		if err := json.Unmarshal(rawBody, &conversations); err == nil && len(conversations.Items) > 0 {
-			return &fwkrh.InferenceRequestBody{Conversations: &conversations}, nil
+		if err := json.Unmarshal(rawBody, &conversations); err != nil {
+			return nil, requestBodyDecodeError(err, validationErr)
 		}
-		return nil, errors.New("invalid conversations request: must have items field")
+		if len(conversations.Items) == 0 {
+			return nil, validationErr
+		}
+		return &fwkrh.InferenceRequestBody{Conversations: &conversations}, nil
 
 	case responsesAPI:
+		validationErr := errors.New("invalid responses request: must have input field")
 		var responses fwkrh.ResponsesRequest
-		if err := json.Unmarshal(rawBody, &responses); err == nil && responses.Input != nil {
-			return &fwkrh.InferenceRequestBody{Responses: &responses}, nil
+		if err := json.Unmarshal(rawBody, &responses); err != nil {
+			return nil, requestBodyDecodeError(err, validationErr)
 		}
-		return nil, errors.New("invalid responses request: must have input field")
+		if responses.Input == nil {
+			return nil, validationErr
+		}
+		return &fwkrh.InferenceRequestBody{Responses: &responses}, nil
 
 	case chatCompletionsAPI:
+		validationErr := errors.New("invalid chat completions request: must have valid messages field")
 		var chatCompletions fwkrh.ChatCompletionsRequest
-		if err := json.Unmarshal(rawBody, &chatCompletions); err == nil {
-			if err = validateChatCompletionsMessages(chatCompletions.Messages); err == nil {
-				return &fwkrh.InferenceRequestBody{ChatCompletions: &chatCompletions}, nil
-			}
+		if err := json.Unmarshal(rawBody, &chatCompletions); err != nil {
+			return nil, requestBodyDecodeError(err, validationErr)
 		}
-		return nil, errors.New("invalid chat completions request: must have valid messages field")
+		if err := validateChatCompletionsMessages(chatCompletions.Messages); err != nil {
+			return nil, validationErr
+		}
+		return &fwkrh.InferenceRequestBody{ChatCompletions: &chatCompletions}, nil
 
 	case completionsAPI:
+		validationErr := errors.New("invalid completions request: must have prompt field")
 		var completions fwkrh.CompletionsRequest
-		if err := json.Unmarshal(rawBody, &completions); err == nil && !completions.Prompt.IsEmpty() {
-			return &fwkrh.InferenceRequestBody{Completions: &completions}, nil
+		if err := json.Unmarshal(rawBody, &completions); err != nil {
+			return nil, requestBodyDecodeError(err, validationErr)
 		}
-		return nil, errors.New("invalid completions request: must have prompt field")
+		if completions.Prompt.IsEmpty() {
+			return nil, validationErr
+		}
+		return &fwkrh.InferenceRequestBody{Completions: &completions}, nil
 
 	case embeddingsAPI:
+		validationErr := errors.New("invalid embeddings request: must have input field")
 		var embeddings fwkrh.EmbeddingsRequest
-		if err := json.Unmarshal(rawBody, &embeddings); err == nil && !embeddings.Input.IsEmpty() {
-			return &fwkrh.InferenceRequestBody{Embeddings: &embeddings}, nil
+		if err := json.Unmarshal(rawBody, &embeddings); err != nil {
+			return nil, requestBodyDecodeError(err, validationErr)
 		}
-		return nil, errors.New("invalid embeddings request: must have input field")
+		if embeddings.Input.IsEmpty() {
+			return nil, validationErr
+		}
+		return &fwkrh.InferenceRequestBody{Embeddings: &embeddings}, nil
 
 	case imagesGenerationsAPI:
+		validationErr := errors.New("invalid images generations request: must have prompt field")
 		var images fwkrh.ImagesGenerationsRequest
-		if err := json.Unmarshal(rawBody, &images); err == nil && images.Prompt != "" {
-			return &fwkrh.InferenceRequestBody{Images: &images}, nil
+		if err := json.Unmarshal(rawBody, &images); err != nil {
+			return nil, requestBodyDecodeError(err, validationErr)
 		}
-		return nil, errors.New("invalid images generations request: must have prompt field")
+		if images.Prompt == "" {
+			return nil, validationErr
+		}
+		return &fwkrh.InferenceRequestBody{Images: &images}, nil
 	default:
 		return nil, errors.New("unsupported API endpoint")
 	}
@@ -385,6 +429,14 @@ func headerValue(headers map[string]string, name string) string {
 		}
 	}
 	return ""
+}
+
+func requestBodyDecodeError(err, validationErr error) error {
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return err
+	}
+	return validationErr
 }
 
 func validateChatCompletionsMessages(messages []fwkrh.Message) error {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"mime/multipart"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -30,6 +31,65 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
+
+var (
+	benchmarkOpenAIParseResult *fwkrh.ParseResult
+	benchmarkOpenAIPayload     []byte
+)
+
+func makeOpenAITokenArrayBody(tokenCount int) []byte {
+	tokens := strings.Repeat("12345,", tokenCount-1) + "12345"
+	return []byte(`{"model":"test","prompt":[` + tokens + `],"max_tokens":1}`)
+}
+
+func benchmarkOpenAIRequestParsing(b *testing.B, rewrite bool) {
+	parser := NewOpenAIParser()
+	headers := map[string]string{":path": "/v1/completions"}
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{name: "String/24KiB", body: []byte(`{"model":"test","prompt":"` + strings.Repeat("a", 24*1024) + `","max_tokens":1}`)},
+		{name: "TokenIDs/4K", body: makeOpenAITokenArrayBody(4 * 1024)},
+		{name: "TokenIDs/32K", body: makeOpenAITokenArrayBody(32 * 1024)},
+		{name: "TokenIDs/256K", body: makeOpenAITokenArrayBody(256 * 1024)},
+		{name: "TokenIDs/1M", body: makeOpenAITokenArrayBody(1_000_000)},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tc.body)))
+			for b.Loop() {
+				result, err := parser.ParseRequest(context.Background(), tc.body, headers)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if !rewrite {
+					benchmarkOpenAIParseResult = result
+					continue
+				}
+				payload := result.Body.Payload.(fwkrh.MarshalablePayload)
+				rewritten, err := parser.RewriteModelName(payload, "backend-model")
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkOpenAIPayload, err = rewritten.Marshal()
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkOpenAIParser_ParseRequest(b *testing.B) {
+	benchmarkOpenAIRequestParsing(b, false)
+}
+
+func BenchmarkOpenAIParser_ParseRequestAndRewrite(b *testing.B) {
+	benchmarkOpenAIRequestParsing(b, true)
+}
 
 func TestNewOpenAIParser(t *testing.T) {
 	parser := NewOpenAIParser()
@@ -118,7 +178,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 				Payload: fwkrh.PayloadMap{
 					"model":  "test",
-					"prompt": []any{json.Number("1"), json.Number("2"), json.Number("3")},
+					"prompt": json.RawMessage(`[1,2,3]`),
 				},
 			},
 		},
@@ -894,7 +954,7 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				},
 				Payload: fwkrh.PayloadMap{
 					"model": "text-embedding-3-small",
-					"input": []any{json.Number("1"), json.Number("2"), json.Number("3")},
+					"input": json.RawMessage(`[1,2,3]`),
 				},
 			},
 		},
@@ -1200,6 +1260,31 @@ func TestOpenAIParser_ParseRequest_ImagesEdits(t *testing.T) {
 	}
 }
 
+func TestOpenAIParser_ParseRequestPreservesJSONError(t *testing.T) {
+	parser := NewOpenAIParser()
+	headers := map[string]string{":path": "/v1/completions"}
+
+	_, err := parser.ParseRequest(
+		context.Background(),
+		[]byte("no healthy upstream"),
+		headers,
+	)
+	if err == nil {
+		t.Fatal("ParseRequest() error = nil, want JSON syntax error")
+	}
+	if !strings.Contains(err.Error(), "invalid character 'o' in literal null") {
+		t.Fatalf("ParseRequest() error = %q, want JSON syntax error", err)
+	}
+
+	_, err = parser.ParseRequest(context.Background(), []byte(`{"prompt":123}`), headers)
+	if err == nil {
+		t.Fatal("ParseRequest() error = nil, want prompt validation error")
+	}
+	if got, want := err.Error(), "error extracting request body: invalid completions request: must have prompt field"; got != want {
+		t.Fatalf("ParseRequest() error = %q, want %q", got, want)
+	}
+}
+
 func TestOpenAIParser_RepackagePreservesLargeJSONInteger(t *testing.T) {
 	const seed = json.Number("9007199254740993")
 
@@ -1237,6 +1322,58 @@ func TestOpenAIParser_RepackagePreservesLargeJSONInteger(t *testing.T) {
 	}
 	if string(got["seed"]) != seed.String() {
 		t.Errorf("repackaged seed = %s, want %s", got["seed"], seed)
+	}
+}
+
+func TestOpenAIParser_RewriteModelNamePreservesTokenInput(t *testing.T) {
+	parser := NewOpenAIParser()
+	tests := []struct {
+		name, path, tokenField, body, wantTokens string
+	}{
+		{
+			name:       "nested completions",
+			path:       "/v1/completions",
+			tokenField: "prompt",
+			body:       `{"model":"client-model","prompt":[[1,2],[3,4294967295]],"max_tokens":8}`,
+			wantTokens: `[[1,2],[3,4294967295]]`,
+		},
+		{
+			name:       "embeddings exponent",
+			path:       "/v1/embeddings",
+			tokenField: "input",
+			body:       `{"model":"client-model","input":[1e0],"encoding_format":"float"}`,
+			wantTokens: `[1e0]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parser.ParseRequest(context.Background(), []byte(tt.body), map[string]string{":path": tt.path})
+			if err != nil {
+				t.Fatalf("ParseRequest() error = %v", err)
+			}
+			payload, ok := result.Body.Payload.(fwkrh.PayloadMap)
+			if !ok {
+				t.Fatalf("Payload type = %T, want PayloadMap", result.Body.Payload)
+			}
+
+			rewritten, err := parser.RewriteModelName(payload, "backend-model")
+			if err != nil {
+				t.Fatalf("RewriteModelName() error = %v", err)
+			}
+			gotBytes, err := rewritten.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+
+			var got map[string]json.RawMessage
+			if err := json.Unmarshal(gotBytes, &got); err != nil {
+				t.Fatalf("unmarshal rewritten payload: %v", err)
+			}
+			if string(got[tt.tokenField]) != tt.wantTokens {
+				t.Errorf("rewritten %s = %s, want %s", tt.tokenField, got[tt.tokenField], tt.wantTokens)
+			}
+		})
 	}
 }
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp.go
@@ -157,6 +157,10 @@ func parseCacheSalt(data json.RawMessage) (string, error) {
 }
 
 func parseInputIDs(data json.RawMessage) ([]uint32, error) {
+	if ids, ok := fwkrh.ParseCanonicalTokenIDs(data); ok {
+		return ids, nil
+	}
+
 	var ids []uint32
 	if err := json.Unmarshal(data, &ids); err != nil {
 		return nil, errors.New("input_ids must be an array of uint32 integers")

--- a/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp/sglanghttp_test.go
@@ -30,6 +30,52 @@ import (
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
 
+var benchmarkSGLangParseResult *fwkrh.ParseResult
+
+func makeSGLangTokenArrayBody(tokenCount int) []byte {
+	tokens := strings.Repeat("12345,", tokenCount-1) + "12345"
+	return []byte(`{"input_ids":[` + tokens + `],"sampling_params":{"max_new_tokens":1}}`)
+}
+
+func BenchmarkSGLangHTTPParser_ParseRequest(b *testing.B) {
+	parser := NewSGLangHTTPParser()
+	headers := map[string]string{":path": "/generate"}
+	for _, tc := range []struct {
+		name  string
+		count int
+	}{
+		{"4K", 4 * 1024},
+		{"32K", 32 * 1024},
+		{"256K", 256 * 1024},
+		{"1M", 1_000_000},
+	} {
+		body := makeSGLangTokenArrayBody(tc.count)
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(body)))
+			for b.Loop() {
+				result, err := parser.ParseRequest(context.Background(), body, headers)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkSGLangParseResult = result
+			}
+		})
+	}
+}
+
+func BenchmarkSGLangHTTPParser_ParseRequestFallback1M(b *testing.B) {
+	parser := NewSGLangHTTPParser()
+	headers := map[string]string{":path": "/generate"}
+	tokens := strings.Repeat("12345,", 1_000_000-1) + "12345.0"
+	body := []byte(`{"input_ids":[` + tokens + `],"sampling_params":{"max_new_tokens":1}}`)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(body)))
+	for b.Loop() {
+		_, _ = parser.ParseRequest(context.Background(), body, headers)
+	}
+}
+
 func TestNewSGLangHTTPParser(t *testing.T) {
 	parser := NewSGLangHTTPParser()
 	want := fwkplugin.TypedName{Type: SGLangHTTPParserType, Name: SGLangHTTPParserType}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/util/json.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/util/json.go
@@ -42,3 +42,31 @@ func Unmarshal(data []byte, v any) error {
 		return fmt.Errorf("%w: %v", ErrTrailingData, err)
 	}
 }
+
+// UnmarshalMapWithRawField decodes a JSON object while preserving one field's
+// original JSON representation. All other numbers are preserved as json.Number.
+func UnmarshalMapWithRawField(data []byte, rawField string) (map[string]any, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		var fallback map[string]json.RawMessage
+		if fallbackErr := Unmarshal(data, &fallback); fallbackErr != nil {
+			return nil, fallbackErr
+		}
+		return nil, err
+	}
+
+	result := make(map[string]any, len(fields))
+	for key, raw := range fields {
+		if key == rawField {
+			result[key] = raw
+			continue
+		}
+
+		var value any
+		if err := Unmarshal(raw, &value); err != nil {
+			return nil, err
+		}
+		result[key] = value
+	}
+	return result, nil
+}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/util/json_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/util/json_test.go
@@ -70,3 +70,72 @@ func TestUnmarshalRejectsTrailingData(t *testing.T) {
 		})
 	}
 }
+
+func TestUnmarshalMapWithRawField(t *testing.T) {
+	const (
+		input    = `{"model":"test","token_ids":[[1.0, 2e0], [3,4]],"seed":9007199254740993,"nested":{"value":1.5}}`
+		rawField = "token_ids"
+		wantRaw  = `[[1.0, 2e0], [3,4]]`
+	)
+
+	var want map[string]any
+	if err := Unmarshal([]byte(input), &want); err != nil {
+		t.Fatalf("full decode error = %v", err)
+	}
+
+	got, err := UnmarshalMapWithRawField([]byte(input), rawField)
+	if err != nil {
+		t.Fatalf("UnmarshalMapWithRawField() error = %v", err)
+	}
+
+	raw, ok := got[rawField].(json.RawMessage)
+	if !ok {
+		t.Fatalf("%s type = %T, want json.RawMessage", rawField, got[rawField])
+	}
+	if string(raw) != wantRaw {
+		t.Fatalf("%s = %s, want %s", rawField, raw, wantRaw)
+	}
+
+	var decoded any
+	if err := Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("raw field decode error = %v", err)
+	}
+	got[rawField] = decoded
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("UnmarshalMapWithRawField() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUnmarshalMapWithRawFieldRejectsInvalidJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr error
+	}{
+		{
+			name:  "malformed raw field",
+			input: `{"token_ids":[1,2,]}`,
+		},
+		{
+			name:    "trailing value",
+			input:   `{"token_ids":[1,2]} true`,
+			wantErr: ErrTrailingData,
+		},
+		{
+			name:  "non-object",
+			input: `[1,2]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := UnmarshalMapWithRawField([]byte(tt.input), "token_ids")
+			if err == nil {
+				t.Fatal("UnmarshalMapWithRawField() unexpectedly succeeded")
+			}
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("UnmarshalMapWithRawField() error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
@@ -114,8 +114,8 @@ func (p *VllmHTTPParser) RewriteModelName(payload fwkrh.MarshalablePayload, mode
 // parseGenerateRequest decodes a /inference/v1/generate body into an
 // InferenceRequestBody. Token IDs are required; everything else is optional.
 func (p *VllmHTTPParser) parseGenerateRequest(rawBody []byte) (*fwkrh.ParseResult, error) {
-	bodyMap := make(map[string]any)
-	if err := parserutil.Unmarshal(rawBody, &bodyMap); err != nil {
+	bodyMap, err := parserutil.UnmarshalMapWithRawField(rawBody, "token_ids")
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp_test.go
@@ -32,6 +32,79 @@ import (
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 )
 
+var (
+	benchmarkVllmParseResult *fwkrh.ParseResult
+	benchmarkVllmPayload     []byte
+)
+
+func makeVllmTokenArrayBody(tokenCount int) []byte {
+	tokens := strings.Repeat("12345,", tokenCount-1) + "12345"
+	return []byte(`{"model":"test","token_ids":[` + tokens + `],"sampling_params":{"max_tokens":1}}`)
+}
+
+func benchmarkVllmRequestParsing(b *testing.B, rewrite bool) {
+	parser := NewVllmHTTPParser()
+	headers := map[string]string{":path": "/inference/v1/generate"}
+	for _, tc := range []struct {
+		name  string
+		count int
+	}{
+		{"4K", 4 * 1024},
+		{"32K", 32 * 1024},
+		{"256K", 256 * 1024},
+		{"1M", 1_000_000},
+	} {
+		body := makeVllmTokenArrayBody(tc.count)
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(body)))
+			for b.Loop() {
+				result, err := parser.ParseRequest(context.Background(), body, headers)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if !rewrite {
+					benchmarkVllmParseResult = result
+					continue
+				}
+				payload := result.Body.Payload.(fwkrh.MarshalablePayload)
+				rewritten, err := parser.RewriteModelName(payload, "backend-model")
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkVllmPayload, err = rewritten.Marshal()
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkVllmHTTPParser_ParseRequest(b *testing.B) {
+	benchmarkVllmRequestParsing(b, false)
+}
+
+func BenchmarkVllmHTTPParser_ParseRequestAndRewrite(b *testing.B) {
+	benchmarkVllmRequestParsing(b, true)
+}
+
+func BenchmarkVllmHTTPParser_ParseRequestFallback1M(b *testing.B) {
+	parser := NewVllmHTTPParser()
+	headers := map[string]string{":path": "/inference/v1/generate"}
+	tokens := strings.Repeat("12345,", 1_000_000-1) + "12345.0"
+	body := []byte(`{"model":"test","token_ids":[` + tokens + `],"sampling_params":{"max_tokens":1}}`)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(body)))
+	for b.Loop() {
+		result, err := parser.ParseRequest(context.Background(), body, headers)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchmarkVllmParseResult = result
+	}
+}
+
 func TestNewVllmHTTPParser(t *testing.T) {
 	parser := NewVllmHTTPParser()
 	want := fwkplugin.TypedName{Type: VllmHTTPParserType, Name: VllmHTTPParserType}
@@ -61,7 +134,7 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 					TokenIDs: []uint32{1, 2, 3},
 				},
 				Payload: fwkrh.PayloadMap{
-					"token_ids": []any{json.Number("1"), json.Number("2"), json.Number("3")},
+					"token_ids": json.RawMessage(`[1,2,3]`),
 				},
 			},
 		},
@@ -78,7 +151,7 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 					CacheSalt: "abc123",
 				},
 				Payload: fwkrh.PayloadMap{
-					"token_ids":  []any{json.Number("10"), json.Number("20"), json.Number("30")},
+					"token_ids":  json.RawMessage(`[10,20,30]`),
 					"cache_salt": "abc123",
 				},
 			},
@@ -99,7 +172,7 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 					TokenIDs: []uint32{1, 2, 3},
 				},
 				Payload: fwkrh.PayloadMap{
-					"token_ids": []any{json.Number("1"), json.Number("2"), json.Number("3")},
+					"token_ids": json.RawMessage(`[1,2,3]`),
 					"sampling_params": map[string]any{
 						"temperature": json.Number("0.8"),
 						"max_tokens":  json.Number("128"),
@@ -137,7 +210,7 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 					TokenIDs: []uint32{5, 6, 7},
 				},
 				Payload: fwkrh.PayloadMap{
-					"token_ids": []any{json.Number("5"), json.Number("6"), json.Number("7")},
+					"token_ids": json.RawMessage(`[5,6,7]`),
 				},
 			},
 		},
@@ -174,11 +247,7 @@ func TestVllmHTTPParser_ParseRequest_Generate(t *testing.T) {
 					},
 				},
 				Payload: fwkrh.PayloadMap{
-					"token_ids": []any{
-						json.Number("151644"), json.Number("872"), json.Number("198"), json.Number("3838"), json.Number("374"), json.Number("279"),
-						json.Number("6722"), json.Number("315"), json.Number("9625"), json.Number("30"), json.Number("151645"), json.Number("198"),
-						json.Number("151644"), json.Number("77091"), json.Number("198"),
-					},
+					"token_ids": json.RawMessage(`[151644,872,198,3838,374,279,6722,315,9625,30,151645,198,151644,77091,198]`),
 					"features": map[string]any{
 						"mm_hashes": map[string]any{
 							"image": []any{"abc123hash", "def456hash"},

--- a/test/integration/epp/hermetic_test.go
+++ b/test/integration/epp/hermetic_test.go
@@ -224,7 +224,7 @@ dataLayer:
 					},
 					wantResponses: ExpectReject(
 						envoyTypePb.StatusCode_BadRequest,
-						"inference error: BadRequest - error unmarshaling request bodyMap: invalid character 'o' in literal null (expecting 'u')",
+						"inference error: BadRequest - error extracting request body: invalid character 'o' in literal null (expecting 'u')",
 					),
 				},
 				{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Large pre-tokenized HTTP requests spend most of their parsing time decoding
token IDs through generic JSON values, creating one or more heap allocations
per token.

This change:

- Adds a canonical `uint32` JSON fast path for flat and nested OpenAI token
  inputs and flat vLLM and SGLang token inputs.
- Falls back to the existing decoder for decimal, exponent, negative, empty,
  malformed, and otherwise non-canonical inputs.
- Preserves token input JSON as `json.RawMessage` in OpenAI and vLLM payloads
  while keeping other numbers as `json.Number`.
- Preserves receiver reuse, vLLM multimodal features, sampling parameters,
  unknown fields, number syntax during model rewriting, and existing fallback
  validation.

The diff is test-heavy: 763 of the 1,059 added lines are tests and benchmarks.
The production change is 296 additions and 12 deletions, concentrated in the
shared token parser and its OpenAI, vLLM, and SGLang integrations.

Representative medians from five runs on linux/amd64 with Go 1.26.6:

| Scenario | Before | After | Latency | B/op before | B/op after | Allocs/op before | Allocs/op after |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| OpenAI completions parse, flat 1M | 170.47 ms | 41.66 ms | -75.56% | 223.303 MiB | 9.553 MiB | 4,000,125 | 44 |
| OpenAI completions parse, nested 1M | 134.08 ms | 40.14 ms | -70.06% | 122.754 MiB | 9.577 MiB | 4,025,074 | 46 |
| OpenAI embeddings parse, flat 1M | 173.13 ms | 40.70 ms | -76.49% | 223.303 MiB | 9.551 MiB | 4,000,121 | 34 |
| OpenAI parse and model rewrite, flat 1M | 205.09 ms | 61.92 ms | -69.81% | 245.03 MiB | 16.43 MiB | 4,000,173 | 55 |
| vLLM generate parse, flat 1M | 170.56 ms | 63.56 ms | -62.73% | 163.852 MiB | 9.552 MiB | 2,000,127 | 50 |
| SGLang generate parse, flat 1M | 76.45 ms | 29.53 ms | -61.37% | 31.57 MiB | 15.27 MiB | 58 | 20 |

The benchmark used `-benchmem -benchtime=300ms -count=5` against
`6f6cd1fa`. OpenAI, vLLM, and SGLang 4K and 32K canonical inputs also improved
by 58-69%. SGLang's 1M fallback path had no statistically significant change.

**Which issue(s) this PR fixes**:

Fixes #2520

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

## Test plan

- [x] Canonical flat and nested token arrays, whitespace, and `MaxUint32`.
- [x] Decimal, exponent, negative, overflow, empty, malformed, and mixed fallback inputs.
- [x] Receiver reuse, contiguous nested storage, vLLM multimodal features, payload types, and model rewrite compatibility.
- [x] `go test ./pkg/epp/framework/interface/requesthandling ./pkg/epp/framework/plugins/requesthandling/parsers/util ./pkg/epp/framework/plugins/requesthandling/parsers/openai ./pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp ./pkg/epp/framework/plugins/requesthandling/parsers/sglanghttp`
- [x] Baseline/current OpenAI, vLLM, and SGLang benchmarks with `-benchmem -benchtime=300ms -count=5`.
- [ ] `make presubmit` was not run.
