### PR TITLE
feat(epp): add OTel span to prefix cache affinity filter decisions

### DIFF
--- a/pkg/common/observability/semconv/llm_d.go
+++ b/pkg/common/observability/semconv/llm_d.go
@@ -38,6 +38,19 @@ const (
 	// LLMDEPPScorerEndpointsScoredKey is the attribute key for total endpoints scored.
 	LLMDEPPScorerEndpointsScoredKey = attribute.Key("llm_d.epp.scorer.endpoints_scored")
 
+	// LLMDEPPFilterDecisionKey is the attribute key for the outcome a filter decided on.
+	LLMDEPPFilterDecisionKey = attribute.Key("llm_d.epp.filter.decision")
+	// LLMDEPPFilterCandidateEndpointsKey is the attribute key for the endpoint count a filter received.
+	LLMDEPPFilterCandidateEndpointsKey = attribute.Key("llm_d.epp.filter.candidate_endpoints")
+	// LLMDEPPFilterFilteredEndpointsKey is the attribute key for the endpoint count a filter returned.
+	LLMDEPPFilterFilteredEndpointsKey = attribute.Key("llm_d.epp.filter.filtered_endpoints")
+	// LLMDEPPFilterStickyEndpointsKey is the attribute key for the endpoint count meeting the affinity threshold.
+	LLMDEPPFilterStickyEndpointsKey = attribute.Key("llm_d.epp.filter.sticky_endpoints")
+	// LLMDEPPFilterAffinityThresholdKey is the attribute key for the configured prefix cache affinity threshold.
+	LLMDEPPFilterAffinityThresholdKey = attribute.Key("llm_d.epp.filter.affinity_threshold")
+	// LLMDEPPFilterTTFTPenaltyMsKey is the attribute key for the TTFT penalty the load gate measured, in milliseconds.
+	LLMDEPPFilterTTFTPenaltyMsKey = attribute.Key("llm_d.epp.filter.ttft_penalty_ms")
+
 	// LLMDEPPDisaggReasonKey is the attribute key for disaggregation reason.
 	LLMDEPPDisaggReasonKey = attribute.Key("llm_d.epp.disagg.reason")
 	// LLMDEPPPDReasonKey is the attribute key for prefill/decode disaggregation reason.
@@ -111,6 +124,36 @@ func LLMDEPPScorerScoreAvg(score float64) attribute.KeyValue {
 // LLMDEPPScorerEndpointsScored returns an attribute for the number of endpoints scored.
 func LLMDEPPScorerEndpointsScored(count int) attribute.KeyValue {
 	return LLMDEPPScorerEndpointsScoredKey.Int(count)
+}
+
+// LLMDEPPFilterDecision returns an attribute for the outcome a filter decided on.
+func LLMDEPPFilterDecision(decision string) attribute.KeyValue {
+	return LLMDEPPFilterDecisionKey.String(decision)
+}
+
+// LLMDEPPFilterCandidateEndpoints returns an attribute for the number of endpoints a filter received.
+func LLMDEPPFilterCandidateEndpoints(count int) attribute.KeyValue {
+	return LLMDEPPFilterCandidateEndpointsKey.Int(count)
+}
+
+// LLMDEPPFilterFilteredEndpoints returns an attribute for the number of endpoints a filter returned.
+func LLMDEPPFilterFilteredEndpoints(count int) attribute.KeyValue {
+	return LLMDEPPFilterFilteredEndpointsKey.Int(count)
+}
+
+// LLMDEPPFilterStickyEndpoints returns an attribute for the number of endpoints meeting the affinity threshold.
+func LLMDEPPFilterStickyEndpoints(count int) attribute.KeyValue {
+	return LLMDEPPFilterStickyEndpointsKey.Int(count)
+}
+
+// LLMDEPPFilterAffinityThreshold returns an attribute for the configured prefix cache affinity threshold.
+func LLMDEPPFilterAffinityThreshold(threshold float64) attribute.KeyValue {
+	return LLMDEPPFilterAffinityThresholdKey.Float64(threshold)
+}
+
+// LLMDEPPFilterTTFTPenaltyMs returns an attribute for the TTFT penalty the load gate measured, in milliseconds.
+func LLMDEPPFilterTTFTPenaltyMs(penalty float64) attribute.KeyValue {
+	return LLMDEPPFilterTTFTPenaltyMsKey.Float64(penalty)
 }
 
 // LLMDEPPProfileHandlerDecision returns an attribute for the profile handler decision.

--- a/pkg/common/observability/semconv/llm_d_test.go
+++ b/pkg/common/observability/semconv/llm_d_test.go
@@ -48,6 +48,42 @@ func TestLLMDSemanticConventions(t *testing.T) {
 			wantType: attribute.STRING,
 		},
 		{
+			name:     "LLMDEPPFilterDecision",
+			got:      LLMDEPPFilterDecision("sticky"),
+			wantKey:  "llm_d.epp.filter.decision",
+			wantType: attribute.STRING,
+		},
+		{
+			name:     "LLMDEPPFilterCandidateEndpoints",
+			got:      LLMDEPPFilterCandidateEndpoints(8),
+			wantKey:  "llm_d.epp.filter.candidate_endpoints",
+			wantType: attribute.INT64,
+		},
+		{
+			name:     "LLMDEPPFilterFilteredEndpoints",
+			got:      LLMDEPPFilterFilteredEndpoints(5),
+			wantKey:  "llm_d.epp.filter.filtered_endpoints",
+			wantType: attribute.INT64,
+		},
+		{
+			name:     "LLMDEPPFilterStickyEndpoints",
+			got:      LLMDEPPFilterStickyEndpoints(3),
+			wantKey:  "llm_d.epp.filter.sticky_endpoints",
+			wantType: attribute.INT64,
+		},
+		{
+			name:     "LLMDEPPFilterAffinityThreshold",
+			got:      LLMDEPPFilterAffinityThreshold(0.8),
+			wantKey:  "llm_d.epp.filter.affinity_threshold",
+			wantType: attribute.FLOAT64,
+		},
+		{
+			name:     "LLMDEPPFilterTTFTPenaltyMs",
+			got:      LLMDEPPFilterTTFTPenaltyMs(1500),
+			wantKey:  "llm_d.epp.filter.ttft_penalty_ms",
+			wantType: attribute.FLOAT64,
+		},
+		{
 			name:     "LLMDEPPPDDisaggregationUsed",
 			got:      LLMDEPPPDDisaggregationUsed(true),
 			wantKey:  "llm_d.epp.pd.disaggregation_used",

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -28,14 +28,18 @@ import (
 	"math"
 	"math/rand"
 
+	"go.opentelemetry.io/otel/trace"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/common/observability/semconv"
+	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrconcurrency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/concurrency"
 	attrlatency "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/latency"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	schedplugins "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling"
 )
 
 const (
@@ -167,11 +171,30 @@ func (p *Plugin) TypedName() fwkplugin.TypedName {
 	return p.typedName
 }
 
-func (p *Plugin) Filter(ctx context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
+func (p *Plugin) Filter(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) []fwksched.Endpoint {
 	logger := log.FromContext(ctx)
+
+	_, span := tracing.Tracer(schedplugins.TracerScope).Start(ctx, "filter_prefix_cache_affinity",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	defer span.End()
+
+	span.SetAttributes(
+		semconv.LLMDEPPFilterCandidateEndpoints(len(endpoints)),
+		semconv.LLMDEPPFilterAffinityThreshold(p.config.AffinityThreshold),
+	)
+	if request != nil {
+		if request.TargetModel != "" {
+			span.SetAttributes(semconv.GenAIRequestModel(request.TargetModel))
+		}
+		if request.RequestID != "" {
+			span.SetAttributes(semconv.GenAIRequestID(request.RequestID))
+		}
+	}
 
 	if len(endpoints) <= 1 || p.config.AffinityThreshold <= 0 {
 		recordDecision(p.typedName.Name, outcomeNotApplicable)
+		span.SetAttributes(semconv.LLMDEPPFilterDecision(outcomeNotApplicable))
 		return endpoints
 	}
 
@@ -180,6 +203,7 @@ func (p *Plugin) Filter(ctx context.Context, _ *fwksched.InferenceRequest, endpo
 		logger.V(logutil.DEBUG).Info("PrefixCacheAffinityFilter: exploration skip, keeping all",
 			"affinityThreshold", p.config.AffinityThreshold, "total", len(endpoints))
 		recordDecision(p.typedName.Name, outcomeExploration)
+		span.SetAttributes(semconv.LLMDEPPFilterDecision(outcomeExploration))
 		return endpoints
 	}
 
@@ -193,11 +217,14 @@ func (p *Plugin) Filter(ctx context.Context, _ *fwksched.InferenceRequest, endpo
 		}
 	}
 
+	span.SetAttributes(semconv.LLMDEPPFilterStickyEndpoints(len(sticky)))
+
 	// No sticky endpoints found, keep all.
 	if len(sticky) == 0 {
 		logger.V(logutil.DEBUG).Info("PrefixCacheAffinityFilter: no sticky endpoints",
 			"affinityThreshold", p.config.AffinityThreshold, "total", len(endpoints))
 		recordDecision(p.typedName.Name, outcomeNoMatch)
+		span.SetAttributes(semconv.LLMDEPPFilterDecision(outcomeNoMatch))
 		return endpoints
 	}
 
@@ -205,11 +232,14 @@ func (p *Plugin) Filter(ctx context.Context, _ *fwksched.InferenceRequest, endpo
 	if p.config.MaxTTFTPenaltyMs > 0 && len(nonSticky) > 0 {
 		bestStickyTTFT := p.bestTTFT(sticky)
 		bestNonStickyTTFT := p.bestTTFT(nonSticky)
-		if bestStickyTTFT-bestNonStickyTTFT > p.config.MaxTTFTPenaltyMs {
+		penalty := bestStickyTTFT - bestNonStickyTTFT
+		span.SetAttributes(semconv.LLMDEPPFilterTTFTPenaltyMs(penalty))
+		if penalty > p.config.MaxTTFTPenaltyMs {
 			logger.V(logutil.DEBUG).Info("PrefixCacheAffinityFilter: TTFT load gate broken",
 				"bestStickyTTFT", bestStickyTTFT, "bestNonStickyTTFT", bestNonStickyTTFT,
-				"penalty", bestStickyTTFT-bestNonStickyTTFT, "maxPenalty", p.config.MaxTTFTPenaltyMs)
+				"penalty", penalty, "maxPenalty", p.config.MaxTTFTPenaltyMs)
 			recordDecision(p.typedName.Name, outcomeLoadOverride)
+			span.SetAttributes(semconv.LLMDEPPFilterDecision(outcomeLoadOverride))
 			return endpoints
 		}
 	}
@@ -217,6 +247,7 @@ func (p *Plugin) Filter(ctx context.Context, _ *fwksched.InferenceRequest, endpo
 	logger.V(logutil.DEBUG).Info("PrefixCacheAffinityFilter: narrowed to sticky",
 		"affinityThreshold", p.config.AffinityThreshold, "sticky", len(sticky), "total", len(endpoints))
 	recordDecision(p.typedName.Name, outcomeSticky)
+	span.SetAttributes(semconv.LLMDEPPFilterDecision(outcomeSticky))
 	return sticky
 }
 


### PR DESCRIPTION
The prefix-cache-affinity filter already records its decision as a metric,
but there's no span for it. So when you look at a trace you can see the
request went through the filter, but not what it decided or why.

This adds a `filter_prefix_cache_affinity` span, following the same
pattern as `pd_profile_handler.go`.

What's on the span:

- `llm_d.epp.filter.decision` - the outcome. I'm setting this from the
  same `outcome*` constants that `recordDecision` already uses, so the
  span value and the metric label are always the same thing and can't
  drift apart later.
- `llm_d.epp.filter.candidate_endpoints` and
  `llm_d.epp.filter.sticky_endpoints` - so you can see how much the
  filter narrowed things down.
- `llm_d.epp.filter.ttft_penalty_ms` - what the load gate actually
  measured. I set this before the threshold check, so you still see the
  number on traces where the gate didn't trip.
- `gen_ai.request.model` and `gen_ai.request.id`, same as the other
  scheduling plugins.

Two small things while I was in there: the request param was `_` so I
named it, since I need it for the request attributes. And
`bestStickyTTFT-bestNonStickyTTFT` was being calculated twice, so I
pulled it into a `penalty` variable.

I didn't add a span test - `disagg` and `preciseprefixcache` don't assert
spans in their unit tests either, so I followed what they do. Let me know
if you'd rather have one.

Also left out `mmobs.SpanAttributes(request)` that the siblings have,
since this filter doesn't deal with multimodal at all. Easy to add if you
want it for consistency.

Fixes #2539