### PR TITLE
Route cached follow-ups by remaining prefill work

### DIFF
--- a/pkg/epp/framework/interface/scheduling/attributes.go
+++ b/pkg/epp/framework/interface/scheduling/attributes.go
@@ -22,18 +22,26 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
 
+// InitializeAttributeStore allocates the request attribute store before the
+// request is shared across goroutines. The data-producer executor calls this
+// before starting a producer so a producer that outlives its cancelled context
+// can safely finish a sync.Map operation while scheduling reads attributes.
+func (r *InferenceRequest) InitializeAttributeStore() {
+	if r.attributes == nil {
+		r.attributes = &sync.Map{}
+	}
+}
+
 // PutAttribute stores value at key in the request's attribute store.
 // The backing store is lazily allocated on first write.
-// Callers must not write concurrently to the same request from multiple goroutines.
+// Call InitializeAttributeStore before sharing a request across goroutines.
 //
 // Keys are DataKey values for the same reason the endpoint AttributeMap uses
 // them: the per-request store is the other half of the producer/consumer
 // exchange, so a plugin reaches an entry only through a key it names in
 // Produces() or Consumes().
 func (r *InferenceRequest) PutAttribute(key fwkplugin.DataKey, value any) {
-	if r.attributes == nil {
-		r.attributes = &sync.Map{}
-	}
+	r.InitializeAttributeStore()
 	r.attributes.Store(key, value)
 }
 

