### PR TITLE
feat(flowcontrol): add program-score ordering policy

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -84,6 +84,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/fairness/roundrobin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/edf"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs"
+	programscore "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/program-score"
 	slodeadline "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization"
@@ -662,6 +663,7 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(evictordering.PriorityThenTimeOrderingType, fwkplugin.StabilityAlpha, evictordering.PriorityThenTimeOrderingFactory)
 	fwkplugin.Register(priorityholdback.PolicyType, fwkplugin.StabilityAlpha, priorityholdback.PolicyFactory)
 	fwkplugin.Register(softreflectiveceiling.PolicyType, fwkplugin.StabilityAlpha, softreflectiveceiling.Factory)
+	fwkplugin.Register(programscore.ProgramScoreOrderingPolicyType, fwkplugin.StabilityAlpha, programscore.ProgramScoreOrderingPolicyFactory)
 
 	// Register Request level data producer plugins as defaults for their respective data keys.
 	// Beta

--- a/pkg/epp/flowcontrol/contracts/mocks/mocks.go
+++ b/pkg/epp/flowcontrol/contracts/mocks/mocks.go
@@ -167,6 +167,7 @@ type MockSafeQueue struct {
 	RemoveFunc  func(handle flowcontrol.QueueItemHandle) (flowcontrol.QueueItemAccessor, error)
 	CleanupFunc func(predicate contracts.PredicateFunc) []flowcontrol.QueueItemAccessor
 	DrainFunc   func() []flowcontrol.QueueItemAccessor
+	RescoreFunc func()
 }
 
 func (m *MockSafeQueue) Len() int         { return m.LenV }
@@ -203,6 +204,12 @@ func (m *MockSafeQueue) Drain() []flowcontrol.QueueItemAccessor {
 	return nil
 }
 
+func (m *MockSafeQueue) Rescore() {
+	if m.RescoreFunc != nil {
+		m.RescoreFunc()
+	}
+}
+
 var _ contracts.SafeQueue = &MockSafeQueue{}
 
 // --- ManagedQueue Mock ---
@@ -236,6 +243,8 @@ type MockManagedQueue struct {
 	CleanupFunc func(predicate contracts.PredicateFunc) []flowcontrol.QueueItemAccessor
 	// DrainFunc allows a test to completely override the default Drain behavior.
 	DrainFunc func() []flowcontrol.QueueItemAccessor
+	// RescoreFunc allows a test to override the default (no-op) Rescore behavior, e.g. to count calls.
+	RescoreFunc func()
 	// OrderingPolicyFunc allows a test to override OrderingPolicy.
 	OrderingPolicyFunc func() flowcontrol.OrderingPolicy
 
@@ -326,6 +335,14 @@ func (m *MockManagedQueue) Drain() []flowcontrol.QueueItemAccessor {
 	}
 	m.items = make(map[flowcontrol.QueueItemHandle]flowcontrol.QueueItemAccessor)
 	return drained
+}
+
+// Rescore checks for a test override before doing nothing: the mock's map-backed state has no
+// ordering to re-establish, so membership-preserving rescoring is otherwise a no-op.
+func (m *MockManagedQueue) Rescore() {
+	if m.RescoreFunc != nil {
+		m.RescoreFunc()
+	}
 }
 
 func (m *MockManagedQueue) FlowKey() flowcontrol.FlowKey { return m.FlowKeyV }

--- a/pkg/epp/flowcontrol/contracts/queue.go
+++ b/pkg/epp/flowcontrol/contracts/queue.go
@@ -49,4 +49,10 @@ type SafeQueue interface {
 	// Drain atomically removes all items from the queue and returns them in a slice.
 	// The handle for all removed items MUST be invalidated. The queue MUST be empty after this operation.
 	Drain() (drainedItems []flowcontrol.QueueItemAccessor)
+
+	// Rescore re-establishes the queue's ordering invariant against its current OrderingPolicy,
+	// without adding, removing, or otherwise changing membership. Callers use this to surface a
+	// ScoringOrderingPolicy's time-decayed score changes, which Add/Remove/Cleanup would not
+	// otherwise trigger for an item that is neither added nor removed.
+	Rescore()
 }

--- a/pkg/epp/flowcontrol/contracts/registry.go
+++ b/pkg/epp/flowcontrol/contracts/registry.go
@@ -179,6 +179,10 @@ type ManagedQueue interface {
 	// Drain removes all items from the underlying queue.
 	Drain() []flowcontrol.QueueItemAccessor
 
+	// Rescore re-establishes the underlying queue's ordering invariant against its current
+	// OrderingPolicy. See SafeQueue.Rescore.
+	Rescore()
+
 	// FlowQueueAccessor returns a read-only, flow-aware accessor for this queue, used by policy plugins.
 	// Conformance: This method MUST NOT return nil.
 	FlowQueueAccessor() flowcontrol.FlowQueueAccessor

--- a/pkg/epp/flowcontrol/controller/internal/processor.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor.go
@@ -34,6 +34,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/types"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/bylabel"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
 )
@@ -110,6 +111,11 @@ type Processor struct {
 	// Written by both the main Run goroutine (enqueue, shutdown) and the runCleanupSweep goroutine (sweep),
 	// so each slot is an atomic to avoid a data race.
 	dropCounts [types.NumQueueOutcomes]atomic.Uint64
+
+	// scoringPolicyNextDue tracks, per ScoringOrderingPolicy TypedName, the next time
+	// rescoreScoringQueues should force a re-heapify of queues using that policy. Read and written
+	// only from the runCleanupSweep goroutine, so it needs no synchronization of its own.
+	scoringPolicyNextDue map[plugin.TypedName]time.Time
 }
 
 // regimeSample is one observation of the unavailability regime: whether the candidate pool was empty, and when that
@@ -151,6 +157,7 @@ func NewProcessor(
 		lifecycleCtx:         ctx,
 		enqueueChan:          make(chan *FlowItem, enqueueChannelBufferSize),
 		reclamation:          reclamation,
+		scoringPolicyNextDue: make(map[plugin.TypedName]time.Time),
 	}
 	// Seeded so readers never handle a nil sample. The pool reads as non-empty until the first dispatch cycle observes
 	// otherwise, which keeps a request that arrives before that cycle on the saturation budget.
