### PR TITLE
feat(datalayer): confine per-request attribute access to declarations

### DIFF
--- a/pkg/epp/datalayer/endpoint_scope.go
+++ b/pkg/epp/datalayer/endpoint_scope.go
@@ -22,14 +22,12 @@ limitations under the License.
 // contract statically, over the declarations alone.
 //
 // The scope covers endpoint attributes reached through the extension points
-// that receive a []scheduling.Endpoint: filters, scorers, and DataProducers.
-// Two paths are deliberately outside it:
+// that receive a []scheduling.Endpoint -- filters, scorers, and DataProducers --
+// and, through request_scope.go, the per-request store at those points plus
+// PreRequest and the profile handler.
 //
-//   - The per-request store (InferenceRequest.PutAttribute/GetAttribute). It is
-//     typed by DataKey but not confined, because in-tree plugins currently
-//     exchange request attributes they do not declare.
-//   - Datalayer extractors, which write through Endpoint.GetAttributes()
-//     directly rather than through a scoped endpoint.
+// Datalayer extractors stay outside it: they write through
+// Endpoint.GetAttributes() directly rather than through a scoped endpoint.
 
 package datalayer
 
@@ -47,9 +45,10 @@ import (
 )
 
 // Violations records what a plugin did outside its declarations during one
-// extension-point invocation. Every endpoint wrapper produced by a single Scope
-// call shares one instance, so a plugin that reaches for the same undeclared key
-// on each of a hundred candidates is reported once rather than a hundred times.
+// extension-point invocation. The scoped request and every endpoint wrapper
+// produced by a single call share one instance, so a plugin that reaches for the
+// same undeclared key on each of a hundred candidates is reported once rather
+// than a hundred times.
 //
 // The lock is taken only on the rejection path. A conforming plugin never
 // touches it, so confinement costs an allowed access nothing beyond the map
