### PR TITLE
Add prefixMatchInfoProducerName to inflightload README.md

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/README.md
@@ -29,6 +29,7 @@ Endpoint departure events (pod removed from the pool) are handled via the `Endpo
 |-----------|------|----------|---------|-------------|
 | `addEstimatedOutputTokens` | `bool` | No | `false` | If true, adds an estimate of the generated output tokens to the in-flight counter. The estimate is read from the output-length bucket published by the `outlen-bucket` plugin; enable that plugin and order it before this producer so requests are classified. |
 | `maxEstimatedOutputTokens` | `int` | No | _(none)_ | Optional upper bound on the estimated output tokens added per request when `addEstimatedOutputTokens` is true. Must be non-negative. Unset means no cap. |
+| `prefixMatchInfoProducerName` | `string` | No | _(none)_ | Optional `prefix-cache producer` name to read to find cached prefix discount. Unset defaults to approximate-prefix producer. |
 
 When `addEstimatedOutputTokens` is true, the estimated output per request is a flat
 value determined by the output-length bucket published by the `outlen-bucket` plugin:


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This was added in https://github.com/llm-d/llm-d-router/commit/e0eda270c96f5c6a47a4599d0665d344e9927af5, but was not added to the README. Simple documentation update, hopefully useful to others. 

Body of text mostly copied from the code comment.


**Which issue(s) this PR fixes**:
None: found while reading code

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
