### PR TITLE
pdd: Allow PD decider to select cache producer

### DIFF
--- a/docs/disaggregation.md
+++ b/docs/disaggregation.md
@@ -423,6 +423,7 @@ Both roles read the same `nonCachedTokens` / `promptTokens` parameters. Declarin
 
 - `nonCachedTokens`: Non-cached suffix length in tokens at which the plugin's gate fires — triggering disaggregation for normal requests, or returning HTTP 412 Precondition Failed for `Prefer: if-available` requests. `0` disables both.
 - `promptTokens`: Minimum prompt length in tokens before the plugin's routing and gating logic applies. Prompts shorter than this run locally on the decode worker without remote prefill; the 412 gate honors the same shortcut. `0` disables it.
+- `prefixMatchInfoProducerName`: Name of the prefix-cache producer whose cache state the decider reads for both the disaggregation decision and the conditional-decode 412 gate. If unspecified, the `approx-prefix-cache-producer` is used.
 
 **Conditional-decode 412 gate**
 

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/README.md
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/README.md
@@ -40,7 +40,7 @@ The handler is invoked repeatedly by the framework until all stages are complete
 
 #### Inputs consumed
 
-- `PrefixCacheMatchInfo` — endpoint attribute from `approx-prefix-cache-producer`, read by the configured prefill decider (e.g. `prefix-based-pd-decider`) when deciding whether to run the prefill stage.
+- `PrefixCacheMatchInfo` — endpoint attribute read by the configured prefill decider (e.g. `prefix-based-pd-decider`) when deciding whether to run the prefill stage. The decider selects which prefix producer it reads, and the handler declares that same key as its data-layer dependency.
 
 #### Configuration
 
@@ -175,11 +175,11 @@ Compares the uncached portion of the request prompt against a configurable thres
 
 #### How It Works
 
-The prompt token count is `request.Body.TokenizedPrompt.TokenCount()`, populated by a `token-producer` — auto-created with the tokenizer-free `estimate` backend when none is configured. `promptTokens` gates on this count directly: prompts shorter than it never disaggregate, regardless of cache state. Prefix cache state is read from the `PrefixCacheMatchInfo` attribute on the decode endpoint, populated by `approx-prefix-cache-producer`. If the attribute is absent or malformed, disaggregation is skipped. Setting `nonCachedTokens: 0` disables the decider entirely (always returns false).
+The prompt token count is `request.Body.TokenizedPrompt.TokenCount()`, populated by a `token-producer` — auto-created with the tokenizer-free `estimate` backend when none is configured. `promptTokens` gates on this count directly: prompts shorter than it never disaggregate, regardless of cache state. Prefix cache state is read from the `PrefixCacheMatchInfo` attribute on the decode endpoint, from the prefix producer selected by `prefixMatchInfoProducerName` (the approximate-prefix producer by default). If the attribute is absent or malformed, disaggregation is skipped. Setting `nonCachedTokens: 0` disables the decider entirely (always returns false).
 
 #### Inputs consumed
 
-- `PrefixCacheMatchInfo` — endpoint attribute from `approx-prefix-cache-producer`, read from the decode endpoint.
+- `PrefixCacheMatchInfo` — endpoint attribute from the prefix producer named by `prefixMatchInfoProducerName` (approximate by default), read from the decode endpoint.
 - `request.Body.TokenizedPrompt` — token data from a `token-producer` plugin; `TokenCount()` is the prompt token count.
 
 #### Configuration
@@ -189,14 +189,17 @@ The prompt token count is `request.Body.TokenizedPrompt.TokenCount()`, populated
 |------|------|----------|---------|-------------|
 | `nonCachedTokens` | `int` | No | `0` | Uncached token threshold above which P/D disaggregation is triggered. `0` disables the decider. |
 | `promptTokens` | `int` | No | `0` | Minimum prompt token count required before disaggregation is considered. Prompts shorter than this never disaggregate. `0` disables this gate. |