@@ -654,6 +661,7 @@ func (p *Processor) runCleanupSweep(ctx context.Context) {
 			return
 		case <-ticker.C():
 			p.sweepFinalizedItems()
+			p.rescoreScoringQueues()
 			p.flushDropSummary()
 		}
 	}
@@ -703,6 +711,67 @@ func (p *Processor) sweepFinalizedItems() {
 		}
 	}
 	p.processAllQueuesConcurrently("sweepFinalizedItems", processFn)
+}
+
+// rescoreScoringQueues re-heapifies queues whose OrderingPolicy is a ScoringOrderingPolicy and is
+// due for a rescore, so that time-decayed score changes on items that were neither added nor
+// removed still surface at the queue root. Plain OrderingPolicy implementations (fcfs, edf,
+// slodeadline) are untouched and pay no cost beyond one failed type assertion per queue per tick.
+//
+// The due set is computed in a single-threaded prelude - this goroutine is the sole reader and
+// writer of scoringPolicyNextDue - before handing off to the existing concurrent worker pool, so
+// the workers only ever read the (by then immutable) due set. This holds even though multiple
+// queues can share one ScoringOrderingPolicy instance, since ordering policies are per-priority-
+// band singletons.
+func (p *Processor) rescoreScoringQueues() {
+	now := p.clock.Now()
+
+	dueSet := make(map[plugin.TypedName]struct{})
+	for _, priority := range p.registry.AllOrderedPriorityLevels() {
+		band, err := p.registry.PriorityBandAccessor(priority)
+		if err != nil {
+			continue
+		}
+		band.IterateQueues(func(queue flowcontrol.FlowQueueAccessor) bool {
+			sp, ok := queue.OrderingPolicy().(flowcontrol.ScoringOrderingPolicy)
+			if !ok {
+				return true
+			}
+			name := sp.TypedName()
+			if _, alreadyDue := dueSet[name]; alreadyDue {
+				return true
+			}
+			interval := sp.RescoreInterval()
+			if interval <= 0 {
+				return true
+			}
+			if interval < p.cleanupSweepInterval {
+				interval = p.cleanupSweepInterval
+			}
+			if nextDue, seen := p.scoringPolicyNextDue[name]; seen && now.Before(nextDue) {
+				return true
+			}
+			dueSet[name] = struct{}{}
+			p.scoringPolicyNextDue[name] = now.Add(interval)
+			return true
+		})
+	}
+	if len(dueSet) == 0 {
+		return
+	}
+
+	processFn := func(managedQ contracts.ManagedQueue, logger logr.Logger) {
+		sp, ok := managedQ.FlowQueueAccessor().OrderingPolicy().(flowcontrol.ScoringOrderingPolicy)
+		if !ok {
+			return
+		}
+		if _, due := dueSet[sp.TypedName()]; !due {
+			return
+		}
+		managedQ.Rescore()
+		logger.V(logutil.TRACE).Info("Rescored queue for time-varying ordering policy", "policy", sp.TypedName())
+	}
+	p.processAllQueuesConcurrently("rescoreScoringQueues", processFn)
 }
 
 // isExpired reports whether item has exhausted the queue-wait budget in force, and the outcome that eviction would

--- a/pkg/epp/flowcontrol/controller/internal/processor_test.go
+++ b/pkg/epp/flowcontrol/controller/internal/processor_test.go
@@ -1961,3 +1961,64 @@ func TestProcessor_QueueWaitBudget(t *testing.T) {
 			"an unchanged regime must not restart the budget")
 	})
 }
+
+// TestProcessor_RescoreScoringQueues verifies rescoreScoringQueues only rescores queues whose
+// OrderingPolicy is a ScoringOrderingPolicy, only once its RescoreInterval has elapsed, and
+// rescores every queue sharing one policy instance.
+func TestProcessor_RescoreScoringQueues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plain OrderingPolicy is never rescored", func(t *testing.T) {
+		t.Parallel()
+		h := newTestHarness(t, testCleanupTick)
+		var calls atomic.Int32
+		q := h.addQueue(testFlow)
+		q.OrderingPolicyFunc = func() flowcontrol.OrderingPolicy { return &fwkfcmocks.MockOrderingPolicy{} }
+		q.RescoreFunc = func() { calls.Add(1) }
+
+		h.processor.rescoreScoringQueues()
+
+		assert.Zero(t, calls.Load(), "a plain OrderingPolicy must never be rescored")
+	})
+
+	t.Run("ScoringOrderingPolicy is rescored once due, on every queue sharing it", func(t *testing.T) {
+		t.Parallel()
+		h := newTestHarness(t, testCleanupTick)
+		policy := &fwkfcmocks.MockScoringOrderingPolicy{RescoreIntervalV: testCleanupTick}
+
+		var calls atomic.Int32
+		q1 := h.addQueue(testFlow)
+		q1.OrderingPolicyFunc = func() flowcontrol.OrderingPolicy { return policy }
+		q1.RescoreFunc = func() { calls.Add(1) }
+		q2 := h.addQueue(flowcontrol.FlowKey{ID: "flow-b", Priority: testFlow.Priority})
+		q2.OrderingPolicyFunc = func() flowcontrol.OrderingPolicy { return policy }
+		q2.RescoreFunc = func() { calls.Add(1) }
+
+		h.processor.rescoreScoringQueues()
+		assert.Equal(t, int32(2), calls.Load(), "both queues sharing the policy must be rescored")
+
+		// Immediately due again: the interval has not elapsed, so nothing should fire.
+		h.processor.rescoreScoringQueues()
+		assert.Equal(t, int32(2), calls.Load(), "must not rescore again before RescoreInterval elapses")
+
+		// Advance the clock past the interval: due again.
+		h.clock.Step(testCleanupTick)
+		h.processor.rescoreScoringQueues()
+		assert.Equal(t, int32(4), calls.Load(), "must rescore again once RescoreInterval elapses")
+	})
+
+	t.Run("a non-positive RescoreInterval disables periodic rescoring", func(t *testing.T) {
+		t.Parallel()
+		h := newTestHarness(t, testCleanupTick)
+		var calls atomic.Int32
+		q := h.addQueue(testFlow)
+		q.OrderingPolicyFunc = func() flowcontrol.OrderingPolicy {
+			return &fwkfcmocks.MockScoringOrderingPolicy{RescoreIntervalV: 0}
+		}
+		q.RescoreFunc = func() { calls.Add(1) }
+
+		h.processor.rescoreScoringQueues()
+
+		assert.Zero(t, calls.Load(), "RescoreInterval <= 0 must disable periodic rescoring")
+	})
+}

