### PR TITLE
feat: parse multipart /v1/images/edits requests in OpenAI parser

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -107,7 +107,8 @@ type InferenceRequestBody struct {
 	// Generate holds pre-tokenized input for native generate endpoints
 	// (vLLM /inference/v1/generate and SGLang /generate).
 	Generate *GenerateRequest `json:"generate,omitempty"`
-	// ImagesGenerationsRequest is the representation of the OpenAI /v1/images/generations request body.
+	// ImagesGenerationsRequest is the representation of the OpenAI /v1/images/generations
+	// or /v1/images/edits request body.
 	Images *ImagesGenerationsRequest `json:"images,omitempty"`
 	// Payload contains the unmarshaled request payload or raw bytes.
 	// If the payload is unmarshaled, we can perform advanced processing (like prefix cache aware routing).
@@ -535,7 +536,7 @@ func (e *EmbeddingsRequest) String() string {
 	return fmt.Sprintf("{InputType: %T}", e.Input)
 }
 
-// ImagesGenerationsRequest represents the OpenAI /v1/images/generations request body
+// ImagesGenerationsRequest represents the OpenAI /v1/images/generations and /v1/images/edits request body
 // structure.
 type ImagesGenerationsRequest struct {
 	// Prompt is the text description of the desired image(s).

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/README.md
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/README.md
@@ -7,7 +7,9 @@ Parses HTTP/H2C requests and responses in the OpenAI API format.
 > [!NOTE]
 > This plugin is enabled by default if no other parser is specified in `EndpointPickerConfig`. You do not need to explicitly declare it in your configuration.
 
-Supports all standard OpenAI-compatible endpoints: completions, chat/completions, conversations, responses, embeddings, and images/generations. The fields parsed out vary by endpoint: the request's input content (prompt, messages, or input), the streaming mode, and token usage from responses that report it.
+Supports all standard OpenAI-compatible endpoints: completions, chat/completions, conversations, responses, embeddings, images/generations, and images/edits. 
+The fields parsed out vary by endpoint: the request's input content (prompt, messages, or input), the streaming mode, and token usage from responses that report it. 
+The images/edits endpoint accepts multipart/form-data.
 
 **Parameters:** None.
 

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -22,6 +22,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
 	"strconv"
 	"strings"
 
@@ -43,6 +46,9 @@ const (
 	embeddingsAPI      = "embeddings"
 	// imagesGenerationsAPI is the OpenAI-compatible image generation endpoint/
 	imagesGenerationsAPI = "images/generations"
+	// imagesEditsAPI is the OpenAI-compatible image edit (image-to-image) endpoint.
+	// Requests are multipart/form-data.
+	imagesEditsAPI = "images/edits"
 
 	streamingRespPrefix = "data: "
 	streamingEndMsg     = "data: [DONE]"
@@ -100,6 +106,7 @@ func (p *OpenAIParser) Claims() fwkrh.Claims {
 			chatCompletionsAPI + "/render",
 			completionsAPI + "/render",
 			imagesGenerationsAPI,
+			imagesEditsAPI,
 		},
 		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
 	}
@@ -116,11 +123,14 @@ func (p *OpenAIParser) WithName(name string) *OpenAIParser {
 
 // ParseRequest parses the request body and headers and returns a map representation.
 func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
+	apiType := determineAPITypeFromPath(request.GetRequestPath(headers))
+	if apiType == imagesEditsAPI {
+		return parseImagesEditsRequest(body, headers)
+	}
 	bodyMap := make(map[string]any)
 	if err := parserutil.Unmarshal(body, &bodyMap); err != nil {
 		return nil, fmt.Errorf("error unmarshaling request bodyMap: %w", err)
 	}
-	apiType := determineAPITypeFromPath(request.GetRequestPath(headers))
 	extractedBody, err := extractRequestBody(apiType, body)
 	if err != nil {
 		return nil, err
@@ -242,6 +252,9 @@ func determineAPITypeFromPath(path string) string {
 	if request.MatchPathSuffix(path, "/images/generations") {
 		return imagesGenerationsAPI
 	}
+	if request.MatchPathSuffix(path, "/images/edits") {
+		return imagesEditsAPI
+	}
 
 	// Default to completions API for backward compatibility with existing clients and integration tests
 	return completionsAPI
@@ -297,6 +310,81 @@ func extractRequestBody(apiType string, rawBody []byte) (*fwkrh.InferenceRequest
 	default:
 		return nil, errors.New("unsupported API endpoint")
 	}
+}
+
+// parseImagesEditsRequest parses a multipart/form-data /v1/images/edits request.
+func parseImagesEditsRequest(body []byte, headers map[string]string) (*fwkrh.ParseResult, error) {
+	mediaType, params, err := mime.ParseMediaType(headerValue(headers, contentType))
+	if err != nil || mediaType != "multipart/form-data" {
+		return nil, errors.New("images edits request must have a multipart/form-data content-type")
+	}
+	boundary := params["boundary"]
+	if boundary == "" {
+		return nil, errors.New("images edits request: content-type is missing the multipart boundary")
+	}
+
+	images := &fwkrh.ImagesGenerationsRequest{}
+	extractedBody := &fwkrh.InferenceRequestBody{
+		Images:  images,
+		Payload: fwkrh.RawPayload(body),
+	}
+	reader := multipart.NewReader(bytes.NewReader(body), boundary)
+	for {
+		part, err := reader.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error reading images edits multipart body: %w", err)
+		}
+		if part.FileName() != "" {
+			continue
+		}
+		value, err := io.ReadAll(part)
+		if err != nil {
+			return nil, fmt.Errorf("error reading images edits form field %q: %w", part.FormName(), err)
+		}
+		switch part.FormName() {
+		case "model":
+			extractedBody.Model = string(value)
+		case "prompt":
+			images.Prompt = string(value)
+		case "size":
+			images.Size = string(value)
+		case "n":
+			n, err := strconv.ParseInt(string(value), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid images edits n field: %w", err)
+			}
+			images.N = &n
+		case "num_inference_steps":
+			steps, err := strconv.ParseInt(string(value), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid images edits num_inference_steps field: %w", err)
+			}
+			images.NumInferenceSteps = &steps
+		case "stream":
+			stream, err := strconv.ParseBool(string(value))
+			if err != nil {
+				return nil, fmt.Errorf("invalid images edits stream field: %w", err)
+			}
+			extractedBody.Stream = stream
+		}
+	}
+	if images.Prompt == "" {
+		return nil, errors.New("invalid images edits request: must have prompt field")
+	}
+	return &fwkrh.ParseResult{Body: extractedBody, SkipResponseProcessing: false}, nil
+}
+
+// headerValue returns the value of the named header, matching case-insensitively.
+func headerValue(headers map[string]string, name string) string {
+	for k, v := range headers {
+		if strings.EqualFold(k, name) {
+			return v
+		}
+	}
+	return ""
 }
 
 func validateChatCompletionsMessages(messages []fwkrh.Message) error {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package openai
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"mime/multipart"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -1065,6 +1067,139 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 	}
 }
 
+// buildMultipartBody builds a multipart/form-data body with the given form
+// fields and one image file part, returning the body and its content-type.
+func buildMultipartBody(t *testing.T, fields map[string]string) ([]byte, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for name, value := range fields {
+		if err := w.WriteField(name, value); err != nil {
+			t.Fatalf("WriteField(%q) error = %v", name, err)
+		}
+	}
+	fw, err := w.CreateFormFile("image", "input.png")
+	if err != nil {
+		t.Fatalf("CreateFormFile() error = %v", err)
+	}
+	if _, err := fw.Write([]byte("fake png bytes")); err != nil {
+		t.Fatalf("writing file part: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	return buf.Bytes(), w.FormDataContentType()
+}
+
+func TestOpenAIParser_ParseRequest_ImagesEdits(t *testing.T) {
+	parser := NewOpenAIParser()
+
+	tests := []struct {
+		name        string
+		path        string
+		fields      map[string]string
+		contentType string // overrides the multipart content-type when set
+		wantModel   string
+		wantStream  bool
+		wantImages  *fwkrh.ImagesGenerationsRequest
+		wantErr     bool
+	}{
+		{
+			name: "images edits request with all scalar fields",
+			path: "/v1/images/edits",
+			fields: map[string]string{
+				"model":               "test-image-model",
+				"prompt":              "add a hat to the cat",
+				"n":                   "2",
+				"size":                "1024x1024",
+				"num_inference_steps": "30",
+			},
+			wantModel: "test-image-model",
+			wantImages: &fwkrh.ImagesGenerationsRequest{
+				Prompt:            "add a hat to the cat",
+				N:                 ptr.To[int64](2),
+				Size:              "1024x1024",
+				NumInferenceSteps: ptr.To[int64](30),
+			},
+		},
+		{
+			name:       "images edits request with prompt only",
+			path:       "/v1/images/edits",
+			fields:     map[string]string{"prompt": "make it night"},
+			wantImages: &fwkrh.ImagesGenerationsRequest{Prompt: "make it night"},
+		},
+		{
+			name: "images edits request with stream",
+			path: "/v1/images/edits",
+			fields: map[string]string{
+				"prompt": "make it night",
+				"stream": "true",
+			},
+			wantStream: true,
+			wantImages: &fwkrh.ImagesGenerationsRequest{Prompt: "make it night"},
+		},
+		{
+			name:       "images edits request via prefix-mounted path",
+			path:       "/openai/v1/images/edits",
+			fields:     map[string]string{"prompt": "make it night"},
+			wantImages: &fwkrh.ImagesGenerationsRequest{Prompt: "make it night"},
+		},
+		{
+			name:    "images edits request missing prompt",
+			path:    "/v1/images/edits",
+			fields:  map[string]string{"model": "test-image-model"},
+			wantErr: true,
+		},
+		{
+			name:    "images edits request with invalid n",
+			path:    "/v1/images/edits",
+			fields:  map[string]string{"prompt": "a cat", "n": "two"},
+			wantErr: true,
+		},
+		{
+			name:        "images edits request with non-multipart content-type",
+			path:        "/v1/images/edits",
+			fields:      map[string]string{"prompt": "a cat"},
+			contentType: "application/json",
+			wantErr:     true,
+		},
+		{
+			name:        "images edits request missing boundary",
+			path:        "/v1/images/edits",
+			fields:      map[string]string{"prompt": "a cat"},
+			contentType: "multipart/form-data",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, ct := buildMultipartBody(t, tt.fields)
+			if tt.contentType != "" {
+				ct = tt.contentType
+			}
+			headers := map[string]string{":path": tt.path, contentType: ct}
+			got, err := parser.ParseRequest(context.Background(), body, headers)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			want := &fwkrh.InferenceRequestBody{
+				Images:  tt.wantImages,
+				Payload: fwkrh.RawPayload(body),
+				Model:   tt.wantModel,
+				Stream:  tt.wantStream,
+			}
+			if diff := cmp.Diff(want, got.Body); diff != "" {
+				t.Errorf("ParseRequest() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestOpenAIParser_RepackagePreservesLargeJSONInteger(t *testing.T) {
 	const seed = json.Number("9007199254740993")
 
@@ -1430,6 +1565,7 @@ func TestOpenAIParser_Claims(t *testing.T) {
 			chatCompletionsAPI + "/render",
 			completionsAPI + "/render",
 			imagesGenerationsAPI,
+			imagesEditsAPI,
 		},
 		Protocols: []v1.AppProtocol{v1.AppProtocolH2C, v1.AppProtocolHTTP},
 	}

--- a/test/integration/epp/hermetic_test.go
+++ b/test/integration/epp/hermetic_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoyTypePb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -246,6 +247,36 @@ dataLayer:
 					wantMetrics: map[string]string{
 						"inference_objective_request_total": cleanMetric(metricReqTotal(modelSheddable, modelSheddableTarget, prio(0))),
 					},
+				},
+				{
+					name: "images edits: multipart body split across chunks, routed unchanged",
+					requests: integration.ReqRaw(
+						map[string]string{
+							":path":                      "/v1/images/edits",
+							"content-type":               "multipart/form-data; boundary=" + imagesEditsBoundary,
+							reqcommon.RequestIDHeaderKey: "test-request-id",
+						},
+						imagesEditsBody[:40],
+						imagesEditsBody[40:],
+					),
+					pods: []PodState{
+						P(0, 3, 0.2),
+						P(1, 0, 0.1), // Winner (Low Queue, Low KV)
+						P(2, 10, 0.2),
+					},
+					wantResponses: expectImagesEditsRouteTo("192.168.1.2:8000"),
+				},
+				{
+					name: "images edits: non-multipart content-type rejected",
+					requests: integration.ReqRaw(
+						map[string]string{
+							":path":        "/v1/images/edits",
+							"content-type": "application/json",
+						},
+						`{"model":"my-model","prompt":"edit"}`,
+					),
+					wantResponses: ExpectReject(envoyTypePb.StatusCode_BadRequest,
+						"inference error: BadRequest - images edits request must have a multipart/form-data content-type"),
 				},
 				{
 					name:     "no backend pods available",
@@ -507,6 +538,45 @@ dataLayer:
 			}
 		})
 	}
+}
+
+const imagesEditsBoundary = "imagesEditsBoundary"
+
+// imagesEditsBody is a multipart /v1/images/edits request carrying form fields and a file part.
+var imagesEditsBody = strings.Join([]string{
+	"--" + imagesEditsBoundary,
+	`Content-Disposition: form-data; name="model"`,
+	"",
+	modelMyModel,
+	"--" + imagesEditsBoundary,
+	`Content-Disposition: form-data; name="prompt"`,
+	"",
+	"make the sky blue",
+	"--" + imagesEditsBoundary,
+	`Content-Disposition: form-data; name="image"; filename="cat.png"`,
+	"Content-Type: image/png",
+	"",
+	"raw-png-bytes",
+	"--" + imagesEditsBoundary + "--",
+	"",
+}, "\r\n")
+
+// expectImagesEditsRouteTo asserts the multipart request is routed to endpoint with its body
+// forwarded unchanged: multipart payloads are raw bytes, so no model rewrite is applied.
+func expectImagesEditsRouteTo(endpoint string) []*extProcPb.ProcessingResponse {
+	return integration.NewRequestBufferedResponse(
+		endpoint,
+		[]byte(imagesEditsBody),
+		&configPb.HeaderValueOption{Header: &configPb.HeaderValue{
+			Key: ":path", RawValue: []byte("/v1/images/edits"),
+		}},
+		&configPb.HeaderValueOption{Header: &configPb.HeaderValue{
+			Key: "content-type", RawValue: []byte("multipart/form-data; boundary=" + imagesEditsBoundary),
+		}},
+		&configPb.HeaderValueOption{Header: &configPb.HeaderValue{
+			Key: reqcommon.RequestIDHeaderKey, RawValue: []byte("test-request-id"),
+		}},
+	)
 }
 
 // loadBaseResources parses the YAML manifest once at startup.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds support for the OpenAI `/v1/images/edits` endpoint to the OpenAI parser.

This endpoint uses `multipart/form-data`, which the existing JSON-only parser cannot read. The parser now:
- registers `images/edits` in its claims and path matching
- parses the multipart body, extracting `model`, `prompt`, `size`, `n`, and `num_inference_steps` into the existing `ImagesGenerationsRequest` type
- skips uploaded image file parts

**Which issue(s) this PR fixes**:
Fixes #2561

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The OpenAI parser supports the /v1/images/edits endpoint (multipart/form-data), extracting the model and cost fields for routing.
```

**Test plan**:
- [x] Multipart /v1/images/edits requests are parsed: model and cost fields extracted, file parts skipped
- [x] Invalid multipart requests (wrong content-type, missing boundary, bad numeric fields) are rejected