--- a/pkg/epp/framework/interface/scheduling/attributes_test.go
+++ b/pkg/epp/framework/interface/scheduling/attributes_test.go
@@ -83,7 +83,7 @@ func TestRequestAttributes_ZeroValueRequestIsUsable(t *testing.T) {
 
 func TestRequestAttributes_ConcurrentAfterInit(t *testing.T) {
 	r := &InferenceRequest{}
-	r.PutAttribute(testKey("seed"), 0) // ensure the store is allocated before concurrent writers start
+	r.InitializeAttributeStore()
 
 	const writers = 8
 	const writes = 200
@@ -105,5 +105,5 @@ func TestRequestAttributes_ConcurrentAfterInit(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.Len(t, r.AttributeKeys(), writers*writes+1)
+	assert.Len(t, r.AttributeKeys(), writers*writes)
 }

--- a/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types.go
@@ -24,9 +24,19 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	approxprefixconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/constants"
+	p2psourceconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/constants"
 )
 
 var PrefixCacheMatchInfoDataKey = plugin.NewDataKey("PrefixCacheMatchInfoDataKey", approxprefixconstants.ApproxPrefixCachePluginType)
+
+// ReusablePrefixTokensDataKey identifies the request-wide reusable prefix
+// token floor published by a p2p-source-producer instance.
+var ReusablePrefixTokensDataKey = plugin.NewDataKey("ReusablePrefixTokensDataKey", p2psourceconstants.P2PSourcePluginType)
+
+// ReusablePrefixTokens is a floor on the prompt tokens every valid destination
+// can reuse either from confirmed local cache or by pulling confirmed CPU-tier
+// blocks from the sampled source.
+type ReusablePrefixTokens int
 
 // SpeculativeTierKey is the CachedBlocksByTier key for speculative index
 // entries, which carry no engine-reported device tier.
@@ -47,6 +57,10 @@ type PrefixCacheMatchInfo struct {
 	// the prefix-based PD decider) get an accurate cached-token figure rather
 	// than a tier-attenuated one. Defaults to matchBlocks when not set.
 	cachedBlockCount int
+	// unweighted count of contiguous cached prefix blocks confirmed by the
+	// engine. Speculative index entries are excluded, while confirmed blocks
+	// can move between device tiers across the prefix.
+	confirmedCachedBlockCount int
 	// per device tier, the unweighted count of contiguous cached prefix blocks
 	// the endpoint holds in that tier, from the first block until the first
 	// block missing from that tier. A block held in several tiers counts once
@@ -96,6 +110,20 @@ func (p *PrefixCacheMatchInfo) CachedBlockCount() int {
 	return p.cachedBlockCount
 }
 
+// WithConfirmedCachedBlockCount sets the unweighted contiguous count of
+// confirmed, non-speculative cached blocks and returns the receiver for
+// chaining.
+func (p *PrefixCacheMatchInfo) WithConfirmedCachedBlockCount(confirmedCachedBlockCount int) *PrefixCacheMatchInfo {
+	p.confirmedCachedBlockCount = confirmedCachedBlockCount
+	return p
+}
+
+// ConfirmedCachedBlockCount returns the unweighted contiguous count of
+// confirmed, non-speculative cached blocks on the endpoint.
+func (p *PrefixCacheMatchInfo) ConfirmedCachedBlockCount() int {
+	return p.confirmedCachedBlockCount
+}
+
 // WithCachedBlocksByTier sets the per-device-tier contiguous cached-block
 // counts and returns the receiver for chaining. Takes ownership of the map;
 // the caller must not mutate it after the call.
@@ -113,11 +141,12 @@ func (p *PrefixCacheMatchInfo) CachedBlocksByTier() map[string]int {
 
 func (p *PrefixCacheMatchInfo) Clone() fwkdl.Cloneable {
 	clone := &PrefixCacheMatchInfo{
-		matchBlocks:        p.matchBlocks,
-		totalBlocks:        p.totalBlocks,
-		blockSizeTokens:    p.blockSizeTokens,
-		cachedBlockCount:   p.cachedBlockCount,
-		cachedBlocksByTier: maps.Clone(p.cachedBlocksByTier),
+		matchBlocks:               p.matchBlocks,
+		totalBlocks:               p.totalBlocks,
+		blockSizeTokens:           p.blockSizeTokens,
+		cachedBlockCount:          p.cachedBlockCount,
+		confirmedCachedBlockCount: p.confirmedCachedBlockCount,
+		cachedBlocksByTier:        maps.Clone(p.cachedBlocksByTier),
 	}
 	if p.mm != nil {
 		clone.mm = ptr.To(*p.mm)

--- a/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types_test.go
+++ b/pkg/epp/framework/plugins/datalayer/attribute/prefix/data_types_test.go
@@ -21,7 +21,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
+
+func TestReusablePrefixTokensDataKeyUsesProducerName(t *testing.T) {
+	key := ReusablePrefixTokensDataKey.WithNonEmptyProducerName("source")
+
+	assert.Equal(t, plugin.NewDataKey("ReusablePrefixTokensDataKey", "source").String(), key.String())
+}
 
 func TestPrefixCacheMatchInfo_CachedBlockCountDefaultsToMatchBlocks(t *testing.T) {
 	info := NewPrefixCacheMatchInfo(5, 10, 16)
@@ -41,19 +49,34 @@ func TestPrefixCacheMatchInfo_WithCachedBlockCount(t *testing.T) {
 	assert.Equal(t, 240, info.CachedBlockCount())
 }
 
-func TestPrefixCacheMatchInfo_CloneCopiesCachedBlockCount(t *testing.T) {
-	orig := NewPrefixCacheMatchInfo(192, 256, 16).WithCachedBlockCount(240)
+func TestPrefixCacheMatchInfo_WithConfirmedCachedBlockCount(t *testing.T) {
+	info := NewPrefixCacheMatchInfo(192, 256, 16).
+		WithCachedBlockCount(240).
+		WithConfirmedCachedBlockCount(224)
+
+	assert.Equal(t, 240, info.CachedBlockCount())
+	assert.Equal(t, 224, info.ConfirmedCachedBlockCount())
+}
+
+func TestPrefixCacheMatchInfo_CloneCopiesCachedBlockCounts(t *testing.T) {
+	orig := NewPrefixCacheMatchInfo(192, 256, 16).
+		WithCachedBlockCount(240).
+		WithConfirmedCachedBlockCount(224)
 	clone, ok := orig.Clone().(*PrefixCacheMatchInfo)
 	require.True(t, ok)
 	assert.Equal(t, orig.MatchBlocks(), clone.MatchBlocks())
 	assert.Equal(t, orig.TotalBlocks(), clone.TotalBlocks())
 	assert.Equal(t, orig.BlockSizeTokens(), clone.BlockSizeTokens())
 	assert.Equal(t, orig.CachedBlockCount(), clone.CachedBlockCount())
+	assert.Equal(t, orig.ConfirmedCachedBlockCount(), clone.ConfirmedCachedBlockCount())
 
 	// Mutating the clone must not affect the original.
 	clone.WithCachedBlockCount(1)
+	clone.WithConfirmedCachedBlockCount(2)
 	assert.Equal(t, 240, orig.CachedBlockCount())
+	assert.Equal(t, 224, orig.ConfirmedCachedBlockCount())
 	assert.Equal(t, 1, clone.CachedBlockCount())
+	assert.Equal(t, 2, clone.ConfirmedCachedBlockCount())
 }
 
 func TestPrefixCacheMatchInfo_CachedBlocksByTierDefaultsToNil(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/README.md
@@ -22,7 +22,7 @@ Producers may also implement additional lifecycle hooks:
 | `predicted-latency-producer` | [`predictedlatency`](predictedlatency/) | `LatencyPredictionInfo` | Trains XGBoost models via a sidecar and generates per-endpoint TTFT/TPOT predictions. |
 | `session-id-producer` | [`sessionid`](sessionid/) | `SessionID` | Extracts a session identifier from a request header or cookie and publishes it for affinity-aware plugins. |
 | `mm-embeddings-cache-producer` | [`multimodal`](multimodal/) | `EncoderCacheMatchInfo` | Tracks which pods recently processed each multimodal input hash and scores encoder-cache affinity. |
-| `p2p-source-producer` | [`p2psource`](p2psource/) | request attribute only | Sets the `x-kv-cache-source-host-port` header to the candidate holding the most cached prefix tokens when it out-caches the pod computing the prefix, for P2P KV pulls. |
+| `p2p-source-producer` | [`p2psource`](p2psource/) | `ReusablePrefixTokens` | Samples a P2P source, publishes a reusable-prefix floor for scheduling, and sets the source header after the computing pod is selected. |
 
 ## Plugin ordering and dependencies
 
@@ -32,7 +32,8 @@ The framework resolves a DAG from each plugin's `Produces` and `Consumes` declar
 - `burst-prefix-cache-producer` **requires** `token-producer` upstream (it consumes `TokenizedPrompt`).
 - `mm-embeddings-cache-producer` **optionally** consumes `TokenizedPrompt`; configure `token-producer` first when multimodal features need tokenizer-derived hashes.
 - `inflight-load-producer` **optionally** consumes `PrefixCacheMatchInfo` from an approx or precise prefix producer; prefix-discounting is applied automatically when the attribute is present.
-- `p2p-source-producer` **requires** `PrefixCacheMatchInfo` from a prefix producer; set `prefixMatchInfoProducerName` to select a non-default producer instance. Omitting it binds the default key, which auto-wires the approximate producer (no error) — set it explicitly for precise-only deployments. Set `prefillProfileName` to match a renamed `disagg-profile-handler` prefill profile.
+- `p2p-source-producer` **requires** `PrefixCacheMatchInfo` from a prefix producer; set `prefixMatchInfoProducerName` to select a non-default producer instance. Omitting it binds the default key, which auto-wires the approximate producer (no error). Set it explicitly for precise-only deployments. Set `prefillProfileName` to match a renamed `disagg-profile-handler` prefill profile.
+- `context-length-aware` can require the name-bound `ReusablePrefixTokens` output by setting `reusableTokensProducerName` to the `p2p-source-producer` instance name. See [P2P cache-aware prefill work](../../scheduling/scorer/contextlengthaware/README.md#p2p-cache-aware-prefill-work) for the profile and label requirements.
 - `predicted-latency-producer` **optionally** consumes `PrefixCacheMatchInfo`; set `prefixMatchInfoProducerName` in its config to the name of the prefix producer instance.
 
 ## Related documentation

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/README.md
@@ -2,37 +2,67 @@
 
 **Type:** `p2p-source-producer`
 
-Sets the `x-kv-cache-source-host-port` header to an endpoint within one block of the most cached prompt prefix, so the routing sidecar can pull those blocks over the P2P connector instead of recomputing them. Runs in the request handling's `DataProducer` phase before scheduling, then emits the header in `PreRequest` after the scheduling decision.
+Selects a peer that can supply the most cached prompt prefix and sets the
+`x-kv-cache-source-host-port` header so the routing sidecar can pull that
+prefix instead of recomputing it. Source selection runs in the `DataProducer`
+phase before scheduling; the header is emitted in `PreRequest` after the
+computing endpoint is known.
 
-For each request the plugin consumes the per-endpoint `PrefixCacheMatchInfo` of a prefix-cache producer (`approx-prefix-cache-producer` or `precise-prefix-cache-producer`) and picks a source among the endpoints caching within one block of the most prompt tokens, weighted by `1/(1+waiting queue)` with a request-ID hash as the sampling coordinate; when the producer supplies per-tier data, only CPU-tier blocks count, since pulls are served from the source's CPU tier. Sampling within the one-block band, rather than argmax, keeps pull traffic from concentrating on a single replica of a widely-cached prefix. After scheduling, the header is set only when the chosen peer out-caches the computing pod by at least `minCachedTokenDelta` tokens; any inbound header value is removed.
+The plugin consumes per-endpoint `PrefixCacheMatchInfo` from an approximate or
+precise prefix-cache producer. It samples among endpoints within one block of
+the largest eligible prefix, weighted by `1/(1+waiting queue)` and a
+request-ID hash. This spreads pulls across replicas that hold nearly identical
+prefixes. After scheduling, the header is set only when the sampled source
+out-caches the computing endpoint by at least `minCachedTokenDelta` tokens.
+Any inbound value of the header is removed.
 
-The plugin also publishes a name-bound `ReusablePrefixTokens` request
-attribute for scheduling plugins. Let `S` be the pull-servable prefix token
-count on the source actually sampled by this plugin (the CPU-tier count when
-per-tier data is available), and let `D` be `minCachedTokenDelta`. The
-published floor is:
+## Reusable Prefix Floor
+
+Per-tier cache data distinguishes the source's pull-servable CPU blocks from
+its GPU-only blocks. For a sampled source with a confirmed contiguous CPU
+prefix, the plugin publishes a name-bound `ReusablePrefixTokens` floor for
+scheduling consumers. Let `S` be that prefix length and `D` be
+`minCachedTokenDelta`:
 
 ```text
 G = max(0, S - D + 1)
 ```
 
-Any computing pod either has at least `G` tokens locally or qualifies for a
-pull from the sampled source under the same routing snapshot. A
+The attribute is omitted when `G` is zero.
+
+The [`ReusablePrefixTokens` type](../../../datalayer/attribute/prefix/data_types.go)
+defines the local-or-pull invariant that scheduling consumers rely on.
+
+Tierless approximate match data remains eligible for header selection because
+it can still identify a likely source. It does not confirm a CPU-tier prefix,
+so it does not publish `ReusablePrefixTokens` for scheduling. A
 [`context-length-aware`](../../../scheduling/scorer/contextlengthaware/README.md)
-instance can consume this floor through `reusableTokensProducerName` and route
-on the remaining prefill work. A request with no CPU-pullable source has no
-floor attribute.
+consumer leaves the total prompt length unchanged when no confirmed floor is
+available.
 
-**Parameters:**
+## Parameters
 
-- `prefixMatchInfoProducerName` (string, optional): Name of the prefix-cache producer instance to consume `PrefixCacheMatchInfo` from, e.g. `precise-prefix-cache-producer`. Empty selects the default (unnamed) producer.
-- `minCachedTokenDelta` (int, optional, default: `1`): Minimum number of cached prompt tokens the best peer must hold beyond the computing pod for the header to be set. Must be `>= 1`. Higher values suppress pulls of short prefixes that are cheap to recompute.
-- `prefillProfileName` (string, optional, default: `prefill`): Name of the P/D disaggregation prefill scheduling profile. The computing pod is read from this profile's target when present; otherwise the primary profile's target is used.
+- `prefixMatchInfoProducerName` (string, optional): Name of the prefix-cache producer instance that supplies `PrefixCacheMatchInfo`. Empty selects the default unnamed producer.
+- `minCachedTokenDelta` (int, optional, default: `1`): Minimum cached-token advantage required to emit the source header. Must be `>= 1`. Higher values avoid transfers for prefixes that are cheap to recompute.
+- `prefillProfileName` (string, optional, default: `prefill`): P/D disaggregation prefill profile containing the endpoint that computes the prefix. If the profile has no target, the primary profile target is used.
 
-**Configuration Example:**
+## Configuration
+
+Cache-aware scheduling requires confirmed per-tier data, so use a named
+`precise-prefix-cache-producer`. Confirmed local-cache accounting excludes
+speculative entries when `speculativeIndexing` is enabled. The token producer
+must render tokens exactly as the serving model does. This example disables
+speculative indexing and shows the producer-side configuration; the consuming
+work classifier is documented under [P2P cache-aware prefill work](../../../scheduling/scorer/contextlengthaware/README.md#p2p-cache-aware-prefill-work).
 
 ```yaml
 plugins:
+  - type: token-producer
+    parameters:
+      modelName: model-name
+      vllm:
+        url: http://render:8000
+  - type: endpoint-notification-source
   - type: precise-prefix-cache-producer
     name: precise-cache
     parameters:
@@ -40,6 +70,9 @@ plugins:
         blockSizeTokens: 64
       kvEventsConfig:
         topicFilter: "kv@"
+        discoverPods: true
+        podDiscoveryConfig:
+          socketPort: 5557
       speculativeIndexing: false
   - type: p2p-source-producer
     name: p2p-cache-source
@@ -47,28 +80,29 @@ plugins:
       prefixMatchInfoProducerName: precise-cache
       prefillProfileName: prefill
       minCachedTokenDelta: 1
+dataLayer:
+  sources:
+    - pluginRef: endpoint-notification-source
+      extractors:
+        - pluginRef: precise-cache
 ```
 
 ## Deployment Requirements
 
-The emitted header only results in a KV transfer when the serving pods are
-configured to serve and pull blocks over the P2P tier:
+The source header results in a transfer only when the serving deployment can
+serve and pull the named blocks:
 
-- vLLM runs the `OffloadingConnector` with a `p2p` secondary tier, and the routing sidecar consumes the header to inject the pull.
-- `offload_prompt_only: false` in `kv_connector_extra_config` on any pod whose cache may be pulled. With the default (`true`), decode-phase (generated) blocks are never offloaded, so a pull of that content misses.
-- Identical `--block-size` across peers; a mismatch makes vLLM reject the transfer (`block_len mismatch`).
-- Identical `PYTHONHASHSEED` across peers, so block hashes match across processes.
+- vLLM includes `OffloadingConnector` with a `p2p` secondary tier, and the routing sidecar is configured to consume the source header.
+- Every potential source uses `offload_prompt_only: false`. The default `true` omits decode-phase blocks from its offload tier.
+- Peers use identical `--block-size` values. vLLM rejects a mismatch with `block_len mismatch`.
+- Peers use the same `PYTHONHASHSEED`, so their block hashes agree.
+- The precise producer receives KV events from every endpoint that may serve as a source and reports per-tier cache data.
 
-Cache-aware prefill-work routing should use a `precise-prefix-cache-producer`
-with per-tier cache data and `speculativeIndexing: false`. The reusable floor
-uses confirmed CPU-tier blocks. Speculative local entries can otherwise
-suppress the source header without providing a pullable prefix. Set
-`prefillProfileName` to the profile selected by `disagg-profile-handler`, and
-reference the consuming `context-length-aware` instance only from that prefill
-profile.
-
----
+For cache-aware prefill-work routing, follow the
+[`context-length-aware` profile and work-range guidance](../../../scheduling/scorer/contextlengthaware/README.md#p2p-cache-aware-prefill-work).
 
 ## Related Documentation
+
+- [Context Length Aware Scorer](../../../scheduling/scorer/contextlengthaware/README.md)
 - [Approximate Prefix Cache Producer](../approximateprefix/README.md)
 - [Precise Prefix Cache Producer](../preciseprefixcache/README.md)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/README.md
@@ -6,6 +6,23 @@ Sets the `x-kv-cache-source-host-port` header to an endpoint within one block of
 
 For each request the plugin consumes the per-endpoint `PrefixCacheMatchInfo` of a prefix-cache producer (`approx-prefix-cache-producer` or `precise-prefix-cache-producer`) and picks a source among the endpoints caching within one block of the most prompt tokens, weighted by `1/(1+waiting queue)` with a request-ID hash as the sampling coordinate; when the producer supplies per-tier data, only CPU-tier blocks count, since pulls are served from the source's CPU tier. Sampling within the one-block band, rather than argmax, keeps pull traffic from concentrating on a single replica of a widely-cached prefix. After scheduling, the header is set only when the chosen peer out-caches the computing pod by at least `minCachedTokenDelta` tokens; any inbound header value is removed.
 
+The plugin also publishes a name-bound `ReusablePrefixTokens` request
+attribute for scheduling plugins. Let `S` be the pull-servable prefix token
+count on the source actually sampled by this plugin (the CPU-tier count when
+per-tier data is available), and let `D` be `minCachedTokenDelta`. The
+published floor is:
+
+```text
+G = max(0, S - D + 1)
+```
+
+Any computing pod either has at least `G` tokens locally or qualifies for a
+pull from the sampled source under the same routing snapshot. A
+[`context-length-aware`](../../../scheduling/scorer/contextlengthaware/README.md)
+instance can consume this floor through `reusableTokensProducerName` and route
+on the remaining prefill work. A request with no CPU-pullable source has no
+floor attribute.
+
 **Parameters:**
 
 - `prefixMatchInfoProducerName` (string, optional): Name of the prefix-cache producer instance to consume `PrefixCacheMatchInfo` from, e.g. `precise-prefix-cache-producer`. Empty selects the default (unnamed) producer.
@@ -17,14 +34,17 @@ For each request the plugin consumes the per-endpoint `PrefixCacheMatchInfo` of 
 ```yaml
 plugins:
   - type: precise-prefix-cache-producer
+    name: precise-cache
     parameters:
       tokenProcessorConfig:
-        blockSize: 64
+        blockSizeTokens: 64
       kvEventsConfig:
         topicFilter: "kv@"
+      speculativeIndexing: false
   - type: p2p-source-producer
+    name: p2p-cache-source
     parameters:
-      prefixMatchInfoProducerName: precise-prefix-cache-producer
+      prefixMatchInfoProducerName: precise-cache
       prefillProfileName: prefill
       minCachedTokenDelta: 1
 ```
@@ -35,9 +55,17 @@ The emitted header only results in a KV transfer when the serving pods are
 configured to serve and pull blocks over the P2P tier:
 
 - vLLM runs the `OffloadingConnector` with a `p2p` secondary tier, and the routing sidecar consumes the header to inject the pull.
-- `offload_prompt_only: false` in `kv_connector_extra_config` on any pod whose cache may be pulled — with the default (`true`), decode-phase (generated) blocks are never offloaded, so a pull of that content misses.
+- `offload_prompt_only: false` in `kv_connector_extra_config` on any pod whose cache may be pulled. With the default (`true`), decode-phase (generated) blocks are never offloaded, so a pull of that content misses.
 - Identical `--block-size` across peers; a mismatch makes vLLM reject the transfer (`block_len mismatch`).
 - Identical `PYTHONHASHSEED` across peers, so block hashes match across processes.
+
+Cache-aware prefill-work routing should use a `precise-prefix-cache-producer`
+with per-tier cache data and `speculativeIndexing: false`. The reusable floor
+uses confirmed CPU-tier blocks. Speculative local entries can otherwise
+suppress the source header without providing a pullable prefix. Set
+`prefillProfileName` to the profile selected by `disagg-profile-handler`, and
+reference the consuming `context-length-aware` instance only from that prefill
+profile.
 
 ---
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/constants/constants.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/constants/constants.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package p2psourceconstants
+
+const (
+	// P2PSourcePluginType is the registered type name of the p2p-source-producer.
+	P2PSourcePluginType = "p2p-source-producer"
+)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer.go
@@ -14,10 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package p2psource emits the KV cache source header: a candidate pod
-// within one block of the most cached prefix KV blocks for the request, for
-// the routing sidecar to pull from over the P2P connector instead of
-// recomputing them.
+// Package p2psource selects a peer within one block of the most cached prompt
+// prefix, publishes a request-wide reusable-prefix floor for scheduling, and
+// emits the selected peer in the KV cache source header after scheduling.
 package p2psource
 
 import (
@@ -50,6 +49,14 @@ const (
 	defaultMinCachedTokenDelta = 1
 )
 
+// ReusablePrefixTokensDataKey identifies the request-wide reusable prefix
+// token floor published by a p2p-source-producer instance.
+var ReusablePrefixTokensDataKey = plugin.NewDataKey("ReusablePrefixTokensDataKey", PluginType)
+
+// ReusablePrefixTokens is a floor on the prompt tokens every valid destination
+// can reuse either locally or by pulling from the sampled source.
+type ReusablePrefixTokens int
+
 // Config configures the p2p-source-producer.
 type Config struct {
 	// PrefixMatchInfoProducerName is the name of the data producer that
@@ -72,16 +79,18 @@ var (
 )
 
 // Producer stashes a pull-source candidate holding within one block of the
-// most cached prefix tokens during Produce, and in PreRequest sets
-// routing.KVCacheSourceHeader to that peer when it out-caches the pod
-// computing the prefix (the prefill endpoint under P/D disaggregation, the
-// primary endpoint otherwise) by at least minCachedTokenDelta tokens.
+// most cached prefix tokens and publishes a reusable-prefix floor during
+// Produce. In PreRequest it sets routing.KVCacheSourceHeader to that peer when
+// it out-caches the pod computing the prefix (the prefill endpoint under P/D
+// disaggregation, the primary endpoint otherwise) by at least
+// minCachedTokenDelta tokens.
 type Producer struct {
-	typedName           plugin.TypedName
-	prefixMatchDataKey  plugin.DataKey
-	minCachedTokenDelta int
-	prefillProfile      string
-	attrKeyValue        plugin.DataKey
+	typedName                   plugin.TypedName
+	prefixMatchDataKey          plugin.DataKey
+	reusablePrefixTokensDataKey plugin.DataKey
+	minCachedTokenDelta         int
+	prefillProfile              string
+	attrKeyValue                plugin.DataKey
 }
 
 // PluginFactory parses the raw plugin configuration and returns a configured
@@ -106,21 +115,27 @@ func New(name string, cfg Config) *Producer {
 	if prefillProfile == "" {
 		prefillProfile = defaultPrefillProfile
 	}
+	minCachedTokenDelta := cfg.MinCachedTokenDelta
+	if minCachedTokenDelta < 1 {
+		minCachedTokenDelta = defaultMinCachedTokenDelta
+	}
 	return &Producer{
-		typedName:           plugin.TypedName{Type: PluginType, Name: name},
-		prefixMatchDataKey:  attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(cfg.PrefixMatchInfoProducerName),
-		minCachedTokenDelta: cfg.MinCachedTokenDelta,
-		prefillProfile:      prefillProfile,
-		attrKeyValue:        plugin.NewDataKey("best-match", PluginType).WithNonEmptyProducerName(name),
+		typedName:                   plugin.TypedName{Type: PluginType, Name: name},
+		prefixMatchDataKey:          attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(cfg.PrefixMatchInfoProducerName),
+		reusablePrefixTokensDataKey: ReusablePrefixTokensDataKey.WithNonEmptyProducerName(name),
+		minCachedTokenDelta:         minCachedTokenDelta,
+		prefillProfile:              prefillProfile,
+		attrKeyValue:                plugin.NewDataKey("best-match", PluginType).WithNonEmptyProducerName(name),
 	}
 }
 
 // TypedName returns the plugin's registered type and name.
 func (p *Producer) TypedName() plugin.TypedName { return p.typedName }
 
-// Produces declares no produced data keys; the best-match result is carried
-// as a request attribute consumed by this plugin's own PreRequest.
-func (p *Producer) Produces() map[plugin.DataKey]any { return map[plugin.DataKey]any{} }
+// Produces declares the request-wide reusable prefix token floor.
+func (p *Producer) Produces() map[plugin.DataKey]any {
+	return map[plugin.DataKey]any{p.reusablePrefixTokensDataKey: ReusablePrefixTokens(0)}
+}
 
 // Consumes declares the PrefixCacheMatchInfo dependency so the data-layer
 // DAG orders the producing plugin before this one.
@@ -145,9 +160,10 @@ func (p *Producer) attrKey() plugin.DataKey {
 	return p.attrKeyValue
 }
 
-// Produce reads each candidate's PrefixCacheMatchInfo and stashes the chosen
-// source on the request: among the endpoints within one block of the most
-// cached prompt tokens, one is sampled with probability proportional to
+// Produce reads each candidate's PrefixCacheMatchInfo, stashes the chosen
+// source, and publishes its request-wide reusable-prefix floor. Among the
+// endpoints within one block of the most cached prompt tokens, one is sampled
+// with probability proportional to
 // 1/(1+waiting queue), using a request-ID hash as the sampling coordinate.
 // Load-blind argmax alone would send every consumer of a widely-replicated
 // prefix to the same peer (equal counts lose to iteration order),
@@ -220,6 +236,11 @@ func (p *Producer) Produce(ctx context.Context, request *scheduling.InferenceReq
 	}
 	if best.cachedTokens > 0 {
 		request.PutAttribute(p.attrKey(), &best)
+		reusableTokens := best.cachedTokens - p.minCachedTokenDelta + 1
+		if reusableTokens < 0 {
+			reusableTokens = 0
+		}
+		request.PutAttribute(p.reusablePrefixTokensDataKey, ReusablePrefixTokens(reusableTokens))
 	}
 	log.FromContext(ctx).WithName(p.typedName.String()).V(logging.TRACE).Info("Produce completed",
 		"requestID", request.RequestID, "endpoints", len(endpoints),

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer.go
@@ -34,11 +34,12 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	p2psourceconstants "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/constants"
 )
 
 const (
 	// PluginType is the registered type name of the p2p-source-producer.
-	PluginType = "p2p-source-producer"
+	PluginType = p2psourceconstants.P2PSourcePluginType
 
 	// defaultPrefillProfile is the disaggregation prefill profile name; when
 	// that profile's result carries an endpoint, that endpoint computes the
@@ -48,14 +49,6 @@ const (
 
 	defaultMinCachedTokenDelta = 1
 )
-
-// ReusablePrefixTokensDataKey identifies the request-wide reusable prefix
-// token floor published by a p2p-source-producer instance.
-var ReusablePrefixTokensDataKey = plugin.NewDataKey("ReusablePrefixTokensDataKey", PluginType)
-
-// ReusablePrefixTokens is a floor on the prompt tokens every valid destination
-// can reuse either locally or by pulling from the sampled source.
-type ReusablePrefixTokens int
 
 // Config configures the p2p-source-producer.
 type Config struct {
@@ -122,7 +115,7 @@ func New(name string, cfg Config) *Producer {
 	return &Producer{
 		typedName:                   plugin.TypedName{Type: PluginType, Name: name},
 		prefixMatchDataKey:          attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(cfg.PrefixMatchInfoProducerName),
-		reusablePrefixTokensDataKey: ReusablePrefixTokensDataKey.WithNonEmptyProducerName(name),
+		reusablePrefixTokensDataKey: attrprefix.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(name),
 		minCachedTokenDelta:         minCachedTokenDelta,
 		prefillProfile:              prefillProfile,
 		attrKeyValue:                plugin.NewDataKey("best-match", PluginType).WithNonEmptyProducerName(name),
@@ -134,7 +127,7 @@ func (p *Producer) TypedName() plugin.TypedName { return p.typedName }
 
 // Produces declares the request-wide reusable prefix token floor.
 func (p *Producer) Produces() map[plugin.DataKey]any {
-	return map[plugin.DataKey]any{p.reusablePrefixTokensDataKey: ReusablePrefixTokens(0)}
+	return map[plugin.DataKey]any{p.reusablePrefixTokensDataKey: attrprefix.ReusablePrefixTokens(0)}
 }
 
 // Consumes declares the PrefixCacheMatchInfo dependency so the data-layer
@@ -152,6 +145,7 @@ func (p *Producer) Consumes() plugin.DataDependencies {
 type bestMatchPeer struct {
 	hostPort     string
 	cachedTokens int
+	hasTierData  bool
 }
 
 // attrKey returns the request-attribute key carrying the best-match peer,
@@ -181,9 +175,10 @@ func (p *Producer) Produce(ctx context.Context, request *scheduling.InferenceReq
 	// join), so they must not pin the pool maximum either: an inflated
 	// maximum would exclude every real endpoint below.
 	type sourceMatch struct {
-		ep        scheduling.Endpoint
-		cached    int
-		blockSize int
+		ep          scheduling.Endpoint
+		cached      int
+		blockSize   int
+		hasTierData bool
 	}
 	maxCached := 0
 	var matches []sourceMatch
@@ -191,11 +186,11 @@ func (p *Producer) Produce(ctx context.Context, request *scheduling.InferenceReq
 		if ep.GetMetadata() == nil {
 			continue
 		}
-		cached, blockSize := p.sourceCachedTokens(ep)
+		cached, blockSize, hasTierData := p.sourceCachedTokens(ep)
 		if cached == 0 {
 			continue
 		}
-		matches = append(matches, sourceMatch{ep: ep, cached: cached, blockSize: blockSize})
+		matches = append(matches, sourceMatch{ep: ep, cached: cached, blockSize: blockSize, hasTierData: hasTierData})
 		if cached > maxCached {
 			maxCached = cached
 		}
@@ -203,8 +198,7 @@ func (p *Producer) Produce(ctx context.Context, request *scheduling.InferenceReq
 
 	best := bestMatchPeer{}
 	if maxCached > 0 {
-		var candidates []scheduling.Endpoint
-		var cachedCounts []int
+		var candidates []sourceMatch
 		var weights []float64
 		total := 0.0
 		for _, m := range matches {
@@ -212,8 +206,7 @@ func (p *Producer) Produce(ctx context.Context, request *scheduling.InferenceReq
 				continue
 			}
 			w := 1.0 / (1.0 + float64(waitingQueueSize(m.ep)))
-			candidates = append(candidates, m.ep)
-			cachedCounts = append(cachedCounts, m.cached)
+			candidates = append(candidates, m)
 			weights = append(weights, w)
 			total += w
 		}
@@ -227,20 +220,28 @@ func (p *Producer) Produce(ctx context.Context, request *scheduling.InferenceReq
 				}
 				target -= w
 			}
-			md := candidates[chosen].GetMetadata()
+			md := candidates[chosen].ep.GetMetadata()
 			best = bestMatchPeer{
 				hostPort:     net.JoinHostPort(md.Address, md.Port),
-				cachedTokens: cachedCounts[chosen],
+				cachedTokens: candidates[chosen].cached,
+				hasTierData:  candidates[chosen].hasTierData,
 			}
 		}
 	}
 	if best.cachedTokens > 0 {
-		request.PutAttribute(p.attrKey(), &best)
-		reusableTokens := best.cachedTokens - p.minCachedTokenDelta + 1
-		if reusableTokens < 0 {
-			reusableTokens = 0
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		request.PutAttribute(p.reusablePrefixTokensDataKey, ReusablePrefixTokens(reusableTokens))
+		request.PutAttribute(p.attrKey(), &best)
+		if best.hasTierData {
+			reusableTokens := best.cachedTokens - p.minCachedTokenDelta + 1
+			if reusableTokens > 0 {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				request.PutAttribute(p.reusablePrefixTokensDataKey, attrprefix.ReusablePrefixTokens(reusableTokens))
+			}
+		}
 	}
 	log.FromContext(ctx).WithName(p.typedName.String()).V(logging.TRACE).Info("Produce completed",
 		"requestID", request.RequestID, "endpoints", len(endpoints),
@@ -324,24 +325,27 @@ const cpuDeviceTier = "cpu"
 // so with per-tier data only the contiguous CPU-tier prefix counts; producers
 // without tier data are trusted as-is - the configured producer instance must
 // approximate the pull-servable (CPU) tier.
-func (p *Producer) sourceCachedTokens(ep scheduling.Endpoint) (tokens, blockSize int) {
+func (p *Producer) sourceCachedTokens(ep scheduling.Endpoint) (tokens, blockSize int, hasTierData bool) {
 	info := p.matchInfo(ep)
 	if info == nil {
-		return 0, 0
+		return 0, 0, false
 	}
 	if byTier := info.CachedBlocksByTier(); byTier != nil {
-		return byTier[cpuDeviceTier] * info.BlockSizeTokens(), info.BlockSizeTokens()
+		return byTier[cpuDeviceTier] * info.BlockSizeTokens(), info.BlockSizeTokens(), true
 	}
-	return info.CachedBlockCount() * info.BlockSizeTokens(), info.BlockSizeTokens()
+	return info.CachedBlockCount() * info.BlockSizeTokens(), info.BlockSizeTokens(), false
 }
 
-// cachedTokenCount returns the endpoint's cached prompt tokens across all
-// tiers, or 0 when its PrefixCacheMatchInfo is absent. Local blocks need no
-// pull whatever their tier, so the computing side stays tier-blind.
+// cachedTokenCount returns the endpoint's confirmed cached prompt tokens
+// across all tiers, or 0 when its PrefixCacheMatchInfo is absent. Producers
+// without tier data keep their trusted tierless count.
 func (p *Producer) cachedTokenCount(ep scheduling.Endpoint) int {
 	info := p.matchInfo(ep)
 	if info == nil {
 		return 0
+	}
+	if info.CachedBlocksByTier() != nil {
+		return info.ConfirmedCachedBlockCount() * info.BlockSizeTokens()
 	}
 	return info.CachedBlockCount() * info.BlockSizeTokens()
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package p2psource
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -59,9 +60,9 @@ func decodeOnly(ep scheduling.Endpoint) *scheduling.SchedulingResult {
 	}
 }
 
-func readReusablePrefixTokens(request *scheduling.InferenceRequest, producerName string) (ReusablePrefixTokens, bool) {
-	key := ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName)
-	return scheduling.ReadRequestAttribute[ReusablePrefixTokens](request, key)
+func readReusablePrefixTokens(request *scheduling.InferenceRequest, producerName string) (attrprefix.ReusablePrefixTokens, bool) {
+	key := attrprefix.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName)
+	return scheduling.ReadRequestAttribute[attrprefix.ReusablePrefixTokens](request, key)
 }
 
 // Factory defaults: token delta 1, default PrefixCacheMatchInfo producer.
@@ -100,13 +101,13 @@ func TestNew_DefaultsMinCachedTokenDelta(t *testing.T) {
 	req := &scheduling.InferenceRequest{RequestID: "req-new-default"}
 
 	require.NoError(t, p.Produce(ctx, req, []scheduling.Endpoint{
-		endpoint(p, "pod-a", "10.0.0.1", 4),
+		tierEndpoint(p, "pod-a", "10.0.0.1", 4, map[string]int{cpuDeviceTier: 4}),
 	}))
 
 	assert.Equal(t, defaultMinCachedTokenDelta, p.minCachedTokenDelta)
 	got, ok := readReusablePrefixTokens(req, "test")
 	require.True(t, ok)
-	assert.Equal(t, ReusablePrefixTokens(4*testBlockSize), got)
+	assert.Equal(t, attrprefix.ReusablePrefixTokens(4*testBlockSize), got)
 }
 
 // Produce stashes the endpoint holding the most cached prompt tokens.
@@ -129,14 +130,15 @@ func TestProduce_StashesBestMatchPeer(t *testing.T) {
 
 func TestProduce_PublishesReusablePrefixTokens(t *testing.T) {
 	tests := []struct {
-		name       string
-		cached     int
-		delta      int
-		wantTokens ReusablePrefixTokens
+		name        string
+		cached      int
+		delta       int
+		wantTokens  attrprefix.ReusablePrefixTokens
+		wantPresent bool
 	}{
-		{name: "delta one", cached: 4, delta: 1, wantTokens: 4 * testBlockSize},
-		{name: "delta equals source", cached: 4, delta: 4 * testBlockSize, wantTokens: 1},
-		{name: "delta exceeds source", cached: 4, delta: 4*testBlockSize + 1, wantTokens: 0},
+		{name: "delta one", cached: 4, delta: 1, wantTokens: 4 * testBlockSize, wantPresent: true},
+		{name: "delta equals source", cached: 4, delta: 4 * testBlockSize, wantTokens: 1, wantPresent: true},
+		{name: "delta exceeds source", cached: 4, delta: 4*testBlockSize + 1},
 	}
 
 	for _, tt := range tests {
@@ -146,12 +148,16 @@ func TestProduce_PublishesReusablePrefixTokens(t *testing.T) {
 			req := &scheduling.InferenceRequest{RequestID: "req-floor-" + tt.name}
 
 			require.NoError(t, p.Produce(ctx, req, []scheduling.Endpoint{
-				endpoint(p, "pod-a", "10.0.0.1", tt.cached),
+				tierEndpoint(p, "pod-a", "10.0.0.1", tt.cached, map[string]int{cpuDeviceTier: tt.cached}),
 			}))
 
 			got, ok := readReusablePrefixTokens(req, "test")
-			require.True(t, ok)
-			assert.Equal(t, tt.wantTokens, got)
+			assert.Equal(t, tt.wantPresent, ok)
+			if tt.wantPresent {
+				assert.Equal(t, tt.wantTokens, got)
+			}
+			_, hasBest := scheduling.ReadRequestAttribute[*bestMatchPeer](req, p.attrKey())
+			assert.True(t, hasBest)
 		})
 	}
 }
@@ -169,12 +175,29 @@ func TestProduce_NoSource_NoReusablePrefixTokens(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestProduce_CancelledContextDoesNotStoreAttributes(t *testing.T) {
+	ctx, cancel := context.WithCancel(utils.NewTestContext(t))
+	cancel()
+	p := New("test", Config{MinCachedTokenDelta: 1})
+	req := &scheduling.InferenceRequest{RequestID: "req-cancelled"}
+
+	err := p.Produce(ctx, req, []scheduling.Endpoint{
+		tierEndpoint(p, "pod-a", "10.0.0.1", 4, map[string]int{cpuDeviceTier: 4}),
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	_, hasBest := scheduling.ReadRequestAttribute[*bestMatchPeer](req, p.attrKey())
+	assert.False(t, hasBest)
+	_, hasReusable := readReusablePrefixTokens(req, "test")
+	assert.False(t, hasReusable)
+}
+
 func TestProduce_ReusablePrefixTokensUsesSampledSource(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	p := New("test", Config{MinCachedTokenDelta: 1})
 	eps := []scheduling.Endpoint{
-		endpointWithLoad(p, "pod-ahead", "10.0.0.1", 4, 20),
-		endpointWithLoad(p, "pod-short", "10.0.0.2", 3, 0),
+		tierEndpointWithLoad(p, "pod-ahead", "10.0.0.1", 4, 20),
+		tierEndpointWithLoad(p, "pod-short", "10.0.0.2", 3, 0),
 	}
 
 	foundShort := false
@@ -189,7 +212,7 @@ func TestProduce_ReusablePrefixTokensUsesSampledSource(t *testing.T) {
 
 		got, ok := readReusablePrefixTokens(req, "test")
 		require.True(t, ok)
-		assert.Equal(t, ReusablePrefixTokens(3*testBlockSize), got)
+		assert.Equal(t, attrprefix.ReusablePrefixTokens(3*testBlockSize), got)
 		foundShort = true
 		break
 	}
@@ -202,24 +225,24 @@ func TestProduce_ReusablePrefixTokensKeyUsesInstanceName(t *testing.T) {
 	req := &scheduling.InferenceRequest{RequestID: "req-custom-key"}
 
 	require.NoError(t, p.Produce(ctx, req, []scheduling.Endpoint{
-		endpoint(p, "pod-a", "10.0.0.1", 2),
+		tierEndpoint(p, "pod-a", "10.0.0.1", 2, map[string]int{cpuDeviceTier: 2}),
 	}))
 
 	got, ok := readReusablePrefixTokens(req, "custom")
 	require.True(t, ok)
-	assert.Equal(t, ReusablePrefixTokens(2*testBlockSize), got)
-	_, ok = scheduling.ReadRequestAttribute[ReusablePrefixTokens](req, ReusablePrefixTokensDataKey)
+	assert.Equal(t, attrprefix.ReusablePrefixTokens(2*testBlockSize), got)
+	_, ok = scheduling.ReadRequestAttribute[attrprefix.ReusablePrefixTokens](req, attrprefix.ReusablePrefixTokensDataKey)
 	assert.False(t, ok)
 }
 
 func TestProduces_DeclaresReusablePrefixTokens(t *testing.T) {
 	p := New("custom", Config{MinCachedTokenDelta: 1})
-	key := ReusablePrefixTokensDataKey.WithNonEmptyProducerName("custom")
+	key := attrprefix.ReusablePrefixTokensDataKey.WithNonEmptyProducerName("custom")
 
 	produced := p.Produces()
 	require.Len(t, produced, 1)
-	assert.Equal(t, ReusablePrefixTokens(0), produced[key])
-	assert.IsType(t, ReusablePrefixTokens(0), produced[key])
+	assert.Equal(t, attrprefix.ReusablePrefixTokens(0), produced[key])
+	assert.IsType(t, attrprefix.ReusablePrefixTokens(0), produced[key])
 	assert.Equal(t, plugin.NewDataKey("ReusablePrefixTokensDataKey", "custom").String(), key.String())
 }
 
@@ -460,6 +483,20 @@ func endpointWithLoad(p *Producer, name, address string, cachedBlocks, waiting i
 	return e
 }
 
+func tierEndpointWithLoad(p *Producer, name, address string, cachedBlocks, waiting int) scheduling.Endpoint {
+	e := scheduling.NewEndpoint(&fwkdl.EndpointMetadata{
+		ID:      k8stypes.NamespacedName{Name: name},
+		Address: address,
+		Port:    "8080",
+	}, &fwkdl.Metrics{WaitingQueueSize: waiting}, nil)
+	e.Put(p.prefixMatchDataKey,
+		attrprefix.NewPrefixCacheMatchInfo(cachedBlocks, 4, testBlockSize).
+			WithCachedBlockCount(cachedBlocks).
+			WithConfirmedCachedBlockCount(cachedBlocks).
+			WithCachedBlocksByTier(map[string]int{cpuDeviceTier: cachedBlocks}))
+	return e
+}
+
 // Equally-cached peers share pull traffic proportionally to 1/(1+queue):
 // the shortest queue receives the most requests, deeper queues fewer, and a
 // small queue difference shifts share without starving anyone.
@@ -611,6 +648,12 @@ func TestProduce_NilMetrics_NeutralLoad(t *testing.T) {
 // tierEndpoint builds a candidate whose PrefixCacheMatchInfo carries a
 // per-tier cached-block map alongside the unweighted total.
 func tierEndpoint(p *Producer, name, address string, cachedBlocks int, byTier map[string]int) scheduling.Endpoint {
+	return tierEndpointWithConfirmed(p, name, address, cachedBlocks, cachedBlocks, byTier)
+}
+
+func tierEndpointWithConfirmed(
+	p *Producer, name, address string, cachedBlocks, confirmedCachedBlocks int, byTier map[string]int,
+) scheduling.Endpoint {
 	e := scheduling.NewEndpoint(&fwkdl.EndpointMetadata{
 		ID:      k8stypes.NamespacedName{Name: name},
 		Address: address,
@@ -619,6 +662,7 @@ func tierEndpoint(p *Producer, name, address string, cachedBlocks int, byTier ma
 	e.Put(p.prefixMatchDataKey,
 		attrprefix.NewPrefixCacheMatchInfo(cachedBlocks, 4, testBlockSize).
 			WithCachedBlockCount(cachedBlocks).
+			WithConfirmedCachedBlockCount(confirmedCachedBlocks).
 			WithCachedBlocksByTier(byTier))
 	return e
 }
@@ -684,9 +728,11 @@ func TestProduce_NoTierData_FallsBackToUnweighted(t *testing.T) {
 	best, ok := scheduling.ReadRequestAttribute[*bestMatchPeer](req, p.attrKey())
 	require.True(t, ok)
 	assert.Equal(t, 4*testBlockSize, best.cachedTokens)
+	_, hasReusable := readReusablePrefixTokens(req, "test")
+	assert.False(t, hasReusable)
 }
 
-// The computing side of the delta stays tier-blind.
+// The computing side counts confirmed local blocks across every real tier.
 func TestPreRequest_ComputingSideCountsAllTiers(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	p := New("test", Config{MinCachedTokenDelta: 2 * testBlockSize})
@@ -700,4 +746,19 @@ func TestPreRequest_ComputingSideCountsAllTiers(t *testing.T) {
 
 	// source 6 cpu blocks minus computing 5 (gpu, but local) = 1 block < delta.
 	assert.Empty(t, req.Headers[routing.KVCacheSourceHeader])
+}
+
+func TestPreRequest_SpeculativeComputingCacheDoesNotSuppressHeader(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	p := New("test", Config{MinCachedTokenDelta: 1})
+
+	src := tierEndpoint(p, "pod-src", "10.0.0.1", 6, map[string]int{cpuDeviceTier: 6})
+	computing := tierEndpointWithConfirmed(p, "pod-comp", "10.0.0.2", 6, 0,
+		map[string]int{attrprefix.SpeculativeTierKey: 6})
+	req := &scheduling.InferenceRequest{RequestID: "req-speculative-computing", Headers: map[string]string{}}
+
+	require.NoError(t, p.Produce(ctx, req, []scheduling.Endpoint{src, computing}))
+	require.NoError(t, p.PreRequest(ctx, req, decodeOnly(computing)))
+
+	assert.Equal(t, "10.0.0.1:8080", req.Headers[routing.KVCacheSourceHeader])
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/llm-d/llm-d-router/pkg/common/routing"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	"github.com/llm-d/llm-d-router/test/utils"
@@ -56,6 +57,11 @@ func decodeOnly(ep scheduling.Endpoint) *scheduling.SchedulingResult {
 			"decode": {TargetEndpoints: []scheduling.Endpoint{ep}},
 		},
 	}
+}
+
+func readReusablePrefixTokens(request *scheduling.InferenceRequest, producerName string) (ReusablePrefixTokens, bool) {
+	key := ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName)
+	return scheduling.ReadRequestAttribute[ReusablePrefixTokens](request, key)
 }
 
 // Factory defaults: token delta 1, default PrefixCacheMatchInfo producer.
@@ -88,6 +94,21 @@ func TestPluginFactory_RejectsZeroDelta(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestNew_DefaultsMinCachedTokenDelta(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	p := New("test", Config{})
+	req := &scheduling.InferenceRequest{RequestID: "req-new-default"}
+
+	require.NoError(t, p.Produce(ctx, req, []scheduling.Endpoint{
+		endpoint(p, "pod-a", "10.0.0.1", 4),
+	}))
+
+	assert.Equal(t, defaultMinCachedTokenDelta, p.minCachedTokenDelta)
+	got, ok := readReusablePrefixTokens(req, "test")
+	require.True(t, ok)
+	assert.Equal(t, ReusablePrefixTokens(4*testBlockSize), got)
+}
+
 // Produce stashes the endpoint holding the most cached prompt tokens.
 func TestProduce_StashesBestMatchPeer(t *testing.T) {
 	ctx := utils.NewTestContext(t)
@@ -104,6 +125,102 @@ func TestProduce_StashesBestMatchPeer(t *testing.T) {
 	require.True(t, ok, "expected best-match attribute to be stashed")
 	assert.Equal(t, "10.0.0.2:8080", best.hostPort)
 	assert.Equal(t, 48, best.cachedTokens)
+}
+
+func TestProduce_PublishesReusablePrefixTokens(t *testing.T) {
+	tests := []struct {
+		name       string
+		cached     int
+		delta      int
+		wantTokens ReusablePrefixTokens
+	}{
+		{name: "delta one", cached: 4, delta: 1, wantTokens: 4 * testBlockSize},
+		{name: "delta equals source", cached: 4, delta: 4 * testBlockSize, wantTokens: 1},
+		{name: "delta exceeds source", cached: 4, delta: 4*testBlockSize + 1, wantTokens: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := utils.NewTestContext(t)
+			p := New("test", Config{MinCachedTokenDelta: tt.delta})
+			req := &scheduling.InferenceRequest{RequestID: "req-floor-" + tt.name}
+
+			require.NoError(t, p.Produce(ctx, req, []scheduling.Endpoint{
+				endpoint(p, "pod-a", "10.0.0.1", tt.cached),
+			}))
+
+			got, ok := readReusablePrefixTokens(req, "test")
+			require.True(t, ok)
+			assert.Equal(t, tt.wantTokens, got)
+		})
+	}
+}
+
+func TestProduce_NoSource_NoReusablePrefixTokens(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	p := New("test", Config{MinCachedTokenDelta: 1})
+	req := &scheduling.InferenceRequest{RequestID: "req-no-floor"}
+
+	require.NoError(t, p.Produce(ctx, req, []scheduling.Endpoint{
+		endpoint(p, "pod-a", "10.0.0.1", 0),
+	}))
+
+	_, ok := readReusablePrefixTokens(req, "test")
+	assert.False(t, ok)
+}
+
+func TestProduce_ReusablePrefixTokensUsesSampledSource(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	p := New("test", Config{MinCachedTokenDelta: 1})
+	eps := []scheduling.Endpoint{
+		endpointWithLoad(p, "pod-ahead", "10.0.0.1", 4, 20),
+		endpointWithLoad(p, "pod-short", "10.0.0.2", 3, 0),
+	}
+
+	foundShort := false
+	for i := 0; i < 400; i++ {
+		req := &scheduling.InferenceRequest{RequestID: fmt.Sprintf("floor-band-%d", i)}
+		require.NoError(t, p.Produce(ctx, req, eps))
+		best, ok := scheduling.ReadRequestAttribute[*bestMatchPeer](req, p.attrKey())
+		require.True(t, ok)
+		if best.hostPort != "10.0.0.2:8080" {
+			continue
+		}
+
+		got, ok := readReusablePrefixTokens(req, "test")
+		require.True(t, ok)
+		assert.Equal(t, ReusablePrefixTokens(3*testBlockSize), got)
+		foundShort = true
+		break
+	}
+	assert.True(t, foundShort, "expected the one-block-short source to be sampled")
+}
+
+func TestProduce_ReusablePrefixTokensKeyUsesInstanceName(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	p := New("custom", Config{MinCachedTokenDelta: 1})
+	req := &scheduling.InferenceRequest{RequestID: "req-custom-key"}
+
+	require.NoError(t, p.Produce(ctx, req, []scheduling.Endpoint{
+		endpoint(p, "pod-a", "10.0.0.1", 2),
+	}))
+
+	got, ok := readReusablePrefixTokens(req, "custom")
+	require.True(t, ok)
+	assert.Equal(t, ReusablePrefixTokens(2*testBlockSize), got)
+	_, ok = scheduling.ReadRequestAttribute[ReusablePrefixTokens](req, ReusablePrefixTokensDataKey)
+	assert.False(t, ok)
+}
+
+func TestProduces_DeclaresReusablePrefixTokens(t *testing.T) {
+	p := New("custom", Config{MinCachedTokenDelta: 1})
+	key := ReusablePrefixTokensDataKey.WithNonEmptyProducerName("custom")
+
+	produced := p.Produces()
+	require.Len(t, produced, 1)
+	assert.Equal(t, ReusablePrefixTokens(0), produced[key])
+	assert.IsType(t, ReusablePrefixTokens(0), produced[key])
+	assert.Equal(t, plugin.NewDataKey("ReusablePrefixTokensDataKey", "custom").String(), key.String())
 }
 
 // No candidate holds any cached block: nothing to pull, no attribute.
@@ -522,6 +639,19 @@ func TestProduce_GPUOnlySource_NotChosen(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "10.0.0.2:8080", best.hostPort)
 	assert.Equal(t, 3*testBlockSize, best.cachedTokens)
+}
+
+func TestProduce_GPUOnlySource_NoReusablePrefixTokens(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	p := New("test", Config{MinCachedTokenDelta: 1})
+	req := &scheduling.InferenceRequest{RequestID: "req-gpu-only-floor"}
+
+	require.NoError(t, p.Produce(ctx, req, []scheduling.Endpoint{
+		tierEndpoint(p, "pod-gpu", "10.0.0.1", 10, map[string]int{"gpu": 10}),
+	}))
+
+	_, ok := readReusablePrefixTokens(req, "test")
+	assert.False(t, ok)
 }
 
 // Speculative entries must not make an endpoint a pull source.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -382,15 +382,18 @@ func (p *Producer) produceFromBlockKeys(ctx context.Context, span trace.Span,
 			maxMatch = matchLen
 		}
 		cachedBlocks := 0
+		confirmedCachedBlocks := 0
 		cachedBlocksByTier := map[string]int{}
 		for _, lu := range lookups {
 			cachedBlocks += matchedBlockCount(lu.keys, lu.keyToPods, addr)
+			confirmedCachedBlocks += matchedConfirmedBlockCount(lu.keys, lu.keyToPods, addr)
 			for tier, count := range matchedBlockCountByTier(lu.keys, lu.keyToPods, addr) {
 				cachedBlocksByTier[tier] += count
 			}
 		}
 		info := attrprefix.NewPrefixCacheMatchInfo(matchLen, totalBlocks, p.blockSizeTokens).
 			WithCachedBlockCount(cachedBlocks).
+			WithConfirmedCachedBlockCount(confirmedCachedBlocks).
 			WithCachedBlocksByTier(cachedBlocksByTier)
 		if len(mmBlockIndices) > 0 {
 			info.WithMM(attrprefix.MMMatchInfo{MatchBlocks: countMMMatchedBlocks(mmBlockIndices, cachedBlocks)})

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -383,6 +383,7 @@ func TestProduce_WritesCachedBlocksByTier(t *testing.T) {
 
 	gpuA := kvblock.PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "gpu"}
 	cpuA := kvblock.PodEntry{PodIdentifier: "10.0.0.1:8080", DeviceTier: "cpu"}
+	speculativeA := kvblock.PodEntry{PodIdentifier: "10.0.0.1:8080", Speculative: true}
 
 	idx := &fakeKVCacheIndexer{
 		computeFromTokens: func(_ context.Context, ts []uint32, _ string, _ []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error) {
@@ -394,10 +395,10 @@ func TestProduce_WritesCachedBlocksByTier(t *testing.T) {
 		index: &fakeKVBlockIndex{
 			lookup: func(_ context.Context, keys []kvblock.BlockHash, _ sets.Set[string]) (map[kvblock.BlockHash][]kvblock.PodEntry, error) {
 				if keys[0] == keysA[0] {
-					// Prompt A: block 0 on gpu+cpu, block 1 on gpu only.
+					// Prompt A: block 0 is confirmed on gpu+cpu; block 1 is speculative only.
 					return map[kvblock.BlockHash][]kvblock.PodEntry{
 						keysA[0]: {gpuA, cpuA},
-						keysA[1]: {gpuA},
+						keysA[1]: {speculativeA},
 					}, nil
 				}
 				// Prompt B: single block on gpu+cpu.
@@ -434,14 +435,18 @@ func TestProduce_WritesCachedBlocksByTier(t *testing.T) {
 	info, ok := raw.(*attrprefix.PrefixCacheMatchInfo)
 	require.True(t, ok)
 	assert.Equal(t, 3, info.CachedBlockCount())
-	// gpu: 2 (prompt A) + 1 (prompt B); cpu: 1 (prompt A) + 1 (prompt B).
-	assert.Equal(t, map[string]int{"gpu": 3, "cpu": 2}, info.CachedBlocksByTier())
+	assert.Equal(t, 2, info.ConfirmedCachedBlockCount())
+	// Each confirmed tier covers one block from each prompt. The speculative
+	// block follows a confirmed block, so it is not contiguous from block zero
+	// within the speculative tier.
+	assert.Equal(t, map[string]int{"gpu": 2, "cpu": 2}, info.CachedBlocksByTier())
 
 	raw, ok = endpoints[1].Get(attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName("test"))
 	require.True(t, ok)
 	info, ok = raw.(*attrprefix.PrefixCacheMatchInfo)
 	require.True(t, ok)
 	assert.Equal(t, 0, info.CachedBlockCount())
+	assert.Equal(t, 0, info.ConfirmedCachedBlockCount())
 	assert.NotNil(t, info.CachedBlocksByTier())
 	assert.Empty(t, info.CachedBlocksByTier())
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils.go
@@ -56,6 +56,22 @@ func matchedBlockCount(keys []kvblock.BlockHash, keyToPods map[kvblock.BlockHash
 	return count
 }
 
+// matchedConfirmedBlockCount returns the number of contiguous prefix blocks
+// held by podID in any non-speculative device tier. The device tier can change
+// between blocks without breaking the confirmed prefix.
+func matchedConfirmedBlockCount(keys []kvblock.BlockHash, keyToPods map[kvblock.BlockHash][]kvblock.PodEntry, podID string) int {
+	count := 0
+	for _, key := range keys {
+		if !slices.ContainsFunc(keyToPods[key], func(e kvblock.PodEntry) bool {
+			return e.PodIdentifier == podID && !e.Speculative
+		}) {
+			break
+		}
+		count++
+	}
+	return count
+}
+
 // matchedBlockCountByTier returns, per device tier, the number of contiguous
 // cached prefix blocks podID holds in that tier, counting from the first
 // block until the first block the pod does not hold in that tier. A block

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils_test.go
@@ -97,6 +97,48 @@ func TestMatchedBlockCount(t *testing.T) {
 	}
 }
 
+func TestMatchedConfirmedBlockCount(t *testing.T) {
+	const pod = "10.0.0.1:8000"
+	keys := []kvblock.BlockHash{1, 2, 3, 4}
+	gpu := func() kvblock.PodEntry { return kvblock.PodEntry{PodIdentifier: pod, DeviceTier: "gpu"} }
+	cpu := func() kvblock.PodEntry { return kvblock.PodEntry{PodIdentifier: pod, DeviceTier: "cpu"} }
+	speculative := func() kvblock.PodEntry { return kvblock.PodEntry{PodIdentifier: pod, Speculative: true} }
+
+	tests := []struct {
+		name      string
+		keyToPods map[kvblock.BlockHash][]kvblock.PodEntry
+		want      int
+	}{
+		{
+			name: "real tier can change across the prefix",
+			keyToPods: map[kvblock.BlockHash][]kvblock.PodEntry{
+				1: {gpu()}, 2: {cpu()}, 3: {gpu(), cpu()}, 4: {cpu()},
+			},
+			want: 4,
+		},
+		{
+			name: "speculative-only block stops confirmed prefix",
+			keyToPods: map[kvblock.BlockHash][]kvblock.PodEntry{
+				1: {gpu(), speculative()}, 2: {speculative()}, 3: {cpu()},
+			},
+			want: 1,
+		},
+		{
+			name: "speculative-only prefix has no confirmed blocks",
+			keyToPods: map[kvblock.BlockHash][]kvblock.PodEntry{
+				1: {speculative()}, 2: {speculative()},
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, matchedConfirmedBlockCount(keys, tt.keyToPods, pod))
+		})
+	}
+}
+
 func TestMatchedBlockCountByTier(t *testing.T) {
 	const (
 		podA = "10.0.0.1:8000"

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/README.md
@@ -38,7 +38,8 @@ metadata:
 - `enableFiltering` (bool, optional, default: `false`): Also act as a filter, removing out-of-range pods before scoring.
 - `reusableTokensProducerName` (string, optional): Name of the
   `p2p-source-producer` instance whose `ReusablePrefixTokens` request attribute
-  is subtracted from the total prompt length. Empty disables cache subtraction.
+  is subtracted from the total prompt length. Requires a `label` other than
+  `llm-d.ai/context-length-range`. Empty disables cache subtraction.
 
 **Configuration Example:**
 ```yaml
@@ -70,18 +71,35 @@ not consume this attribute and always uses total prompt length.
 #### P2P Cache-Aware Prefill Work
 
 The named [P2P source producer](../../../requestcontrol/dataproducer/p2psource/README.md)
-publishes a request-wide reusable-prefix floor `G`. The context-length-aware
-plugin uses:
+publishes a request-wide reusable-prefix floor `G` from confirmed CPU-tier
+cache data. The context-length-aware plugin uses:
 
 ```text
-routingLength = max(0, totalPromptTokens - G)
+routingLength = 0                              when totalPromptTokens is 0
+routingLength = max(1, totalPromptTokens - G) otherwise
 ```
 
-The routing length is a conservative upper bound on the prefill work under the
-router's cache snapshot: a destination either has at least `G` tokens locally
-or qualifies for the P2P pull. Cache state can change and transfers can fail,
-so every destination, including P-short, must support the request's full
-logical sequence.
+Missing floor data leaves a known total unchanged.
+
+Let `S` be the confirmed prefix on the sampled source, `D` be
+`minCachedTokenDelta`, and `newTokens` be the prompt tokens after that prefix.
+For a positive floor and a follow-up with positive `newTokens`:
+
+```text
+totalPromptTokens = S + newTokens
+G = S - D + 1
+routingLength = newTokens + D - 1
+```
+
+The delta is part of the routed work. If P-short is intended to accept at most
+`N` new tokens, its work-range ceiling must be at least `N + D - 1`; a ceiling
+of `N` is sufficient only when `D` is `1`. Start the next work range above the
+adjusted ceiling.
+
+The routing length is a conservative upper bound under the producer's cache
+snapshot. Every destination, including P-short, must still support the
+request's full logical sequence because cache state can change and a transfer
+can fail.
 
 Use cache subtraction only in the prefill scheduling profile. Use a separate
 work-range label such as `llm-d.ai/prefill-work-range`; the default
@@ -89,27 +107,14 @@ work-range label such as `llm-d.ai/prefill-work-range`; the default
 by a pod. Label every candidate in the prefill profile because unlabeled pods
 are retained by filtering as general-purpose candidates.
 
-The following excerpt configures a precise cache producer, P2P source
-selection, and a prefill-only work classifier in a disaggregated
-configuration. The `p2p-cache-source` name binds the producer and consumer.
-The `prefill` name must also be the prefill profile selected by
-`disagg-profile-handler`; that handler and the profile's existing candidate
-filters and picker are omitted here.
+Configure `p2p-cache-source` as shown in the
+[producer configuration](../../../requestcontrol/dataproducer/p2psource/README.md#configuration).
+Its `prefillProfileName` must match both the profile selected by
+`disagg-profile-handler` and the profile that references the work classifier.
+The profile's candidate filters and picker are omitted here.
 
 ```yaml
 plugins:
-  - type: precise-prefix-cache-producer
-    name: precise-cache
-    parameters:
-      tokenProcessorConfig:
-        blockSizeTokens: 64
-      speculativeIndexing: false
-  - type: p2p-source-producer
-    name: p2p-cache-source
-    parameters:
-      prefixMatchInfoProducerName: precise-cache
-      minCachedTokenDelta: 1
-      prefillProfileName: prefill
   - type: context-length-aware
     name: prefill-work-router
     parameters:
@@ -122,9 +127,9 @@ schedulingProfiles:
       - pluginRef: prefill-work-router
 ```
 
-The cache producer and serving pods must satisfy the
-[`p2p-source-producer` deployment requirements](../../../requestcontrol/dataproducer/p2psource/README.md#deployment-requirements).
-A short-work pod can use labels such as:
+The producer and serving pods must satisfy the
+[deployment requirements](../../../requestcontrol/dataproducer/p2psource/README.md#deployment-requirements).
+With `D = 1`, a short-work class for up to 8192 new tokens can use:
 
 ```yaml
 metadata:
@@ -133,8 +138,9 @@ metadata:
     llm-d.ai/context-length-range: "0-131072"
 ```
 
-The P-long candidates can use `llm-d.ai/prefill-work-range: "8193-131072"`
-while retaining the same logical context range.
+P-long candidates can use `llm-d.ai/prefill-work-range: "8193-131072"` while
+retaining the same logical context range. For larger `D`, raise the short
+ceiling and the long lower bound by `D - 1`.
 
 **Example — Scorer with token-producer:**
 ```yaml

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/README.md
@@ -2,7 +2,10 @@
 
 **Type:** `context-length-aware`
 
-Routes inference requests based on context length (token count), with optional filtering. Scoring is always applied; filtering is off by default. Enables optimized resource allocation by directing requests to pods configured for specific context length ranges.
+Routes inference requests based on a token count, with optional filtering.
+Scoring is always applied; filtering is off by default. The routing length is
+the total prompt length unless `reusableTokensProducerName` enables P2P cache
+subtraction.
 
 **Use Cases:**
 - Route short prompts to pods with smaller GPU memory.
@@ -10,14 +13,17 @@ Routes inference requests based on context length (token count), with optional f
 - Optimize performance by matching workload characteristics to hardware capabilities.
 - Support heterogeneous deployments with different GPU configurations.
 
-Each pod declares its supported range via the `label` parameter (default: `"llm-d.ai/context-length-range"`), formatted as `"min-max"` (e.g. `"0-2048"`).
+Each pod declares its range via the `label` parameter (default:
+`"llm-d.ai/context-length-range"`), formatted as `"min-max"` (e.g.
+`"0-2048"`).
 
 Scoring rules:
 - **In-range match (0.3–1.0]:** Higher scores for tighter/more specific ranges; lower scores for very wide generalist ranges. Always strictly above `0.3`.
 - **Out-of-range fallback [0.0–0.3):** Pods are ranked by proximity to the request (e.g. a 9000-token request prefers a pod with `max=8192` over `max=2048`).
-- **Neutral score (0.5):** Pods without the context length label.
+- **Neutral score (0.5):** Pods without the configured range label.
 
-When `enableFiltering` is `true`, pods whose range does not contain the request's context length are also filtered out.
+When `enableFiltering` is `true`, pods whose range does not contain the
+request's routing length are also filtered out.
 
 #### Pod Label Format
 
@@ -30,6 +36,9 @@ metadata:
 **Parameters:**
 - `label` (string, optional, default: `"llm-d.ai/context-length-range"`): Pod label key carrying the `"min-max"` range.
 - `enableFiltering` (bool, optional, default: `false`): Also act as a filter, removing out-of-range pods before scoring.
+- `reusableTokensProducerName` (string, optional): Name of the
+  `p2p-source-producer` instance whose `ReusablePrefixTokens` request attribute
+  is subtracted from the total prompt length. Empty disables cache subtraction.
 
 **Configuration Example:**
 ```yaml
@@ -48,7 +57,84 @@ schedulingProfiles:
 
 #### Token Counting
 
-Derives context length from `len(request.Body.TokenizedPrompt.TokenIDs)`, written by a `token-producer` — auto-created with the tokenizer-free `estimate` backend when none is configured, so context-length scoring works without extra setup.
+Reads total prompt tokens from `request.Body.TokenizedRequest.TokenCount()`.
+A `token-producer` populates this data and is auto-created with the
+tokenizer-free `estimate` backend when none is configured.
+
+When `reusableTokensProducerName` is configured, the plugin requires the
+name-bound attribute from that `p2p-source-producer`. Missing request data at
+runtime leaves the total prompt length unchanged. This includes requests for
+which the producer finds no pullable source. The default configuration does
+not consume this attribute and always uses total prompt length.
+
+#### P2P Cache-Aware Prefill Work
+
+The named [P2P source producer](../../../requestcontrol/dataproducer/p2psource/README.md)
+publishes a request-wide reusable-prefix floor `G`. The context-length-aware
+plugin uses:
+
+```text
+routingLength = max(0, totalPromptTokens - G)
+```
+
+The routing length is a conservative upper bound on the prefill work under the
+router's cache snapshot: a destination either has at least `G` tokens locally
+or qualifies for the P2P pull. Cache state can change and transfers can fail,
+so every destination, including P-short, must support the request's full
+logical sequence.
+
+Use cache subtraction only in the prefill scheduling profile. Use a separate
+work-range label such as `llm-d.ai/prefill-work-range`; the default
+`llm-d.ai/context-length-range` describes the logical context length supported
+by a pod. Label every candidate in the prefill profile because unlabeled pods
+are retained by filtering as general-purpose candidates.
+
+The following excerpt configures a precise cache producer, P2P source
+selection, and a prefill-only work classifier in a disaggregated
+configuration. The `p2p-cache-source` name binds the producer and consumer.
+The `prefill` name must also be the prefill profile selected by
+`disagg-profile-handler`; that handler and the profile's existing candidate
+filters and picker are omitted here.
+
+```yaml
+plugins:
+  - type: precise-prefix-cache-producer
+    name: precise-cache
+    parameters:
+      tokenProcessorConfig:
+        blockSizeTokens: 64
+      speculativeIndexing: false
+  - type: p2p-source-producer
+    name: p2p-cache-source
+    parameters:
+      prefixMatchInfoProducerName: precise-cache
+      minCachedTokenDelta: 1
+      prefillProfileName: prefill
+  - type: context-length-aware
+    name: prefill-work-router
+    parameters:
+      label: llm-d.ai/prefill-work-range
+      enableFiltering: true
+      reusableTokensProducerName: p2p-cache-source
+schedulingProfiles:
+  - name: prefill
+    plugins:
+      - pluginRef: prefill-work-router
+```
+
+The cache producer and serving pods must satisfy the
+[`p2p-source-producer` deployment requirements](../../../requestcontrol/dataproducer/p2psource/README.md#deployment-requirements).
+A short-work pod can use labels such as:
+
+```yaml
+metadata:
+  labels:
+    llm-d.ai/prefill-work-range: "0-8192"
+    llm-d.ai/context-length-range: "0-131072"
+```
+
+The P-long candidates can use `llm-d.ai/prefill-work-range: "8193-131072"`
+while retaining the same logical context range.
 
 **Example — Scorer with token-producer:**
 ```yaml

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware.go
@@ -13,7 +13,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource"
+	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 )
 
@@ -24,6 +24,8 @@ const (
 	// DefaultContextLengthLabel is the default label name used to identify context length ranges on pods
 	DefaultContextLengthLabel = "llm-d.ai/context-length-range"
 )
+
+var routingLengthDataKey = plugin.NewDataKey("RoutingLengthDataKey", ContextLengthAwareType)
 
 type contextLengthAwareParameters struct {
 	// Label is the pod label name to check for context length range.
@@ -67,6 +69,9 @@ func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.
 	if parameters.Label == "" {
 		return nil, fmt.Errorf("invalid configuration for '%s' plugin: 'label' must be specified", ContextLengthAwareType)
 	}
+	if parameters.ReusableTokensProducerName != "" && parameters.Label == DefaultContextLengthLabel {
+		return nil, fmt.Errorf("invalid configuration for '%s' plugin: reusableTokensProducerName requires a work-range label other than %q", ContextLengthAwareType, DefaultContextLengthLabel)
+	}
 
 	return NewContextLengthAware(name, parameters), nil
 }
@@ -78,8 +83,9 @@ func NewContextLengthAware(name string, params *contextLengthAwareParameters) *C
 		labelName:                  params.Label,
 		enableFiltering:            params.EnableFiltering,
 		reusableTokensProducerName: params.ReusableTokensProducerName,
-		reusableTokensDataKey: p2psource.ReusablePrefixTokensDataKey.
+		reusableTokensDataKey: attrprefix.ReusablePrefixTokensDataKey.
 			WithNonEmptyProducerName(params.ReusableTokensProducerName),
+		routingLengthDataKey: routingLengthDataKey.WithNonEmptyProducerName(name),
 	}
 }
 
@@ -104,6 +110,8 @@ type ContextLengthAware struct {
 	reusableTokensProducerName string
 	// reusableTokensDataKey identifies the configured producer's request data.
 	reusableTokensDataKey plugin.DataKey
+	// routingLengthDataKey identifies this plugin instance's request snapshot.
+	routingLengthDataKey plugin.DataKey
 }
 
 // TypedName returns the typed name of the plugin.
@@ -114,6 +122,7 @@ func (p *ContextLengthAware) TypedName() plugin.TypedName {
 // WithName sets the name of the plugin.
 func (p *ContextLengthAware) WithName(name string) *ContextLengthAware {
 	p.typedName.Name = name
+	p.routingLengthDataKey = routingLengthDataKey.WithNonEmptyProducerName(name)
 	return p
 }
 
@@ -125,7 +134,7 @@ func (p *ContextLengthAware) Consumes() plugin.DataDependencies {
 		tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedRequest{},
 	}
 	if p.reusableTokensProducerName != "" {
-		required[p.reusableTokensDataKey] = p2psource.ReusablePrefixTokens(0)
+		required[p.reusableTokensDataKey] = attrprefix.ReusablePrefixTokens(0)
 	}
 	return plugin.DataDependencies{
 		Required: required,
@@ -220,21 +229,37 @@ func (p *ContextLengthAware) Category() scheduling.ScorerCategory {
 }
 
 // getContextLength returns the token count after subtracting the configured
-// producer's reusable prefix token floor. Missing reusable-token data leaves
-// the total token count unchanged. When tokens are unavailable it returns 0.
+// producer's reusable prefix token floor. Positive token counts have at least
+// one token of prefill work. Missing reusable-token data leaves the total token
+// count unchanged. When tokens are unavailable it returns 0. With cache
+// subtraction enabled, the result is stored per request and plugin instance so
+// Filter and Score use the same value.
 func (p *ContextLengthAware) getContextLength(request *scheduling.InferenceRequest) int {
-	if request == nil || request.Body == nil || request.Body.TokenizedRequest == nil {
+	if request == nil {
 		return 0
 	}
-	total := request.Body.TokenizedRequest.TokenCount()
 	if p.reusableTokensProducerName == "" {
-		return total
+		if request.Body == nil || request.Body.TokenizedRequest == nil {
+			return 0
+		}
+		return request.Body.TokenizedRequest.TokenCount()
 	}
-	reusable, ok := scheduling.ReadRequestAttribute[p2psource.ReusablePrefixTokens](request, p.reusableTokensDataKey)
-	if !ok {
-		return total
+	if routingLength, ok := scheduling.ReadRequestAttribute[int](request, p.routingLengthDataKey); ok {
+		return routingLength
 	}
-	return max(0, total-int(reusable))
+
+	routingLength := 0
+	if request.Body != nil && request.Body.TokenizedRequest != nil {
+		total := request.Body.TokenizedRequest.TokenCount()
+		routingLength = total
+		if total > 0 {
+			if reusable, ok := scheduling.ReadRequestAttribute[attrprefix.ReusablePrefixTokens](request, p.reusableTokensDataKey); ok {
+				routingLength = max(1, total-int(reusable))
+			}
+		}
+	}
+	request.PutAttribute(p.routingLengthDataKey, routingLength)
+	return routingLength
 }
 
 // parseContextRange parses a label value into a single context range.

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware.go
@@ -13,6 +13,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource"
 	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 )
 
@@ -34,6 +35,11 @@ type contextLengthAwareParameters struct {
 	// If false, the plugin only scores pods.
 	// Default is false.
 	EnableFiltering bool `json:"enableFiltering"`
+
+	// ReusableTokensProducerName is the name of the p2p-source-producer whose
+	// reusable prefix token count is subtracted from the request length. Empty
+	// disables cache subtraction.
+	ReusableTokensProducerName string `json:"reusableTokensProducerName,omitempty"`
 }
 
 // contextRange represents a single context length range.
@@ -68,9 +74,12 @@ func Factory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.
 // NewContextLengthAware creates and returns an instance of the ContextLengthAware plugin.
 func NewContextLengthAware(name string, params *contextLengthAwareParameters) *ContextLengthAware {
 	return &ContextLengthAware{
-		typedName:       plugin.TypedName{Type: ContextLengthAwareType, Name: name},
-		labelName:       params.Label,
-		enableFiltering: params.EnableFiltering,
+		typedName:                  plugin.TypedName{Type: ContextLengthAwareType, Name: name},
+		labelName:                  params.Label,
+		enableFiltering:            params.EnableFiltering,
+		reusableTokensProducerName: params.ReusableTokensProducerName,
+		reusableTokensDataKey: p2psource.ReusablePrefixTokensDataKey.
+			WithNonEmptyProducerName(params.ReusableTokensProducerName),
 	}
 }
 
@@ -80,9 +89,10 @@ func NewContextLengthAware(name string, params *contextLengthAwareParameters) *C
 // If filtering is enabled, endpoints that don't support the request's context length are filtered out.
 // Additionally, it scores endpoints based on how well their context length ranges match the request.
 //
-// The context length is the token count from InferenceRequestBody.TokenizedRequest as
-// populated by the tokenizer DataProducer plugin. When tokens are not available it is
-// treated as 0 (unknown).
+// The context length is the token count from InferenceRequestBody.TokenizedRequest.
+// When reusableTokensProducerName is configured, the request-wide reusable
+// prefix token floor is subtracted from that count. Missing tokens are treated
+// as 0 (unknown).
 type ContextLengthAware struct {
 	// typedName defines the plugin typed name
 	typedName plugin.TypedName
@@ -90,6 +100,10 @@ type ContextLengthAware struct {
 	labelName string
 	// enableFiltering indicates whether filtering is enabled
 	enableFiltering bool
+	// reusableTokensProducerName enables cache subtraction when non-empty.
+	reusableTokensProducerName string
+	// reusableTokensDataKey identifies the configured producer's request data.
+	reusableTokensDataKey plugin.DataKey
 }
 
 // TypedName returns the typed name of the plugin.
@@ -103,12 +117,18 @@ func (p *ContextLengthAware) WithName(name string) *ContextLengthAware {
 	return p
 }
 
-// Consumes declares the TokenizedRequest dependency so the data-layer DAG orders
-// the token-producer before this plugin runs and auto-creates one when none is
-// configured; the context length is the token count it provides.
+// Consumes declares the TokenizedRequest dependency and, when configured, the
+// reusable prefix token dependency. The data-layer DAG orders those producers
+// before this plugin runs.
 func (p *ContextLengthAware) Consumes() plugin.DataDependencies {
+	required := map[plugin.DataKey]any{
+		tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedRequest{},
+	}
+	if p.reusableTokensProducerName != "" {
+		required[p.reusableTokensDataKey] = p2psource.ReusablePrefixTokens(0)
+	}
 	return plugin.DataDependencies{
-		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedRequest{}},
+		Required: required,
 	}
 }
 
@@ -120,7 +140,7 @@ func (p *ContextLengthAware) Filter(ctx context.Context, request *scheduling.Inf
 	}
 
 	logger := log.FromContext(ctx).V(logging.DEBUG).WithName("ContextLengthAware.Filter")
-	contextLength := getContextLength(request)
+	contextLength := p.getContextLength(request)
 	logger.V(logging.TRACE).Info("Filtering endpoints by context length", "contextLength", contextLength)
 
 	filteredEndpoints := []scheduling.Endpoint{}
@@ -160,7 +180,7 @@ func (p *ContextLengthAware) Filter(ctx context.Context, request *scheduling.Inf
 // Endpoints with tighter/more specific ranges matching the request get higher scores.
 func (p *ContextLengthAware) Score(ctx context.Context, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64 {
 	logger := log.FromContext(ctx).V(logging.DEBUG).WithName("ContextLengthAware.Score")
-	contextLength := getContextLength(request)
+	contextLength := p.getContextLength(request)
 	logger.V(logging.TRACE).Info("Scoring endpoints by context length", "contextLength", contextLength)
 
 	scoredEndpoints := make(map[scheduling.Endpoint]float64)
@@ -199,14 +219,22 @@ func (p *ContextLengthAware) Category() scheduling.ScorerCategory {
 	return scheduling.Affinity
 }
 
-// getContextLength returns the context length (token count) for the request, read solely
-// from InferenceRequestBody.TokenizedRequest as populated by the tokenizer DataProducer
-// plugin. When tokens are unavailable it returns 0 (unknown).
-func getContextLength(request *scheduling.InferenceRequest) int {
+// getContextLength returns the token count after subtracting the configured
+// producer's reusable prefix token floor. Missing reusable-token data leaves
+// the total token count unchanged. When tokens are unavailable it returns 0.
+func (p *ContextLengthAware) getContextLength(request *scheduling.InferenceRequest) int {
 	if request == nil || request.Body == nil || request.Body.TokenizedRequest == nil {
 		return 0
 	}
-	return request.Body.TokenizedRequest.TokenCount()
+	total := request.Body.TokenizedRequest.TokenCount()
+	if p.reusableTokensProducerName == "" {
+		return total
+	}
+	reusable, ok := scheduling.ReadRequestAttribute[p2psource.ReusablePrefixTokens](request, p.reusableTokensDataKey)
+	if !ok {
+		return total
+	}
+	return max(0, total-int(reusable))
 }
 
 // parseContextRange parses a label value into a single context range.

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
@@ -13,12 +13,15 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource"
+	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/test/utils"
 )
 
-const testReusableTokensProducerName = "p2p-source"
+const (
+	testReusableTokensProducerName = "p2p-source"
+	testPrefillWorkRangeLabel      = "llm-d.ai/prefill-work-range"
+)
 
 // Helper functions
 
@@ -71,9 +74,21 @@ func TestFactory(t *testing.T) {
 			expectErr:  true,
 		},
 		{
-			name:       "reusable tokens producer enables cache subtraction",
+			name:       "reusable tokens producer with default label should error",
 			pluginName: "ctx-aware",
 			jsonParams: `{"reusableTokensProducerName": "p2p-source"}`,
+			expectErr:  true,
+		},
+		{
+			name:       "reusable tokens producer with explicit default label should error",
+			pluginName: "ctx-aware",
+			jsonParams: `{"label": "llm-d.ai/context-length-range", "reusableTokensProducerName": "p2p-source"}`,
+			expectErr:  true,
+		},
+		{
+			name:       "reusable tokens producer with work label",
+			pluginName: "ctx-aware",
+			jsonParams: `{"label": "llm-d.ai/prefill-work-range", "reusableTokensProducerName": "p2p-source"}`,
 			expectErr:  false,
 		},
 		{
@@ -113,46 +128,68 @@ func TestConsumesReusableTokensOnlyWhenConfigured(t *testing.T) {
 
 	producerName := "session-p2p-source"
 	configuredPlugin := NewContextLengthAware("configured", &contextLengthAwareParameters{
-		Label:                      DefaultContextLengthLabel,
+		Label:                      testPrefillWorkRangeLabel,
 		ReusableTokensProducerName: producerName,
 	})
 	configuredDependencies := configuredPlugin.Consumes()
 	require.Len(t, configuredDependencies.Required, 2)
-	expectedKey := p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName)
-	assert.Equal(t, p2psource.ReusablePrefixTokens(0), configuredDependencies.Required[expectedKey])
+	expectedKey := attrprefix.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName)
+	assert.Equal(t, attrprefix.ReusablePrefixTokens(0), configuredDependencies.Required[expectedKey])
 }
 
 func TestFactoryConfiguresReusableTokensProducer(t *testing.T) {
 	producerName := "session-p2p-source"
 	created, err := Factory("cache-aware", fwkplugin.StrictDecoder([]byte(
-		`{"reusableTokensProducerName": "session-p2p-source"}`)), nil)
+		`{"label": "llm-d.ai/prefill-work-range", "reusableTokensProducerName": "session-p2p-source"}`)), nil)
 	require.NoError(t, err)
 	configured := created.(*ContextLengthAware)
 
 	assert.Equal(t, producerName, configured.reusableTokensProducerName)
-	expectedKey := p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName)
+	expectedKey := attrprefix.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName)
 	assert.Equal(t, expectedKey, configured.reusableTokensDataKey)
 	assert.Contains(t, configured.Consumes().Required, expectedKey)
+}
+
+func TestRoutingLengthSnapshotIgnoresLateReusableTokens(t *testing.T) {
+	producerName := testReusableTokensProducerName
+	plugin := NewContextLengthAware("cache-aware", &contextLengthAwareParameters{
+		Label:                      testPrefillWorkRangeLabel,
+		ReusableTokensProducerName: producerName,
+	})
+	request := createHundredTokenRequest()
+
+	assert.Equal(t, 100, plugin.getContextLength(request))
+	request.PutAttribute(
+		attrprefix.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName),
+		attrprefix.ReusablePrefixTokens(60),
+	)
+	assert.Equal(t, 100, plugin.getContextLength(request))
+
+	otherPlugin := NewContextLengthAware("other-cache-aware", &contextLengthAwareParameters{
+		Label:                      testPrefillWorkRangeLabel,
+		ReusableTokensProducerName: producerName,
+	})
+	assert.Equal(t, 40, otherPlugin.getContextLength(request))
 }
 
 func TestReusableTokensFilter(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	endpoints := []scheduling.Endpoint{
 		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "short"},
-			"10.0.0.1", map[string]string{DefaultContextLengthLabel: "0-50"}),
+			"10.0.0.1", map[string]string{testPrefillWorkRangeLabel: "1-50"}),
 		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "long"},
-			"10.0.0.2", map[string]string{DefaultContextLengthLabel: "51-100"}),
+			"10.0.0.2", map[string]string{testPrefillWorkRangeLabel: "51-100"}),
 	}
 
 	t.Run("disabled configuration keeps total length", func(t *testing.T) {
 		plugin := NewContextLengthAware("default", &contextLengthAwareParameters{
-			Label:           DefaultContextLengthLabel,
+			Label:           testPrefillWorkRangeLabel,
 			EnableFiltering: true,
 		})
 		request := createHundredTokenRequest()
 		request.PutAttribute(
-			p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(testReusableTokensProducerName),
-			p2psource.ReusablePrefixTokens(60),
+			attrprefix.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(testReusableTokensProducerName),
+			attrprefix.ReusablePrefixTokens(60),
 		)
 
 		filtered := plugin.Filter(ctx, request, endpoints)
@@ -163,14 +200,14 @@ func TestReusableTokensFilter(t *testing.T) {
 	t.Run("configured producer subtracts reusable tokens", func(t *testing.T) {
 		producerName := testReusableTokensProducerName
 		plugin := NewContextLengthAware("cache-aware", &contextLengthAwareParameters{
-			Label:                      DefaultContextLengthLabel,
+			Label:                      testPrefillWorkRangeLabel,
 			EnableFiltering:            true,
 			ReusableTokensProducerName: producerName,
 		})
 		request := createHundredTokenRequest()
 		request.PutAttribute(
-			p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName),
-			p2psource.ReusablePrefixTokens(60),
+			attrprefix.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName),
+			attrprefix.ReusablePrefixTokens(60),
 		)
 
 		filtered := plugin.Filter(ctx, request, endpoints)
@@ -180,7 +217,7 @@ func TestReusableTokensFilter(t *testing.T) {
 
 	t.Run("missing runtime attribute keeps total length", func(t *testing.T) {
 		plugin := NewContextLengthAware("cache-aware", &contextLengthAwareParameters{
-			Label:                      DefaultContextLengthLabel,
+			Label:                      testPrefillWorkRangeLabel,
 			EnableFiltering:            true,
 			ReusableTokensProducerName: testReusableTokensProducerName,
 		})
@@ -193,13 +230,13 @@ func TestReusableTokensFilter(t *testing.T) {
 	t.Run("wrong runtime attribute type keeps total length", func(t *testing.T) {
 		producerName := testReusableTokensProducerName
 		plugin := NewContextLengthAware("cache-aware", &contextLengthAwareParameters{
-			Label:                      DefaultContextLengthLabel,
+			Label:                      testPrefillWorkRangeLabel,
 			EnableFiltering:            true,
 			ReusableTokensProducerName: producerName,
 		})
 		request := createHundredTokenRequest()
 		request.PutAttribute(
-			p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName),
+			attrprefix.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName),
 			"invalid",
 		)
 
@@ -208,22 +245,51 @@ func TestReusableTokensFilter(t *testing.T) {
 		assert.Equal(t, "long", filtered[0].GetMetadata().ID.Name)
 	})
 
-	t.Run("reusable tokens are clamped to total length", func(t *testing.T) {
+	t.Run("positive total with a fully reusable prefix routes on one token", func(t *testing.T) {
 		producerName := testReusableTokensProducerName
 		plugin := NewContextLengthAware("cache-aware", &contextLengthAwareParameters{
-			Label:                      DefaultContextLengthLabel,
+			Label:                      testPrefillWorkRangeLabel,
 			EnableFiltering:            true,
 			ReusableTokensProducerName: producerName,
 		})
 		request := createHundredTokenRequest()
 		request.PutAttribute(
-			p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName),
-			p2psource.ReusablePrefixTokens(120),
+			attrprefix.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName),
+			attrprefix.ReusablePrefixTokens(120),
 		)
 
 		filtered := plugin.Filter(ctx, request, endpoints)
 		require.Len(t, filtered, 1)
 		assert.Equal(t, "short", filtered[0].GetMetadata().ID.Name)
+	})
+
+	t.Run("unknown token count remains zero", func(t *testing.T) {
+		producerName := testReusableTokensProducerName
+		plugin := NewContextLengthAware("cache-aware", &contextLengthAwareParameters{
+			Label:                      testPrefillWorkRangeLabel,
+			EnableFiltering:            true,
+			ReusableTokensProducerName: producerName,
+		})
+		request := &scheduling.InferenceRequest{
+			RequestID: "unknown-token-count",
+			Body: &fwkrh.InferenceRequestBody{
+				TokenizedRequest: &fwkrh.TokenizedRequest{},
+			},
+		}
+		request.PutAttribute(
+			attrprefix.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName),
+			attrprefix.ReusablePrefixTokens(120),
+		)
+		unknownEndpoints := []scheduling.Endpoint{
+			createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "unknown"},
+				"10.0.0.3", map[string]string{testPrefillWorkRangeLabel: "0-0"}),
+			createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "positive"},
+				"10.0.0.4", map[string]string{testPrefillWorkRangeLabel: "1-50"}),
+		}
+
+		filtered := plugin.Filter(ctx, request, unknownEndpoints)
+		require.Len(t, filtered, 1)
+		assert.Equal(t, "unknown", filtered[0].GetMetadata().ID.Name)
 	})
 }
 
@@ -231,19 +297,19 @@ func TestReusableTokensScore(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	endpoints := []scheduling.Endpoint{
 		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "short"},
-			"10.0.0.1", map[string]string{DefaultContextLengthLabel: "0-50"}),
+			"10.0.0.1", map[string]string{testPrefillWorkRangeLabel: "1-50"}),
 		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "long"},
-			"10.0.0.2", map[string]string{DefaultContextLengthLabel: "51-100"}),
+			"10.0.0.2", map[string]string{testPrefillWorkRangeLabel: "51-100"}),
 	}
 	producerName := testReusableTokensProducerName
 	plugin := NewContextLengthAware("cache-aware", &contextLengthAwareParameters{
-		Label:                      DefaultContextLengthLabel,
+		Label:                      testPrefillWorkRangeLabel,
 		ReusableTokensProducerName: producerName,
 	})
 	request := createHundredTokenRequest()
 	request.PutAttribute(
-		p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName),
-		p2psource.ReusablePrefixTokens(60),
+		attrprefix.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName),
+		attrprefix.ReusablePrefixTokens(60),
 	)
 
 	scores := plugin.Score(ctx, request, endpoints)

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
@@ -13,8 +13,12 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/test/utils"
 )
+
+const testReusableTokensProducerName = "p2p-source"
 
 // Helper functions
 
@@ -36,6 +40,17 @@ func createRequest() *scheduling.InferenceRequest {
 	}
 }
 
+func createHundredTokenRequest() *scheduling.InferenceRequest {
+	return &scheduling.InferenceRequest{
+		RequestID: "test-request",
+		Body: &fwkrh.InferenceRequestBody{
+			TokenizedRequest: &fwkrh.TokenizedRequest{
+				Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 100)}},
+			},
+		},
+	}
+}
+
 func TestFactory(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -54,6 +69,12 @@ func TestFactory(t *testing.T) {
 			pluginName: "empty-label",
 			jsonParams: `{"label": ""}`,
 			expectErr:  true,
+		},
+		{
+			name:       "reusable tokens producer enables cache subtraction",
+			pluginName: "ctx-aware",
+			jsonParams: `{"reusableTokensProducerName": "p2p-source"}`,
+			expectErr:  false,
 		},
 		{
 			name:       "malformed JSON should error",
@@ -80,6 +101,153 @@ func TestFactory(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConsumesReusableTokensOnlyWhenConfigured(t *testing.T) {
+	defaultPlugin := NewContextLengthAware("default", &contextLengthAwareParameters{
+		Label: DefaultContextLengthLabel,
+	})
+	defaultDependencies := defaultPlugin.Consumes()
+	require.Len(t, defaultDependencies.Required, 1)
+	assert.Contains(t, defaultDependencies.Required, tokenproducer.TokenizedPromptDataKey)
+
+	producerName := "session-p2p-source"
+	configuredPlugin := NewContextLengthAware("configured", &contextLengthAwareParameters{
+		Label:                      DefaultContextLengthLabel,
+		ReusableTokensProducerName: producerName,
+	})
+	configuredDependencies := configuredPlugin.Consumes()
+	require.Len(t, configuredDependencies.Required, 2)
+	expectedKey := p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName)
+	assert.Equal(t, p2psource.ReusablePrefixTokens(0), configuredDependencies.Required[expectedKey])
+}
+
+func TestFactoryConfiguresReusableTokensProducer(t *testing.T) {
+	producerName := "session-p2p-source"
+	created, err := Factory("cache-aware", fwkplugin.StrictDecoder([]byte(
+		`{"reusableTokensProducerName": "session-p2p-source"}`)), nil)
+	require.NoError(t, err)
+	configured := created.(*ContextLengthAware)
+
+	assert.Equal(t, producerName, configured.reusableTokensProducerName)
+	expectedKey := p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName)
+	assert.Equal(t, expectedKey, configured.reusableTokensDataKey)
+	assert.Contains(t, configured.Consumes().Required, expectedKey)
+}
+
+func TestReusableTokensFilter(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	endpoints := []scheduling.Endpoint{
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "short"},
+			"10.0.0.1", map[string]string{DefaultContextLengthLabel: "0-50"}),
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "long"},
+			"10.0.0.2", map[string]string{DefaultContextLengthLabel: "51-100"}),
+	}
+
+	t.Run("disabled configuration keeps total length", func(t *testing.T) {
+		plugin := NewContextLengthAware("default", &contextLengthAwareParameters{
+			Label:           DefaultContextLengthLabel,
+			EnableFiltering: true,
+		})
+		request := createHundredTokenRequest()
+		request.PutAttribute(
+			p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(testReusableTokensProducerName),
+			p2psource.ReusablePrefixTokens(60),
+		)
+
+		filtered := plugin.Filter(ctx, request, endpoints)
+		require.Len(t, filtered, 1)
+		assert.Equal(t, "long", filtered[0].GetMetadata().ID.Name)
+	})
+
+	t.Run("configured producer subtracts reusable tokens", func(t *testing.T) {
+		producerName := testReusableTokensProducerName
+		plugin := NewContextLengthAware("cache-aware", &contextLengthAwareParameters{
+			Label:                      DefaultContextLengthLabel,
+			EnableFiltering:            true,
+			ReusableTokensProducerName: producerName,
+		})
+		request := createHundredTokenRequest()
+		request.PutAttribute(
+			p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName),
+			p2psource.ReusablePrefixTokens(60),
+		)
+
+		filtered := plugin.Filter(ctx, request, endpoints)
+		require.Len(t, filtered, 1)
+		assert.Equal(t, "short", filtered[0].GetMetadata().ID.Name)
+	})
+
+	t.Run("missing runtime attribute keeps total length", func(t *testing.T) {
+		plugin := NewContextLengthAware("cache-aware", &contextLengthAwareParameters{
+			Label:                      DefaultContextLengthLabel,
+			EnableFiltering:            true,
+			ReusableTokensProducerName: testReusableTokensProducerName,
+		})
+
+		filtered := plugin.Filter(ctx, createHundredTokenRequest(), endpoints)
+		require.Len(t, filtered, 1)
+		assert.Equal(t, "long", filtered[0].GetMetadata().ID.Name)
+	})
+
+	t.Run("wrong runtime attribute type keeps total length", func(t *testing.T) {
+		producerName := testReusableTokensProducerName
+		plugin := NewContextLengthAware("cache-aware", &contextLengthAwareParameters{
+			Label:                      DefaultContextLengthLabel,
+			EnableFiltering:            true,
+			ReusableTokensProducerName: producerName,
+		})
+		request := createHundredTokenRequest()
+		request.PutAttribute(
+			p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName),
+			"invalid",
+		)
+
+		filtered := plugin.Filter(ctx, request, endpoints)
+		require.Len(t, filtered, 1)
+		assert.Equal(t, "long", filtered[0].GetMetadata().ID.Name)
+	})
+
+	t.Run("reusable tokens are clamped to total length", func(t *testing.T) {
+		producerName := testReusableTokensProducerName
+		plugin := NewContextLengthAware("cache-aware", &contextLengthAwareParameters{
+			Label:                      DefaultContextLengthLabel,
+			EnableFiltering:            true,
+			ReusableTokensProducerName: producerName,
+		})
+		request := createHundredTokenRequest()
+		request.PutAttribute(
+			p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName),
+			p2psource.ReusablePrefixTokens(120),
+		)
+
+		filtered := plugin.Filter(ctx, request, endpoints)
+		require.Len(t, filtered, 1)
+		assert.Equal(t, "short", filtered[0].GetMetadata().ID.Name)
+	})
+}
+
+func TestReusableTokensScore(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	endpoints := []scheduling.Endpoint{
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "short"},
+			"10.0.0.1", map[string]string{DefaultContextLengthLabel: "0-50"}),
+		createEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "long"},
+			"10.0.0.2", map[string]string{DefaultContextLengthLabel: "51-100"}),
+	}
+	producerName := testReusableTokensProducerName
+	plugin := NewContextLengthAware("cache-aware", &contextLengthAwareParameters{
+		Label:                      DefaultContextLengthLabel,
+		ReusableTokensProducerName: producerName,
+	})
+	request := createHundredTokenRequest()
+	request.PutAttribute(
+		p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(producerName),
+		p2psource.ReusablePrefixTokens(60),
+	)
+
+	scores := plugin.Score(ctx, request, endpoints)
+	assert.Greater(t, scores[endpoints[0]], scores[endpoints[1]])
 }
 
 func TestContextLengthAwareFilter(t *testing.T) {

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/p2p_migration_lifecycle_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/p2p_migration_lifecycle_test.go
@@ -50,7 +50,7 @@ func TestP2PReusablePrefixDependency(t *testing.T) {
 		Label:                      migrationWorkRangeLabel,
 		ReusableTokensProducerName: migrationP2PProducer,
 	})
-	key := p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(migrationP2PProducer)
+	key := attrprefix.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(migrationP2PProducer)
 
 	produced, producesKey := p2p.Produces()[key]
 	consumed, consumesKey := workRouter.Consumes().Required[key]
@@ -77,7 +77,7 @@ func TestP2PReusablePrefixRoutesFollowUpToShortPrefiller(t *testing.T) {
 		EnableFiltering:            true,
 		ReusableTokensProducerName: migrationP2PProducer,
 	})
-	reusableTokensKey := p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(migrationP2PProducer)
+	reusableTokensKey := attrprefix.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(migrationP2PProducer)
 
 	// A cold 100K-token request has no transferable source, so its full prompt
 	// is prefill work and only the long-prefill worker matches.
@@ -88,7 +88,7 @@ func TestP2PReusablePrefixRoutesFollowUpToShortPrefiller(t *testing.T) {
 	coldRequest := migrationTokenizedRequest("cold-100k", migrationInitialTokens)
 
 	require.NoError(t, p2p.Produce(ctx, coldRequest, []scheduling.Endpoint{coldLong, coldShort}))
-	_, hasReusableTokens := scheduling.ReadRequestAttribute[p2psource.ReusablePrefixTokens](coldRequest, reusableTokensKey)
+	_, hasReusableTokens := scheduling.ReadRequestAttribute[attrprefix.ReusablePrefixTokens](coldRequest, reusableTokensKey)
 	assert.False(t, hasReusableTokens)
 	coldCandidates := workRouter.Filter(ctx, coldRequest, []scheduling.Endpoint{coldLong, coldShort})
 	require.Len(t, coldCandidates, 1)
@@ -106,9 +106,9 @@ func TestP2PReusablePrefixRoutesFollowUpToShortPrefiller(t *testing.T) {
 	followUpRequest := migrationTokenizedRequest("follow-up-101k", migrationFollowUpTokens)
 
 	require.NoError(t, p2p.Produce(ctx, followUpRequest, []scheduling.Endpoint{warmLong, warmShort}))
-	reusableTokens, ok := scheduling.ReadRequestAttribute[p2psource.ReusablePrefixTokens](followUpRequest, reusableTokensKey)
+	reusableTokens, ok := scheduling.ReadRequestAttribute[attrprefix.ReusablePrefixTokens](followUpRequest, reusableTokensKey)
 	require.True(t, ok)
-	assert.Equal(t, p2psource.ReusablePrefixTokens(migrationInitialTokens), reusableTokens)
+	assert.Equal(t, attrprefix.ReusablePrefixTokens(migrationInitialTokens), reusableTokens)
 	warmCandidates := workRouter.Filter(ctx, followUpRequest, []scheduling.Endpoint{warmLong, warmShort})
 	require.Len(t, warmCandidates, 1)
 	assert.Equal(t, "p-short", warmCandidates[0].GetMetadata().ID.Name)
@@ -131,6 +131,7 @@ func migrationPrefiller(
 	endpoint.Put(prefixDataKey,
 		attrprefix.NewPrefixCacheMatchInfo(cachedBlocks, totalBlocks, migrationBlockSize).
 			WithCachedBlockCount(cachedBlocks).
+			WithConfirmedCachedBlockCount(cachedBlocks).
 			WithCachedBlocksByTier(map[string]int{"cpu": cachedBlocks}))
 	return endpoint
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/p2p_migration_lifecycle_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/p2p_migration_lifecycle_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contextlengthaware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/llm-d/llm-d-router/pkg/common/routing"
+	concretedatalayer "github.com/llm-d/llm-d-router/pkg/epp/datalayer"
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource"
+)
+
+const (
+	migrationBlockSize         = 64
+	migrationInitialTokens     = 102400
+	migrationFollowUpTokens    = 103424
+	migrationWorkRangeLabel    = "llm-d.ai/prefill-work-range"
+	migrationPrefixProducer    = "precise-prefix"
+	migrationP2PProducer       = "session-migration-p2p"
+	migrationLongSourceAddress = "10.0.0.10"
+)
+
+func TestP2PReusablePrefixDependency(t *testing.T) {
+	p2p := p2psource.New(migrationP2PProducer, p2psource.Config{MinCachedTokenDelta: 1})
+	workRouter := NewContextLengthAware("prefill-work-router", &contextLengthAwareParameters{
+		Label:                      migrationWorkRangeLabel,
+		ReusableTokensProducerName: migrationP2PProducer,
+	})
+	key := p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(migrationP2PProducer)
+
+	produced, producesKey := p2p.Produces()[key]
+	consumed, consumesKey := workRouter.Consumes().Required[key]
+	require.True(t, producesKey)
+	require.True(t, consumesKey)
+	assert.IsType(t, produced, consumed)
+
+	ordered, err := concretedatalayer.ValidateAndOrderDataDependencies([]fwkplugin.Plugin{workRouter, p2p})
+	require.NoError(t, err)
+	assert.Less(t, pluginOrder(ordered, p2p.TypedName().String()),
+		pluginOrder(ordered, workRouter.TypedName().String()))
+}
+
+func TestP2PReusablePrefixRoutesFollowUpToShortPrefiller(t *testing.T) {
+	ctx := context.Background()
+	prefixDataKey := attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(migrationPrefixProducer)
+	p2p := p2psource.New(migrationP2PProducer, p2psource.Config{
+		PrefixMatchInfoProducerName: migrationPrefixProducer,
+		MinCachedTokenDelta:         1,
+		PrefillProfileName:          "prefill",
+	})
+	workRouter := NewContextLengthAware("prefill-work-router", &contextLengthAwareParameters{
+		Label:                      migrationWorkRangeLabel,
+		EnableFiltering:            true,
+		ReusableTokensProducerName: migrationP2PProducer,
+	})
+	reusableTokensKey := p2psource.ReusablePrefixTokensDataKey.WithNonEmptyProducerName(migrationP2PProducer)
+
+	// A cold 100K-token request has no transferable source, so its full prompt
+	// is prefill work and only the long-prefill worker matches.
+	coldLong := migrationPrefiller("p-long", migrationLongSourceAddress, "8193-131072",
+		prefixDataKey, 0, migrationInitialTokens/migrationBlockSize)
+	coldShort := migrationPrefiller("p-short", "10.0.0.20", "0-8192",
+		prefixDataKey, 0, migrationInitialTokens/migrationBlockSize)
+	coldRequest := migrationTokenizedRequest("cold-100k", migrationInitialTokens)
+
+	require.NoError(t, p2p.Produce(ctx, coldRequest, []scheduling.Endpoint{coldLong, coldShort}))
+	_, hasReusableTokens := scheduling.ReadRequestAttribute[p2psource.ReusablePrefixTokens](coldRequest, reusableTokensKey)
+	assert.False(t, hasReusableTokens)
+	coldCandidates := workRouter.Filter(ctx, coldRequest, []scheduling.Endpoint{coldLong, coldShort})
+	require.Len(t, coldCandidates, 1)
+	assert.Equal(t, "p-long", coldCandidates[0].GetMetadata().ID.Name)
+	require.NoError(t, p2p.PreRequest(ctx, coldRequest, migrationPrefillResult(coldCandidates[0])))
+	assert.NotContains(t, coldRequest.Headers, routing.KVCacheSourceHeader)
+
+	// The next turn has 102400 CPU-tier tokens on P-long and 1024 new tokens.
+	// Produce publishes that request-wide reusable floor before filtering, so
+	// the work-range filter selects P-short and PreRequest points it at P-long.
+	warmLong := migrationPrefiller("p-long", migrationLongSourceAddress, "8193-131072",
+		prefixDataKey, migrationInitialTokens/migrationBlockSize, migrationFollowUpTokens/migrationBlockSize)
+	warmShort := migrationPrefiller("p-short", "10.0.0.20", "0-8192",
+		prefixDataKey, 0, migrationFollowUpTokens/migrationBlockSize)
+	followUpRequest := migrationTokenizedRequest("follow-up-101k", migrationFollowUpTokens)
+
+	require.NoError(t, p2p.Produce(ctx, followUpRequest, []scheduling.Endpoint{warmLong, warmShort}))
+	reusableTokens, ok := scheduling.ReadRequestAttribute[p2psource.ReusablePrefixTokens](followUpRequest, reusableTokensKey)
+	require.True(t, ok)
+	assert.Equal(t, p2psource.ReusablePrefixTokens(migrationInitialTokens), reusableTokens)
+	warmCandidates := workRouter.Filter(ctx, followUpRequest, []scheduling.Endpoint{warmLong, warmShort})
+	require.Len(t, warmCandidates, 1)
+	assert.Equal(t, "p-short", warmCandidates[0].GetMetadata().ID.Name)
+	require.NoError(t, p2p.PreRequest(ctx, followUpRequest, migrationPrefillResult(warmCandidates[0])))
+	assert.Equal(t, migrationLongSourceAddress+":8080", followUpRequest.Headers[routing.KVCacheSourceHeader])
+}
+
+func migrationPrefiller(
+	name, address, workRange string,
+	prefixDataKey fwkplugin.DataKey,
+	cachedBlocks, totalBlocks int,
+) scheduling.Endpoint {
+	endpoint := scheduling.NewEndpoint(&fwkdl.EndpointMetadata{
+		ID:      k8stypes.NamespacedName{Namespace: "default", Name: name},
+		Name:    name,
+		Address: address,
+		Port:    "8080",
+		Labels:  map[string]string{migrationWorkRangeLabel: workRange},
+	}, nil, nil)
+	endpoint.Put(prefixDataKey,
+		attrprefix.NewPrefixCacheMatchInfo(cachedBlocks, totalBlocks, migrationBlockSize).
+			WithCachedBlockCount(cachedBlocks).
+			WithCachedBlocksByTier(map[string]int{"cpu": cachedBlocks}))
+	return endpoint
+}
+
+func migrationTokenizedRequest(requestID string, tokenCount int) *scheduling.InferenceRequest {
+	return &scheduling.InferenceRequest{
+		RequestID: requestID,
+		Headers:   map[string]string{},
+		Body: &fwkrh.InferenceRequestBody{
+			TokenizedRequest: &fwkrh.TokenizedRequest{
+				Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, tokenCount)}},
+			},
+		},
+	}
+}
+
+func migrationPrefillResult(endpoint scheduling.Endpoint) *scheduling.SchedulingResult {
+	return &scheduling.SchedulingResult{
+		PrimaryProfileName: "decode",
+		ProfileResults: map[string]*scheduling.ProfileRunResult{
+			"prefill": {TargetEndpoints: []scheduling.Endpoint{endpoint}},
+		},
+	}
+}
+
+func pluginOrder(plugins []string, name string) int {
+	for i, pluginName := range plugins {
+		if pluginName == name {
+			return i
+		}
+	}
+	return len(plugins)
+}

--- a/pkg/epp/requestcontrol/plugin_executor.go
+++ b/pkg/epp/requestcontrol/plugin_executor.go
@@ -66,6 +66,10 @@ func producerTimeout(p fwkrc.DataProducer) time.Duration {
 // (e.g. abort outbound HTTP calls) and avoid committing state after the director has moved on.
 func dataProducerPluginsWithTimeout(ctx context.Context, timeout time.Duration, plugins []fwkrc.DataProducer,
 	request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+	// The timeout path does not join the producer goroutine. Allocate the
+	// sync.Map before launching it so any cancellation-aware producer finishing
+	// a write cannot race with scheduling over lazy store initialization.
+	request.InitializeAttributeStore()
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 

--- a/pkg/epp/requestcontrol/plugin_executor_test.go
+++ b/pkg/epp/requestcontrol/plugin_executor_test.go
@@ -93,6 +93,31 @@ func (p *ctxObservingPlugin) Produce(ctx context.Context, _ *fwksched.InferenceR
 
 func (p *ctxObservingPlugin) Produces() map[fwkplugin.DataKey]any { return nil }
 
+// lateAttributePlugin ignores cancellation and writes after the timeout path
+// has returned, modeling a producer that does not stop promptly on ctx.Done().
+type lateAttributePlugin struct {
+	key     fwkplugin.DataKey
+	started chan struct{}
+	release chan struct{}
+	done    chan struct{}
+}
+
+func (p *lateAttributePlugin) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "mock", Name: "late-attribute"}
+}
+
+func (p *lateAttributePlugin) Produce(_ context.Context, request *fwksched.InferenceRequest, _ []fwksched.Endpoint) error {
+	close(p.started)
+	<-p.release
+	request.PutAttribute(p.key, 1)
+	close(p.done)
+	return nil
+}
+
+func (p *lateAttributePlugin) Produces() map[fwkplugin.DataKey]any {
+	return map[fwkplugin.DataKey]any{p.key: 0}
+}
+
 // TestDataProducerPluginsWithTimeout_CancelsPluginContext verifies that the
 // child context passed to plugins is cancelled with DeadlineExceeded when the
 // timeout fires. Without this cancellation, a slow plugin would continue
@@ -118,6 +143,47 @@ func TestDataProducerPluginsWithTimeout_CancelsPluginContext(t *testing.T) {
 	plugin.wg.Wait()
 	assert.ErrorIs(t, plugin.observedCtxErr, context.DeadlineExceeded,
 		"plugin's context should be cancelled with DeadlineExceeded when timeout fires")
+}
+
+func TestDataProducerPluginsWithTimeout_LateAttributeWriteIsSafe(t *testing.T) {
+	request := &fwksched.InferenceRequest{}
+	plugin := &lateAttributePlugin{
+		key:     fwkplugin.NewDataKey("late", "mock"),
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+
+	err := dataProducerPluginsWithTimeout(
+		context.Background(),
+		20*time.Millisecond,
+		[]fwkrc.DataProducer{plugin},
+		request,
+		nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DataProducer execution timed out")
+	<-plugin.started
+
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		for {
+			select {
+			case <-plugin.done:
+				return
+			default:
+				_, _ = request.GetAttribute(plugin.key)
+			}
+		}
+	}()
+	close(plugin.release)
+	<-plugin.done
+	<-readerDone
+
+	value, ok := fwksched.ReadRequestAttribute[int](request, plugin.key)
+	require.True(t, ok)
+	assert.Equal(t, 1, value)
 }
 
 func TestDataProducerPluginsWithTimeout(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Routes long-context follow-ups by their remaining prefill work instead of
their total context length, so a cached follow-up moves to a short-work
prefiller and pulls its prefix over the P2P tier instead of queueing behind
cold long prefills.

Mechanism: `p2p-source-producer.Produce` publishes a name-bound
`ReusablePrefixTokens` request attribute - a floor `G = S - D + 1` on the
tokens every valid destination can reuse either locally or by pulling from
the sampled source (`S` = the source's confirmed CPU-tier prefix, `D` =
`minCachedTokenDelta`). `context-length-aware` gains an opt-in
`reusableTokensProducerName` parameter and routes on
`max(1, totalTokens - G)` against a dedicated work-range label. The P2P
source header name and `host:port` value format are unchanged. Its emission
gate now ignores speculative cache entries on the computing endpoint, so
unconfirmed blocks cannot suppress a required pull. This gate correction
applies whenever `p2p-source-producer` uses tier-aware cache data,
independently of `reusableTokensProducerName`. The remaining-work scheduling
behavior is opt-in: without `reusableTokensProducerName`,
`context-length-aware` behaves exactly as before.

Soundness of the floor against the header gate:

- The computing-side cached count excludes speculative index entries
  (`ConfirmedCachedBlockCount` on `PrefixCacheMatchInfo`, populated by the
  precise producer), so a phantom speculative overlap cannot suppress the
  pull after the floor routed the request.
- The floor publishes only from sources with per-tier data; tier-less
  producers keep their header behavior but never publish a floor.
- Routing length is clamped to a minimum of 1 so work-range labels with a
  nonzero minimum cannot empty the candidate pool.
- The factory rejects `reusableTokensProducerName` combined with the default
  context-length label, which describes logical capacity, not prefill work.

Also included, delineated for review: the request attribute store is
eagerly initialized before producer goroutines launch
(`InitializeAttributeStore` in `pkg/epp/framework/interface/scheduling`,
called from the producer executor), removing a lazy-init data race with a
timeout-abandoned producer writing concurrently with scheduling reads; and
`getContextLength` memoizes its routing length per request so Filter and
Score cannot disagree if a floor lands mid-cycle. Both carry regression
tests (the race test fails under `-race` without the fix).

Validated on two clusters; full data, figures, exact manifests, and a
deploy guide:
https://github.com/nilig/llm-d/blob/findings/p2p-context-migration-glm-c64/findings/p2p-context-migration-glm/RESULTS.md

- Llama-3.1-8B (single-GPU workers): exact mechanism counters end to end;
  under a real capacity queue, follow-up TTFT 23.1s -> 3.0s; idle parity
  when migration is gated by the existing `prefix-cache-affinity-filter`
  (config-only composition, no new policy code).
- GLM-5.2-FP8 (three DP8 H200 engines, AgentX agentic traces, C64,
  counterbalanced ABBA blocks): cached-follow-up TTFT p50 -53%, fleet p90
  -31%, +7% turns completed. With `--long-prefill-token-threshold` live on
  all prefill workers as a stronger baseline, the engine mitigation recovers
  ~8% and remaining-work routing adds -33% on top - the measured queueing is
  KV-capacity-bound, so the mechanisms compose.

**Which issue(s) this PR fixes**:

Fixes #2540

**Test plan**:

- [x] Unit tests for the floor publication (per-tier gating, delta
  arithmetic, no-source absence, instance-name key binding) and for the
  scorer's subtraction (filter and score modes, missing/wrong-typed
  attribute fallback, clamping, factory validation)
- [x] Lifecycle test: cold request stays on the long-work class, cached
  follow-up routes to the short-work class and the source header points at
  the holder
- [x] Regression tests: speculative-only destination still receives the
  header; cancelled producer context stores no attributes; late attribute
  write is race-free under `-race`; routing-length snapshot ignores a
  late-arriving floor
- [x] `go test -race` on all touched packages; `make presubmit` and the full
  unit suite green at the branch tip and at the merge point with current
  `main`
- [x] End-to-end on two clusters (counters exact to the token; see the
  results link above)

**Release note**:
```release-note
The `context-length-aware` scorer can route requests by remaining prefill
work: the new optional `reusableTokensProducerName` parameter subtracts the
P2P-transferable prefix published by a named `p2p-source-producer`, so
cached long-context follow-ups can be routed to short-work prefill workers
and pull their prefix over the P2P tier.

The `p2p-source-producer` header gate now considers only confirmed
destination cache blocks when tier data is available. With speculative
indexing enabled, unconfirmed blocks no longer suppress a required P2P pull.
```