--- a/pkg/epp/flowcontrol/queue/priorityqueue.go
+++ b/pkg/epp/flowcontrol/queue/priorityqueue.go
@@ -237,6 +237,18 @@ func (pq *priorityQueue) Cleanup(predicate contracts.PredicateFunc) []flowcontro
 	return removedItems
 }
 
+// Rescore re-establishes the heap property against the current OrderingPolicy, without changing
+// which items are queued. Add, Remove, and Cleanup only ever compare the items directly involved
+// in that call, so an item whose relative order changes purely because time passed (as with a
+// ScoringOrderingPolicy) would otherwise sit at a stale position until an unrelated Add or Remove
+// happened to touch it.
+func (pq *priorityQueue) Rescore() {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	heap.Init(pq.heap)
+}
+
 // Drain removes all items from the queue.
 func (pq *priorityQueue) Drain() []flowcontrol.QueueItemAccessor {
 	pq.mu.Lock()

--- a/pkg/epp/flowcontrol/queue/priorityqueue_test.go
+++ b/pkg/epp/flowcontrol/queue/priorityqueue_test.go
@@ -325,6 +325,38 @@ func TestPriorityQueue_Drain(t *testing.T) {
 	})
 }
 
+// TestPriorityQueue_Rescore verifies that Rescore re-establishes the heap property after external
+// state read by the OrderingPolicy changes, without Add or Remove being called - the scenario a
+// ScoringOrderingPolicy relies on to surface a time-decayed score at the queue root, since Peek
+// never re-runs comparisons and Add/Remove/Cleanup only ever compare the items directly involved.
+func TestPriorityQueue_Rescore(t *testing.T) {
+	t.Parallel()
+
+	scores := map[string]int{"r-1": 1, "r-2": 2, "r-3": 3}
+	scorePolicy := &mocks.MockOrderingPolicy{
+		TypedNameV: plugin.TypedName{Name: "external_score_asc"},
+		LessFunc: func(a, b flowcontrol.QueueItemAccessor) bool {
+			return scores[a.OriginalRequest().ID()] < scores[b.OriginalRequest().ID()]
+		},
+	}
+
+	q := New(scorePolicy)
+	q.Add(mocks.NewMockQueueItemAccessor(10, "r-1", testFlowKey))
+	q.Add(mocks.NewMockQueueItemAccessor(10, "r-2", testFlowKey))
+	q.Add(mocks.NewMockQueueItemAccessor(10, "r-3", testFlowKey))
+
+	require.Equal(t, "r-1", q.Peek().OriginalRequest().ID(), "r-1 has the lowest score initially")
+
+	// r-3 now has the lowest score. The stale root must persist until Rescore forces a
+	// re-heapify: Peek alone must not re-run comparisons.
+	scores["r-3"] = 0
+	assert.Equal(t, "r-1", q.Peek().OriginalRequest().ID(), "Peek alone must not re-run comparisons")
+
+	q.Rescore()
+	assert.Equal(t, "r-3", q.Peek().OriginalRequest().ID(), "Rescore must re-establish the heap property")
+	assert.Equal(t, 3, q.Len(), "Rescore must not change membership")
+}
+
 // TestPriorityQueue_Concurrency drives a mix of concurrent operations and verifies that the
 // accounting stays consistent: items drained at the end must equal initial + adds - removes.
 func TestPriorityQueue_Concurrency(t *testing.T) {

--- a/pkg/epp/flowcontrol/registry/managedqueue.go
+++ b/pkg/epp/flowcontrol/registry/managedqueue.go
@@ -176,6 +176,15 @@ func (mq *managedQueue) Drain() []flowcontrol.QueueItemAccessor {
 	return drainedItems
 }
 
+// Rescore re-establishes the underlying queue's ordering invariant against its current
+// OrderingPolicy. Membership is unchanged, so no statistics delta is measured or propagated.
+func (mq *managedQueue) Rescore() {
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+
+	mq.queue.Rescore()
+}
+
 // Len returns the current number of items in the queue.
 func (mq *managedQueue) Len() int {
 	return mq.queue.Len()

--- a/pkg/epp/framework/interface/flowcontrol/mocks/mocks.go
+++ b/pkg/epp/framework/interface/flowcontrol/mocks/mocks.go
@@ -216,6 +216,16 @@ func (m *MockOrderingPolicy) Less(a, b flowcontrol.QueueItemAccessor) bool {
 
 var _ flowcontrol.OrderingPolicy = &MockOrderingPolicy{}
 
+// MockScoringOrderingPolicy is a behavioral mock for the ScoringOrderingPolicy interface.
+type MockScoringOrderingPolicy struct {
+	MockOrderingPolicy
+	RescoreIntervalV time.Duration
+}
+
+func (m *MockScoringOrderingPolicy) RescoreInterval() time.Duration { return m.RescoreIntervalV }
+
+var _ flowcontrol.ScoringOrderingPolicy = &MockScoringOrderingPolicy{}
+
 // MockFairnessPolicy is a behavioral mock for the FairnessPolicy interface.
 // Simple accessors are configured with public value fields (e.g., NameV).
 // Complex methods with logic are configured with function fields (e.g., PickFunc).

--- a/pkg/epp/framework/interface/flowcontrol/plugins.go
+++ b/pkg/epp/framework/interface/flowcontrol/plugins.go
@@ -19,6 +19,7 @@ package flowcontrol
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
@@ -105,6 +106,24 @@ type OrderingPolicy interface {
 	//
 	// Invariant: returning true means 'a' has higher priority than 'b'.
 	Less(a, b QueueItemAccessor) bool
+}
+
+// ScoringOrderingPolicy is an OrderingPolicy whose Less result can change purely with elapsed
+// time (not only in response to an Add or Remove on the queue) — for example, a policy scoring
+// items by a decaying measure of resource consumption. Queues are not re-sorted on a schedule by
+// default, so without periodic re-heapification a stale score would sit at the wrong position
+// until the next Add or Remove happens to touch it. The FlowController detects this interface via
+// type assertion and periodically re-heapifies queues using such a policy so time-decayed score
+// changes surface at dispatch time.
+//
+// Conformance: implementations MUST also satisfy every conformance requirement of OrderingPolicy.
+type ScoringOrderingPolicy interface {
+	OrderingPolicy
+
+	// RescoreInterval returns the minimum interval at which queues using this policy should be
+	// re-sorted. A value <= 0 disables periodic rescoring for this policy. An interval finer than
+	// the controller's own expiry-sweep cadence is clamped to it.
+	RescoreInterval() time.Duration
 }
 
 // SaturationDetector provides real-time load signals.

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/README.md
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/README.md
@@ -13,6 +13,7 @@ This corresponds to **Tier 3** of the strict 3-Tier Dispatch Hierarchy in the Fl
 *   **[First-Come, First-Served (FCFS)](./fcfs/README.md)** (`fcfs-ordering-policy`): Selects requests based on their arrival order. This is the default policy.
 *   **[Earliest Deadline First (EDF)](./edf/README.md)** (`edf-ordering-policy`): Selects requests based on their absolute deadline, derived from TTL.
 *   **[SLO Deadline](./slodeadline/README.md)** (`slo-deadline-ordering-policy`): Selects requests based on a deadline derived from an SLO header (e.g., target TTFT).
+*   **[Program-Score](./program-score/README.md)** (`program-score-ordering-policy`): Selects requests by the originating program/agent's decayed turns taken and tokens consumed, within a single shared queue.
 
 ## Conformance Testing
 

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/functional_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/functional_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/edf"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs"
+	programscore "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/program-score"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline"
 )
 
@@ -37,9 +38,10 @@ func TestOrderingPolicyConformance(t *testing.T) {
 	t.Parallel()
 
 	policies := map[string]plugin.FactoryFunc{
-		fcfs.FCFSOrderingPolicyType:               fcfs.FCFSOrderingPolicyFactory,
-		edf.EDFOrderingPolicyType:                 edf.EDFOrderingPolicyFactory,
-		slodeadline.SLODeadlineOrderingPolicyType: slodeadline.SLODeadlineOrderingPolicyFactory,
+		fcfs.FCFSOrderingPolicyType:                 fcfs.FCFSOrderingPolicyFactory,
+		edf.EDFOrderingPolicyType:                   edf.EDFOrderingPolicyFactory,
+		slodeadline.SLODeadlineOrderingPolicyType:   slodeadline.SLODeadlineOrderingPolicyFactory,
+		programscore.ProgramScoreOrderingPolicyType: programscore.ProgramScoreOrderingPolicyFactory,
 	}
 
 	for name, factory := range policies {

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/program-score/README.md
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/program-score/README.md
@@ -1,0 +1,88 @@
+# Program-Score Ordering Policy
+
+**Type:** `program-score-ordering-policy`
+
+The program-score ordering policy orders requests within a single queue by the originating
+program/agent's decayed turns taken and tokens consumed, dispatching the least-served program's
+request first.
+
+## Why Choose This Policy?
+
+- **Per-agent queue-per-tenant granularity problem:** the `program-aware-fairness` policy maps
+  each agent identity to its own queue, so a tenant running 5 agents gets 5 queues and 5x the
+  dispatch share of a tenant running 1 agent. Scoring within one shared queue removes that
+  dependency on how many agents a tenant happens to run.
+- **Program-aware without an extra queue per agent:** suited to configurations where many agents
+  share a single `FlowKey` (e.g. one FairnessID-less priority band) but should still take turns
+  fairly by their own consumption, not by arrival order alone.
+
+## What It Does
+
+Each item's program is identified by its request's FairnessID (falling back to the default flow ID
+when unset, same as `program-aware-fairness`). Two signals are tracked per program, each decaying
+independently with the same exponential half-life:
+
+- **Turns taken**, incremented once per dispatched request.
+- **Tokens consumed**, incremented by `PromptTokens + CompletionTokens` once a response completes.
+
+The combined cost is `weightTurns*decayedTurns + weightTokens*decayedTokens`; the item belonging to
+the program with the **lower** cost dispatches first. Equal cost falls back to FCFS (enqueue time).
+
+This is a `ScoringOrderingPolicy`: because turns/tokens decay with elapsed time, the FlowController
+periodically re-heapifies queues using this policy so an item that has been sitting in the queue
+(while other programs are served) surfaces at the root as its relative cost falls, even though it
+was never itself added or removed.
+
+## Inputs consumed
+
+- **FairnessID** (via the request's `InferenceRequest`), to identify the program.
+- **Dispatch events**, via the `PreRequest` hook, to increment turns.
+- **Response token usage**, via the `ResponseBody` hook (`response.Usage`, only on the final/only
+  chunk), to increment tokens.
+- **Logical Enqueue Time**, as the FCFS tie-breaker.
+
+## Behavior and Queue Pairing
+
+Requires the same heap-based priority queue capability as `edf-ordering-policy`.
+
+## Configuration
+
+```yaml
+orderingPolicyRef: program-score-ordering-policy
+```
+
+| Field                     | Default | Description                                                  |
+| ------------------------- | ------- | -------------------------------------------------------------|
+| `weightTurns`              | `1`     | Weight applied to the decayed turn count.                    |
+| `weightTokens`             | `0.01`  | Weight applied to the decayed token count.                   |
+| `halfLifeSeconds`          | `60`    | Exponential decay half-life applied to both signals.          |
+| `rescoreIntervalSeconds`   | `1`     | Minimum interval between forced queue re-heapifies.           |
+| `evictionTtlSeconds`       | `3600`  | How long an idle program's state is kept. `0` disables eviction. |
+| `evictionSweepSeconds`     | `300`   | Interval between idle-eviction sweeps.                        |
+
+`weightTokens` defaults small relative to `weightTurns` since token counts typically run one to two
+orders of magnitude higher than turn counts; tune both to your workload's actual token volume.
+
+## Observability
+
+| Metric                             | Type    | Labels       | Description                              |
+| ----------------------------------- | ------- | ------------ | ----------------------------------------- |
+| `program_score_decayed_turns`       | Gauge   | `program_id` | Current decayed turn count per program.   |
+| `program_score_decayed_tokens`      | Gauge   | `program_id` | Current decayed token cost per program.   |
+
+## Trade-offs
+
+- **Rescore cost:** a full band rescore is `O(n log n)` in the queue's size, run at most once per
+  `rescoreIntervalSeconds` (never finer than the FlowController's own expiry-sweep cadence).
+- **Unbounded program cardinality:** per-program state grows with distinct FairnessIDs seen;
+  `evictionTtlSeconds` bounds this by dropping idle programs, at the cost of a program's history
+  resetting if it goes idle past the TTL.
+- **Extensibility:** additional scoring signals (e.g. a future longest-prefix-match signal to
+  prioritize cache-warm requests) are meant to be added as further independently-weighted,
+  independently-decayed terms in the same cost function, not a new abstraction layer.
+
+## Related Documentation
+
+- [Ordering Overview](../README.md)
+- [Program-Aware Fairness Policy](../../fairness/program-aware/README.md)
+- [Flow Control User Guide](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/v1.5.0/site-src/guides/flow-control.md)

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/program-score/program_score.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/program-score/program_score.go
@@ -1,0 +1,253 @@
+// Package programscore implements a ScoringOrderingPolicy that orders requests within a single
+// queue by the originating program/agent's decayed turns taken and tokens consumed, dispatching
+// the least-served program first.
+//
+// For detailed documentation, see README.md.
+package programscore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
+)
+
+// ProgramScoreOrderingPolicyType is the registration type for the program-score ordering policy.
+const ProgramScoreOrderingPolicyType = "program-score-ordering-policy"
+
+// Config is the JSON configuration for the program-score ordering policy.
+type Config struct {
+	// WeightTurns weights the decayed turn count in the combined cost.
+	WeightTurns float64 `json:"weightTurns,omitempty"`
+	// WeightTokens weights the decayed token count in the combined cost.
+	WeightTokens float64 `json:"weightTokens,omitempty"`
+	// HalfLifeSeconds is the exponential decay half-life applied to both turns and tokens.
+	HalfLifeSeconds float64 `json:"halfLifeSeconds,omitempty"`
+	// RescoreIntervalSeconds is how often the FlowController re-heapifies queues using this
+	// policy; see flowcontrol.ScoringOrderingPolicy.RescoreInterval.
+	RescoreIntervalSeconds float64 `json:"rescoreIntervalSeconds,omitempty"`
+	// EvictionTTLSeconds is how long an idle program's state is retained before eviction. 0
+	// disables eviction.
+	EvictionTTLSeconds float64 `json:"evictionTtlSeconds,omitempty"`
+	// EvictionSweepSeconds is the interval between idle-eviction sweeps.
+	EvictionSweepSeconds float64 `json:"evictionSweepSeconds,omitempty"`
+}
+
+// DefaultConfig returns the default configuration. WeightTokens is small relative to WeightTurns
+// since token counts typically run one to two orders of magnitude higher than turn counts;
+// operators should tune both to their own workload.
+func DefaultConfig() Config {
+	return Config{
+		WeightTurns:            1,
+		WeightTokens:           0.01,
+		HalfLifeSeconds:        60,
+		RescoreIntervalSeconds: 1,
+		EvictionTTLSeconds:     3600,
+		EvictionSweepSeconds:   300,
+	}
+}
+
+func (c Config) validate() error {
+	if c.WeightTurns < 0 {
+		return fmt.Errorf("weightTurns must be >= 0, got %v", c.WeightTurns)
+	}
+	if c.WeightTokens < 0 {
+		return fmt.Errorf("weightTokens must be >= 0, got %v", c.WeightTokens)
+	}
+	if c.HalfLifeSeconds < 0 {
+		return fmt.Errorf("halfLifeSeconds must be >= 0, got %v", c.HalfLifeSeconds)
+	}
+	if c.RescoreIntervalSeconds < 0 {
+		return fmt.Errorf("rescoreIntervalSeconds must be >= 0, got %v", c.RescoreIntervalSeconds)
+	}
+	if c.EvictionTTLSeconds < 0 {
+		return fmt.Errorf("evictionTtlSeconds must be >= 0, got %v", c.EvictionTTLSeconds)
+	}
+	if c.EvictionSweepSeconds <= 0 {
+		return fmt.Errorf("evictionSweepSeconds must be > 0, got %v", c.EvictionSweepSeconds)
+	}
+	return nil
+}
+
+var (
+	_ flowcontrol.ScoringOrderingPolicy = &ProgramScorePolicy{}
+	_ fwkrc.PreRequest                  = &ProgramScorePolicy{}
+	_ fwkrc.ResponseBodyProcessor       = &ProgramScorePolicy{}
+)
+
+// ProgramScoreOrderingPolicyFactory creates a new ProgramScorePolicy instance. handle may be nil
+// (e.g. conformance tests), in which case metrics registration and the eviction sweep are skipped.
+func ProgramScoreOrderingPolicyFactory(name string, parameters *json.Decoder, handle plugin.Handle) (plugin.Plugin, error) {
+	cfg := DefaultConfig()
+	if parameters != nil {
+		if err := parameters.Decode(&cfg); err != nil {
+			return nil, fmt.Errorf("invalid config for %s plugin %q: %w", ProgramScoreOrderingPolicyType, name, err)
+		}
+	}
+	if err := cfg.validate(); err != nil {
+		return nil, fmt.Errorf("%s plugin %q: %w", ProgramScoreOrderingPolicyType, name, err)
+	}
+	p := newProgramScorePolicy(cfg).withName(name)
+	if handle != nil {
+		if reg := handle.Metrics(); reg != nil {
+			for _, c := range GetCollectors() {
+				reg.MustRegister(c)
+			}
+		}
+		if cfg.EvictionTTLSeconds > 0 {
+			interval := time.Duration(cfg.EvictionSweepSeconds * float64(time.Second))
+			ttl := time.Duration(cfg.EvictionTTLSeconds * float64(time.Second))
+			go p.runEviction(handle.Context(), interval, ttl)
+		}
+	}
+	return p, nil
+}
+
+// ProgramScorePolicy orders requests within a single queue by decayed turns taken and tokens
+// consumed by the originating program (FairnessID), lower cost dispatching first. See the
+// documentation for ProgramScoreOrderingPolicyType for detailed behavioral guarantees.
+type ProgramScorePolicy struct {
+	name string
+	cfg  Config
+
+	states sync.Map // key: program ID (string), value: *programState
+}
+
+func newProgramScorePolicy(cfg Config) *ProgramScorePolicy {
+	return &ProgramScorePolicy{name: ProgramScoreOrderingPolicyType, cfg: cfg}
+}
+
+func (p *ProgramScorePolicy) withName(name string) *ProgramScorePolicy {
+	if name != "" {
+		p.name = name
+	}
+	return p
+}
+
+// TypedName returns the type and name tuple of this plugin instance.
+func (p *ProgramScorePolicy) TypedName() plugin.TypedName {
+	return plugin.TypedName{Type: ProgramScoreOrderingPolicyType, Name: p.name}
+}
+
+// RescoreInterval implements flowcontrol.ScoringOrderingPolicy.
+func (p *ProgramScorePolicy) RescoreInterval() time.Duration {
+	return time.Duration(p.cfg.RescoreIntervalSeconds * float64(time.Second))
+}
+
+// Less returns true if item 'a' should be dispatched before item 'b': the program with the lower
+// weighted, decayed cost (turns taken and tokens consumed) goes first, so a tenant running many
+// agents does not out-dispatch one running few merely by occupying more of the shared queue.
+// FCFS (enqueue time) breaks ties.
+func (p *ProgramScorePolicy) Less(a, b flowcontrol.QueueItemAccessor) bool {
+	if a == nil && b == nil {
+		return false
+	}
+	if a == nil {
+		return false
+	}
+	if b == nil {
+		return true
+	}
+
+	now := time.Now()
+	costA := p.cost(a, now)
+	costB := p.cost(b, now)
+	if costA != costB {
+		return costA < costB
+	}
+	return a.EnqueueTime().Before(b.EnqueueTime())
+}
+
+func (p *ProgramScorePolicy) cost(item flowcontrol.QueueItemAccessor, now time.Time) float64 {
+	id := programID(item.OriginalRequest().InferenceRequest())
+	turns, tokens := p.getOrCreateState(id).Cost(now, p.cfg.HalfLifeSeconds)
+	return p.cfg.WeightTurns*turns + p.cfg.WeightTokens*tokens
+}
+
+// programID returns req's FairnessID, or metadata.DefaultFairnessID if req is nil or has none.
+func programID(req *fwksched.InferenceRequest) string {
+	if req == nil || req.FairnessID == "" {
+		return metadata.DefaultFairnessID
+	}
+	return req.FairnessID
+}
+
+func (p *ProgramScorePolicy) getOrCreateState(id string) *programState {
+	if a, ok := p.states.Load(id); ok {
+		if st, ok := a.(*programState); ok {
+			return st
+		}
+	}
+	fresh := &programState{lastActive: time.Now()}
+	actual, _ := p.states.LoadOrStore(id, fresh)
+	if st, ok := actual.(*programState); ok {
+		return st
+	}
+	p.states.Store(id, fresh)
+	return fresh
+}
+
+// PreRequest records one turn for the request's program.
+func (p *ProgramScorePolicy) PreRequest(_ context.Context, request *fwksched.InferenceRequest, _ *fwksched.SchedulingResult) error {
+	if request == nil {
+		return nil
+	}
+	id := programID(request)
+	turns := p.getOrCreateState(id).AddTurn(time.Now(), p.cfg.HalfLifeSeconds)
+	decayedTurns.WithLabelValues(id).Set(turns)
+	return nil
+}
+
+// ResponseBody records the request's token cost against its program once the response completes.
+// Intermediate stream chunks are no-ops.
+func (p *ProgramScorePolicy) ResponseBody(_ context.Context, request *fwksched.InferenceRequest, response *fwkrc.Response, _ *datalayer.EndpointMetadata) {
+	if request == nil || response == nil || !response.EndOfStream {
+		return
+	}
+	id := programID(request)
+	cost := float64(response.Usage.PromptTokens + response.Usage.CompletionTokens)
+	tokens := p.getOrCreateState(id).AddTokens(cost, time.Now(), p.cfg.HalfLifeSeconds)
+	decayedTokens.WithLabelValues(id).Set(tokens)
+}
+
+func (p *ProgramScorePolicy) runEviction(ctx context.Context, interval, ttl time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.evictIdle(ttl)
+		}
+	}
+}
+
+// evictIdle is best-effort: a request landing strictly after the gate can recreate a
+// freshly-deleted entry via getOrCreateState.
+func (p *ProgramScorePolicy) evictIdle(ttl time.Duration) {
+	now := time.Now()
+	p.states.Range(func(key, value any) bool {
+		st, ok := value.(*programState)
+		if !ok {
+			p.states.Delete(key)
+			return true
+		}
+		if now.Sub(st.LastActive()) <= ttl {
+			return true
+		}
+		p.states.Delete(key)
+		if id, ok := key.(string); ok {
+			DeleteSharedSeries(id)
+		}
+		return true
+	})
+}

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/program-score/program_score_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/program-score/program_score_test.go
@@ -1,0 +1,156 @@
+package programscore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol/mocks"
+	fwkrc "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+var testFlowKey = flowcontrol.FlowKey{ID: "test-flow", Priority: 0}
+
+// itemFor builds a mock queue item whose program is identified by fairnessID.
+func itemFor(id, fairnessID string, enqueue time.Time) *mocks.MockQueueItemAccessor {
+	req := mocks.NewMockFlowControlRequest(10, id, testFlowKey)
+	req.InferenceRequestV = &fwksched.InferenceRequest{FairnessID: fairnessID}
+	return &mocks.MockQueueItemAccessor{OriginalRequestV: req, EnqueueTimeV: enqueue}
+}
+
+func TestConfig_Validate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr bool
+	}{
+		{"defaults are valid", func(*Config) {}, false},
+		{"negative WeightTurns", func(c *Config) { c.WeightTurns = -1 }, true},
+		{"negative WeightTokens", func(c *Config) { c.WeightTokens = -1 }, true},
+		{"negative HalfLifeSeconds", func(c *Config) { c.HalfLifeSeconds = -1 }, true},
+		{"negative RescoreIntervalSeconds", func(c *Config) { c.RescoreIntervalSeconds = -1 }, true},
+		{"negative EvictionTTLSeconds", func(c *Config) { c.EvictionTTLSeconds = -1 }, true},
+		{"zero EvictionSweepSeconds", func(c *Config) { c.EvictionSweepSeconds = 0 }, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := DefaultConfig()
+			tc.mutate(&cfg)
+			err := cfg.validate()
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFactory_NilHandle(t *testing.T) {
+	t.Parallel()
+	p, err := ProgramScoreOrderingPolicyFactory(ProgramScoreOrderingPolicyType, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, ProgramScoreOrderingPolicyType, p.TypedName().Name)
+}
+
+func TestProgramScorePolicy_Less(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	t.Run("fewer turns dispatches first", func(t *testing.T) {
+		t.Parallel()
+		p := newProgramScorePolicy(DefaultConfig())
+		busy := itemFor("busy-req", "busy-program", now)
+		idle := itemFor("idle-req", "idle-program", now)
+
+		// Give "busy-program" three turns; "idle-program" stays at zero.
+		for range 3 {
+			require.NoError(t, p.PreRequest(context.Background(), busy.OriginalRequestV.InferenceRequest(), nil))
+		}
+
+		assert.True(t, p.Less(idle, busy), "the program with fewer turns should dispatch first")
+		assert.False(t, p.Less(busy, idle))
+	})
+
+	t.Run("tokens consumed also weigh in", func(t *testing.T) {
+		t.Parallel()
+		p := newProgramScorePolicy(DefaultConfig())
+		heavy := itemFor("heavy-req", "heavy-program", now)
+		light := itemFor("light-req", "light-program", now)
+
+		p.ResponseBody(context.Background(), heavy.OriginalRequestV.InferenceRequest(),
+			&fwkrc.Response{EndOfStream: true, Usage: fwkrh.Usage{PromptTokens: 10000, CompletionTokens: 10000}}, nil)
+
+		assert.True(t, p.Less(light, heavy), "the program that consumed fewer tokens should dispatch first")
+	})
+
+	t.Run("equal cost breaks tie by enqueue time", func(t *testing.T) {
+		t.Parallel()
+		p := newProgramScorePolicy(DefaultConfig())
+		earlier := itemFor("earlier", "same-program-a", now.Add(-time.Second))
+		later := itemFor("later", "same-program-b", now)
+
+		assert.True(t, p.Less(earlier, later))
+		assert.False(t, p.Less(later, earlier))
+	})
+
+	t.Run("intermediate stream chunks do not add token cost", func(t *testing.T) {
+		t.Parallel()
+		p := newProgramScorePolicy(DefaultConfig())
+		req := &fwksched.InferenceRequest{FairnessID: "streaming-program"}
+		p.ResponseBody(context.Background(), req,
+			&fwkrc.Response{EndOfStream: false, Usage: fwkrh.Usage{PromptTokens: 10000}}, nil)
+
+		turns, tokens := p.getOrCreateState("streaming-program").Cost(now, p.cfg.HalfLifeSeconds)
+		assert.Zero(t, turns)
+		assert.Zero(t, tokens, "a non-final chunk must not be charged")
+	})
+}
+
+func TestProgramScorePolicy_RescoreInterval(t *testing.T) {
+	t.Parallel()
+	p := newProgramScorePolicy(Config{RescoreIntervalSeconds: 2.5})
+	assert.Equal(t, 2500*time.Millisecond, p.RescoreInterval())
+}
+
+// TestProgramScorePolicy_EqualizesShareAcrossManyAgentsInOneQueue is the regression test for the
+// issue's motivating claim: a tenant running many agents under one shared queue must not out-
+// dispatch a tenant running few, because dispatch order tracks per-program turns/tokens rather
+// than how many of a tenant's agents occupy the queue.
+func TestProgramScorePolicy_EqualizesShareAcrossManyAgentsInOneQueue(t *testing.T) {
+	t.Parallel()
+	p := newProgramScorePolicy(DefaultConfig())
+	now := time.Now()
+
+	// tenant-many has 5 agents, each already dispatched once (5 turns total). tenant-few has 1
+	// agent, never dispatched (0 turns). All 6 requests share one queue/FlowKey.
+	for i := range 5 {
+		agentID := "tenant-many-agent-" + string(rune('a'+i))
+		require.NoError(t, p.PreRequest(context.Background(), &fwksched.InferenceRequest{FairnessID: agentID}, nil))
+	}
+	newTurn := itemFor("tenant-many-req", "tenant-many-agent-a", now)
+	fewTurn := itemFor("tenant-few-req", "tenant-few-agent", now)
+
+	assert.True(t, p.Less(fewTurn, newTurn),
+		"tenant-few's single, never-dispatched agent must go before tenant-many's already-served agent")
+}
+
+func TestProgramScorePolicy_EvictIdle(t *testing.T) {
+	t.Parallel()
+	p := newProgramScorePolicy(DefaultConfig())
+	p.getOrCreateState("idle-program").AddTurn(time.Now().Add(-time.Hour), 0)
+
+	p.evictIdle(time.Minute)
+
+	_, loaded := p.states.Load("idle-program")
+	assert.False(t, loaded, "an idle-past-TTL program must be evicted")
+}

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/program-score/prometheus.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/program-score/prometheus.go
@@ -1,0 +1,38 @@
+package programscore
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	compbasemetrics "k8s.io/component-base/metrics"
+
+	metricsutil "github.com/llm-d/llm-d-router/pkg/common/observability/metrics"
+	eppmetrics "github.com/llm-d/llm-d-router/pkg/epp/metrics"
+)
+
+var (
+	decayedTurns = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: eppmetrics.LLMDRouterEndpointPickerSubsystem,
+			Name:      "program_score_decayed_turns",
+			Help:      metricsutil.HelpMsgWithStability("Time-decayed turn count per program.", compbasemetrics.ALPHA),
+		},
+		[]string{"program_id"},
+	)
+
+	decayedTokens = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: eppmetrics.LLMDRouterEndpointPickerSubsystem,
+			Name:      "program_score_decayed_tokens",
+			Help:      metricsutil.HelpMsgWithStability("Time-decayed token cost per program.", compbasemetrics.ALPHA),
+		},
+		[]string{"program_id"},
+	)
+)
+
+func GetCollectors() []prometheus.Collector {
+	return []prometheus.Collector{decayedTurns, decayedTokens}
+}
+
+func DeleteSharedSeries(id string) {
+	decayedTurns.DeleteLabelValues(id)
+	decayedTokens.DeleteLabelValues(id)
+}

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/program-score/state.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/program-score/state.go
@@ -1,0 +1,75 @@
+package programscore
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+// programState tracks one program's decayed turn count and decayed token cost. The two accumulate
+// and decay independently so Less can weight them independently, and so a future third signal
+// (e.g. prefix-match) is one more accumulator rather than a redesign.
+//
+// Decay mirrors programaware's lasState: folded lazily on read/write so an idle program's cost
+// ages out in wall-clock time without the program ever being visited.
+type programState struct {
+	mu          sync.Mutex
+	turns       float64
+	tokens      float64
+	decayAnchor time.Time
+	lastActive  time.Time
+}
+
+// decayLocked folds in the decay accrued since decayAnchor and advances the anchor to now.
+// halfLifeSeconds <= 0 disables decay. The caller must hold mu.
+func (s *programState) decayLocked(now time.Time, halfLifeSeconds float64) {
+	if s.decayAnchor.IsZero() {
+		s.decayAnchor = now
+		return
+	}
+	elapsed := now.Sub(s.decayAnchor).Seconds()
+	if elapsed <= 0 {
+		return
+	}
+	if halfLifeSeconds > 0 {
+		factor := math.Exp2(-elapsed / halfLifeSeconds)
+		s.turns *= factor
+		s.tokens *= factor
+	}
+	s.decayAnchor = now
+}
+
+// Cost returns the decayed turns and tokens as of now, with decay folded in.
+func (s *programState) Cost(now time.Time, halfLifeSeconds float64) (turns, tokens float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.decayLocked(now, halfLifeSeconds)
+	return s.turns, s.tokens
+}
+
+// AddTurn folds in pending decay, increments the turn count by one, and returns the new total.
+func (s *programState) AddTurn(now time.Time, halfLifeSeconds float64) float64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.decayLocked(now, halfLifeSeconds)
+	s.turns++
+	s.lastActive = now
+	return s.turns
+}
+
+// AddTokens folds in pending decay, accumulates the token cost, and returns the new total.
+func (s *programState) AddTokens(cost float64, now time.Time, halfLifeSeconds float64) float64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.decayLocked(now, halfLifeSeconds)
+	s.tokens += cost
+	s.lastActive = now
+	return s.tokens
+}
+
+// LastActive reports the last time this program's state was touched, used by idle eviction.
+func (s *programState) LastActive() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastActive
+}

