### PR TITLE
fix(epp): preserve endpoint attributes in data-parallel profile

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler.go
@@ -124,7 +124,7 @@ func (h *ProfileHandler) ProcessResults(_ context.Context, request *scheduling.I
 	for _, target := range profileResult.TargetEndpoints {
 		newMetadata := target.GetMetadata().Clone()
 		newMetadata.Port = h.primaryPort
-		targetEndpoint := scheduling.NewEndpoint(newMetadata, target.GetMetrics().Clone(), nil)
+		targetEndpoint := scheduling.NewEndpoint(newMetadata, target.GetMetrics(), target.Clone())
 		newResult.TargetEndpoints = append(newResult.TargetEndpoints, targetEndpoint)
 	}
 	modifiedResults := map[string]*scheduling.ProfileRunResult{singleProfileName: &newResult}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/dataparallel/dp_profile_handler_test.go
@@ -240,7 +240,14 @@ func Test_ProfileHandler_Pick(t *testing.T) {
 	}
 }
 
+type cloneableStr string
+
+func (s cloneableStr) Clone() fwkdl.Cloneable { return s }
+
 func Test_ProfileHandler_ProcessResults(t *testing.T) {
+	profileResult := newMockProfileRunResult(DefaultTestPodPort, "pod1")
+	key := plugin.NewDataKey("test-key", "test-producer")
+	profileResult.TargetEndpoints[0].Put(key, cloneableStr("test-value"))
 	tests := []struct {
 		name           string
 		primaryPort    int
@@ -307,6 +314,20 @@ func Test_ProfileHandler_ProcessResults(t *testing.T) {
 					assert.Equal(t, "8080", p.GetMetadata().Port)
 				}
 				assert.Equal(t, net.JoinHostPort("10.0.0.1", DefaultTestPodPort), headers[routing.DataParallelEndpointHeader])
+			},
+		},
+		{
+			name:        "success: target endpoint attributes are preserved",
+			primaryPort: 8080,
+			profileResults: map[string]*scheduling.ProfileRunResult{
+				"dp-profile": profileResult,
+			},
+			expectError: false,
+			checkResult: func(t *testing.T, res *scheduling.SchedulingResult, _ map[string]string) {
+				pod := res.ProfileResults["dp-profile"].TargetEndpoints[0]
+				value, ok := pod.Get(key)
+				assert.True(t, ok)
+				assert.Equal(t, cloneableStr("test-value"), value)
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Preserves endpoint attributes when `DataParallelProfileHandler.ProcessResults`
rebuilds target endpoints to override the primary port.

Previously, the rebuilt endpoint passed `nil` attributes to `NewEndpoint`,
which caused `PreRequest` plugins to receive an empty attribute map.

This change carries the original endpoint attributes forward while keeping the
existing metadata port rewrite behavior unchanged.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2411 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```