+| `prefixMatchInfoProducerName` | `string` | No | `approx-prefix-cache-producer` | Prefix-cache producer instance whose `PrefixCacheMatchInfo` the decider reads. A named producer other than the default must be present in the configuration. |
 
 ##### Example
 ```yaml
 plugins:
+  - type: precise-prefix-cache-producer
   - type: prefix-based-pd-decider
     parameters:
       nonCachedTokens: 512
       promptTokens: 1024
+      prefixMatchInfoProducerName: precise-prefix-cache-producer
   - type: disagg-profile-handler
     parameters:
       deciders:

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/decider_plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/decider_plugin.go
@@ -13,3 +13,10 @@ type deciderPlugin interface {
 	plugin.Plugin
 	disaggregate(ctx context.Context, request *scheduling.InferenceRequest, endpoint scheduling.Endpoint) bool
 }
+
+// prefixMatchInfoConsumer is implemented by deciders that read PrefixCacheMatchInfo
+// from endpoint attributes. The profile handler declares the decider's key in its own
+// Consumes() so the data layer wires the producer the decider reads.
+type prefixMatchInfoConsumer interface {
+	prefixMatchInfoDataKey() plugin.DataKey
+}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -241,11 +241,17 @@ func (h *Handler) WithStageOrder(stageOrder StageOrder) *Handler {
 }
 
 // Consumes defines data types consumed by this plugin (through the PD decider).
-func (*Handler) Consumes() plugin.DataDependencies {
+func (h *Handler) Consumes() plugin.DataDependencies {
+	prefixMatchInfoDK := attrprefix.PrefixCacheMatchInfoDataKey
+	if h.pdDecider != nil {
+		if consumer, ok := h.pdDecider.(prefixMatchInfoConsumer); ok {
+			prefixMatchInfoDK = consumer.prefixMatchInfoDataKey()
+		}
+	}
 	return plugin.DataDependencies{
 		Required: map[plugin.DataKey]any{
-			attrprefix.PrefixCacheMatchInfoDataKey: attrprefix.PrefixCacheMatchInfo{},
-			tokenproducer.TokenizedPromptDataKey:   scheduling.TokenizedRequest{},
+			prefixMatchInfoDK:                    attrprefix.PrefixCacheMatchInfo{},
+			tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedRequest{},
 		},
 	}
 }

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/llm-d/llm-d-router/pkg/common/routing"
@@ -17,6 +18,7 @@ import (
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/test/utils"
 )
 
@@ -280,6 +282,62 @@ func TestHandlerFactory(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, p)
+			}
+		})
+	}
+}
+
+func TestHandler_Consumes_PrefixMatchInfoProducerName(t *testing.T) {
+	const preciseName = "precise-prefix-cache-producer"
+
+	prefixDecider := func(t *testing.T, producerName string) deciderPlugin {
+		t.Helper()
+		decider, err := NewPrefixBasedPDDecider(PrefixBasedPDDeciderConfig{
+			NonCachedTokens:             4,
+			PrefixMatchInfoProducerName: producerName,
+		})
+		require.NoError(t, err)
+		return decider
+	}
+
+	tests := []struct {
+		name        string
+		pdDecider   func(t *testing.T) deciderPlugin
+		expectedKey plugin.DataKey
+	}{
+		{
+			name:        "nil pd decider",
+			pdDecider:   func(*testing.T) deciderPlugin { return nil },
+			expectedKey: attrprefix.PrefixCacheMatchInfoDataKey,
+		},
+		{
+			name:        "decider that does not select a prefix producer",
+			pdDecider:   func(*testing.T) deciderPlugin { return newAlwaysDisaggPDDecider() },
+			expectedKey: attrprefix.PrefixCacheMatchInfoDataKey,
+		},
+		{
+			name:        "empty prefixMatchInfoProducerName",
+			pdDecider:   func(t *testing.T) deciderPlugin { return prefixDecider(t, "") },
+			expectedKey: attrprefix.PrefixCacheMatchInfoDataKey,
+		},
+		{
+			name:        "named prefixMatchInfoProducerName",
+			pdDecider:   func(t *testing.T) deciderPlugin { return prefixDecider(t, preciseName) },
+			expectedKey: attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(preciseName),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewDisaggProfileHandler(
+				defaultDecodeProfile, defaultPrefillProfile, defaultEncodeProfile,
+				tt.pdDecider(t), nil,
+			)
+
+			consumed := handler.Consumes()
+			assert.Contains(t, consumed.Required, tt.expectedKey)
+			assert.Contains(t, consumed.Required, tokenproducer.TokenizedPromptDataKey)
+			if tt.expectedKey != attrprefix.PrefixCacheMatchInfoDataKey {
+				assert.NotContains(t, consumed.Required, attrprefix.PrefixCacheMatchInfoDataKey)
 			}
 		})
 	}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider.go
@@ -32,6 +32,11 @@ type PrefixBasedPDDeciderConfig struct {
 	// as character-count / AverageCharactersPerToken) required before applying
 	// prefix-cache-based disaggregation logic. Zero disables this prompt-length gate.
 	PromptTokens int `json:"promptTokens"`
+
+	// PrefixMatchInfoProducerName selects which prefix-cache producer's
+	// PrefixCacheMatchInfo to read on the decode endpoint. Empty defaults to the
+	// approximate-prefix producer.
+	PrefixMatchInfoProducerName string `json:"prefixMatchInfoProducerName,omitempty"`
 }
 
 func (p PrefixBasedPDDeciderConfig) validate() error {
@@ -48,9 +53,10 @@ func (p PrefixBasedPDDeciderConfig) validate() error {
 
 // compile-time type assertions
 var (
-	_ deciderPlugin         = &PrefixBasedPDDecider{}
-	_ fwkrc.PreRequest      = &PrefixBasedPDDecider{}
-	_ plugin.ConsumerPlugin = &PrefixBasedPDDecider{}
+	_ deciderPlugin           = &PrefixBasedPDDecider{}
+	_ fwkrc.PreRequest        = &PrefixBasedPDDecider{}
+	_ plugin.ConsumerPlugin   = &PrefixBasedPDDecider{}
+	_ prefixMatchInfoConsumer = &PrefixBasedPDDecider{}
 )
 
 // errCondDecodeCacheMiss is the 412 returned by the conditional-decode gate
@@ -72,8 +78,9 @@ type remotePrefillDecision struct {
 
 // PrefixBasedPDDecider is a PD decider plugin which decision is based prefix aware
 type PrefixBasedPDDecider struct {
-	typedName plugin.TypedName
-	config    PrefixBasedPDDeciderConfig
+	typedName         plugin.TypedName
+	config            PrefixBasedPDDeciderConfig
+	prefixMatchInfoDK plugin.DataKey
 }
 
 // PrefixBasedPDDeciderPluginFactory defines the factory function for creating
@@ -113,7 +120,14 @@ func NewPrefixBasedPDDecider(config PrefixBasedPDDeciderConfig) (*PrefixBasedPDD
 	return &PrefixBasedPDDecider{
 		typedName: plugin.TypedName{Type: PrefixBasedPDDeciderPluginType},
 		config:    config,
+		prefixMatchInfoDK: attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(
+			config.PrefixMatchInfoProducerName,
+		),
 	}, nil
+}
+
+func (d *PrefixBasedPDDecider) prefixMatchInfoDataKey() plugin.DataKey {
+	return d.prefixMatchInfoDK
 }
 
 // TypedName returns the typed name of the plugin.
@@ -135,8 +149,8 @@ func (d *PrefixBasedPDDecider) WithName(name string) *PrefixBasedPDDecider {
 func (d *PrefixBasedPDDecider) Consumes() plugin.DataDependencies {
 	return plugin.DataDependencies{
 		Required: map[plugin.DataKey]any{
-			attrprefix.PrefixCacheMatchInfoDataKey: attrprefix.PrefixCacheMatchInfo{},
-			tokenproducer.TokenizedPromptDataKey:   scheduling.TokenizedRequest{},
+			d.prefixMatchInfoDK:                  attrprefix.PrefixCacheMatchInfo{},
+			tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedRequest{},
 		},
 	}
 }
@@ -255,13 +269,14 @@ func (d *PrefixBasedPDDecider) computeNeedsRemotePrefill(ctx context.Context, re
 			"inputTokens", inputTokens, "threshold", d.config.NonCachedTokens)
 		return false, nil
 	}
-	prefixInfoRaw, ok := endpoint.Get(attrprefix.PrefixCacheMatchInfoDataKey)
+	prefixInfoRaw, ok := endpoint.Get(d.prefixMatchInfoDK)
 	if !ok || prefixInfoRaw == nil {
-		return false, errors.New("unable to read prefix cache state")
+		return false, fmt.Errorf("unable to read prefix cache state for %s", d.prefixMatchInfoDK)
 	}
 	info, ok := prefixInfoRaw.(*attrprefix.PrefixCacheMatchInfo)
 	if !ok {
-		return false, fmt.Errorf("prefix cache match info has unexpected type: %T", prefixInfoRaw)
+		return false, fmt.Errorf("prefix cache match info from %s has unexpected type: %T",
+			d.prefixMatchInfoDK, prefixInfoRaw)
 	}
 	hitPrefixTokens := info.CachedBlockCount() * info.BlockSizeTokens()
 	nonCachedTokens := inputTokens - hitPrefixTokens

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
@@ -16,6 +16,7 @@ import (
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/test/utils"
 )
 
@@ -222,12 +223,13 @@ func TestPrefixBasedPDDeciderConfigValidation(t *testing.T) {
 
 func TestPrefixBasedPDDeciderFactory(t *testing.T) {
 	tests := []struct {
-		name             string
-		pluginName       string
-		rawParams        string
-		expectErr        bool
-		expectNonCached  int
-		expectPluginName string
+		name               string
+		pluginName         string
+		rawParams          string
+		expectErr          bool
+		expectNonCached    int
+		expectPluginName   string
+		expectProducerName string
 	}{
 		{
 			name:             "default parameters (nil)",
@@ -244,6 +246,15 @@ func TestPrefixBasedPDDeciderFactory(t *testing.T) {
 			expectErr:        false,
 			expectNonCached:  50,
 			expectPluginName: "custom-decider",
+		},
+		{
+			name:               "custom prefixMatchInfoProducerName",
+			pluginName:         "precise-decider",
+			rawParams:          `{"nonCachedTokens": 50, "prefixMatchInfoProducerName": "precise-prefix-cache-producer"}`,
+			expectErr:          false,
+			expectNonCached:    50,
+			expectPluginName:   "precise-decider",
+			expectProducerName: "precise-prefix-cache-producer",
 		},
 		{
 			name:       "negative nonCachedTokens",
@@ -280,6 +291,46 @@ func TestPrefixBasedPDDeciderFactory(t *testing.T) {
 			require.True(t, ok)
 			assert.Equal(t, tt.expectPluginName, decider.TypedName().Name)
 			assert.Equal(t, tt.expectNonCached, decider.config.NonCachedTokens)
+			// An empty expectProducerName resolves to the default approximate-prefix producer.
+			assert.Equal(t,
+				attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(tt.expectProducerName),
+				decider.prefixMatchInfoDataKey())
+		})
+	}
+}
+
+func TestPrefixBasedPDDecider_Consumes(t *testing.T) {
+	const preciseName = "precise-prefix-cache-producer"
+
+	tests := []struct {
+		name        string
+		producer    string
+		expectedKey fwkplugin.DataKey
+	}{
+		{
+			name:        "default producer",
+			expectedKey: attrprefix.PrefixCacheMatchInfoDataKey,
+		},
+		{
+			name:        "named producer",
+			producer:    preciseName,
+			expectedKey: attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(preciseName),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decider, err := NewPrefixBasedPDDecider(PrefixBasedPDDeciderConfig{
+				NonCachedTokens:             4,
+				PrefixMatchInfoProducerName: tt.producer,
+			})
+			require.NoError(t, err)
+
+			consumed := decider.Consumes()
+			assert.Contains(t, consumed.Required, tt.expectedKey)
+			assert.Contains(t, consumed.Required, tokenproducer.TokenizedPromptDataKey)
+			if tt.expectedKey != attrprefix.PrefixCacheMatchInfoDataKey {
+				assert.NotContains(t, consumed.Required, attrprefix.PrefixCacheMatchInfoDataKey)
+			}
 		})
 	}
 }
@@ -474,6 +525,24 @@ func TestDisaggregateWrongPrefixInfoType(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.False(t, decider.disaggregate(ctx, makeRequestWithTokens(100), ep))
+}
+
+func TestDisaggregateWithNamedProducer(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+
+	const preciseName = "precise-prefix-cache-producer"
+	preciseKey := attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(preciseName)
+
+	decider, err := NewPrefixBasedPDDecider(PrefixBasedPDDeciderConfig{
+		NonCachedTokens:             5,
+		PrefixMatchInfoProducerName: preciseName,
+	})
+	require.NoError(t, err)
+
+	ep := makeTestEndpointBase()
+	ep.Put(preciseKey, attrprefix.NewPrefixCacheMatchInfo(2, testTotalTokens, testBlockSize))
+
+	assert.True(t, decider.disaggregate(ctx, makeRequestWithTokens(10), ep))
 }
 
 func TestWithName(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind feature
/kind bug (debatable)

**What this PR does / why we need it**:

Allows different cache producers to be used with the PD decider.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2554

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Allow `prefix-based-pd-decider` to specify `prefixMatchInfoProducerName`
```