--- a/pkg/epp/framework/plugins/flowcontrol/ordering/program-score/state_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/ordering/program-score/state_test.go
@@ -1,0 +1,45 @@
+package programscore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProgramState_AddAndDecay(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	s := &programState{}
+	turns := s.AddTurn(now, 60)
+	assert.Equal(t, 1.0, turns)
+	tokens := s.AddTokens(100, now, 60)
+	assert.Equal(t, 100.0, tokens)
+
+	// One half-life later, both accumulators should have halved.
+	later := now.Add(60 * time.Second)
+	gotTurns, gotTokens := s.Cost(later, 60)
+	assert.InDelta(t, 0.5, gotTurns, 1e-9)
+	assert.InDelta(t, 50.0, gotTokens, 1e-9)
+}
+
+func TestProgramState_ZeroHalfLifeDisablesDecay(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	s := &programState{}
+	s.AddTurn(now, 0)
+	gotTurns, _ := s.Cost(now.Add(time.Hour), 0)
+	assert.Equal(t, 1.0, gotTurns, "halfLifeSeconds <= 0 must disable decay")
+}
+
+func TestProgramState_LastActive(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	s := &programState{}
+	assert.Zero(t, s.LastActive())
+	s.AddTurn(now, 60)
+	assert.Equal(t, now, s.LastActive())
+}


### PR DESCRIPTION
Adds ScoringOrderingPolicy, an OrderingPolicy extension for policies whose Less result changes purely with elapsed time. The FlowController periodically re-heapifies queues using such a policy (reusing the existing cleanup-sweep goroutine and worker pool) so a time-decayed score surfaces at dispatch time even for an item that is never itself added or removed; plain OrderingPolicy implementations are unaffected.

Adds program-score-ordering-policy, the first ScoringOrderingPolicy: it orders requests within a single shared queue by the originating program/agent's decayed turns taken and tokens consumed, dispatching the least-served program first. This avoids the queue-per-agent granularity problem of program-aware-fairness, where a tenant running more agents gets a proportionally larger dispatch share purely by occupying more queues. Session state (turns, tokens) is tracked internally by the plugin via the existing PreRequest/ResponseBody hooks, independent of #2524.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #2548 
