### PR TITLE
fix(sidecar): forward untouched request fields as raw JSON to keep key order

### DIFF
--- a/pkg/sidecar/proxy/connector_ec_common.go
+++ b/pkg/sidecar/proxy/connector_ec_common.go
@@ -56,7 +56,7 @@ func truncateLongStrings(v any, maxLen int) any {
 func extractMMItems(requestData map[string]any) []map[string]any {
 	var items []map[string]any
 
-	messages, ok := requestData["messages"].([]any)
+	messages, ok := requestMessages(requestData)
 	if !ok {
 		return items
 	}

--- a/pkg/sidecar/proxy/connector_ec_common.go
+++ b/pkg/sidecar/proxy/connector_ec_common.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/go-logr/logr"
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 	"golang.org/x/sync/errgroup"
@@ -53,17 +54,18 @@ func truncateLongStrings(v any, maxLen int) any {
 }
 
 // extractMMItems extracts all multimodal items from the request messages.
-func extractMMItems(requestData map[string]any) []map[string]any {
+func extractMMItems(logger logr.Logger, requestData map[string]any) []map[string]any {
 	var items []map[string]any
 
-	messages, ok := requestMessages(requestData)
-	if !ok {
+	messages, err := requestMessages(requestData)
+	if err != nil {
+		logger.V(logging.DEBUG).Info("cannot read request messages for multimodal extraction", "error", err)
 		return items
 	}
 
 	for _, msg := range messages {
-		msgMap, ok := msg.(map[string]any)
-		if !ok {
+		var msgMap map[string]any
+		if err := json.Unmarshal(msg, &msgMap); err != nil {
 			continue
 		}
 
@@ -139,7 +141,7 @@ func mmItemURL(item map[string]any) string {
 // there is no multimodal content. The caller should skip the encoder
 // stage in that case.
 func (s *Server) mmItemsForFanout(originalRequest map[string]any, requestID string) []map[string]any {
-	raw := extractMMItems(originalRequest)
+	raw := extractMMItems(s.logger, originalRequest)
 	if len(raw) == 0 {
 		return nil
 	}

--- a/pkg/sidecar/proxy/connector_ec_shared_storage_test.go
+++ b/pkg/sidecar/proxy/connector_ec_shared_storage_test.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -141,7 +142,12 @@ func TestExtractMMItems(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			items := extractMMItems(tt.request)
+			body, err := json.Marshal(tt.request)
+			assert.NoError(t, err)
+			parsed, err := decodeRequestBody(body)
+			assert.NoError(t, err)
+
+			items := extractMMItems(log.Log, parsed)
 			assert.Equal(t, tt.expected, len(items), "unexpected number of MM items")
 		})
 	}
@@ -318,17 +324,13 @@ func inlineAudioItem(data, format string) map[string]any {
 	return map[string]any{"type": "input_audio", "input_audio": map[string]any{"data": data, "format": format}}
 }
 
-// userMessageRequest wraps content items in a minimal chat-completions request.
+// userMessageRequest wraps content items in a minimal chat-completions request,
+// with messages held as raw bytes the way decodeRequestBody leaves them.
 func userMessageRequest(items ...map[string]any) map[string]any {
-	content := make([]any, len(items))
-	for i, item := range items {
-		content[i] = item
-	}
-	return map[string]any{
-		"messages": []any{
-			map[string]any{"role": "user", "content": content},
-		},
-	}
+	messages, _ := json.Marshal([]any{
+		map[string]any{"role": "user", "content": items},
+	})
+	return map[string]any{"messages": json.RawMessage(messages)}
 }
 
 func TestFanoutEncoderPrimerDeduplication(t *testing.T) {

--- a/pkg/sidecar/proxy/connector_mooncake.go
+++ b/pkg/sidecar/proxy/connector_mooncake.go
@@ -49,8 +49,8 @@ func (s *Server) handleMooncake(w http.ResponseWriter, r *http.Request, prefillP
 		return
 	}
 
-	var requestData map[string]any
-	if err := json.Unmarshal(body, &requestData); err != nil {
+	requestData, err := decodeRequestBody(body)
+	if err != nil {
 		if err := errorJSONInvalid(err, w); err != nil {
 			s.logger.Error(err, "failed to send error response to client")
 		}

--- a/pkg/sidecar/proxy/connector_nixlv2_test.go
+++ b/pkg/sidecar/proxy/connector_nixlv2_test.go
@@ -172,6 +172,27 @@ var _ = Describe("NIXL Connector (v2)", func() {
 
 	})
 
+	It("should forward untouched fields byte-for-byte, preserving nested key order", func() {
+		proxyBaseAddr := startProxy()
+
+		tools := `[{"type":"function","function":{"name":"example","parameters":{"properties":{"some-parameter":{"type":"string"},"xyz":{"type":"string"},"123":{"type":"string"},"another-parameter":{"type":"string"}}}}}]`
+		body := `{"model":"Qwen/Qwen2-0.5B","messages":[{"role":"user","content":"Hello"}],"max_tokens":50,"tools":` + tools + `}`
+
+		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(body)))
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+
+		rp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		defer rp.Body.Close()
+		Expect(rp.StatusCode).To(Equal(http.StatusOK))
+
+		Expect(testInfo.prefillHandler.CompletionRawBodies).To(HaveLen(1))
+		Expect(string(testInfo.prefillHandler.CompletionRawBodies[0])).To(ContainSubstring(`"tools":` + tools))
+		Expect(testInfo.decodeHandler.CompletionRawBodies).To(HaveLen(1))
+		Expect(string(testInfo.decodeHandler.CompletionRawBodies[0])).To(ContainSubstring(`"tools":` + tools))
+	})
+
 	It("should add prefiller cached tokens when decoder usage details omit cached_tokens", func() {
 		testInfo.decodeHandler.RawResponse = `{"id":"chatcmpl-test","object":"chat.completion","choices":[],"usage":{"prompt_tokens":64,"completion_tokens":1,"total_tokens":65,"prompt_tokens_details":{}}}`
 		proxyBaseAddr := startProxy()

--- a/pkg/sidecar/proxy/connector_nixlv2_test.go
+++ b/pkg/sidecar/proxy/connector_nixlv2_test.go
@@ -176,7 +176,8 @@ var _ = Describe("NIXL Connector (v2)", func() {
 		proxyBaseAddr := startProxy()
 
 		tools := `[{"type":"function","function":{"name":"example","parameters":{"properties":{"some-parameter":{"type":"string"},"xyz":{"type":"string"},"123":{"type":"string"},"another-parameter":{"type":"string"}}}}}]`
-		body := `{"model":"Qwen/Qwen2-0.5B","messages":[{"role":"user","content":"Hello"}],"max_tokens":50,"tools":` + tools + `}`
+		messages := `[{"role":"user","content":[{"type":"text","text":"Hello"}]}]`
+		body := `{"model":"Qwen/Qwen2-0.5B","messages":` + messages + `,"max_tokens":50,"tools":` + tools + `}`
 
 		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(body)))
 		Expect(err).ToNot(HaveOccurred())
@@ -187,10 +188,14 @@ var _ = Describe("NIXL Connector (v2)", func() {
 		defer rp.Body.Close()
 		Expect(rp.StatusCode).To(Equal(http.StatusOK))
 
-		Expect(testInfo.prefillHandler.CompletionRawBodies).To(HaveLen(1))
-		Expect(string(testInfo.prefillHandler.CompletionRawBodies[0])).To(ContainSubstring(`"tools":` + tools))
-		Expect(testInfo.decodeHandler.CompletionRawBodies).To(HaveLen(1))
-		Expect(string(testInfo.decodeHandler.CompletionRawBodies[0])).To(ContainSubstring(`"tools":` + tools))
+		prefillBodies := testInfo.prefillHandler.GetCompletionRawBodies()
+		Expect(prefillBodies).To(HaveLen(1))
+		Expect(string(prefillBodies[0])).To(ContainSubstring(`"tools":` + tools))
+		Expect(string(prefillBodies[0])).To(ContainSubstring(`"messages":` + messages))
+		decodeBodies := testInfo.decodeHandler.GetCompletionRawBodies()
+		Expect(decodeBodies).To(HaveLen(1))
+		Expect(string(decodeBodies[0])).To(ContainSubstring(`"tools":` + tools))
+		Expect(string(decodeBodies[0])).To(ContainSubstring(`"messages":` + messages))
 	})
 
 	It("should add prefiller cached tokens when decoder usage details omit cached_tokens", func() {

--- a/pkg/sidecar/proxy/connector_p2p.go
+++ b/pkg/sidecar/proxy/connector_p2p.go
@@ -52,8 +52,8 @@ func (s *Server) handleP2P(w http.ResponseWriter, r *http.Request, prefillPodHos
 		return
 	}
 
-	var requestData map[string]any
-	if err := json.Unmarshal(body, &requestData); err != nil {
+	requestData, err := decodeRequestBody(body)
+	if err != nil {
 		if err := errorJSONInvalid(err, w); err != nil {
 			s.logger.Error(err, "failed to send error response to client")
 		}

--- a/pkg/sidecar/proxy/connector_sglang.go
+++ b/pkg/sidecar/proxy/connector_sglang.go
@@ -205,8 +205,8 @@ func (s *Server) parseSGLangRequest(r *http.Request) (map[string]interface{}, er
 		return nil, fmt.Errorf("failed to read request body: %w", err)
 	}
 
-	var requestData map[string]interface{}
-	if err := json.Unmarshal(body, &requestData); err != nil {
+	requestData, err := decodeRequestBody(body)
+	if err != nil {
 		return nil, fmt.Errorf("failed to parse request body: %w", err)
 	}
 

--- a/pkg/sidecar/proxy/decode.go
+++ b/pkg/sidecar/proxy/decode.go
@@ -423,7 +423,7 @@ func appendChunkToRequest(req map[string]any, text string) {
 	if text == "" {
 		return
 	}
-	messages, _ := req[requestFieldMessages].([]any)
+	messages, _ := requestMessages(req)
 	req[requestFieldMessages] = append(messages, map[string]any{
 		requestFieldRole:    roleAssistant,
 		requestFieldContent: text,

--- a/pkg/sidecar/proxy/decode.go
+++ b/pkg/sidecar/proxy/decode.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -234,7 +235,7 @@ func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request,
 		// Append the generated text to the request so the next chunk continues
 		// from where this one left off.
 		s.logger.V(logging.TRACE).Info("chunked decode: appending chunk text to request", "chunkText", chunkText)
-		appendChunkToRequest(completionRequest, chunkText)
+		appendChunkToRequest(s.logger, completionRequest, chunkText)
 	}
 
 	span.SetAttributes(
@@ -418,16 +419,26 @@ func extractChoiceText(choice map[string]any) string {
 }
 
 // appendChunkToRequest appends the generated text from a chunk to the request
-// so the next chunk continues from where this one left off.
-func appendChunkToRequest(req map[string]any, text string) {
+// so the next chunk continues from where this one left off. The messages the
+// client sent are appended to as raw bytes, keeping their key order intact
+// across chunks.
+func appendChunkToRequest(logger logr.Logger, req map[string]any, text string) {
 	if text == "" {
 		return
 	}
-	messages, _ := requestMessages(req)
-	req[requestFieldMessages] = append(messages, map[string]any{
+	messages, err := requestMessages(req)
+	if err != nil {
+		logger.V(logging.DEBUG).Info("chunked decode: cannot read request messages", "error", err)
+	}
+	chunk, err := json.Marshal(map[string]any{
 		requestFieldRole:    roleAssistant,
 		requestFieldContent: text,
 	})
+	if err != nil {
+		logger.V(logging.DEBUG).Info("chunked decode: cannot encode chunk text", "error", err)
+		return
+	}
+	req[requestFieldMessages] = append(messages, chunk)
 }
 
 // toInt converts a JSON number value (float64, int, or json.Number) to int.

--- a/pkg/sidecar/proxy/decode_test.go
+++ b/pkg/sidecar/proxy/decode_test.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2" // nolint:revive
 	. "github.com/onsi/gomega"    // nolint:revive
 )
@@ -302,20 +303,33 @@ var _ = Describe("Chunked Decode", func() {
 
 		It("appendChunkToRequest appends assistant message to chat messages", func() {
 			req := map[string]any{
-				requestFieldMessages: []any{map[string]any{requestFieldRole: "user", requestFieldContent: "Hi"}},
+				requestFieldMessages: json.RawMessage(`[{"role":"user","content":"Hi"}]`),
 			}
-			appendChunkToRequest(req, "hello")
-			msgs := req[requestFieldMessages].([]any)
+			appendChunkToRequest(logr.Discard(), req, "hello")
+			msgs := req[requestFieldMessages].([]json.RawMessage)
 			Expect(msgs).To(HaveLen(2))
-			last := msgs[1].(map[string]any)
+			var last map[string]any
+			Expect(json.Unmarshal(msgs[1], &last)).To(Succeed())
 			Expect(last[requestFieldRole]).To(Equal("assistant"))
 			Expect(last[requestFieldContent]).To(Equal("hello"))
 		})
 
+		It("appendChunkToRequest keeps the client's messages byte-for-byte across chunks", func() {
+			userMessage := `{"role":"user","content":[{"type":"text","b":"1","a":"2"}]}`
+			req := map[string]any{requestFieldMessages: json.RawMessage(`[` + userMessage + `]`)}
+
+			appendChunkToRequest(logr.Discard(), req, "one")
+			appendChunkToRequest(logr.Discard(), req, "two")
+
+			body, err := json.Marshal(req)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(body)).To(ContainSubstring(userMessage))
+		})
+
 		It("appendChunkToRequest is a no-op for empty text", func() {
-			req := map[string]any{requestFieldMessages: []any{}}
-			appendChunkToRequest(req, "")
-			Expect(req[requestFieldMessages].([]any)).To(BeEmpty())
+			req := map[string]any{requestFieldMessages: json.RawMessage(`[]`)}
+			appendChunkToRequest(logr.Discard(), req, "")
+			Expect(req[requestFieldMessages]).To(Equal(json.RawMessage(`[]`)))
 		})
 	})
 })

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -197,21 +197,24 @@ var inspectedRequestFields = map[string]struct{}{
 	requestFieldAddGenerationPrompt:  {},
 }
 
-// requestMessages returns the request's messages array, decoding it from raw
-// bytes on first use. The second return value is false when the field is
-// absent or not an array.
-func requestMessages(req map[string]any) ([]any, bool) {
+// requestMessages returns the request's messages, decoding the array on first
+// use and keeping each element as raw bytes so that re-marshaling the request
+// preserves the key order inside every message. An absent field yields a nil
+// slice and no error.
+func requestMessages(req map[string]any) ([]json.RawMessage, error) {
 	switch v := req[requestFieldMessages].(type) {
-	case []any:
-		return v, true
+	case nil:
+		return nil, nil
+	case []json.RawMessage:
+		return v, nil
 	case json.RawMessage:
-		var messages []any
+		var messages []json.RawMessage
 		if err := json.Unmarshal(v, &messages); err != nil {
-			return nil, false
+			return nil, err
 		}
-		return messages, true
+		return messages, nil
 	default:
-		return nil, false
+		return nil, fmt.Errorf("messages is %T, want a JSON array", v)
 	}
 }
 

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -195,7 +195,24 @@ var inspectedRequestFields = map[string]struct{}{
 	requestFieldCacheHitThreshold:    {},
 	requestFieldContinueFinalMessage: {},
 	requestFieldAddGenerationPrompt:  {},
-	requestFieldMessages:             {},
+}
+
+// requestMessages returns the request's messages array, decoding it from raw
+// bytes on first use. The second return value is false when the field is
+// absent or not an array.
+func requestMessages(req map[string]any) ([]any, bool) {
+	switch v := req[requestFieldMessages].(type) {
+	case []any:
+		return v, true
+	case json.RawMessage:
+		var messages []any
+		if err := json.Unmarshal(v, &messages); err != nil {
+			return nil, false
+		}
+		return messages, true
+	default:
+		return nil, false
+	}
 }
 
 // decodeRequestBody parses a JSON object body. Fields in inspectedRequestFields

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -218,12 +218,14 @@ func requestMessages(req map[string]any) ([]json.RawMessage, error) {
 	}
 }
 
-// decodeRequestBody parses a JSON object body. Fields in inspectedRequestFields
-// are decoded to Go values; all others are kept as json.RawMessage.
+// decodeRequestBody parses a JSON object body, applying inspectedRequestFields.
 func decodeRequestBody(raw []byte) (map[string]any, error) {
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &fields); err != nil {
 		return nil, err
+	}
+	if fields == nil {
+		return nil, errors.New("request body is not a JSON object")
 	}
 	parsed := make(map[string]any, len(fields))
 	for k, v := range fields {

--- a/pkg/sidecar/proxy/proxy_helpers.go
+++ b/pkg/sidecar/proxy/proxy_helpers.go
@@ -169,11 +169,55 @@ func bodyAsJSON(r *http.Request) ([]byte, map[string]any, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	var parsed map[string]any
-	if err := json.Unmarshal(raw, &parsed); err != nil {
+	parsed, err := decodeRequestBody(raw)
+	if err != nil {
 		return nil, nil, fmt.Errorf("%w: %w", errInvalidJSON, err)
 	}
 	return raw, parsed, nil
+}
+
+// inspectedRequestFields lists the top-level request fields the sidecar reads
+// as Go values. decodeRequestBody decodes only these; every other field stays
+// a json.RawMessage so its bytes are forwarded unchanged. encoding/json sorts
+// map keys at every depth on Marshal, which would reorder free-form content
+// such as tools[].function.parameters that chat templates render into the
+// prompt verbatim.
+var inspectedRequestFields = map[string]struct{}{
+	requestFieldKVTransferParams:     {},
+	requestFieldECTransferParams:     {},
+	requestFieldMaxTokens:            {},
+	requestFieldMaxCompletionTokens:  {},
+	requestFieldMaxOutputTokens:      {},
+	requestFieldMinTokens:            {},
+	requestFieldSamplingParams:       {},
+	requestFieldStream:               {},
+	requestFieldStreamOptions:        {},
+	requestFieldCacheHitThreshold:    {},
+	requestFieldContinueFinalMessage: {},
+	requestFieldAddGenerationPrompt:  {},
+	requestFieldMessages:             {},
+}
+
+// decodeRequestBody parses a JSON object body. Fields in inspectedRequestFields
+// are decoded to Go values; all others are kept as json.RawMessage.
+func decodeRequestBody(raw []byte) (map[string]any, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, err
+	}
+	parsed := make(map[string]any, len(fields))
+	for k, v := range fields {
+		if _, ok := inspectedRequestFields[k]; !ok {
+			parsed[k] = v
+			continue
+		}
+		var decoded any
+		if err := json.Unmarshal(v, &decoded); err != nil {
+			return nil, err
+		}
+		parsed[k] = decoded
+	}
+	return parsed, nil
 }
 
 func (s *Server) readJSONBody(r *http.Request, w http.ResponseWriter) ([]byte, map[string]any, bool) {

--- a/pkg/sidecar/proxy/proxy_helpers_test.go
+++ b/pkg/sidecar/proxy/proxy_helpers_test.go
@@ -41,6 +41,9 @@ var _ = Describe("decodeRequestBody", func() {
 	It("rejects non-object bodies", func() {
 		_, err := decodeRequestBody([]byte(`[1,2]`))
 		Expect(err).To(HaveOccurred())
+
+		_, err = decodeRequestBody([]byte(`null`))
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("keeps messages raw and decodes them on use", func() {

--- a/pkg/sidecar/proxy/proxy_helpers_test.go
+++ b/pkg/sidecar/proxy/proxy_helpers_test.go
@@ -42,4 +42,32 @@ var _ = Describe("decodeRequestBody", func() {
 		_, err := decodeRequestBody([]byte(`[1,2]`))
 		Expect(err).To(HaveOccurred())
 	})
+
+	It("keeps messages raw and decodes them on use", func() {
+		messages := `[{"role":"user","content":"Hi"}]`
+		parsed, err := decodeRequestBody([]byte(`{"messages":` + messages + `}`))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(parsed[requestFieldMessages]).To(Equal(json.RawMessage(messages)))
+
+		decoded, err := requestMessages(parsed)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(decoded).To(HaveLen(1))
+	})
+
+	It("treats a null messages field as absent", func() {
+		parsed, err := decodeRequestBody([]byte(`{"messages":null}`))
+		Expect(err).ToNot(HaveOccurred())
+
+		decoded, err := requestMessages(parsed)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(decoded).To(BeNil())
+	})
+
+	It("reports a messages field that is not an array", func() {
+		_, err := requestMessages(map[string]any{requestFieldMessages: json.RawMessage(`{}`)})
+		Expect(err).To(HaveOccurred())
+
+		_, err = requestMessages(map[string]any{requestFieldMessages: 5})
+		Expect(err).To(HaveOccurred())
+	})
 })

--- a/pkg/sidecar/proxy/proxy_helpers_test.go
+++ b/pkg/sidecar/proxy/proxy_helpers_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2" // nolint:revive
+	. "github.com/onsi/gomega"    // nolint:revive
+)
+
+var _ = Describe("decodeRequestBody", func() {
+	It("decodes inspected fields and keeps the rest as raw bytes", func() {
+		tools := `[{"type":"function","function":{"parameters":{"properties":{"b":{},"a":{}}}}}]`
+		parsed, err := decodeRequestBody([]byte(`{"stream":true,"max_tokens":5,"tools":` + tools + `}`))
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(parsed[requestFieldStream]).To(BeTrue())
+		Expect(parsed[requestFieldMaxTokens]).To(BeNumerically("==", 5))
+		Expect(parsed["tools"]).To(Equal(json.RawMessage(tools)))
+
+		out, err := json.Marshal(parsed)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(out)).To(ContainSubstring(`"tools":` + tools))
+	})
+
+	It("rejects non-object bodies", func() {
+		_, err := decodeRequestBody([]byte(`[1,2]`))
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/test/sidecar/mock/chat_completions_handler.go
+++ b/test/sidecar/mock/chat_completions_handler.go
@@ -71,6 +71,15 @@ func (cc *ChatCompletionHandler) GetCompletionRequests() []map[string]any {
 	return append([]map[string]any(nil), cc.CompletionRequests...)
 }
 
+// GetCompletionRawBodies returns a snapshot of the received request bodies as
+// sent on the wire, appended in lockstep with GetCompletionRequests, safe for
+// concurrent access.
+func (cc *ChatCompletionHandler) GetCompletionRawBodies() [][]byte {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	return append([][]byte(nil), cc.CompletionRawBodies...)
+}
+
 // GetCompletionHeaders returns a snapshot of the received request headers,
 // appended in lockstep with GetCompletionRequests, safe for concurrent access.
 func (cc *ChatCompletionHandler) GetCompletionHeaders() []http.Header {

--- a/test/sidecar/mock/chat_completions_handler.go
+++ b/test/sidecar/mock/chat_completions_handler.go
@@ -53,6 +53,7 @@ type ChatCompletionHandler struct {
 	MoRIIOWriteMode     bool
 	RequestCount        atomic.Int32
 	CompletionRequests  []map[string]any
+	CompletionRawBodies [][]byte
 	CompletionHeaders   []http.Header
 	CompletionResponses []map[string]any
 	mu                  sync.Mutex
@@ -107,6 +108,7 @@ func (cc *ChatCompletionHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	cc.mu.Lock()
 	cc.CompletionRequests = append(cc.CompletionRequests, completionRequest)
+	cc.CompletionRawBodies = append(cc.CompletionRawBodies, b)
 	cc.CompletionHeaders = append(cc.CompletionHeaders, r.Header.Clone())
 	cc.mu.Unlock()
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The sidecar decodes the request body into `map[string]any` and marshals it again for the prefill and decode legs. `encoding/json` sorts map keys at every depth on Marshal, so nested key order in fields the sidecar never touches is lost. `tools[].function.parameters.properties` is the visible case: chat templates render `tools` into the prompt verbatim, so the model sees the schema in alphabetical order instead of the order the client sent.

Providers are tested for this. The [MiniMax-Provider-Verifier](https://github.com/MiniMax-AI/MiniMax-Provider-Verifier) `Scenario-Check-Pass-Rate` metric checks whether the provider preserves the original JSON key order in tool definitions and is expected to be 100%; reordering `parameters.properties` (alphabetical sorting) fails it. A P/D deployment fronted by the sidecar fails this check today.

`decodeRequestBody` decodes only the top-level fields the sidecar reads or rewrites (`stream`, `max_tokens`, `kv_transfer_params`, ...). Every other field stays a `json.RawMessage`, so its bytes are forwarded unchanged. `messages` is also kept raw and decoded element-by-element by `requestMessages` only when a connector needs it. All connectors that parse the body (NIXLv2, shared storage, P2P, Mooncake, SGLang, EC, chunked decode) go through it.

**Which issue(s) this PR fixes**:
Fixes #2590

**Test plan**:
- [x] Fields not inspected by the sidecar are kept as raw bytes and marshal back unchanged; inspected fields are decoded
- [x] NIXLv2 prefill and decode request bodies carry `tools` byte-for-byte, including nested key order
- [x] Chunked decode keeps the client's messages byte-for-byte across multiple chunks
- [x] A `null` request body is rejected; a `null` messages field reads as absent

**Release note**:
```release-note
The P/D sidecar forwards request fields it does not modify byte-for-byte, so nested JSON key order (for example in `tools[].function.parameters`) is preserved when proxying to prefill and decode.
```



