### PR TITLE
Credit shared KV tiers via node:/pool: pseudo-pod identities

### DIFF
--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -339,6 +339,7 @@ func (ds *datastore) podUpdateOrAddIfNotExist(ctx context.Context, pod *corev1.P
 				Name:        pod.Name,
 				Address:     pod.Status.PodIP,
 				NodeAddress: pod.Status.HostIP,
+				NodeName:    pod.Spec.NodeName,
 				Port:        strconv.Itoa(port),
 				MetricsHost: net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(port)),
 				Labels:      labels,

--- a/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
+++ b/pkg/epp/framework/interface/datalayer/endpoint_metadata.go
@@ -37,6 +37,9 @@ type EndpointMetadata struct {
 	// NodeAddress is the node IP hosting this pod (pod.Status.HostIP).
 	// Empty for non-Kubernetes discovery sources (e.g. file discovery).
 	NodeAddress string
+	// NodeName is the name of the node hosting this pod (pod.Spec.NodeName).
+	// Empty for non-Kubernetes discovery sources.
+	NodeName    string
 	Port        string
 	MetricsHost string
 	Labels      map[string]string
@@ -69,6 +72,7 @@ func (epm *EndpointMetadata) Clone() *EndpointMetadata {
 		Name:        epm.Name,
 		Address:     epm.Address,
 		NodeAddress: epm.NodeAddress,
+		NodeName:    epm.NodeName,
 		Port:        epm.Port,
 		MetricsHost: epm.MetricsHost,
 		Labels:      clonedLabels,
@@ -86,6 +90,7 @@ func (epm *EndpointMetadata) Equal(other *EndpointMetadata) bool {
 		epm.Name == other.Name &&
 		epm.Address == other.Address &&
 		epm.NodeAddress == other.NodeAddress &&
+		epm.NodeName == other.NodeName &&
 		epm.Port == other.Port &&
 		epm.MetricsHost == other.MetricsHost &&
 		epm.RankIndex == other.RankIndex &&
@@ -125,6 +130,14 @@ func (epm *EndpointMetadata) GetNodeAddress() string {
 		return ""
 	}
 	return epm.NodeAddress
+}
+
+// GetNodeName returns the name of the node hosting this endpoint.
+func (epm *EndpointMetadata) GetNodeName() string {
+	if epm == nil {
+		return ""
+	}
+	return epm.NodeName
 }
 
 // GetPort returns the Endpoint's inference port.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -174,8 +174,11 @@ func New(ctx context.Context, name string, config PluginConfig) (*Producer, erro
 	go indexer.Run(ctx)
 
 	scorerConfig := kvcache.DefaultKVBlockScorerConfig()
-	if config.IndexerConfig != nil && config.IndexerConfig.BackendConfigs != nil {
-		scorerConfig.BackendConfigs = config.IndexerConfig.BackendConfigs
+	if config.IndexerConfig != nil {
+		if config.IndexerConfig.BackendConfigs != nil {
+			scorerConfig.BackendConfigs = config.IndexerConfig.BackendConfigs
+		}
+		scorerConfig.DefaultWeight = config.IndexerConfig.DefaultBackendWeight
 	}
 	kvBlockScorer, err := kvcache.NewKVBlockScorer(scorerConfig)
 	if err != nil {
@@ -343,6 +346,7 @@ func (p *Producer) produceFromBlockKeys(ctx context.Context, span trace.Span,
 ) error {
 	logger := log.FromContext(ctx).WithName(p.typedName.String())
 	endpointSet := extractEndpointSet(endpoints)
+	byNode, allEndpoints := endpointsByNode(endpoints)
 
 	type promptLookup struct {
 		keys      []kvblock.BlockHash
@@ -358,6 +362,10 @@ func (p *Producer) produceFromBlockKeys(ctx context.Context, span trace.Span,
 			span.SetStatus(codes.Error, err.Error())
 			return fmt.Errorf("failed to lookup block keys: %w", err)
 		}
+		// Shared-tier entries (node:<n>, pool:<name>) are credited to the
+		// candidate endpoints they cover so scoring and per-tier counts see
+		// only real endpoint identifiers.
+		keyToPods = kvblock.ResolvePseudoPods(keyToPods, byNode, allEndpoints)
 		scores, err := p.kvBlockScorer.Score(ctx, blockKeys, keyToPods)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/pseudo_pod_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/pseudo_pod_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preciseprefixcache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	"github.com/llm-d/llm-d-router/pkg/kvcache"
+	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
+	"github.com/llm-d/llm-d-router/test/utils"
+)
+
+func endpointOnNode(name, address, node string) scheduling.Endpoint {
+	return scheduling.NewEndpoint(&fwkdl.EndpointMetadata{
+		ID:       k8stypes.NamespacedName{Name: name},
+		Address:  address,
+		Port:     "8080",
+		NodeName: node,
+	}, nil, nil)
+}
+
+func matchInfo(t *testing.T, ep scheduling.Endpoint) *attrprefix.PrefixCacheMatchInfo {
+	t.Helper()
+	raw, ok := ep.Get(attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName("test"))
+	require.True(t, ok)
+	info, ok := raw.(*attrprefix.PrefixCacheMatchInfo)
+	require.True(t, ok)
+	return info
+}
+
+// A node:<n> index entry credits only the candidate endpoints on node n; a
+// pool:<name> entry credits every candidate endpoint. The lookup filter
+// carries the node pseudo-pods of all candidate nodes.
+func TestProduce_PseudoPodEntriesCreditEndpoints(t *testing.T) {
+	ctx := utils.NewTestContext(t)
+	endpoints := []scheduling.Endpoint{
+		endpointOnNode("pod-a", "10.0.0.1", "node-n"),
+		endpointOnNode("pod-b", "10.0.0.2", "node-n"),
+		endpointOnNode("pod-c", "10.0.0.3", "node-m"),
+	}
+
+	prompt := []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
+	keys := []kvblock.BlockHash{0xA1, 0xA2}
+	var seenFilter sets.Set[string]
+
+	idx := &fakeKVCacheIndexer{
+		computeFromTokens: func(_ context.Context, _ []uint32, _ string, _ []*kvblock.BlockExtraFeatures) ([]kvblock.BlockHash, error) {
+			return keys, nil
+		},
+		index: &fakeKVBlockIndex{
+			lookup: func(_ context.Context, _ []kvblock.BlockHash, podSet sets.Set[string]) (map[kvblock.BlockHash][]kvblock.PodEntry, error) {
+				seenFilter = podSet
+				return map[kvblock.BlockHash][]kvblock.PodEntry{
+					keys[0]: {{PodIdentifier: kvblock.NodePseudoPod("node-n"), DeviceTier: "lmcache-l1"}},
+					keys[1]: {{PodIdentifier: kvblock.PoolPseudoPod("fs"), DeviceTier: "lmcache-l2-fs"}},
+				}, nil
+			},
+		},
+	}
+	scorer, err := kvcache.NewKVBlockScorer(kvcache.DefaultKVBlockScorerConfig())
+	require.NoError(t, err)
+
+	p := newProducerWithIndexer(ctx, idx, scorer)
+	req := &scheduling.InferenceRequest{
+		RequestID:   "req-pseudo-pod",
+		TargetModel: "test-model",
+		Body: &fwkrh.InferenceRequestBody{
+			TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: prompt}}},
+		},
+	}
+	require.NoError(t, p.Produce(ctx, req, endpoints))
+
+	assert.True(t, seenFilter.HasAll("10.0.0.1:8080", "10.0.0.2:8080", "10.0.0.3:8080",
+		kvblock.NodePseudoPod("node-n"), kvblock.NodePseudoPod("node-m")))
+
+	for _, ep := range endpoints[:2] {
+		info := matchInfo(t, ep)
+		assert.Equal(t, 2, info.CachedBlockCount(), ep.GetMetadata().Name)
+		// Per-tier counts are contiguous from block 0; lmcache-l2-fs starts at block 1.
+		assert.Equal(t, map[string]int{"lmcache-l1": 1}, info.CachedBlocksByTier())
+		// lmcache-l1 weight 0.8 + unknown lmcache-l2-fs at default weight 1.0.
+		assert.Equal(t, 1, info.MatchBlocks())
+	}
+
+	// pod-c is on another node: the node:node-n entry at block 0 breaks its
+	// prefix chain, so the pool entry at block 1 does not count.
+	info := matchInfo(t, endpoints[2])
+	assert.Equal(t, 0, info.CachedBlockCount())
+	assert.Empty(t, info.CachedBlocksByTier())
+	assert.Equal(t, 0, info.MatchBlocks())
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/utils.go
@@ -27,17 +27,42 @@ import (
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
 )
 
-// extractEndpointSet builds the "address:port" identifier set used to filter
-// kvblock.Index lookups to candidate endpoints. Endpoints without metadata
-// are skipped.
+// extractEndpointSet builds the identifier set used to filter kvblock.Index
+// lookups to candidate endpoints: each endpoint's "address:port" plus the
+// node pseudo-pod of every node hosting a candidate. Endpoints without
+// metadata are skipped.
 func extractEndpointSet(endpoints []scheduling.Endpoint) sets.Set[string] {
 	endpointSet := sets.New[string]()
 	for _, ep := range endpoints {
 		if m := ep.GetMetadata(); m != nil {
 			endpointSet.Insert(fmt.Sprintf("%s:%s", m.Address, m.Port))
+			if m.NodeName != "" {
+				endpointSet.Insert(kvblock.NodePseudoPod(m.NodeName))
+			}
 		}
 	}
 	return endpointSet
+}
+
+// endpointsByNode groups candidate "address:port" identifiers by the node
+// hosting them, and returns the flat list of all identifiers. Endpoints
+// without metadata are skipped; endpoints without a node name appear only in
+// the flat list.
+func endpointsByNode(endpoints []scheduling.Endpoint) (map[string][]string, []string) {
+	byNode := map[string][]string{}
+	all := make([]string, 0, len(endpoints))
+	for _, ep := range endpoints {
+		m := ep.GetMetadata()
+		if m == nil {
+			continue
+		}
+		addr := fmt.Sprintf("%s:%s", m.Address, m.Port)
+		all = append(all, addr)
+		if m.NodeName != "" {
+			byNode[m.NodeName] = append(byNode[m.NodeName], addr)
+		}
+	}
+	return byNode, all
 }
 
 // matchedBlockCount returns the number of contiguous cached prefix blocks held

--- a/pkg/kvcache/README.md
+++ b/pkg/kvcache/README.md
@@ -30,6 +30,31 @@ indexer owns block-key computation, index lookup, and scoring.
   consecutive block hits starting from block 0, weighted per device tier
   (`BackendConfigs`), so a pod that holds a longer contiguous prefix ranks
   higher.
+- **Shared tiers.** Index entries keyed by a pseudo-pod identifier
+  (`node:<nodeName>` for a node-local tier shared by all pods on a node,
+  `pool:<name>` for a fleet-wide tier) are resolved to the candidate endpoints
+  they cover before scoring (`kvblock.ResolvePseudoPods`). `pool:` entries
+  pass every `Lookup` filter; `node:` entries must be named in the filter.
+
+## Device Tier Weights
+
+`kvCacheBackendConfigs` maps a `medium` string carried by KV events to a
+scoring weight. Defaults: `gpu` 1.0, `cpu` 0.8, `lmcache-l1` 0.8. Tiers absent
+from the list score at `kvCacheDefaultBackendWeight` (default 1.0). Slower
+shared tiers such as `lmcache-l2-<backend>` have no default entry; configure
+them explicitly, for example:
+
+```yaml
+indexerConfig:
+  kvCacheDefaultBackendWeight: 0.5
+  kvCacheBackendConfigs:
+    - name: gpu
+      weight: 1.0
+    - name: lmcache-l1
+      weight: 0.8
+    - name: lmcache-l2-fs
+      weight: 0.4
+```
 - **Tracing.** The index and scorer are wrapped with OpenTelemetry
   instrumentation that is a no-op when tracing is not configured.
 

--- a/pkg/kvcache/backend.go
+++ b/pkg/kvcache/backend.go
@@ -27,5 +27,6 @@ func DefaultKVCacheBackendConfig() []*KVCacheBackendConfig {
 	return []*KVCacheBackendConfig{
 		{Name: "gpu", Weight: 1.0},
 		{Name: "cpu", Weight: 0.8},
+		{Name: "lmcache-l1", Weight: 0.8},
 	}
 }

--- a/pkg/kvcache/indexer.go
+++ b/pkg/kvcache/indexer.go
@@ -39,6 +39,9 @@ type Config struct {
 	KVBlockIndexConfig  *kvblock.IndexConfig    `json:"kvBlockIndexConfig"`
 	KVBlockScorerConfig *KVBlockScorerConfig    // not exported
 	BackendConfigs      []*KVCacheBackendConfig `json:"kvCacheBackendConfigs"`
+	// DefaultBackendWeight is the scoring weight for device tiers absent from
+	// BackendConfigs.
+	DefaultBackendWeight float64 `json:"kvCacheDefaultBackendWeight"`
 
 	// TokenizersPoolConfig configured the deprecated in-process tokenization
 	// pool. The pool itself lives in llm-d-kv-cache; the indexer no longer
@@ -52,9 +55,10 @@ type Config struct {
 // NewDefaultConfig returns a default configuration for the Indexer module.
 func NewDefaultConfig() (*Config, error) {
 	return &Config{
-		KVBlockIndexConfig:  kvblock.DefaultIndexConfig(),
-		KVBlockScorerConfig: DefaultKVBlockScorerConfig(),
-		BackendConfigs:      DefaultKVCacheBackendConfig(),
+		KVBlockIndexConfig:   kvblock.DefaultIndexConfig(),
+		KVBlockScorerConfig:  DefaultKVBlockScorerConfig(),
+		BackendConfigs:       DefaultKVCacheBackendConfig(),
+		DefaultBackendWeight: DefaultBackendWeight,
 	}, nil
 }
 
@@ -88,6 +92,7 @@ func NewKVCacheIndexer(ctx context.Context, config *Config, tokenProcessor kvblo
 
 	// override backend configs with the ones from the config, if the defaults are not used.
 	config.KVBlockScorerConfig.BackendConfigs = config.BackendConfigs
+	config.KVBlockScorerConfig.DefaultWeight = config.DefaultBackendWeight
 	scorer, err := NewKVBlockScorer(config.KVBlockScorerConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create KVBlockScorer: %w", err)

--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -309,7 +309,7 @@ func (m *CostAwareMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHa
 				// Filter pods based on the provided pod identifiers
 				pods.cache.Range(func(k, value interface{}) bool {
 					if pod, ok := k.(PodEntry); ok {
-						if podIdentifierSet.Has(pod.PodIdentifier) {
+						if InPodFilter(podIdentifierSet, pod.PodIdentifier) {
 							podsPerKey[key] = append(podsPerKey[key], pod)
 						}
 					}

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -134,7 +134,7 @@ func (m *InMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 			} else {
 				// Filter pods based on the provided pod identifiers
 				for _, pod := range pods.cache.Keys() {
-					if podIdentifierSet.Has(pod.PodIdentifier) {
+					if InPodFilter(podIdentifierSet, pod.PodIdentifier) {
 						podsPerKey[requestKey] = append(podsPerKey[requestKey], pod)
 					}
 				}

--- a/pkg/kvcache/kvblock/pseudo_pod.go
+++ b/pkg/kvcache/kvblock/pseudo_pod.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// Pseudo-pod identifiers name KV tiers that are not owned by a single pod.
+// A KV-event topic "kv@node:<nodeName>@<model>" credits every candidate
+// endpoint scheduled on that node (a node-local cache server shared by all
+// pods on the node); "kv@pool:<name>@<model>" credits every candidate endpoint
+// (a fleet-wide shared storage tier). The index stores pseudo-pod identifiers
+// as opaque pod identifiers; expansion to real endpoints happens at lookup.
+const (
+	nodePseudoPodPrefix = "node:"
+	poolPseudoPodPrefix = "pool:"
+)
+
+// NodePseudoPod returns the pseudo-pod identifier for a node-local shared tier.
+func NodePseudoPod(nodeName string) string {
+	return nodePseudoPodPrefix + nodeName
+}
+
+// PoolPseudoPod returns the pseudo-pod identifier for a fleet-wide shared tier.
+func PoolPseudoPod(name string) string {
+	return poolPseudoPodPrefix + name
+}
+
+// IsPoolPseudoPod reports whether podIdentifier names a fleet-wide shared tier.
+func IsPoolPseudoPod(podIdentifier string) bool {
+	return strings.HasPrefix(podIdentifier, poolPseudoPodPrefix)
+}
+
+// IsPseudoPod reports whether podIdentifier is a node: or pool: pseudo-pod.
+func IsPseudoPod(podIdentifier string) bool {
+	return strings.HasPrefix(podIdentifier, nodePseudoPodPrefix) || IsPoolPseudoPod(podIdentifier)
+}
+
+// InPodFilter reports whether an index entry for podIdentifier passes a
+// non-empty Lookup filter. Pool pseudo-pods always pass: their names cannot be
+// enumerated by the caller and they credit every candidate endpoint.
+func InPodFilter(podIdentifierSet sets.Set[string], podIdentifier string) bool {
+	return podIdentifierSet.Has(podIdentifier) || IsPoolPseudoPod(podIdentifier)
+}
+
+// ResolvePseudoPods rewrites pseudo-pod entries in keyToPods into entries for
+// the real endpoints they credit, keeping the device tier. A node:<n> entry
+// becomes one entry per endpoint in endpointsByNode[n]; a pool: entry becomes
+// one entry per endpoint in allEndpoints. Pseudo-pod entries that resolve to
+// no endpoint are dropped. The map is modified in place and returned.
+func ResolvePseudoPods(keyToPods map[BlockHash][]PodEntry,
+	endpointsByNode map[string][]string, allEndpoints []string,
+) map[BlockHash][]PodEntry {
+	for key, entries := range keyToPods {
+		if !hasPseudoPod(entries) {
+			continue
+		}
+		resolved := make([]PodEntry, 0, len(entries))
+		for _, e := range entries {
+			switch {
+			case IsPoolPseudoPod(e.PodIdentifier):
+				resolved = appendFor(resolved, e, allEndpoints)
+			case strings.HasPrefix(e.PodIdentifier, nodePseudoPodPrefix):
+				node := strings.TrimPrefix(e.PodIdentifier, nodePseudoPodPrefix)
+				resolved = appendFor(resolved, e, endpointsByNode[node])
+			default:
+				resolved = append(resolved, e)
+			}
+		}
+		keyToPods[key] = resolved
+	}
+	return keyToPods
+}
+
+func hasPseudoPod(entries []PodEntry) bool {
+	for _, e := range entries {
+		if IsPseudoPod(e.PodIdentifier) {
+			return true
+		}
+	}
+	return false
+}
+
+func appendFor(dst []PodEntry, template PodEntry, endpoints []string) []PodEntry {
+	for _, ep := range endpoints {
+		e := template
+		e.PodIdentifier = ep
+		dst = append(dst, e)
+	}
+	return dst
+}

--- a/pkg/kvcache/kvblock/pseudo_pod_test.go
+++ b/pkg/kvcache/kvblock/pseudo_pod_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvblock_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
+)
+
+func TestPseudoPodIdentifiers(t *testing.T) {
+	tests := []struct {
+		id       string
+		isPseudo bool
+		isPool   bool
+		inFilter bool
+	}{
+		{id: kvblock.NodePseudoPod("n1"), isPseudo: true, isPool: false, inFilter: false},
+		{id: kvblock.PoolPseudoPod("fs"), isPseudo: true, isPool: true, inFilter: true},
+		{id: "10.0.0.1:8000", isPseudo: false, isPool: false, inFilter: true},
+		{id: "10.0.0.9:8000", isPseudo: false, isPool: false, inFilter: false},
+		{id: "nodeless", isPseudo: false, isPool: false, inFilter: false},
+		{id: "", isPseudo: false, isPool: false, inFilter: false},
+	}
+	filter := sets.New("10.0.0.1:8000")
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			assert.Equal(t, tt.isPseudo, kvblock.IsPseudoPod(tt.id))
+			assert.Equal(t, tt.isPool, kvblock.IsPoolPseudoPod(tt.id))
+			assert.Equal(t, tt.inFilter, kvblock.InPodFilter(filter, tt.id))
+		})
+	}
+	assert.Equal(t, "node:n1", kvblock.NodePseudoPod("n1"))
+	assert.Equal(t, "pool:fs", kvblock.PoolPseudoPod("fs"))
+}
+
+func TestResolvePseudoPods(t *testing.T) {
+	byNode := map[string][]string{"n1": {"a", "b"}, "n2": {"c"}}
+	all := []string{"a", "b", "c"}
+	in := map[kvblock.BlockHash][]kvblock.PodEntry{
+		1: {
+			{PodIdentifier: "a", DeviceTier: "gpu"},
+			{PodIdentifier: "node:n1", DeviceTier: "lmcache-l1"},
+		},
+		2: {{PodIdentifier: "pool:fs", DeviceTier: "lmcache-l2-fs"}},
+		3: {{PodIdentifier: "node:unknown", DeviceTier: "lmcache-l1"}},
+		4: {{PodIdentifier: "c", DeviceTier: "gpu"}},
+	}
+	got := kvblock.ResolvePseudoPods(in, byNode, all)
+	assert.ElementsMatch(t, []kvblock.PodEntry{
+		{PodIdentifier: "a", DeviceTier: "gpu"},
+		{PodIdentifier: "a", DeviceTier: "lmcache-l1"},
+		{PodIdentifier: "b", DeviceTier: "lmcache-l1"},
+	}, got[1])
+	assert.ElementsMatch(t, []kvblock.PodEntry{
+		{PodIdentifier: "a", DeviceTier: "lmcache-l2-fs"},
+		{PodIdentifier: "b", DeviceTier: "lmcache-l2-fs"},
+		{PodIdentifier: "c", DeviceTier: "lmcache-l2-fs"},
+	}, got[2])
+	assert.Empty(t, got[3])
+	assert.Equal(t, []kvblock.PodEntry{{PodIdentifier: "c", DeviceTier: "gpu"}}, got[4])
+}

--- a/pkg/kvcache/kvblock/redis.go
+++ b/pkg/kvcache/kvblock/redis.go
@@ -155,7 +155,7 @@ func (r *RedisIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 			if !ok {
 				continue
 			}
-			if !filterPods || podIdentifierSet.Has(pod.PodIdentifier) {
+			if !filterPods || InPodFilter(podIdentifierSet, pod.PodIdentifier) {
 				filteredPods = append(filteredPods, pod)
 			}
 		}

--- a/pkg/kvcache/kvblock_scorer.go
+++ b/pkg/kvcache/kvblock_scorer.go
@@ -35,13 +35,20 @@ const (
 type KVBlockScorerConfig struct {
 	ScoringStrategy KVScoringStrategy
 	BackendConfigs  []*KVCacheBackendConfig `json:"backendConfigs"`
+	// DefaultWeight is the scoring weight for blocks on a device tier that has
+	// no entry in BackendConfigs.
+	DefaultWeight float64 `json:"defaultWeight"`
 }
+
+// DefaultBackendWeight is the DefaultWeight used when none is configured.
+const DefaultBackendWeight = 1.0
 
 // DefaultKVBlockScorerConfig returns the default configuration for the KVBlockScorer.
 func DefaultKVBlockScorerConfig() *KVBlockScorerConfig {
 	return &KVBlockScorerConfig{
 		ScoringStrategy: LongestPrefixMatch,
 		BackendConfigs:  DefaultKVCacheBackendConfig(),
+		DefaultWeight:   DefaultBackendWeight,
 	}
 }
 
@@ -68,6 +75,7 @@ func NewKVBlockScorer(config *KVBlockScorerConfig) (KVBlockScorer, error) {
 
 		return &LongestPrefixScorer{
 			MediumWeights: weightMap,
+			DefaultWeight: config.DefaultWeight,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported scoring strategy: %s", config.ScoringStrategy)
@@ -77,8 +85,10 @@ func NewKVBlockScorer(config *KVBlockScorerConfig) (KVBlockScorer, error) {
 // LongestPrefixScorer scores based on longest consecutive block matches count
 // starting from block 0.
 type LongestPrefixScorer struct {
-	// mediumWeights maps medium/device tier names to their scoring weights
+	// MediumWeights maps medium/device tier names to their scoring weights
 	MediumWeights map[string]float64
+	// DefaultWeight applies to device tiers absent from MediumWeights.
+	DefaultWeight float64
 }
 
 // Strategy returns the strategy type: LongestPrefixMatch.
@@ -88,9 +98,11 @@ func (s *LongestPrefixScorer) Strategy() KVScoringStrategy {
 
 // fillMaxWeights populates dst with the maximum weight per podID across all
 // device tiers for the given entries. The caller must clear dst before calling.
-func fillMaxWeights(dst map[string]float64, entries []kvblock.PodEntry, mediumWeights map[string]float64) {
+func fillMaxWeights(dst map[string]float64, entries []kvblock.PodEntry,
+	mediumWeights map[string]float64, defaultWeight float64,
+) {
 	for _, entry := range entries {
-		weight := 1.0
+		weight := defaultWeight
 		if mediumWeights != nil {
 			if w, exists := mediumWeights[entry.DeviceTier]; exists {
 				weight = w
@@ -118,7 +130,7 @@ func (s *LongestPrefixScorer) Score(
 	curWeights := make(map[string]float64)
 
 	// Build weight index for the first key in a single pass over entries.
-	fillMaxWeights(curWeights, keyToPods[keys[0]], s.MediumWeights)
+	fillMaxWeights(curWeights, keyToPods[keys[0]], s.MediumWeights, s.DefaultWeight)
 
 	// activePods tracks pods still in the consecutive prefix chain.
 	// Using a plain map and in-place deletion avoids allocating new sets
@@ -136,7 +148,7 @@ func (s *LongestPrefixScorer) Score(
 
 		// Reuse scratch map: clear and refill for current key.
 		clear(curWeights)
-		fillMaxWeights(curWeights, keyToPods[keys[i]], s.MediumWeights)
+		fillMaxWeights(curWeights, keyToPods[keys[i]], s.MediumWeights, s.DefaultWeight)
 
 		// In-place intersection: delete pods from activePods that are not
 		// in the current key, and accumulate scores for those that remain.

--- a/pkg/kvcache/kvblock_scorer_default_weight_test.go
+++ b/pkg/kvcache/kvblock_scorer_default_weight_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvcache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/llm-d/llm-d-router/pkg/kvcache"
+	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
+)
+
+func TestLongestPrefixScorerDefaultWeight(t *testing.T) {
+	blockKeys := int64KeysToKVBlockKeys([]uint64{1001, 1002})
+	hitmap := map[kvblock.BlockHash][]kvblock.PodEntry{
+		1001: {{PodIdentifier: podA, DeviceTier: "gpu"}, {PodIdentifier: podB, DeviceTier: "unknown-tier"}},
+		1002: {{PodIdentifier: podA, DeviceTier: "gpu"}, {PodIdentifier: podB, DeviceTier: "unknown-tier"}},
+	}
+
+	tests := []struct {
+		name          string
+		defaultWeight float64
+		wantB         float64
+	}{
+		{name: "configured", defaultWeight: 0.25, wantB: 0.5},
+		{name: "default keeps unknown tiers at full weight", defaultWeight: kvcache.DefaultKVBlockScorerConfig().DefaultWeight, wantB: 2.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := kvcache.DefaultKVBlockScorerConfig()
+			cfg.DefaultWeight = tt.defaultWeight
+			scorer, err := kvcache.NewKVBlockScorer(cfg)
+			require.NoError(t, err)
+
+			scored, err := scorer.Score(context.Background(), blockKeys, hitmap)
+			require.NoError(t, err)
+			assert.InDelta(t, 2.0, scored[podA], 0.0001)
+			assert.InDelta(t, tt.wantB, scored[podB], 0.0001)
+		})
+	}
+}
+
+func TestDefaultKVCacheBackendConfigIncludesLMCacheL1(t *testing.T) {
+	cfg := kvcache.DefaultKVBlockScorerConfig()
+	scorer, err := kvcache.NewKVBlockScorer(cfg)
+	require.NoError(t, err)
+
+	keys := int64KeysToKVBlockKeys([]uint64{1001})
+	scored, err := scorer.Score(context.Background(), keys, map[kvblock.BlockHash][]kvblock.PodEntry{
+		1001: {{PodIdentifier: podA, DeviceTier: "lmcache-l1"}},
+	})
+	require.NoError(t, err)
+	assert.InDelta(t, 0.8, scored[podA], 0.0001)
+}

--- a/pkg/kvevents/README.md
+++ b/pkg/kvevents/README.md
@@ -23,6 +23,14 @@ engines.
   them down as pods come and go.
 - **Decoding.** Each message is parsed by the engine adapter for its topic,
   producing canonical block-stored / block-removed / all-blocks-cleared events.
+- **Pod identity.** The topic `kv@<pod-id>@<model>` names the pod credited
+  with the blocks. Publishers for tiers not owned by one pod use a pseudo-pod
+  segment instead: `node:<nodeName>` for a cache shared by all pods on a node,
+  `pool:<name>` for a fleet-wide shared tier. The index stores these as opaque
+  identifiers; the [`kvcache`](../kvcache/README.md) scorer resolves them to
+  candidate endpoints at lookup. Pseudo-pod topics take effect on the shared
+  (`zmqEndpoint`) subscription only; a per-pod subscription attributes every
+  message to its own pod.
 - **Worker pool.** `Pool` fans messages out to workers keyed by a sharding key
   so events for the same block are processed in order, then applies them to the
   index.

--- a/pkg/kvevents/pseudo_pod_test.go
+++ b/pkg/kvevents/pseudo_pod_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kvevents
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
+)
+
+// topicAdapter takes the pod identifier and model from the topic
+// "kv@<pod>@<model>", as the engine adapters do, and emits one block-stored
+// event carrying 16 tokens on the "lmcache-l1" tier.
+type topicAdapter struct{}
+
+func (a *topicAdapter) ParseMessage(msg *RawMessage) (string, string, EventBatch, error) {
+	parts := strings.Split(msg.Topic, "@")
+	return parts[1], parts[2], EventBatch{
+		Events: []GenericEvent{
+			&BlockStoredEvent{
+				BlockHashes: []uint64{uint64(msg.Payload[0])},
+				Tokens:      makeTokens(16),
+				DeviceTier:  "lmcache-l1",
+			},
+		},
+	}, nil
+}
+
+func (a *topicAdapter) ShardingKey(msg *RawMessage) string {
+	return strings.Split(msg.Topic, "@")[1]
+}
+
+// A pseudo-pod topic segment is indexed as an opaque pod identifier: it is
+// stored, passes a Lookup filter naming it, and is removed by a reset.
+func TestPool_PseudoPodTopicIndexedAsOpaqueIdentifier(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, tokenProcessor := newTestPool(t, 16)
+	pool.adapter = &topicAdapter{}
+
+	pool.processRawMessage(ctx, &RawMessage{Topic: "kv@node:n1@test-model", Payload: []byte{1}})
+	pool.processRawMessage(ctx, &RawMessage{Topic: "kv@pool:fs@test-model", Payload: []byte{1}})
+
+	keys, err := tokenProcessor.TokensToKVBlockKeys(kvblock.EmptyBlockHash, makeTokens(16), "test-model", nil)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+
+	result, err := idx.Lookup(ctx, keys, nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []kvblock.PodEntry{
+		{PodIdentifier: "node:n1", DeviceTier: "lmcache-l1"},
+		{PodIdentifier: "pool:fs", DeviceTier: "lmcache-l1"},
+	}, result[keys[0]])
+
+	// A filter naming only real endpoints still returns the pool entry;
+	// the node entry needs its identifier in the filter.
+	result, err = idx.Lookup(ctx, keys, sets.New("10.0.0.1:8000"))
+	require.NoError(t, err)
+	assert.Equal(t, []kvblock.PodEntry{{PodIdentifier: "pool:fs", DeviceTier: "lmcache-l1"}}, result[keys[0]])
+
+	result, err = idx.Lookup(ctx, keys, sets.New("10.0.0.1:8000", kvblock.NodePseudoPod("n1")))
+	require.NoError(t, err)
+	assert.Len(t, result[keys[0]], 2)
+
+	pool.processRawMessage(ctx, &RawMessage{Topic: "kv@node:n1@test-model", reset: true})
+	result, err = idx.Lookup(ctx, keys, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []kvblock.PodEntry{{PodIdentifier: "pool:fs", DeviceTier: "lmcache-l1"}}, result[keys[0]])
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

External KV tiers that are not owned by one pod cannot be expressed in the pod-keyed block index today. Two cases:

- A node-local cache server shared by all pods on the node (for example an LMCache multiprocess server, one per node). The emitter has to fan out one KV event per pod on the node, and cannot say "any pod on this node".
- A fleet-wide shared storage tier. llm-d's own `llmd_fs_backend` publishes under `kv@<MEDIUM>@<model>`; that segment is treated as a pod identifier, so the shared tier lands in the index as a phantom pod and never credits any real endpoint.

Also, a `medium` string with no entry in `kvCacheBackendConfigs` scores at 1.0, the same as GPU, so any tier a new publisher introduces is over-credited until the operator configures it.

Changes:

- **Pseudo-pod identities.** KV-event topics whose pod segment is `node:<nodeName>` or `pool:<name>` are accepted. The `kvblock.Index` interface and backends store them as opaque pod identifiers (the only backend change is that `pool:` entries pass a non-empty `Lookup` filter, via `kvblock.InPodFilter`). The precise-prefix-cache producer expands them at lookup with `kvblock.ResolvePseudoPods`: a `node:<n>` entry becomes one entry per candidate endpoint on node n, a `pool:` entry one entry per candidate endpoint, tier preserved, so scoring and per-tier counts run unchanged on real endpoint identifiers. The lookup filter includes `node:<n>` for every node hosting a candidate.
- **Node name on endpoints.** `EndpointMetadata.NodeName` (from `pod.Spec.NodeName`), alongside the existing `NodeAddress`.
- **Tier weight hardening.** `kvCacheDefaultBackendWeight` (default 1.0, unchanged behaviour) is the weight for tiers absent from `kvCacheBackendConfigs`; `lmcache-l1` is added to the defaults at 0.8. `lmcache-l2-*` tiers are documented as explicit configuration (no wildcard matching).

This is engine-agnostic: any publisher that speaks the vLLM KV-event wire format can use a pseudo-pod topic. Pseudo-pod topics take effect on the shared `zmqEndpoint` subscription; a per-pod subscription attributes every message to its own pod, as today.

Context: LMCache RFC https://github.com/LMCache/LMCache/issues/4770 (emitter PR LMCache/LMCache#4768), LMCache issue https://github.com/LMCache/LMCache/issues/4352.

Test plan (new tests, all passing locally in the builder container together with the existing suites of the touched packages; `golangci-lint` and `typos` clean on the touched packages):

- [x] Pseudo-pod identifier helpers and `ResolvePseudoPods` (node scoping, pool fan-out, unknown node dropped, real entries untouched)
- [x] Producer: two endpoints on node N and one on node M; a `node:N` entry credits only N's endpoints, `pool:fs` credits all; lookup filter carries both nodes' pseudo-pods
- [x] Scorer: unknown tier scores at the configured default weight; default config keeps 1.0; `lmcache-l1` defaults to 0.8
- [x] kvevents pool: topic `kv@node:n1@model` is indexed under `node:n1`, filtered lookup and reset (`AllBlocksCleared`) treat it as an opaque identifier; `pool:fs` passes a filter naming only real endpoints

**Which issue(s) this PR fixes**:

Refs https://github.com/LMCache/LMCache/issues/4352 (no llm-d-router issue yet; happy to file one if maintainers want this tracked).

**Release note**:
```release-note
KV-event topics may name a shared tier instead of a pod: `kv@node:<nodeName>@<model>` credits every endpoint on that node and `kv@pool:<name>@<model>` credits every endpoint. Device tiers missing from `kvCacheBackendConfigs` score at the new `kvCacheDefaultBackendWeight` (default 1.0), and `lmcache-l1` is included in the default backend weights at 0.8.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