@@ -105,9 +104,16 @@ func (v *Violations) recordRead() bool {
 // cannot fail the request still makes a misdeclared plugin visible in
 // production rather than leaving it to log verbosity.
 type ScopedEndpoint struct {
-	inner          fwksched.Endpoint
-	allowedPut     map[fwkplugin.DataKey]struct{}
-	allowedGet     map[fwkplugin.DataKey]struct{}
+	inner      fwksched.Endpoint
+	allowedPut map[fwkplugin.DataKey]struct{}
+	allowedGet map[fwkplugin.DataKey]struct{}
+	reporter
+}
+
+// reporter counts, logs, and accumulates the rejections of one plugin during one
+// extension-point invocation. ScopedEndpoint and requestScope share it so an
+// endpoint attribute and a request attribute are reported the same way.
+type reporter struct {
 	typedName      fwkplugin.TypedName
 	extensionPoint string
 	logger         logr.Logger
@@ -147,22 +153,22 @@ func (e *ScopedEndpoint) Get(key fwkplugin.DataKey) (fwkdl.Cloneable, bool) {
 // invocation is logged at Error, the rest at DEBUG: a plugin that misreaches on
 // every candidate endpoint would otherwise emit one error line per endpoint per
 // request.
-func (e *ScopedEndpoint) reject(access string, err error) {
-	metrics.RecordPluginDataScopeViolation(e.extensionPoint, e.typedName.Type, e.typedName.Name, access)
+func (r *reporter) reject(access string, err error) {
+	metrics.RecordPluginDataScopeViolation(r.extensionPoint, r.typedName.Type, r.typedName.Name, access)
 
 	first := false
 	if access == metrics.DataScopeAccessWrite {
-		first = e.violations.recordWrite(err)
+		first = r.violations.recordWrite(err)
 	} else {
-		first = e.violations.recordRead()
+		first = r.violations.recordRead()
 	}
 	if first {
-		e.logger.Error(err, "Rejected access outside the plugin's declared keys",
-			"extensionPoint", e.extensionPoint, "access", access)
+		r.logger.Error(err, "Rejected access outside the plugin's declared keys",
+			"extensionPoint", r.extensionPoint, "access", access)
 		return
 	}
-	e.logger.V(logging.DEBUG).Info("Rejected access outside the plugin's declared keys",
-		"extensionPoint", e.extensionPoint, "access", access, "error", err.Error())
+	r.logger.V(logging.DEBUG).Info("Rejected access outside the plugin's declared keys",
+		"extensionPoint", r.extensionPoint, "access", access, "error", err.Error())
 }
 
 // Keys returns only the declared keys that are present, so enumeration cannot
@@ -196,10 +202,6 @@ type scopeSpec struct {
 	allowedPut map[fwkplugin.DataKey]struct{}
 	allowedGet map[fwkplugin.DataKey]struct{}
 }
-
-// denyAllSpec confines an unregistered plugin the same way as one that
-// declares nothing.
-var denyAllSpec = &scopeSpec{}
 
 // scopeSpecs maps a plugin's TypedName().String() to the spec derived from its
 // declarations. RegisterScopeSpecs writes it during startup; Scope only reads.
@@ -253,22 +255,31 @@ func buildScopeSpec(plugin fwkplugin.Plugin) *scopeSpec {
 	return spec
 }
 
-// scopeSpecFor returns the registered spec for a plugin's typed name, or the
-// deny-all spec when none was registered. The miss is logged once per typed
-// name: it indicates a wiring bug, and the resulting confinement also shows up
-// through the violation counter as soon as the plugin touches an attribute.
-func scopeSpecFor(logger logr.Logger, name string) *scopeSpec {
+// scopeSpecFor returns the registered spec for a plugin, deriving and caching
+// one from its own declarations when startup registration missed it. The
+// declarations are fixed at construction, so a derived spec is the one
+// RegisterScopeSpecs would have stored; the miss is a wiring bug worth an error
+// log, reported once per typed name, but not a reason to cut a plugin off from
+// the data it declared.
+func scopeSpecFor(logger logr.Logger, p fwkplugin.Plugin) *scopeSpec {
+	name := p.TypedName().String()
 	scopeSpecsMu.RLock()
 	spec, ok := scopeSpecs[name]
 	scopeSpecsMu.RUnlock()
 	if ok {
 		return spec
 	}
+
+	spec = buildScopeSpec(p)
+	scopeSpecsMu.Lock()
+	scopeSpecs[name] = spec
+	scopeSpecsMu.Unlock()
+
 	if _, reported := unregisteredReported.LoadOrStore(name, struct{}{}); !reported {
 		logger.Error(fmt.Errorf("plugin %q has no registered scope spec; pass it to RegisterScopeSpecs", name),
-			"Confining an unregistered plugin to nothing")
+			"Deriving a plugin's scope from its declarations")
 	}
-	return denyAllSpec
+	return spec
 }
 
 // Scope confines endpoints to what plugin declares. extensionPoint labels the
@@ -281,29 +292,36 @@ func scopeSpecFor(logger logr.Logger, name string) *scopeSpec {
 //
 // The allowed-key sets come from the registry populated by RegisterScopeSpecs
 // at startup, treating Produces() and Consumes() as immutable after
-// construction. A plugin that was never registered is confined to nothing.
+// construction. A plugin missing from the registry has its spec derived from
+// its own declarations on first use.
 func Scope(logger logr.Logger, extensionPoint string, plugin fwkplugin.Plugin, endpoints []fwksched.Endpoint) ([]fwksched.Endpoint, *Violations) {
-	typedName := plugin.TypedName()
-	spec := scopeSpecFor(logger, typedName.String())
-
 	violations := &Violations{}
+	return scopeEndpoints(logger, extensionPoint, plugin, endpoints, violations), violations
+}
+
+func scopeEndpoints(logger logr.Logger, extensionPoint string, plugin fwkplugin.Plugin, endpoints []fwksched.Endpoint, violations *Violations) []fwksched.Endpoint {
+	typedName := plugin.TypedName()
+	spec := scopeSpecFor(logger, plugin)
+
 	// One backing array rather than an allocation per endpoint: this runs for
 	// every filter and scorer on every request, over the whole candidate set.
 	wrappers := make([]ScopedEndpoint, len(endpoints))
 	scoped := make([]fwksched.Endpoint, len(endpoints))
 	for i, endpoint := range endpoints {
 		wrappers[i] = ScopedEndpoint{
-			inner:          endpoint,
-			allowedPut:     spec.allowedPut,
-			allowedGet:     spec.allowedGet,
-			typedName:      typedName,
-			extensionPoint: extensionPoint,
-			logger:         logger,
-			violations:     violations,
+			inner:      endpoint,
+			allowedPut: spec.allowedPut,
+			allowedGet: spec.allowedGet,
+			reporter: reporter{
+				typedName:      typedName,
+				extensionPoint: extensionPoint,
+				logger:         logger,
+				violations:     violations,
+			},
 		}
 		scoped[i] = &wrappers[i]
 	}
-	return scoped, violations
+	return scoped
 }
 
 // Unscope restores the underlying endpoints of a plugin's result.

--- a/pkg/epp/datalayer/endpoint_scope_test.go
+++ b/pkg/epp/datalayer/endpoint_scope_test.go
@@ -263,7 +263,11 @@ func TestUnscope_LeavesUnwrappedEndpointsAlone(t *testing.T) {
 // Declarations grant nothing on their own: the allowed sets come from the
 // registry, and a plugin nobody registered is confined like one that declares
 // nothing.
-func TestScope_UnregisteredPluginIsConfinedToNothing(t *testing.T) {
+// A plugin that startup registration missed is still confined to its own
+// declarations rather than to nothing: the spec is derived from the plugin on
+// first use. Missing the registration is a wiring bug, not grounds for cutting
+// the plugin off from data it declared.
+func TestScope_UnregisteredPluginFallsBackToItsOwnDeclarations(t *testing.T) {
 	plug := &producerConsumerPlugin{}
 	plug.name = "never-registered"
 	plug.produces = map[fwkplugin.DataKey]any{producedKey: nil}
@@ -273,11 +277,19 @@ func TestScope_UnregisteredPluginIsConfinedToNothing(t *testing.T) {
 	scoped, violations := Scope(testLogger(), "test-extension-point", plug, []fwksched.Endpoint{endpoint})
 	require.Len(t, scoped, 1)
 
-	_, ok := scoped[0].Get(consumedKey)
-	assert.False(t, ok, "a declared read must not resolve without registration")
-	scoped[0].Put(producedKey, cloneableStr("nope"))
-	_, ok = endpoint.Get(producedKey)
-	assert.False(t, ok, "a declared write must not reach the endpoint without registration")
+	value, ok := scoped[0].Get(consumedKey)
+	assert.True(t, ok, "a declared read resolves from the derived spec")
+	assert.Equal(t, cloneableStr("consumed-value"), value)
+	scoped[0].Put(producedKey, cloneableStr("written"))
+	written, ok := endpoint.Get(producedKey)
+	assert.True(t, ok, "a declared write reaches the endpoint")
+	assert.Equal(t, cloneableStr("written"), written)
+	assert.NoError(t, violations.Write())
+
+	// An undeclared key is still rejected, leaving the endpoint's value intact.
+	scoped[0].Put(undeclaredKey, cloneableStr("nope"))
+	kept, _ := endpoint.Get(undeclaredKey)
+	assert.Equal(t, cloneableStr("secret"), kept)
 	assert.Error(t, violations.Write())
 }
 

--- a/pkg/epp/datalayer/request_scope.go
+++ b/pkg/epp/datalayer/request_scope.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Runtime confinement of a plugin's per-request attribute access, the other
+// half of the endpoint confinement in endpoint_scope.go. Both read the same
+// allowed-key sets, report through the same counter, and accumulate into the
+// same Violations, so one invocation that misreaches on either store fails or
+// is counted identically.
+//
+// An endpoint is confined by wrapping it, because plugins receive endpoints
+// through an interface. A request is a struct, so it is confined by handing the
+// plugin a shallow copy carrying the scope; the copy shares the backing store,
+// so allowed writes are visible to the framework and to later plugins.
+
+package datalayer
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
+)
+
+// requestScope confines a plugin's request-attribute access to the keys it
+// declares, on the same terms as ScopedEndpoint: a write outside Produces() is
+// dropped and recorded, a read outside Consumes() resolves as absent.
+type requestScope struct {
+	allowedPut map[fwkplugin.DataKey]struct{}
+	allowedGet map[fwkplugin.DataKey]struct{}
+	reporter
+}
+
+var _ fwksched.AttributeScope = &requestScope{}
+
+func (s *requestScope) AllowPut(key fwkplugin.DataKey) bool {
+	if _, ok := s.allowedPut[key]; ok {
+		return true
+	}
+	s.reject(metrics.DataScopeAccessWrite, fmt.Errorf(
+		"plugin %q wrote undeclared request attribute %q; add it to Produces()", s.typedName.String(), key))
+	return false
+}
+
+func (s *requestScope) AllowGet(key fwkplugin.DataKey) bool {
+	if _, ok := s.allowedGet[key]; ok {
+		return true
+	}
+	s.reject(metrics.DataScopeAccessRead, fmt.Errorf(
+		"plugin %q read undeclared request attribute %q; add it to Consumes()", s.typedName.String(), key))
+	return false
+}
+
+func (s *requestScope) Declares(key fwkplugin.DataKey) bool {
+	_, ok := s.allowedGet[key]
+	return ok
+}
+
+// ScopeRequest confines a plugin's request-attribute access for one invocation
+// of extensionPoint. Use it where the plugin receives no endpoints; where it
+// receives both, ScopeInvocation reports the two halves together.
+func ScopeRequest(logger logr.Logger, extensionPoint string, plugin fwkplugin.Plugin,
+	request *fwksched.InferenceRequest) (*fwksched.InferenceRequest, *Violations) {
+	violations := &Violations{}
+	return scopeRequest(logger, extensionPoint, plugin, request, violations), violations
+}
+
+// ScopeInvocation confines both stores a plugin reaches during one invocation
+// under a single Violations, so a caller with an error return fails the request
+// on the first rejected write wherever it happened.
+func ScopeInvocation(logger logr.Logger, extensionPoint string, plugin fwkplugin.Plugin,
+	request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) (*fwksched.InferenceRequest, []fwksched.Endpoint, *Violations) {
+	violations := &Violations{}
+	return scopeRequest(logger, extensionPoint, plugin, request, violations),
+		scopeEndpoints(logger, extensionPoint, plugin, endpoints, violations),
+		violations
+}
+
+func scopeRequest(logger logr.Logger, extensionPoint string, plugin fwkplugin.Plugin,
+	request *fwksched.InferenceRequest, violations *Violations) *fwksched.InferenceRequest {
+	if request == nil {
+		return nil
+	}
+	typedName := plugin.TypedName()
+	spec := scopeSpecFor(logger, plugin)
+	return request.WithAttributeScope(&requestScope{
+		allowedPut: spec.allowedPut,
+		allowedGet: spec.allowedGet,
+		reporter: reporter{
+			typedName:      typedName,
+			extensionPoint: extensionPoint,
+			logger:         logger,
+			violations:     violations,
+		},
+	})
+}

--- a/pkg/epp/datalayer/request_scope_test.go
+++ b/pkg/epp/datalayer/request_scope_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datalayer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+)
+
+func newRequestScopePlugin(name string) *producerConsumerPlugin {
+	plug := &producerConsumerPlugin{}
+	plug.name = name
+	plug.produces = map[fwkplugin.DataKey]any{producedKey: nil}
+	plug.consumes = &fwkplugin.DataDependencies{Optional: map[fwkplugin.DataKey]any{consumedKey: nil}}
+	return plug
+}
+
+func TestScopeRequest_AllowsDeclaredAccess(t *testing.T) {
+	plug := newRequestScopePlugin("request-declared")
+	RegisterScopeSpecs([]fwkplugin.Plugin{plug})
+
+	request := &fwksched.InferenceRequest{RequestID: "req"}
+	request.PutAttribute(consumedKey, "consumed-value")
+
+	scoped, violations := ScopeRequest(testLogger(), "test-extension-point", plug, request)
+
+	value, ok := scoped.GetAttribute(consumedKey)
+	assert.True(t, ok, "a key in Consumes resolves")
+	assert.Equal(t, "consumed-value", value)
+
+	// A producer may read back what it wrote.
+	scoped.PutAttribute(producedKey, "produced-value")
+	value, ok = scoped.GetAttribute(producedKey)
+	assert.True(t, ok)
+	assert.Equal(t, "produced-value", value)
+	assert.NoError(t, violations.Write())
+
+	// The write reached the store the framework owns, not just the copy.
+	value, ok = request.GetAttribute(producedKey)
+	assert.True(t, ok, "an allowed write is visible on the unscoped request")
+	assert.Equal(t, "produced-value", value)
+}
+
+func TestScopeRequest_DropsUndeclaredWrite(t *testing.T) {
+	plug := newRequestScopePlugin("request-undeclared-write")
+	RegisterScopeSpecs([]fwkplugin.Plugin{plug})
+
+	request := &fwksched.InferenceRequest{RequestID: "req"}
+	scoped, violations := ScopeRequest(testLogger(), "test-extension-point", plug, request)
+
+	scoped.PutAttribute(undeclaredKey, "nope")
+
+	_, ok := request.GetAttribute(undeclaredKey)
+	assert.False(t, ok, "an undeclared write must not reach the store")
+	require.Error(t, violations.Write(), "the rejection is reportable by an extension point with an error return")
+	assert.Contains(t, violations.Write().Error(), "add it to Produces()")
+}
+
+func TestScopeRequest_UndeclaredReadResolvesAsAbsent(t *testing.T) {
+	plug := newRequestScopePlugin("request-undeclared-read")
+	RegisterScopeSpecs([]fwkplugin.Plugin{plug})
+
+	request := &fwksched.InferenceRequest{RequestID: "req"}
+	request.PutAttribute(undeclaredKey, "secret")
+
+	scoped, violations := ScopeRequest(testLogger(), "test-extension-point", plug, request)
+
+	value, ok := scoped.GetAttribute(undeclaredKey)
+	assert.False(t, ok, "an undeclared read resolves as absent")
+	assert.Nil(t, value)
+	// A read is not reportable: Filter and Score have no error return.
+	assert.NoError(t, violations.Write())
+
+	// The value is untouched for the plugin that did declare it.
+	value, ok = request.GetAttribute(undeclaredKey)
+	assert.True(t, ok)
+	assert.Equal(t, "secret", value)
+}
+
+// Enumeration lists only the keys the plugin may read, so it cannot be used to
+// discover an attribute another plugin owns.
+func TestScopeRequest_AttributeKeysListsOnlyDeclaredKeys(t *testing.T) {
+	plug := newRequestScopePlugin("request-keys")
+	RegisterScopeSpecs([]fwkplugin.Plugin{plug})
+
+	request := &fwksched.InferenceRequest{RequestID: "req"}
+	request.PutAttribute(consumedKey, "consumed-value")
+	request.PutAttribute(undeclaredKey, "secret")
+
+	scoped, _ := ScopeRequest(testLogger(), "test-extension-point", plug, request)
+
+	assert.ElementsMatch(t, []fwkplugin.DataKey{consumedKey}, scoped.AttributeKeys())
+	assert.ElementsMatch(t, []fwkplugin.DataKey{consumedKey, undeclaredKey}, request.AttributeKeys())
+}
+
+// The scoped request is a shallow copy, so a lazily allocated store or header
+// map must be materialized on the original before the copy is taken. A
+// PreRequest plugin initializes Headers before setting one.
+func TestScopeRequest_MaterializesLazyFieldsOnTheOriginal(t *testing.T) {
+	plug := newRequestScopePlugin("request-lazy-fields")
+	RegisterScopeSpecs([]fwkplugin.Plugin{plug})
+
+	request := &fwksched.InferenceRequest{RequestID: "req"}
+	require.Nil(t, request.Headers)
+
+	scoped, _ := ScopeRequest(testLogger(), "test-extension-point", plug, request)
+	require.NotNil(t, request.Headers, "Headers is materialized so a plugin's write is not lost")
+
+	scoped.Headers["x-set-by-plugin"] = "value"
+	assert.Equal(t, "value", request.Headers["x-set-by-plugin"])
+
+	scoped.PutAttribute(producedKey, "written-through-the-copy")
+	value, ok := request.GetAttribute(producedKey)
+	assert.True(t, ok, "the copy shares the backing store with the original")
+	assert.Equal(t, "written-through-the-copy", value)
+}
+
+// The framework's own request carries no scope and reaches the whole store,
+// which is how the director reads attributes a plugin published.
+func TestScopeRequest_UnscopedRequestIsUnconfined(t *testing.T) {
+	request := &fwksched.InferenceRequest{RequestID: "req"}
+	request.PutAttribute(undeclaredKey, "secret")
+
+	value, ok := request.GetAttribute(undeclaredKey)
+	assert.True(t, ok)
+	assert.Equal(t, "secret", value)
+}
+
+// One invocation reaching outside its declarations on either store reports
+// through the same Violations, so a caller with an error return fails once.
+func TestScopeInvocation_SharesViolationsAcrossBothStores(t *testing.T) {
+	plug := newRequestScopePlugin("invocation-shared")
+	RegisterScopeSpecs([]fwkplugin.Plugin{plug})
+
+	request := &fwksched.InferenceRequest{RequestID: "req"}
+	endpoint := newEndpoint(t)
+
+	scopedRequest, scopedEndpoints, violations := ScopeInvocation(
+		testLogger(), "test-extension-point", plug, request, []fwksched.Endpoint{endpoint})
+	require.Len(t, scopedEndpoints, 1)
+
+	scopedRequest.PutAttribute(undeclaredKey, "nope")
+	require.Error(t, violations.Write())
+	first := violations.Write()
+
+	// The endpoint half records into the same Violations, and the first
+	// rejection is the one reported.
+	scopedEndpoints[0].Put(undeclaredKey, cloneableStr("nope"))
+	assert.Equal(t, first, violations.Write())
+}
+
+func TestScopeRequest_NilRequest(t *testing.T) {
+	plug := newRequestScopePlugin("request-nil")
+	RegisterScopeSpecs([]fwkplugin.Plugin{plug})
+
+	scoped, violations := ScopeRequest(testLogger(), "test-extension-point", plug, nil)
+	assert.Nil(t, scoped)
+	assert.NoError(t, violations.Write())
+}

--- a/pkg/epp/framework/interface/scheduling/attributes.go
+++ b/pkg/epp/framework/interface/scheduling/attributes.go
@@ -22,6 +22,51 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
 
+// AttributeScope decides whether the plugin holding a request may reach a
+// request-attribute key. It is the request-store half of the confinement the
+// datalayer package applies to endpoint attributes, and datalayer implements
+// it; the interface lives here so InferenceRequest can consult it without
+// importing that package.
+//
+// Both methods record the rejection they report, so a caller that denies an
+// access does not also have to count it.
+type AttributeScope interface {
+	// AllowPut reports whether the plugin declared key in Produces().
+	AllowPut(key fwkplugin.DataKey) bool
+	// AllowGet reports whether the plugin declared key in Consumes(), or in
+	// Produces() since a producer may read back its own output.
+	AllowGet(key fwkplugin.DataKey) bool
+	// Declares answers the same question as AllowGet without recording a
+	// rejection, for enumerating the store. Listing a key the plugin may not
+	// read is not an access, so it counts as no violation.
+	Declares(key fwkplugin.DataKey) bool
+}
+
+// WithAttributeScope returns a shallow copy of the request whose attribute
+// access is confined to what scope allows. The copy shares the backing store,
+// so an allowed write is visible to the framework and to every later plugin.
+// A nil scope returns the request unchanged, leaving it unconfined.
+//
+// The store and the header map are materialized on the receiver before the
+// copy is taken. A shallow copy cannot propagate an assignment to a field, and
+// both are lazily allocated by their writers -- PreRequest plugins initialize
+// Headers before setting one -- so an allocation that landed on the copy would
+// be dropped when the plugin returned.
+func (r *InferenceRequest) WithAttributeScope(scope AttributeScope) *InferenceRequest {
+	if r == nil || scope == nil {
+		return r
+	}
+	if r.attributes == nil {
+		r.attributes = &sync.Map{}
+	}
+	if r.Headers == nil {
+		r.Headers = map[string]string{}
+	}
+	scoped := *r
+	scoped.scope = scope
+	return &scoped
+}
+
 // PutAttribute stores value at key in the request's attribute store.
 // The backing store is lazily allocated on first write.
 // Callers must not write concurrently to the same request from multiple goroutines.
@@ -30,7 +75,14 @@ import (
 // them: the per-request store is the other half of the producer/consumer
 // exchange, so a plugin reaches an entry only through a key it names in
 // Produces() or Consumes().
+//
+// A write the request's scope rejects is dropped. The extension points with an
+// error return surface it through Violations; the rest leave the counter as the
+// only signal, matching endpoint attributes.
 func (r *InferenceRequest) PutAttribute(key fwkplugin.DataKey, value any) {
+	if r.scope != nil && !r.scope.AllowPut(key) {
+		return
+	}
 	if r.attributes == nil {
 		r.attributes = &sync.Map{}
 	}
@@ -38,8 +90,12 @@ func (r *InferenceRequest) PutAttribute(key fwkplugin.DataKey, value any) {
 }
 
 // GetAttribute returns the value stored at key, or nil and false if absent.
+// A read the request's scope rejects resolves as absent.
 // Prefer ReadRequestAttribute for type-safe access.
 func (r *InferenceRequest) GetAttribute(key fwkplugin.DataKey) (any, bool) {
+	if r.scope != nil && !r.scope.AllowGet(key) {
+		return nil, false
+	}
 	if r.attributes == nil {
 		return nil, false
 	}
@@ -47,7 +103,8 @@ func (r *InferenceRequest) GetAttribute(key fwkplugin.DataKey) (any, bool) {
 }
 
 // AttributeKeys returns the keys currently present in the request's attribute store.
-// The order is unspecified.
+// The order is unspecified. Under a scope only the declared keys are returned,
+// so enumeration cannot be used to discover an attribute the plugin may not read.
 func (r *InferenceRequest) AttributeKeys() []fwkplugin.DataKey {
 	keys := make([]fwkplugin.DataKey, 0)
 	if r.attributes == nil {
@@ -55,7 +112,10 @@ func (r *InferenceRequest) AttributeKeys() []fwkplugin.DataKey {
 	}
 	// PutAttribute is the only writer, so every key is a DataKey.
 	r.attributes.Range(func(k, _ any) bool {
-		keys = append(keys, k.(fwkplugin.DataKey))
+		key := k.(fwkplugin.DataKey)
+		if r.scope == nil || r.scope.Declares(key) {
+			keys = append(keys, key)
+		}
 		return true
 	})
 	return keys

--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -65,6 +65,11 @@ type InferenceRequest struct {
 	// Access via PutAttribute, GetAttribute, AttributeKeys, and ReadRequestAttribute.
 	// A nil pointer is valid; the store is lazily allocated on first write.
 	attributes *sync.Map
+
+	// scope confines attribute access to the keys one plugin declares. Nil on
+	// the request the framework owns, which reaches the store unconfined; set
+	// on the shallow copy WithAttributeScope hands to a plugin.
+	scope AttributeScope
 }
 
 func (r *InferenceRequest) String() string {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/producer.go
@@ -118,9 +118,12 @@ func New(name string, cfg Config) *Producer {
 // TypedName returns the plugin's registered type and name.
 func (p *Producer) TypedName() plugin.TypedName { return p.typedName }
 
-// Produces declares no produced data keys; the best-match result is carried
-// as a request attribute consumed by this plugin's own PreRequest.
-func (p *Producer) Produces() map[plugin.DataKey]any { return map[plugin.DataKey]any{} }
+// Produces declares the best-match peer this plugin stashes on the request for
+// its own PreRequest to read back. The key is name-bound to this instance, so
+// two configured p2p-source producers do not share the stash.
+func (p *Producer) Produces() map[plugin.DataKey]any {
+	return map[plugin.DataKey]any{p.attrKeyValue: (*bestMatchPeer)(nil)}
+}
 
 // Consumes declares the PrefixCacheMatchInfo dependency so the data-layer
 // DAG orders the producing plugin before this one.

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/encoded_endpoint_header.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/encoded_endpoint_header.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	sessionutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/util/sessionaffinity"
@@ -41,6 +42,12 @@ func newEncodedEndpointHeaderStrategy(params parameters) strategy {
 
 // filter returns the session's pod alone when it is among the candidates,
 // otherwise all candidates so downstream filters and scorers can decide.
+// Consumes reports no request attributes: this strategy reads the session
+// header, not the attribute store.
+func (e *encodedEndpointHeaderStrategy) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{}
+}
+
 func (e *encodedEndpointHeaderStrategy) filter(ctx context.Context, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) []scheduling.Endpoint {
 	podName := sessionutil.DecodePodName(ctx, request.Headers[e.sessionHeader])
 	if podName == "" {

--- a/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity/session_affinity.go
@@ -120,6 +120,9 @@ func NewSessionAffinity(name, sessionHeader, profileName string) *SessionAffinit
 // session's candidate set is filtered, how a fresh pick is recorded, and what
 // (if anything) is written back to the client.
 type strategy interface {
+	// Consumes reports the request attributes the strategy reads, so the
+	// plugin's declaration follows its configuration.
+	Consumes() plugin.DataDependencies
 	filter(ctx context.Context, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) []scheduling.Endpoint
 	preRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult)
 	responseHeader(ctx context.Context, request *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata)
@@ -143,6 +146,11 @@ type SessionAffinity struct {
 // TypedName returns the typed name of the plugin.
 func (s *SessionAffinity) TypedName() plugin.TypedName {
 	return s.typedName
+}
+
+// Consumes reports the request attributes the configured strategy reads.
+func (s *SessionAffinity) Consumes() plugin.DataDependencies {
+	return s.strategy.Consumes()
 }
 
 // Filter returns the endpoint running the session when it is among the

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter.go
@@ -88,13 +88,18 @@ func (f *Filter) TypedName() fwkplugin.TypedName {
 	return f.typedName
 }
 
-// Consumes returns the Topology attribute as optional: a missing producer
-// logs a startup warning rather than an error, since the filter fails open
-// (no peer topology means the candidates pass through unfiltered) rather
-// than depending on the attribute to function.
+// Consumes returns the Topology attribute and the peer endpoint the filter
+// compares against as optional: a missing producer logs a startup warning
+// rather than an error, since the filter fails open (no peer topology means
+// the candidates pass through unfiltered) rather than depending on either to
+// function. The peer endpoint is a request attribute published by the disagg
+// profile handler, which is absent in deployments that do not disaggregate.
 func (f *Filter) Consumes() fwkplugin.DataDependencies {
 	return fwkplugin.DataDependencies{
-		Optional: map[fwkplugin.DataKey]any{f.dataKey: attrtopology.Topology{}},
+		Optional: map[fwkplugin.DataKey]any{
+			f.dataKey:                    attrtopology.Topology{},
+			topoutil.PeerEndpointDataKey: fwksched.Endpoint(nil),
+		},
 	}
 }
 

--- a/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/topologyaffinity/filter_test.go
@@ -131,8 +131,13 @@ func TestFilter_Consumes(t *testing.T) {
 	consumes := f.Consumes()
 
 	assert.Empty(t, consumes.Required)
-	require.Len(t, consumes.Optional, 1)
+	require.Len(t, consumes.Optional, 2)
 	assert.Equal(t, attrtopology.Topology{}, consumes.Optional[f.dataKey])
+
+	// The peer endpoint the filter compares against is a request attribute; the
+	// filter reads it through topoutil.PeerTopology, so it belongs in Consumes.
+	require.Contains(t, consumes.Optional, disagg.PeerEndpointAttributeKey)
+	assert.Nil(t, consumes.Optional[disagg.PeerEndpointAttributeKey])
 }
 
 func TestFactory_Defaults(t *testing.T) {

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -201,6 +201,8 @@ func NewDisaggProfileHandler(decodeProfile, prefillProfile, encodeProfile string
 var (
 	_ scheduling.ProfileHandler = &Handler{}
 	_ requestcontrol.PreRequest = &Handler{}
+	_ plugin.ProducerPlugin     = &Handler{}
+	_ plugin.ConsumerPlugin     = &Handler{}
 )
 
 // Handler is the unified disaggregation profile handler.
@@ -238,6 +240,33 @@ func (h *Handler) WithName(name string) *Handler {
 func (h *Handler) WithStageOrder(stageOrder StageOrder) *Handler {
 	h.stageOrder = stageOrder
 	return h
+}
+
+// Produces declares the request attributes the handler publishes for later
+// scheduling phases and for its own ProcessResults, plus everything its
+// deciders write. Both live in the per-request store rather than on an
+// endpoint.
+//
+// The deciders run inside this handler's extension points, through the request
+// the handler was handed, so their keys are confined against this declaration
+// rather than their own. Consumes covers their reads for the same reason.
+func (h *Handler) Produces() map[plugin.DataKey]any {
+	produced := map[plugin.DataKey]any{
+		// Endpoint is an interface; its zero value is the type witness the
+		// data graph compares against a consumer's declaration.
+		PeerEndpointAttributeKey:    scheduling.Endpoint(nil),
+		prefillDeclinedAttributeKey: false,
+	}
+	for _, decider := range []deciderPlugin{h.pdDecider, h.encodeDecider} {
+		producer, ok := decider.(plugin.ProducerPlugin)
+		if !ok {
+			continue
+		}
+		for key, witness := range producer.Produces() {
+			produced[key] = witness
+		}
+	}
+	return produced
 }
 
 // Consumes defines data types consumed by this plugin (through the PD decider).

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider.go
@@ -51,6 +51,7 @@ var (
 	_ deciderPlugin         = &PrefixBasedPDDecider{}
 	_ fwkrc.PreRequest      = &PrefixBasedPDDecider{}
 	_ plugin.ConsumerPlugin = &PrefixBasedPDDecider{}
+	_ plugin.ProducerPlugin = &PrefixBasedPDDecider{}
 )
 
 // errCondDecodeCacheMiss is the 412 returned by the conditional-decode gate
@@ -125,6 +126,17 @@ func (d *PrefixBasedPDDecider) TypedName() plugin.TypedName {
 func (d *PrefixBasedPDDecider) WithName(name string) *PrefixBasedPDDecider {
 	d.typedName.Name = name
 	return d
+}
+
+// Produces declares the request attributes the plugin writes: the
+// conditional-decode ownership marker the director reads to decide whether the
+// "Prefer: if-available" header was evaluated, and the memoized remote-prefill
+// outcome this plugin reads back in PreRequest.
+func (d *PrefixBasedPDDecider) Produces() map[plugin.DataKey]any {
+	return map[plugin.DataKey]any{
+		fwkrc.ConditionalDecodeHandledAttributeKey: false,
+		remotePrefillDecisionAttributeKey:          remotePrefillDecision{},
+	}
 }
 
 // Consumes declares the request- and endpoint-scoped data the plugin reads

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/encoded_endpoint_header.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/encoded_endpoint_header.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	sessionutil "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/util/sessionaffinity"
@@ -38,6 +39,12 @@ func newEncodedEndpointHeaderStrategy(params parameters) strategy {
 		sessionHeader: sessionutil.NormalizeHeader(params.EncodedEndpointHeaderConfig.Header),
 		profileName:   params.ProfileName,
 	}
+}
+
+// Consumes reports no request attributes: this strategy reads the session
+// header, not the attribute store.
+func (e *encodedEndpointHeaderStrategy) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{}
 }
 
 func (e *encodedEndpointHeaderStrategy) score(ctx context.Context, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64 {

--- a/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity/session_affinity.go
@@ -117,6 +117,9 @@ func NewSessionAffinity(name, sessionHeader, profileName string) *SessionAffinit
 // session's preferred pod is scored, how a fresh pick is recorded, and what
 // (if anything) is written back to the client.
 type strategy interface {
+	// Consumes reports the request attributes the strategy reads, so the
+	// plugin's declaration follows its configuration.
+	Consumes() plugin.DataDependencies
 	score(ctx context.Context, request *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) map[scheduling.Endpoint]float64
 	preRequest(ctx context.Context, request *scheduling.InferenceRequest, schedulingResult *scheduling.SchedulingResult)
 	responseHeader(ctx context.Context, request *scheduling.InferenceRequest, response *requestcontrol.Response, targetPod *datalayer.EndpointMetadata)
@@ -138,6 +141,11 @@ type SessionAffinity struct {
 
 func (s *SessionAffinity) TypedName() plugin.TypedName {
 	return s.typedName
+}
+
+// Consumes reports the request attributes the configured strategy reads.
+func (s *SessionAffinity) Consumes() plugin.DataDependencies {
+	return s.strategy.Consumes()
 }
 
 func (s *SessionAffinity) Category() scheduling.ScorerCategory {

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer.go
@@ -88,13 +88,18 @@ func (s *Scorer) TypedName() fwkplugin.TypedName {
 	return s.typedName
 }
 
-// Consumes returns the Topology attribute as optional: a missing producer
-// logs a startup warning rather than an error, since the scorer scores every
-// endpoint 0 (no signal, not an error) rather than depending on the
-// attribute to function.
+// Consumes returns the Topology attribute and the peer endpoint the scorer
+// grades against as optional: a missing producer logs a startup warning rather
+// than an error, since the scorer scores every endpoint 0 (no signal, not an
+// error) rather than depending on either to function. The peer endpoint is a
+// request attribute published by the disagg profile handler, which is absent in
+// deployments that do not disaggregate.
 func (s *Scorer) Consumes() fwkplugin.DataDependencies {
 	return fwkplugin.DataDependencies{
-		Optional: map[fwkplugin.DataKey]any{s.dataKey: attrtopology.Topology{}},
+		Optional: map[fwkplugin.DataKey]any{
+			s.dataKey:                    attrtopology.Topology{},
+			topoutil.PeerEndpointDataKey: fwksched.Endpoint(nil),
+		},
 	}
 }
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/topologyaffinity/scorer_test.go
@@ -122,8 +122,13 @@ func TestScorer_Consumes(t *testing.T) {
 	consumes := s.Consumes()
 
 	assert.Empty(t, consumes.Required)
-	require.Len(t, consumes.Optional, 1)
+	require.Len(t, consumes.Optional, 2)
 	assert.Equal(t, attrtopology.Topology{}, consumes.Optional[s.dataKey])
+
+	// The peer endpoint the scorer grades against is a request attribute; the
+	// scorer reads it through topoutil.PeerTopology, so it belongs in Consumes.
+	require.Contains(t, consumes.Optional, disagg.PeerEndpointAttributeKey)
+	assert.Nil(t, consumes.Optional[disagg.PeerEndpointAttributeKey])
 }
 
 func TestFactory_Defaults(t *testing.T) {

--- a/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/session_id.go
+++ b/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/session_id.go
@@ -138,6 +138,26 @@ type SessionIDHeader struct {
 	pluginState *plugin.PluginState
 }
 
+// Consumes declares the request attributes the configured sources read. They
+// are optional: a source whose producer is absent leaves the identifier
+// unresolved and the next source, or the header, answers instead.
+//
+// The value witness is nil because attributeString accepts any value of string
+// kind, so no single concrete type describes the key.
+func (s *SessionIDHeader) Consumes() plugin.DataDependencies {
+	optional := map[plugin.DataKey]any{}
+	for _, source := range s.sources {
+		if source.Attribute == "" {
+			continue
+		}
+		optional[plugin.NewDataKey(source.Attribute, "").WithNonEmptyProducerName(source.Producer)] = nil
+	}
+	if len(optional) == 0 {
+		return plugin.DataDependencies{}
+	}
+	return plugin.DataDependencies{Optional: optional}
+}
+
 // boundPodPresence records, for one request, whether the session's bound pod
 // was present in the candidate set scored. PreRequest reads this so it can
 // tell a genuine absence from the picker merely choosing a different pod.

--- a/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/session_id_test.go
+++ b/pkg/epp/framework/plugins/scheduling/util/sessionaffinity/session_id_test.go
@@ -577,3 +577,65 @@ func TestSessionIDConfig_Validate(t *testing.T) {
 		})
 	}
 }
+
+// Consumes must name every attribute source configured, so the runtime scope
+// lets the reads in resolveSessionID through. Header sources contribute
+// nothing: headers are not part of the attribute store.
+func TestSessionIDHeader_Consumes(t *testing.T) {
+	handle := utils.NewTestHandle(utils.NewTestContext(t))
+
+	tests := []struct {
+		name    string
+		sources []SessionIDSource
+		want    []plugin.DataKey
+	}{
+		{
+			name:    "header source only",
+			sources: []SessionIDSource{{Header: DefaultHeader}},
+		},
+		{
+			name:    "attribute with a named producer",
+			sources: []SessionIDSource{{Attribute: "session-id", Producer: "session-id-producer"}},
+			want:    []plugin.DataKey{plugin.NewDataKey("session-id", "session-id-producer")},
+		},
+		{
+			name:    "producer-agnostic attribute",
+			sources: []SessionIDSource{{Attribute: "agent-identity"}},
+			want:    []plugin.DataKey{plugin.NewDataKey("agent-identity", "")},
+		},
+		{
+			name: "header and attribute sources mixed",
+			sources: []SessionIDSource{
+				{Header: DefaultHeader},
+				{Attribute: "session-id", Producer: "session-id-producer"},
+				{Attribute: "agent-identity"},
+			},
+			want: []plugin.DataKey{
+				plugin.NewDataKey("session-id", "session-id-producer"),
+				plugin.NewDataKey("agent-identity", ""),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewSessionIDHeader(
+				SessionIDConfig{Sources: tt.sources, EvictionTTLSeconds: 300, EvictionSweepSeconds: 10},
+				"", testPluginKey, handle,
+			)
+
+			consumes := s.Consumes()
+			if len(consumes.Required) != 0 {
+				t.Errorf("Required = %v, want empty", consumes.Required)
+			}
+			if len(consumes.Optional) != len(tt.want) {
+				t.Fatalf("Optional = %v, want %d keys", consumes.Optional, len(tt.want))
+			}
+			for _, key := range tt.want {
+				if _, ok := consumes.Optional[key]; !ok {
+					t.Errorf("Optional is missing %v", key)
+				}
+			}
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/scheduling/util/topology/peer.go
+++ b/pkg/epp/framework/plugins/scheduling/util/topology/peer.go
@@ -24,6 +24,11 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/disagg"
 )
 
+// PeerEndpointDataKey is the request-attribute key PeerTopology reads. Plugins
+// that call PeerTopology name it in Consumes() through this alias rather than
+// importing the profile-handler package for a key.
+var PeerEndpointDataKey = disagg.PeerEndpointAttributeKey
+
 // PeerTopology returns the topology of the endpoint selected in the peer
 // scheduling phase, or false when no peer topology is available.
 //

--- a/pkg/epp/metrics/llm_d_router_metrics.go
+++ b/pkg/epp/metrics/llm_d_router_metrics.go
@@ -284,10 +284,11 @@ var (
 		prometheus.CounterOpts{
 			Subsystem: LLMDRouterEndpointPickerSubsystem,
 			Name:      "plugin_data_scope_violations_total",
-			Help: metricsutil.HelpMsgWithStability("Total number of endpoint attribute accesses rejected because the "+
-				"plugin did not declare the DataKey in Produces() or Consumes(), by extension point, plugin type, "+
-				"plugin name and access kind (read or write). A non-zero value means a plugin's implementation has "+
-				"drifted from its declaration; rejected reads resolve as absent and rejected writes are dropped.", compbasemetrics.ALPHA),
+			Help: metricsutil.HelpMsgWithStability("Total number of endpoint and per-request attribute accesses "+
+				"rejected because the plugin did not declare the DataKey in Produces() or Consumes(), by extension "+
+				"point, plugin type, plugin name and access kind (read or write). A non-zero value means a plugin's "+
+				"implementation has drifted from its declaration; rejected reads resolve as absent and rejected "+
+				"writes are dropped.", compbasemetrics.ALPHA),
 		},
 		[]string{"extension_point", "plugin_type", "plugin_name", "access"},
 	)

--- a/pkg/epp/metrics/testdata/llm_d_plugin_data_scope_violations_total_metric
+++ b/pkg/epp/metrics/testdata/llm_d_plugin_data_scope_violations_total_metric
@@ -1,4 +1,4 @@
-# HELP llm_d_epp_plugin_data_scope_violations_total [ALPHA] Total number of endpoint attribute accesses rejected because the plugin did not declare the DataKey in Produces() or Consumes(), by extension point, plugin type, plugin name and access kind (read or write). A non-zero value means a plugin's implementation has drifted from its declaration; rejected reads resolve as absent and rejected writes are dropped.
+# HELP llm_d_epp_plugin_data_scope_violations_total [ALPHA] Total number of endpoint and per-request attribute accesses rejected because the plugin did not declare the DataKey in Produces() or Consumes(), by extension point, plugin type, plugin name and access kind (read or write). A non-zero value means a plugin's implementation has drifted from its declaration; rejected reads resolve as absent and rejected writes are dropped.
 # TYPE llm_d_epp_plugin_data_scope_violations_total counter
 llm_d_epp_plugin_data_scope_violations_total{access="read",extension_point="Filter",plugin_name="f1",plugin_type="test-filter"} 3
 llm_d_epp_plugin_data_scope_violations_total{access="write",extension_point="DataProducer",plugin_name="p1",plugin_type="test-producer"} 1

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -627,7 +627,8 @@ func (d *Director) GetRandomEndpoint() *fwkdl.EndpointMetadata {
 // its side effects and the caller sees all failures.
 func (d *Director) runPreRequestPlugins(ctx context.Context, request *fwksched.InferenceRequest,
 	schedulingResult *fwksched.SchedulingResult) error {
-	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
+	logger := log.FromContext(ctx)
+	loggerDebug := logger.V(logutil.DEBUG)
 	debugEnabled := loggerDebug.Enabled()
 	var errs []error
 	for _, plugin := range d.requestControlPlugins.preRequestPlugins {
@@ -635,9 +636,13 @@ func (d *Director) runPreRequestPlugins(ctx context.Context, request *fwksched.I
 		if debugEnabled {
 			loggerDebug.Info("Running PreRequest plugin", "plugin", name)
 		}
+		scopedRequest, violations := datalayer.ScopeRequest(logger, fwkrc.PreRequestExtensionPoint, plugin, request)
 		before := time.Now()
-		err := plugin.PreRequest(ctx, request, schedulingResult)
+		err := plugin.PreRequest(ctx, scopedRequest, schedulingResult)
 		metrics.RecordPluginProcessingLatency(fwkrc.PreRequestExtensionPoint, name.Type, name.Name, time.Since(before))
+		if err == nil {
+			err = violations.Write()
+		}
 		if err != nil {
 			if debugEnabled {
 				loggerDebug.Info("PreRequest plugin failed", "plugin", name, "error", err.Error())

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -185,10 +185,17 @@ type mockPreRequestPlugin struct {
 	name     string
 	modifyFn func(request *fwksched.InferenceRequest)
 	err      error
+	// produces declares the request attributes modifyFn writes, so the scope
+	// the director applies at PreRequest lets them through.
+	produces map[fwkplugin.DataKey]any
 }
 
 func (m *mockPreRequestPlugin) TypedName() fwkplugin.TypedName {
 	return fwkplugin.TypedName{Name: m.name, Type: "mock"}
+}
+
+func (m *mockPreRequestPlugin) Produces() map[fwkplugin.DataKey]any {
+	return m.produces
 }
 
 func (m *mockPreRequestPlugin) PreRequest(ctx context.Context, request *fwksched.InferenceRequest, schedulingResult *fwksched.SchedulingResult) error {
@@ -2184,6 +2191,7 @@ func TestPrepareRequest_ConditionalDecodeDefaultDeny(t *testing.T) {
 		modifyFn: func(r *fwksched.InferenceRequest) {
 			r.PutAttribute(fwkrc.ConditionalDecodeHandledAttributeKey, true)
 		},
+		produces: map[fwkplugin.DataKey]any{fwkrc.ConditionalDecodeHandledAttributeKey: false},
 	}
 
 	tests := []struct {

--- a/pkg/epp/requestcontrol/plugin_executor.go
+++ b/pkg/epp/requestcontrol/plugin_executor.go
@@ -36,9 +36,9 @@ import (
 func executePluginsAsDAG(ctx context.Context, plugins []fwkrc.DataProducer, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	logger := log.FromContext(ctx)
 	for _, plugin := range plugins {
-		scoped, violations := datalayer.Scope(logger, fwkrc.DataProducerExtensionPoint, plugin, endpoints)
+		scopedRequest, scoped, violations := datalayer.ScopeInvocation(logger, fwkrc.DataProducerExtensionPoint, plugin, request, endpoints)
 		before := time.Now()
-		err := plugin.Produce(ctx, request, scoped)
+		err := plugin.Produce(ctx, scopedRequest, scoped)
 		metrics.RecordPluginProcessingLatency(fwkrc.DataProducerExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
 		if err != nil {
 			return fmt.Errorf("DataProducer %q failed: %w", plugin.TypedName().String(), err)

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -31,6 +31,7 @@ import (
 
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
+	"github.com/llm-d/llm-d-router/pkg/epp/datalayer"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
 )
@@ -58,7 +59,8 @@ type Scheduler struct {
 
 // Schedule finds the target pod based on metrics and the requested lora adapter.
 func (s *Scheduler) Schedule(ctx context.Context, request *fwksched.InferenceRequest, candidateEndpoints []fwksched.Endpoint) (result *fwksched.SchedulingResult, err error) {
-	loggerVerbose := log.FromContext(ctx).V(logutil.VERBOSE)
+	logger := log.FromContext(ctx)
+	loggerVerbose := logger.V(logutil.VERBOSE)
 	verboseEnabled := loggerVerbose.Enabled()
 	handlerName := s.profileHandler.TypedName()
 
@@ -79,8 +81,13 @@ func (s *Scheduler) Schedule(ctx context.Context, request *fwksched.InferenceReq
 		if verboseEnabled {
 			loggerVerbose.Info("Running profile handler, Pick profiles", "plugin", handlerName)
 		}
+		// violations dropped: Pick has no error return, so a rejected write is
+		// visible only through plugin_data_scope_violations_total. The profiles
+		// the handler returns run against the unscoped request below; each
+		// filter and scorer is scoped against its own declarations.
+		scopedRequest, _ := datalayer.ScopeRequest(logger, profilePickerExtensionPoint, s.profileHandler, request)
 		before := time.Now()
-		profiles := s.profileHandler.Pick(ctx, request, s.profiles, profileRunResults)
+		profiles := s.profileHandler.Pick(ctx, scopedRequest, s.profiles, profileRunResults)
 		metrics.RecordPluginProcessingLatency(profilePickerExtensionPoint, handlerName.Type, handlerName.Name, time.Since(before))
 		if verboseEnabled {
 			loggerVerbose.Info("Completed running profile handler Pick profiles successfully", "plugin", handlerName, "result", profiles)
@@ -122,9 +129,13 @@ func (s *Scheduler) Schedule(ctx context.Context, request *fwksched.InferenceReq
 	if verboseEnabled {
 		loggerVerbose.Info("Running profile handler, ProcessResults", "plugin", handlerName)
 	}
+	scopedRequest, violations := datalayer.ScopeRequest(logger, processProfilesResultsExtensionPoint, s.profileHandler, request)
 	before := time.Now()
-	result, err = s.profileHandler.ProcessResults(ctx, request, profileRunResults)
+	result, err = s.profileHandler.ProcessResults(ctx, scopedRequest, profileRunResults)
 	metrics.RecordPluginProcessingLatency(processProfilesResultsExtensionPoint, handlerName.Type, handlerName.Name, time.Since(before))
+	if err == nil {
+		err = violations.Write()
+	}
 	if verboseEnabled {
 		loggerVerbose.Info("Completed running profile handler ProcessResults successfully", "plugin", handlerName)
 	}

--- a/pkg/epp/scheduling/scheduler_profile.go
+++ b/pkg/epp/scheduling/scheduler_profile.go
@@ -171,13 +171,14 @@ func (p *SchedulerProfile) runFilterPlugins(ctx context.Context, request *fwksch
 			verbose.Info("Running filter plugin", "plugin", typedName)
 		}
 		// The violations are dropped: Filter has no error return, so a rejected
-		// write cannot fail the request here. Scope has already dropped the write,
-		// logged it, and counted it under plugin_data_scope_violations_total, which
-		// is where a misdeclared filter surfaces in production. Producers run under
-		// executePluginsAsDAG, which does fail the request on one.
-		scoped, _ := datalayer.Scope(logger, filterExtensionPoint, filter, filteredEndpoints)
+		// write cannot fail the request here. The scope has already dropped the
+		// write, logged it, and counted it under
+		// plugin_data_scope_violations_total, which is where a misdeclared filter
+		// surfaces in production. Producers run under executePluginsAsDAG, which
+		// does fail the request on one.
+		scopedRequest, scoped, _ := datalayer.ScopeInvocation(logger, filterExtensionPoint, filter, request, filteredEndpoints)
 		before := time.Now()
-		filteredEndpoints = datalayer.Unscope(filter.Filter(ctx, request, scoped))
+		filteredEndpoints = datalayer.Unscope(filter.Filter(ctx, scopedRequest, scoped))
 		metrics.RecordPluginProcessingLatency(filterExtensionPoint, typedName.Type, typedName.Name, time.Since(before))
 		if debugEnabled {
 			debug.Info("Completed running filter plugin successfully", "plugin", typedName, "endpoints", filteredEndpoints)
@@ -276,11 +277,12 @@ func runScorer(ctx context.Context, tracer trace.Tracer, tracingActive bool, sco
 	// embeds the Scorer interface, which does not carry Produces/Consumes, so
 	// scoping the wrapper would hide every declaration the scorer makes.
 	logger := log.FromContext(ctx)
-	scoped, _ := datalayer.Scope(logger, scorerExtensionPoint, scorer.Scorer, endpoints) // violations dropped: Score has no error return, see runFilterPlugins
+	// violations dropped: Score has no error return, see runFilterPlugins
+	scopedRequest, scoped, _ := datalayer.ScopeInvocation(logger, scorerExtensionPoint, scorer.Scorer, request, endpoints)
 
 	if !tracingActive {
 		before := time.Now()
-		scores := datalayer.UnscopeScores(scorer.Score(ctx, request, scoped))
+		scores := datalayer.UnscopeScores(scorer.Score(ctx, scopedRequest, scoped))
 		metrics.RecordPluginProcessingLatency(scorerExtensionPoint, typedName.Type, typedName.Name, time.Since(before))
 		return scores
 	}
@@ -295,7 +297,7 @@ func runScorer(ctx context.Context, tracer trace.Tracer, tracingActive bool, sco
 	)
 
 	before := time.Now()
-	scores := datalayer.UnscopeScores(scorer.Score(ctx, request, scoped))
+	scores := datalayer.UnscopeScores(scorer.Score(ctx, scopedRequest, scoped))
 	metrics.RecordPluginProcessingLatency(scorerExtensionPoint, typedName.Type, typedName.Name, time.Since(before))
 
 	if len(scores) > 0 {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

#2190 made `Produces()`/`Consumes()` a runtime contract for endpoint attributes through `datalayer.Scope`, and left the per-request store typed by `DataKey` but unconfined. The asymmetry was recorded in a doc comment rather than tracked, because in-tree plugins were exchanging request attributes they never declared. This closes that half.

**Declarations first.** Confinement cannot land before the declarations, or it rejects accesses the plugins already depend on:

- `p2p-source-producer` declares its name-bound `best-match/<instance>` key instead of returning an empty map.
- `disagg-profile-handler` and `prefix-based-pd-decider` gain `Produces()` for the four request attributes they publish. The handler merges its deciders' declarations, matching how `precise-prefix-cache-scorer` merges its inner producer's.
- `topology-affinity-scorer` and `topology-affinity-filter` declare the peer endpoint they read, as Optional. Required would send `CreateMissingDataProducers` looking for a producer that exists only under disaggregation, failing startup for every non-disaggregated deployment.
- `session-affinity` declared no `Consumes()` at all, as either a filter or a scorer. Its dependencies follow its configuration, so `Consumes()` delegates to the configured strategy.

The filter and the session-affinity cases are not in the issue's list; they surfaced when running the change against a live EPP.

**Confinement.** `pkg/epp/datalayer/request_scope.go` sits beside the endpoint scope and shares its allowed-key sets, its `Violations` accumulator, and `llm_d_epp_plugin_data_scope_violations_total`. `InferenceRequest` is a struct rather than an interface, so a plugin receives a shallow copy carrying a scope instead of a wrapper. The copy shares the backing store, so an allowed write stays visible to the framework and to later plugins.

| Extension point | Stores confined | Rejected write |
|---|---|---|
| Filter | request + endpoints | counted |
| Scorer | request + endpoints | counted |
| DataProducer | request + endpoints | fails request |
| PreRequest | request | fails request |
| ProfilePicker | request | counted |
| ProcessProfilesResults | request | fails request |

Rejected reads resolve as absent everywhere.

**Two changes worth attention in review:**

1. `scopeSpecFor` no longer returns a deny-all spec for a plugin missing from `RegisterScopeSpecs`. It derives the spec from the plugin's own declarations and caches it, still logging the miss once per typed name. This became necessary once confinement reached the profile handler, whose deciders are constructed through a path startup registration does not cover.

2. A shallow copy cannot carry a field assignment back to the original. `p2p-source-producer`'s `PreRequest` lazily initializes `request.Headers`, and the attribute store is lazily allocated the same way; on a copy both allocations would be dropped on return. `WithAttributeScope` materializes them on the receiver before copying, and the constraint is documented on the method.

**Not covered.** Datalayer extractors still write through `Endpoint.GetAttributes()` directly, and `Admitter`/`Screener` still receive endpoints unscoped. Both were listed in #2190 and neither is tracked yet.

**Which issue(s) this PR fixes**:
Fixes #2574

**Release note**:
```release-note
Plugin access to the per-request attribute store is now confined at runtime to the DataKeys the plugin declares in Produces()/Consumes(), matching the existing confinement of endpoint attributes. A rejected read resolves as absent and a rejected write is dropped; at extension points with an error return (DataProducer, PreRequest, ProcessProfilesResults) a rejected write also fails the request.

The `llm_d_epp_plugin_data_scope_violations_total` metric now counts per-request attribute violations alongside endpoint ones, and reports the PreRequest, ProfilePicker, and ProcessProfilesResults extension points.

Out-of-tree plugins that read or write request attributes must declare those DataKeys in Produces()/Consumes(). An undeclared access is rejected rather than silently resolving.
