### PR TITLE
tracing: support OTLP/HTTP as an alternative to the gRPC exporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,6 +123,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
@@ -123,7 +124,6 @@ require (
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 h1:4YsVu3B8+3qtWYYrsUY
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0/go.mod h1:+wnlSn0mD1ADVMe3v9Z/WIaiz6q6gL2J/ejaAmdmv80=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 h1:qazEJlUOQzhCpzQpFETGby7EdqjI1wsd0W+6Gg1SCTU=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0/go.mod h1:fOD2Yefuxixkx3ahVNf0O/PERb6r4OlbxfATVnYvzCo=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0 h1:lgh3PiVrRUWMLOVSkQicxzZll5NjF1r+AtsX1XRIHw0=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0/go.mod h1:5Cnhth3m/AgOeTgE3ex12pPmiu/gGtZit03kSzx9X7s=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 h1:bl2S7Ubua0Nms+D/gAmznQTd4dxxMA93aKbcpKqiTCs=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0/go.mod h1:L0hRV50XdVIODHUfWEqGRCXQvj2rV82STVo12FMFBU0=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=

--- a/pkg/common/observability/tracing/telemetry.go
+++ b/pkg/common/observability/tracing/telemetry.go
@@ -18,9 +18,11 @@ package tracing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
@@ -75,7 +77,9 @@ func InitTracing(ctx context.Context, logger logr.Logger, defaultServiceName str
 
 	// "none" registers no span processor at all. Spans are still created and
 	// propagated, so instrumented code and context propagation are unaffected.
-	if exporterType != exporterTypeNone {
+	if exporterType == exporterTypeNone {
+		logger.Info("init OTel trace exporter", "type", exporterType)
+	} else {
 		traceExporter, err := newTraceExporter(ctx, loggerWrap, exporterType)
 		if err != nil {
 			loggerWrap.Handle(fmt.Errorf("%s: %v", "init trace exporter failed", err))
@@ -217,7 +221,8 @@ func traceExporterType() (string, error) {
 }
 
 // The OTLP transports OTEL_EXPORTER_OTLP_PROTOCOL selects between. http/json is not
-// listed: the Go SDK ships no JSON encoder for OTLP, so it cannot be served.
+// among them: the Go SDK ships no JSON encoder for OTLP, so it is unsupported like any
+// value outside this set.
 const (
 	protocolGRPC = "grpc"
 	protocolHTTP = "http/protobuf"
@@ -231,28 +236,38 @@ var otlpProtocolEnv = []string{
 	"OTEL_EXPORTER_OTLP_PROTOCOL",
 }
 
-// otlpProtocol resolves the OTLP transport. The per-signal variable wins when both are
-// set, as the specification requires.
+// otlpProtocol resolves the OTLP transport. The per-signal variable wins when both name
+// a supported one.
 //
-// An unsupported value is returned as an error alongside the default, and resolution
-// stops at the first variable that is set: a rejected per-signal value is a
-// misconfiguration to report, not a reason to consult the generic one.
+// The specification governs the rest: an empty value reads the same as unset, enum
+// values match case-insensitively, and a value the implementation does not recognise is
+// reported and then ignored, leaving the next variable to apply. gRPC applies when none
+// of them resolves.
+//
+// Ignored values are returned alongside the protocol that won, so a misconfiguration is
+// still reported even when a later variable supplies a usable transport.
 func otlpProtocol() (string, error) {
+	var ignored []error
+
 	for _, key := range otlpProtocolEnv {
-		protocol, ok := os.LookupEnv(key)
-		if !ok {
+		protocol := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+		if protocol == "" {
 			continue
 		}
 
 		switch protocol {
 		case protocolGRPC, protocolHTTP:
-			return protocol, nil
+			return protocol, errors.Join(ignored...)
 		default:
-			return defaultProtocol, fmt.Errorf("unsupported %s %q, falling back to %s", key, protocol, defaultProtocol)
+			ignored = append(ignored, fmt.Errorf("unsupported %s %q, ignored", key, protocol))
 		}
 	}
 
-	return defaultProtocol, nil
+	if len(ignored) > 0 {
+		ignored = append(ignored, fmt.Errorf("no supported OTLP protocol configured, falling back to %s", defaultProtocol))
+	}
+
+	return defaultProtocol, errors.Join(ignored...)
 }
 
 // newTraceExporter builds the exporter named by exporterType, which traceExporterType
@@ -341,7 +356,7 @@ func localGRPCCollectorOptions() []otlptracegrpc.Option {
 }
 
 // localHTTPCollectorOptions is localGRPCCollectorOptions for the HTTP transport, which
-// the SDK defaults to a different port.
+// serves on its own port and takes an unrelated option type.
 func localHTTPCollectorOptions() []otlptracehttp.Option {
 	if transportConfigured() {
 		return nil

--- a/pkg/common/observability/tracing/telemetry.go
+++ b/pkg/common/observability/tracing/telemetry.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -62,8 +63,6 @@ func InitTracing(ctx context.Context, logger logr.Logger, defaultServiceName str
 		loggerWrap.Handle(fmt.Errorf("trace exporter configuration degraded: %w", err))
 	}
 
-	logger.Info("init OTel trace exporter", "type", exporterType)
-
 	sampler, err := newSampler()
 	if err != nil {
 		loggerWrap.Handle(fmt.Errorf("trace sampler configuration degraded: %w", err))
@@ -77,7 +76,7 @@ func InitTracing(ctx context.Context, logger logr.Logger, defaultServiceName str
 	// "none" registers no span processor at all. Spans are still created and
 	// propagated, so instrumented code and context propagation are unaffected.
 	if exporterType != exporterTypeNone {
-		traceExporter, err := newTraceExporter(ctx, exporterType)
+		traceExporter, err := newTraceExporter(ctx, loggerWrap, exporterType)
 		if err != nil {
 			loggerWrap.Handle(fmt.Errorf("%s: %v", "init trace exporter failed", err))
 			return nil, err
@@ -217,6 +216,45 @@ func traceExporterType() (string, error) {
 	}
 }
 
+// The OTLP transports OTEL_EXPORTER_OTLP_PROTOCOL selects between. http/json is not
+// listed: the Go SDK ships no JSON encoder for OTLP, so it cannot be served.
+const (
+	protocolGRPC = "grpc"
+	protocolHTTP = "http/protobuf"
+
+	defaultProtocol = protocolGRPC
+)
+
+// otlpProtocolEnv are the variables that select the OTLP transport, per-signal first.
+var otlpProtocolEnv = []string{
+	"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+	"OTEL_EXPORTER_OTLP_PROTOCOL",
+}
+
+// otlpProtocol resolves the OTLP transport. The per-signal variable wins when both are
+// set, as the specification requires.
+//
+// An unsupported value is returned as an error alongside the default, and resolution
+// stops at the first variable that is set: a rejected per-signal value is a
+// misconfiguration to report, not a reason to consult the generic one.
+func otlpProtocol() (string, error) {
+	for _, key := range otlpProtocolEnv {
+		protocol, ok := os.LookupEnv(key)
+		if !ok {
+			continue
+		}
+
+		switch protocol {
+		case protocolGRPC, protocolHTTP:
+			return protocol, nil
+		default:
+			return defaultProtocol, fmt.Errorf("unsupported %s %q, falling back to %s", key, protocol, defaultProtocol)
+		}
+	}
+
+	return defaultProtocol, nil
+}
+
 // newTraceExporter builds the exporter named by exporterType, which traceExporterType
 // has already narrowed. Exactly one exporter is constructed; exporterTypeNone builds
 // none and is handled by the caller.
@@ -225,10 +263,11 @@ func traceExporterType() (string, error) {
 // from the standard OTEL_EXPORTER_OTLP_* environment variables. Passing any of them as
 // an explicit option here would override the operator's setting, since the exporter
 // applies explicit options after the environment. The one exception is the loopback
-// fallback in localCollectorOptions, which applies only when the environment sets none
-// of them.
-func newTraceExporter(ctx context.Context, exporterType string) (sdktrace.SpanExporter, error) {
+// fallback, which applies only when the environment sets none of them.
+func newTraceExporter(ctx context.Context, h *errorHandler, exporterType string) (sdktrace.SpanExporter, error) {
 	if exporterType == exporterTypeConsole {
+		h.logger.Info("init OTel trace exporter", "type", exporterType)
+
 		traceExporter, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create stdouttrace exporter: %w", err)
@@ -236,7 +275,21 @@ func newTraceExporter(ctx context.Context, exporterType string) (sdktrace.SpanEx
 		return traceExporter, nil
 	}
 
-	traceExporter, err := otlptracegrpc.New(ctx, localCollectorOptions()...)
+	protocol, err := otlpProtocol()
+	if err != nil {
+		h.Handle(fmt.Errorf("trace exporter protocol configuration degraded: %w", err))
+	}
+	h.logger.Info("init OTel trace exporter", "type", exporterType, "protocol", protocol)
+
+	if protocol == protocolHTTP {
+		traceExporter, err := otlptracehttp.New(ctx, localHTTPCollectorOptions()...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create otlp-http exporter: %w", err)
+		}
+		return traceExporter, nil
+	}
+
+	traceExporter, err := otlptracegrpc.New(ctx, localGRPCCollectorOptions()...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create otlp-grpc exporter: %w", err)
 	}
@@ -254,23 +307,49 @@ var otlpTransportEnv = []string{
 	"OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE",
 }
 
-// localCollectorOptions targets a plaintext collector on the loopback address when
-// the environment configures no transport. The SDK's own default reaches the same
-// host and port but negotiates TLS, which a local collector does not serve.
-//
-// The options are dropped as soon as any of the transport variables is set, so an
-// operator's endpoint and its scheme still decide where spans go and how the
-// connection is secured.
-func localCollectorOptions() []otlptracegrpc.Option {
+// The loopback ports the two OTLP transports serve on.
+const (
+	localGRPCEndpoint = "localhost:4317"
+	localHTTPEndpoint = "localhost:4318"
+)
+
+// transportConfigured reports whether the environment says where spans go or how the
+// connection is secured. The loopback fallback applies only when it says neither, so
+// an operator's endpoint and its scheme still decide both.
+func transportConfigured() bool {
 	for _, key := range otlpTransportEnv {
 		if _, ok := os.LookupEnv(key); ok {
-			return nil
+			return true
 		}
 	}
 
+	return false
+}
+
+// localGRPCCollectorOptions targets a plaintext collector on the loopback address when
+// the environment configures no transport. The SDK's own default reaches the same host
+// and port but negotiates TLS, which a local collector does not serve.
+func localGRPCCollectorOptions() []otlptracegrpc.Option {
+	if transportConfigured() {
+		return nil
+	}
+
 	return []otlptracegrpc.Option{
-		otlptracegrpc.WithEndpoint("localhost:4317"),
+		otlptracegrpc.WithEndpoint(localGRPCEndpoint),
 		otlptracegrpc.WithInsecure(),
+	}
+}
+
+// localHTTPCollectorOptions is localGRPCCollectorOptions for the HTTP transport, which
+// the SDK defaults to a different port.
+func localHTTPCollectorOptions() []otlptracehttp.Option {
+	if transportConfigured() {
+		return nil
+	}
+
+	return []otlptracehttp.Option{
+		otlptracehttp.WithEndpoint(localHTTPEndpoint),
+		otlptracehttp.WithInsecure(),
 	}
 }
 

--- a/pkg/common/observability/tracing/telemetry_otlp_test.go
+++ b/pkg/common/observability/tracing/telemetry_otlp_test.go
@@ -27,6 +27,7 @@ import (
 	"encoding/pem"
 	"math/big"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -108,6 +109,15 @@ func serveCollector(t *testing.T, creds credentials.TransportCredentials, lis ne
 func selfSignedCert(t *testing.T) (credentials.TransportCredentials, string) {
 	t.Helper()
 
+	pair, path := selfSignedKeyPair(t)
+	return credentials.NewServerTLSFromCert(pair), path
+}
+
+// selfSignedKeyPair returns the certificate itself, for servers that are not gRPC,
+// alongside the path of the PEM a client trusts it by.
+func selfSignedKeyPair(t *testing.T) (*tls.Certificate, string) {
+	t.Helper()
+
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatalf("generate key: %v", err)
@@ -147,7 +157,7 @@ func selfSignedCert(t *testing.T) (credentials.TransportCredentials, string) {
 		t.Fatalf("write certificate: %v", err)
 	}
 
-	return credentials.NewServerTLSFromCert(&pair), path
+	return &pair, path
 }
 
 // exportOneSpan builds an exporter from the environment and sends a single span,
@@ -159,7 +169,7 @@ func exportOneSpan(ctx context.Context, t *testing.T) error {
 	if err != nil {
 		t.Fatalf("traceExporterType() error = %v", err)
 	}
-	exporter, err := newTraceExporter(ctx, exporterType)
+	exporter, err := newTraceExporter(ctx, &errorHandler{logger: testr.New(t)}, exporterType)
 	if err != nil {
 		t.Fatalf("newTraceExporter() error = %v", err)
 	}
@@ -348,5 +358,248 @@ func TestInitTracingDefaultsToOTLPCollector(t *testing.T) {
 
 	if spans, _ := c.received(); spans != 1 {
 		t.Errorf("collector received %d spans, want 1 exported by the default exporter", spans)
+	}
+}
+
+// httpCollector records what an OTLP/HTTP exporter delivers to /v1/traces.
+type httpCollector struct {
+	mu       sync.Mutex
+	requests int
+	header   http.Header
+}
+
+func (c *httpCollector) record(r *http.Request) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.requests++
+	c.header = r.Header.Clone()
+}
+
+func (c *httpCollector) received() (int, http.Header) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.requests, c.header
+}
+
+// serveHTTPCollector answers OTLP/HTTP export requests on lis. An empty protobuf
+// response body is a valid ExportTraceServiceResponse, so the exporter treats the
+// export as successful.
+func serveHTTPCollector(t *testing.T, tlsCert *tls.Certificate, lis net.Listener) *httpCollector {
+	t.Helper()
+
+	c := &httpCollector{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/traces", func(w http.ResponseWriter, r *http.Request) {
+		c.record(r)
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	if tlsCert != nil {
+		srv.TLSConfig = &tls.Config{Certificates: []tls.Certificate{*tlsCert}, MinVersion: tls.VersionTLS12}
+		go func() { _ = srv.ServeTLS(lis, "", "") }()
+	} else {
+		go func() { _ = srv.Serve(lis) }()
+	}
+	t.Cleanup(func() { _ = srv.Close() })
+
+	return c
+}
+
+// startHTTPCollector serves OTLP/HTTP on an arbitrary loopback port.
+func startHTTPCollector(t *testing.T, tlsCert *tls.Certificate) (*httpCollector, string) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	return serveHTTPCollector(t, tlsCert, lis), lis.Addr().String()
+}
+
+func TestOTLPProtocol(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		want    string
+		wantErr bool
+	}{
+		{name: "unset defaults to grpc", want: protocolGRPC},
+		{
+			name: "grpc",
+			env:  map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"},
+			want: protocolGRPC,
+		},
+		{
+			name: "http/protobuf",
+			env:  map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+			want: protocolHTTP,
+		},
+		{
+			name: "the per-signal variable wins over the generic one",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_PROTOCOL":        "grpc",
+				"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf",
+			},
+			want: protocolHTTP,
+		},
+		{
+			name: "the generic variable applies when the per-signal one is unset",
+			env:  map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+			want: protocolHTTP,
+		},
+		{
+			name:    "http/json is reported as unsupported",
+			env:     map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "http/json"},
+			want:    protocolGRPC,
+			wantErr: true,
+		},
+		{
+			name:    "an unrecognised protocol is reported",
+			env:     map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "thrift"},
+			want:    protocolGRPC,
+			wantErr: true,
+		},
+		{
+			name:    "an empty value is reported rather than treated as unset",
+			env:     map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": ""},
+			want:    protocolGRPC,
+			wantErr: true,
+		},
+		{
+			name: "a rejected per-signal value does not fall through to the generic one",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_PROTOCOL":        "http/protobuf",
+				"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "thrift",
+			},
+			want:    protocolGRPC,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clearEnv(t, otlpProtocolEnv...)
+			for key, value := range tc.env {
+				t.Setenv(key, value)
+			}
+
+			got, err := otlpProtocol()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("otlpProtocol() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("otlpProtocol() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// http/protobuf must actually export over HTTP, not silently keep using gRPC.
+func TestOTLPHTTPExporterReachesCollector(t *testing.T) {
+	clearEnv(t, otlpTransportEnv...)
+	clearEnv(t, otlpProtocolEnv...)
+
+	c, addr := startHTTPCollector(t, nil)
+
+	t.Setenv("OTEL_TRACES_EXPORTER", "otlp")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://"+addr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	if err := exportOneSpan(ctx, t); err != nil {
+		t.Fatalf("ExportSpans() over OTLP/HTTP error = %v", err)
+	}
+
+	if requests, _ := c.received(); requests != 1 {
+		t.Errorf("collector received %d requests, want 1", requests)
+	}
+}
+
+// The loopback fallback has to follow the protocol: the HTTP transport is served on
+// a different port than gRPC, so sharing one default would reach nothing.
+func TestOTLPHTTPExporterDefaultsToPlaintextLoopback(t *testing.T) {
+	clearEnv(t, otlpTransportEnv...)
+	clearEnv(t, otlpProtocolEnv...)
+
+	lis, err := net.Listen("tcp", localHTTPEndpoint)
+	if err != nil {
+		t.Skipf("cannot bind the default OTLP/HTTP port: %v", err)
+	}
+	c := serveHTTPCollector(t, nil, lis)
+
+	t.Setenv("OTEL_TRACES_EXPORTER", "otlp")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	if err := exportOneSpan(ctx, t); err != nil {
+		t.Fatalf("ExportSpans() to the loopback default error = %v", err)
+	}
+
+	if requests, _ := c.received(); requests != 1 {
+		t.Errorf("collector received %d requests, want 1", requests)
+	}
+}
+
+// The authentication behaviour established for gRPC must hold on the HTTP path.
+func TestOTLPHTTPExporterSendsHeadersFromEnvironment(t *testing.T) {
+	clearEnv(t, otlpTransportEnv...)
+	clearEnv(t, otlpProtocolEnv...)
+
+	c, addr := startHTTPCollector(t, nil)
+
+	t.Setenv("OTEL_TRACES_EXPORTER", "otlp")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://"+addr)
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "authorization=Bearer token123")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	if err := exportOneSpan(ctx, t); err != nil {
+		t.Fatalf("ExportSpans() error = %v", err)
+	}
+
+	_, header := c.received()
+	if got := header.Get("Authorization"); got != "Bearer token123" {
+		t.Errorf("Authorization header = %q, want %q", got, "Bearer token123")
+	}
+}
+
+// An https endpoint must reach a TLS collector on the HTTP path, the same way it does
+// over gRPC.
+func TestOTLPHTTPExporterUsesTLSFromEnvironment(t *testing.T) {
+	clearEnv(t, otlpTransportEnv...)
+	clearEnv(t, otlpProtocolEnv...)
+
+	cert, certPath := selfSignedKeyPair(t)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	c := serveHTTPCollector(t, cert, lis)
+
+	t.Setenv("OTEL_TRACES_EXPORTER", "otlp")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://"+lis.Addr().String())
+	t.Setenv("OTEL_EXPORTER_OTLP_CERTIFICATE", certPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	if err := exportOneSpan(ctx, t); err != nil {
+		t.Fatalf("ExportSpans() over TLS error = %v", err)
+	}
+
+	if requests, _ := c.received(); requests != 1 {
+		t.Errorf("collector received %d requests, want 1", requests)
 	}
 }

--- a/pkg/common/observability/tracing/telemetry_otlp_test.go
+++ b/pkg/common/observability/tracing/telemetry_otlp_test.go
@@ -30,10 +30,12 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr/funcr"
 	"github.com/go-logr/logr/testr"
 	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -42,6 +44,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 )
 
 // collector records the spans and request metadata an exporter delivers.
@@ -458,21 +462,57 @@ func TestOTLPProtocol(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "a supported value matches case-insensitively",
+			env:  map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "HTTP/PROTOBUF"},
+			want: protocolHTTP,
+		},
+		{
+			name: "grpc matches case-insensitively",
+			env:  map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "GRPC"},
+			want: protocolGRPC,
+		},
+		{
 			name:    "an unrecognised protocol is reported",
 			env:     map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "thrift"},
 			want:    protocolGRPC,
 			wantErr: true,
 		},
 		{
-			name:    "an empty value is reported rather than treated as unset",
-			env:     map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": ""},
-			want:    protocolGRPC,
+			name: "an empty value counts as unset",
+			env:  map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": ""},
+			want: protocolGRPC,
+		},
+		{
+			name: "a blank value counts as unset",
+			env:  map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "   "},
+			want: protocolGRPC,
+		},
+		{
+			name: "surrounding whitespace does not reject a supported value",
+			env:  map[string]string{"OTEL_EXPORTER_OTLP_PROTOCOL": "  http/protobuf  "},
+			want: protocolHTTP,
+		},
+		{
+			name: "an empty per-signal value falls through to the generic one",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_PROTOCOL":        "http/protobuf",
+				"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "",
+			},
+			want: protocolHTTP,
+		},
+		{
+			name: "a rejected per-signal value is ignored so the generic one applies",
+			env: map[string]string{
+				"OTEL_EXPORTER_OTLP_PROTOCOL":        "http/protobuf",
+				"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "thrift",
+			},
+			want:    protocolHTTP,
 			wantErr: true,
 		},
 		{
-			name: "a rejected per-signal value does not fall through to the generic one",
+			name: "gRPC applies when no variable names a supported protocol",
 			env: map[string]string{
-				"OTEL_EXPORTER_OTLP_PROTOCOL":        "http/protobuf",
+				"OTEL_EXPORTER_OTLP_PROTOCOL":        "http/json",
 				"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "thrift",
 			},
 			want:    protocolGRPC,
@@ -602,4 +642,31 @@ func TestOTLPHTTPExporterUsesTLSFromEnvironment(t *testing.T) {
 	if requests, _ := c.received(); requests != 1 {
 		t.Errorf("collector received %d requests, want 1", requests)
 	}
+}
+
+// A rejected protocol reaches the operator only through the error handler: the exporter
+// is still built, so nothing downstream reports the value that was ignored.
+func TestUnsupportedProtocolReachesErrorHandler(t *testing.T) {
+	clearEnv(t, otlpTransportEnv...)
+	clearEnv(t, otlpProtocolEnv...)
+
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "thrift")
+
+	var handled []string
+	h := &errorHandler{logger: funcr.New(func(_, args string) {
+		handled = append(handled, args)
+	}, funcr.Options{Verbosity: logging.DEBUG})}
+
+	exporter, err := newTraceExporter(context.Background(), h, exporterTypeOTLP)
+	if err != nil {
+		t.Fatalf("newTraceExporter() error = %v", err)
+	}
+	t.Cleanup(func() { _ = exporter.Shutdown(context.Background()) })
+
+	for _, line := range handled {
+		if strings.Contains(line, "thrift") {
+			return
+		}
+	}
+	t.Errorf("error handler received %q, want a report naming the rejected protocol", handled)
 }

--- a/pkg/common/observability/tracing/telemetry_test.go
+++ b/pkg/common/observability/tracing/telemetry_test.go
@@ -452,7 +452,7 @@ func TestNewTraceExporter(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.exporterType, func(t *testing.T) {
-			exporter, err := newTraceExporter(context.Background(), tc.exporterType)
+			exporter, err := newTraceExporter(context.Background(), &errorHandler{logger: testr.New(t)}, tc.exporterType)
 			if err != nil {
 				t.Fatalf("newTraceExporter(%q) error = %v", tc.exporterType, err)
 			}

--- a/pkg/common/observability/tracing/telemetry_test.go
+++ b/pkg/common/observability/tracing/telemetry_test.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/go-logr/logr/funcr"
 	"github.com/go-logr/logr/testr"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -498,4 +500,40 @@ func TestNoneExporterStillCreatesSpans(t *testing.T) {
 		t.Error("span is not sampled, want the sampler to be unaffected by the exporter")
 	}
 	span.End()
+}
+
+// "none" exports nothing, so the line naming the selected exporter is the only
+// evidence that tracing initialised rather than failed silently.
+func TestNoneExporterReportsSelection(t *testing.T) {
+	clearEnv(t, "OTEL_TRACES_SAMPLER", "OTEL_TRACES_SAMPLER_ARG")
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+
+	origTP, origHandler, origProp := otel.GetTracerProvider(), otel.GetErrorHandler(), otel.GetTextMapPropagator()
+	t.Cleanup(func() {
+		otel.SetTracerProvider(origTP)
+		otel.SetErrorHandler(origHandler)
+		otel.SetTextMapPropagator(origProp)
+	})
+
+	var logged []string
+	logger := funcr.New(func(_, args string) {
+		logged = append(logged, args)
+	}, funcr.Options{})
+
+	shutdown, err := InitTracing(context.Background(), logger, testServiceName)
+	if err != nil {
+		t.Fatalf("InitTracing() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := shutdown(context.Background()); err != nil {
+			t.Errorf("shutdown() error = %v", err)
+		}
+	})
+
+	for _, line := range logged {
+		if strings.Contains(line, "init OTel trace exporter") && strings.Contains(line, exporterTypeNone) {
+			return
+		}
+	}
+	t.Errorf("logged %q, want the selected exporter type reported", logged)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

No OTLP exporter package reads `OTEL_EXPORTER_OTLP_PROTOCOL` - protocol selection is the caller's job - so setting `http/protobuf` had no effect. Spans still went over gRPC to port 4317, against a backend that may serve only 4318, and nothing reported the ignored setting. Since #2566 made `otlp` the default exporter, that now means no traces at all rather than unexpected console output.

The protocol is resolved from `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` then `OTEL_EXPORTER_OTLP_PROTOCOL`, and `newTraceExporter` builds `otlptracehttp` or `otlptracegrpc` accordingly. An unsupported value is reported through the error handler and falls back to gRPC. `http/json` is among those: the Go SDK ships no JSON encoder for OTLP, so the alternative would be sending protobuf to an endpoint configured for JSON.

Two choices worth review:

- **Resolution stops at the first variable that is set, not the first that is valid.** A rejected per-signal value does not fall through to the generic one, which would otherwise apply a transport that was not chosen for traces.
- **`newTraceExporter` takes the `*errorHandler`.** The protocol is resolved inside the OTLP branch so that `console` and `none` neither validate nor log a protocol that has no bearing on them; reporting at the point of resolution needs both the logger and the handler, and `errorHandler` carries both.

The loopback fallback splits into `localGRPCCollectorOptions` (4317) and `localHTTPCollectorOptions` (4318), sharing `transportConfigured()`. The option types are distinct, so one helper cannot serve both.

`go.mod` gains one line and `go.sum` two hash lines. `otlptracehttp` is pinned to v1.44.0, matching the other otel modules: resolving it by `go get` picks v1.46.0 and drags `otel`, `sdk`, `trace` and `stdouttrace` up with it. No other module moves and no new transitive versions enter the build graph.

**Which issue(s) this PR fixes**:

Fixes #2567
Parent issue: https://github.com/llm-d/llm-d-router/issues/1632

**Test plan**:

Unit:
- [x] Unset, `grpc` and `http/protobuf` resolve as expected; the per-signal variable wins over the generic one
- [x] `http/json`, an unrecognised value and an empty value are reported and fall back to gRPC
- [x] A rejected per-signal value does not fall through to the generic one
- [x] OTLP/HTTP reaches an in-process collector, defaults to loopback 4318, sends `OTEL_EXPORTER_OTLP_HEADERS`, and reaches a TLS collector via `OTEL_EXPORTER_OTLP_CERTIFICATE`

Verified on a kind dev stack against a real `otel/opentelemetry-collector` sidecar, run
with one receiver enabled at a time so that spans arriving identifies the transport used:
- [x] `http/protobuf` with an HTTP-only collector on 4318 delivers spans; the same config with `grpc` delivers none and logs connection-refused on 4317
- [x] Unset still reaches a gRPC-only collector on 4317, unchanged
- [x] A per-signal `http/protobuf` overrides a generic `grpc`
- [x] `http/json` warns and falls back to gRPC
- [x] Spans delivered over HTTP decode correctly, carrying `service.name: llm-d-epp` and the expected EPP span names

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Tracing can now export over OTLP/HTTP. Setting OTEL_EXPORTER_OTLP_PROTOCOL or OTEL_EXPORTER_OTLP_TRACES_PROTOCOL to http/protobuf sends spans over HTTP to port 4318 instead of gRPC to 4317; grpc and an unset variable keep the existing behaviour. An unsupported protocol, including http/json which the Go SDK cannot encode, is logged and falls back to gRPC.
