### PR TITLE
Add audio content block support to tokenizer for multimodal routing

### DIFF
--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -664,14 +664,19 @@ type Content struct {
 }
 
 type ContentBlock struct {
-	Type       string     `json:"type"`
-	Text       string     `json:"text,omitempty"`
-	ImageURL   ImageBlock `json:"image_url"`
-	InputAudio AudioBlock `json:"input_audio"`
-	VideoURL   VideoBlock `json:"video_url"`
+	Type       string        `json:"type"`
+	Text       string        `json:"text,omitempty"`
+	ImageURL   ImageBlock    `json:"image_url"`
+	AudioURL   AudioURLBlock `json:"audio_url"`
+	InputAudio AudioBlock    `json:"input_audio"`
+	VideoURL   VideoBlock    `json:"video_url"`
 }
 
 type ImageBlock struct {
+	URL string `json:"url,omitempty"`
+}
+
+type AudioURLBlock struct {
 	URL string `json:"url,omitempty"`
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
@@ -339,15 +339,6 @@ func appendMMAsset(out []byte, features []fwkrh.MultiModalFeature, modality fwkr
 	return out, features
 }
 
-// assetPlaceholderCount derives a deterministic placeholder count (>= 1) from an
-// asset's byte length for modalities without a dedicated estimator.
-func assetPlaceholderCount(dataLen int) int {
-	if n := (dataLen + bytesPerToken - 1) / bytesPerToken; n > 0 {
-		return n
-	}
-	return 1
-}
-
 // packBytes packs bytes into little-endian uint32 tokens (zero-padded tail).
 // Reinterpreting them reproduces the input, so locality keys are unchanged.
 func packBytes(raw []byte) []uint32 {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate.go
@@ -42,12 +42,17 @@ const bytesPerToken = 4
 type estimateBackend struct {
 	img imageEstimator
 	vid videoEstimator
+	aud audioEstimator
 }
 
 // parseMMMetadataHeaders reads the x-llm-d-* request headers into an mmMetadata.
-// Only video is populated today; image and audio parsing slot in here later.
+// Video and audio are populated from headers; image parsing follows the same
+// pattern when its headers are added.
 func parseMMMetadataHeaders(headers map[string]string) mmMetadata {
-	return mmMetadata{video: parseVideoMetadataHeaders(headers)}
+	return mmMetadata{
+		video: parseVideoMetadataHeaders(headers),
+		audio: parseAudioMetadataHeaders(headers),
+	}
 }
 
 // mmMetadataCtxKey keys the request-scoped mmMetadata on the context, carrying it
@@ -84,6 +89,30 @@ func parseVideoMetadataHeaders(headers map[string]string) videoMetadata {
 	}
 	if s, ok := metadata.GetLowerCaseHeaderValue(headers, metadata.VideoResolutionHeaderKey); ok {
 		meta.width, meta.height = parseResolution(s)
+	}
+	return meta
+}
+
+// parseAudioMetadataHeaders reads the x-llm-d-audio- request headers into an
+// audioMetadata, using metadata.GetLowerCaseHeaderValue so aliases resolve the
+// same way as the SLO headers. Missing or malformed values leave their field zero
+// so the estimator falls back per field to config and then defaults.
+func parseAudioMetadataHeaders(headers map[string]string) audioMetadata {
+	var meta audioMetadata
+	if s, ok := metadata.GetLowerCaseHeaderValue(headers, metadata.AudioDurationHeaderKey); ok {
+		if v, err := strconv.ParseFloat(s, 64); err == nil && v > 0 {
+			meta.duration = v
+		}
+	}
+	if s, ok := metadata.GetLowerCaseHeaderValue(headers, metadata.AudioSampleRateHeaderKey); ok {
+		if v, err := strconv.Atoi(s); err == nil && v > 0 {
+			meta.sampleRate = v
+		}
+	}
+	if s, ok := metadata.GetLowerCaseHeaderValue(headers, metadata.AudioChannelsHeaderKey); ok {
+		if v, err := strconv.Atoi(s); err == nil && v > 0 {
+			meta.channels = v
+		}
 	}
 	return meta
 }
@@ -229,9 +258,11 @@ func (b estimateBackend) appendChatMessage(out []byte, features []fwkrh.MultiMod
 			out, features = appendMMAsset(out, features, fwkrh.ModalityImage, block.ImageURL.URL, b.img.placeholderCount(block.ImageURL.URL))
 		case "video_url":
 			out, features = appendMMAsset(out, features, fwkrh.ModalityVideo, block.VideoURL.URL, b.vid.placeholderCount(meta.video))
-		case "input_audio", "audio_url":
-			data := block.InputAudio.Data + block.InputAudio.Format
-			out, features = appendMMAsset(out, features, fwkrh.ModalityAudio, data, assetPlaceholderCount(len(data)))
+		case "audio_url":
+			out, features = appendMMAsset(out, features, fwkrh.ModalityAudio, block.AudioURL.URL, b.aud.placeholderCount(block.AudioURL.URL, false, meta.audio))
+		case "input_audio", "audio":
+			data := block.InputAudio.Data
+			out, features = appendMMAsset(out, features, fwkrh.ModalityAudio, data, b.aud.placeholderCount(data, true, meta.audio))
 		}
 	}
 	return out, features

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/estimate_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"strconv"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -533,6 +534,124 @@ func TestVideoEstimator_HeaderRespectsMaxVideoTokens(t *testing.T) {
 	tp, err := b.produce(videoCtx(videoMetadata{width: 320, height: 240, duration: 3}), chatVideoBody("https://example.com/clip.mp4"))
 	require.NoError(t, err)
 	assert.Equal(t, 100, tp.Prompts[0].MultiModalFeatures[0].Length)
+}
+
+// chatInputAudioBody builds a chat request carrying a single input_audio block.
+func chatInputAudioBody(data, format string) *fwkrh.InferenceRequestBody {
+	return &fwkrh.InferenceRequestBody{ChatCompletions: &fwkrh.ChatCompletionsRequest{
+		Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Structured: []fwkrh.ContentBlock{
+			{Type: "input_audio", InputAudio: fwkrh.AudioBlock{Data: data, Format: format}},
+		}}}},
+	}}
+}
+
+// TestEstimateBackend_ChatAudioFeature asserts a chat audio emits a multimodal
+// feature with the audio modality and the URL content hash, occupies more than
+// one placeholder pseudo-token (weighting), and points within the token stream.
+func TestEstimateBackend_ChatAudioFeature(t *testing.T) {
+	const url = "https://example.com/speech.wav"
+	body := &fwkrh.InferenceRequestBody{
+		ChatCompletions: &fwkrh.ChatCompletionsRequest{
+			Messages: []fwkrh.Message{{
+				Role: "user",
+				Content: fwkrh.Content{Structured: []fwkrh.ContentBlock{
+					{Type: "text", Text: "transcribe this"},
+					{Type: "audio_url", AudioURL: fwkrh.AudioURLBlock{URL: url}},
+				}},
+			}},
+		},
+	}
+	tp, err := estimateBackend{}.produce(context.Background(), body)
+	require.NoError(t, err)
+	require.Len(t, tp.Prompts, 1)
+	require.Len(t, tp.Prompts[0].MultiModalFeatures, 1)
+	f := tp.Prompts[0].MultiModalFeatures[0]
+	assert.Equal(t, fwkrh.ModalityAudio, f.Modality)
+	assert.Equal(t, strconv.FormatUint(xxhash.Sum64String(url), 16), f.Hash)
+	assert.Greater(t, f.Length, 1, "audio length must be > 1 (placeholder weighting)")
+	assert.GreaterOrEqual(t, f.Offset, 0)
+	tokens := tp.Prompts[0].TokenIDs
+	assert.LessOrEqual(t, f.Offset+f.Length, len(tokens), "feature span [%d,%d) outside token stream of len %d", f.Offset, f.Offset+f.Length, len(tokens))
+	for i := f.Offset; i < f.Offset+f.Length; i++ {
+		assert.Equal(t, uint32(xxhash.Sum64String(url)), tokens[i], "token %d: got %d, want audio placeholder token", i, tokens[i])
+	}
+}
+
+// TestAudioEstimator_Base64DurationEstimation asserts base64 data uses
+// file-size-based duration estimation instead of the default 10s.
+func TestAudioEstimator_Base64DurationEstimation(t *testing.T) {
+	// 8000 base64 chars ≈ 6000 raw bytes ≈ 0.75s → clamped to 1s min → 25 tokens.
+	short := estimateBackend{}
+	tp, err := short.produce(context.Background(), chatInputAudioBody("AABBCCDD", "wav"))
+	require.NoError(t, err)
+	require.Len(t, tp.Prompts[0].MultiModalFeatures, 1)
+	assert.GreaterOrEqual(t, tp.Prompts[0].MultiModalFeatures[0].Length, 1, "short base64 must produce at least 1 token")
+
+	// 80000 base64 chars ≈ 60000 raw bytes ≈ 7.5s → 7.5 * 25 = 187 tokens.
+	long := estimateBackend{}
+	longBase64 := strings.Repeat("A", 80000)
+	tp2, err := long.produce(context.Background(), chatInputAudioBody(longBase64, "wav"))
+	require.NoError(t, err)
+	require.Len(t, tp2.Prompts[0].MultiModalFeatures, 1)
+	expectedTokens := int(float64(audioTokensPerSecond) * (float64(len(longBase64)) * 0.75 / float64(audioBytesPerSecondEstimate)))
+	assert.Equal(t, expectedTokens, tp2.Prompts[0].MultiModalFeatures[0].Length, "large base64 audio duration estimation")
+}
+
+// TestParseAudioMetadataHeaders covers full, partial, missing, and malformed
+// header sets, matching the structure of TestParseVideoMetadataHeaders.
+func TestParseAudioMetadataHeaders(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+		want    audioMetadata
+	}{
+		{
+			name: "all present",
+			headers: map[string]string{
+				metadata.AudioDurationHeaderKey:   "12.5",
+				metadata.AudioSampleRateHeaderKey: "44100",
+				metadata.AudioChannelsHeaderKey:   "2",
+			},
+			want: audioMetadata{duration: 12.5, sampleRate: 44100, channels: 2},
+		},
+		{
+			name:    "duration only",
+			headers: map[string]string{metadata.AudioDurationHeaderKey: "5.0"},
+			want:    audioMetadata{duration: 5.0},
+		},
+		{
+			name:    "sample rate only",
+			headers: map[string]string{metadata.AudioSampleRateHeaderKey: "16000"},
+			want:    audioMetadata{sampleRate: 16000},
+		},
+		{
+			name:    "empty",
+			headers: map[string]string{},
+			want:    audioMetadata{},
+		},
+		{
+			name: "malformed values ignored",
+			headers: map[string]string{
+				metadata.AudioDurationHeaderKey:   "abc",
+				metadata.AudioSampleRateHeaderKey: "",
+				metadata.AudioChannelsHeaderKey:   "x",
+			},
+			want: audioMetadata{},
+		},
+		{
+			name: "non-positive ignored",
+			headers: map[string]string{
+				metadata.AudioDurationHeaderKey:   "-1",
+				metadata.AudioSampleRateHeaderKey: "0",
+				metadata.AudioChannelsHeaderKey:   "0",
+			},
+			want: audioMetadata{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseAudioMetadataHeaders(tc.headers))
+		})
+	}
 }
 
 // TestEstimateBackend_MessagesImageFeature asserts an Anthropic messages image

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/mm_estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/mm_estimate.go
@@ -359,8 +359,8 @@ const (
 	audioModeDynamic = "dynamic"
 	audioModeStatic  = "static"
 
-	defaultAudioDuration        = 10  // seconds
-	audioTokensPerSecond        = 25  // placeholder tokens per second
+	defaultAudioDuration        = 10   // seconds
+	audioTokensPerSecond        = 25   // placeholder tokens per second
 	audioBytesPerSecondEstimate = 8000 // compressed audio bytes/sec (OGG ~1500, MP3 ~16000)
 )
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/mm_estimate.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/mm_estimate.go
@@ -167,10 +167,11 @@ func imageDimensionsFromBase64Payload(rawB64 string) (width, height int, ok bool
 }
 
 // mmMetadata carries per-request multimodal properties parsed from the
-// x-llm-d-* request headers. Only video is populated today; image and audio
-// fields follow the same pattern when their headers are added.
+// x-llm-d-* request headers. Video and audio are populated from headers;
+// image parsing follows the same pattern when its headers are added.
 type mmMetadata struct {
 	video videoMetadata
+	audio audioMetadata
 }
 
 // videoMetadata carries per-request video properties parsed from the
@@ -181,6 +182,15 @@ type videoMetadata struct {
 	width, height int
 	duration      float64 // seconds
 	fps           float64 // source frames per second
+}
+
+// audioMetadata carries per-request audio properties parsed from the
+// x-llm-d-audio- request headers. A zero field means "not provided"; the
+// estimator falls back per field to configuration and then built-in defaults.
+type audioMetadata struct {
+	duration   float64 // seconds
+	sampleRate int     // Hz
+	channels   int
 }
 
 // videoEstimator estimates a video's placeholder-token count as
@@ -342,4 +352,79 @@ func (e videoEstimator) tokensPerFrame(meta videoMetadata) int {
 		return n
 	}
 	return 1
+}
+
+const (
+	// Audio estimation modes.
+	audioModeDynamic = "dynamic"
+	audioModeStatic  = "static"
+
+	defaultAudioDuration        = 10  // seconds
+	audioTokensPerSecond        = 25  // placeholder tokens per second
+	audioBytesPerSecondEstimate = 8000 // compressed audio bytes/sec (OGG ~1500, MP3 ~16000)
+)
+
+// audioEstimator estimates an audio's placeholder-token count from configured or
+// default parameters. The zero value is valid and uses all built-in defaults.
+type audioEstimator struct {
+	mode         string
+	staticToken  int
+	tokensPerSec int
+}
+
+// newAudioEstimator resolves an estimateConfig into an audioEstimator, leaving
+// unset fields zero so placeholderCount applies built-in defaults.
+func newAudioEstimator(cfg *estimateConfig) audioEstimator {
+	if cfg == nil || cfg.Audio == nil {
+		return audioEstimator{}
+	}
+	aud := cfg.Audio
+	est := audioEstimator{mode: aud.Mode}
+	if aud.Static != nil {
+		est.staticToken = aud.Static.NumTokens
+	}
+	if aud.Dynamic != nil {
+		est.tokensPerSec = aud.Dynamic.TokensPerSecond
+	}
+	return est
+}
+
+// placeholderCount estimates placeholder tokens for audio content.
+// If meta has a non-zero duration, it is used directly; otherwise the estimator
+// falls back to file-size estimation for base64 data or the default duration.
+func (e audioEstimator) placeholderCount(dataOrURL string, isBase64 bool, meta audioMetadata) int {
+	if e.mode == audioModeStatic {
+		if e.staticToken > 0 {
+			return e.staticToken
+		}
+		return 1
+	}
+
+	tokensPerSec := e.tokensPerSec
+	if tokensPerSec <= 0 {
+		tokensPerSec = audioTokensPerSecond
+	}
+
+	// Use header-provided duration if available
+	duration := meta.duration
+	if duration <= 0 {
+		// Fall back to file-size estimation for base64 data
+		duration = float64(defaultAudioDuration)
+		if isBase64 && len(dataOrURL) > 0 {
+			// Rough estimation: base64 expands 3 bytes to 4 chars
+			// Use mid-range estimate for compressed audio (~8000 bytes/sec)
+			// Base64 size * 3/4 = raw bytes, then / 8000 = seconds
+			rawBytes := float64(len(dataOrURL)) * 0.75
+			duration = rawBytes / float64(audioBytesPerSecondEstimate)
+			if duration < 1 {
+				duration = 1
+			}
+		}
+	}
+
+	tokens := int(float64(tokensPerSec) * duration)
+	if tokens < 1 {
+		tokens = 1
+	}
+	return tokens
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -108,6 +108,30 @@ type estimateConfig struct {
 	Image *imageEstimateConfig `json:"image,omitempty"`
 	// Video tunes multimodal video placeholder-token estimation.
 	Video *videoEstimateConfig `json:"video,omitempty"`
+	// Audio tunes multimodal audio placeholder-token estimation.
+	Audio *audioEstimateConfig `json:"audio,omitempty"`
+}
+
+// audioEstimateConfig tunes how an audio's placeholder-token count is estimated.
+type audioEstimateConfig struct {
+	// Mode selects "dynamic" (tokens-per-second * duration) or "static" (a constant count).
+	Mode string `json:"mode,omitempty"`
+	// Static configures the static (constant per-audio) mode.
+	Static *staticAudioConfig `json:"static,omitempty"`
+	// Dynamic configures the dynamic (tokens-per-second) mode.
+	Dynamic *dynamicAudioConfig `json:"dynamic,omitempty"`
+}
+
+// staticAudioConfig is the static-mode parameter.
+type staticAudioConfig struct {
+	// NumTokens is the per-audio placeholder count.
+	NumTokens int `json:"numTokens,omitempty"`
+}
+
+// dynamicAudioConfig is the dynamic-mode parameter.
+type dynamicAudioConfig struct {
+	// TokensPerSecond is the placeholder tokens per second of audio.
+	TokensPerSecond int `json:"tokensPerSecond,omitempty"`
 }
 
 // imageEstimateConfig tunes how an image's placeholder-token count is estimated.
@@ -307,7 +331,7 @@ func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) 
 		}
 		backend = renderBackend{tk: renderer}
 	default:
-		backend = estimateBackend{img: newImageEstimator(config.Estimate), vid: newVideoEstimator(config.Estimate)}
+		backend = estimateBackend{img: newImageEstimator(config.Estimate), vid: newVideoEstimator(config.Estimate), aud: newAudioEstimator(config.Estimate)}
 	}
 
 	p := &Plugin{
@@ -396,9 +420,11 @@ func ChatCompletionsToRenderChatRequest(chat *fwkrh.ChatCompletionsRequest) *tok
 		}
 		for _, block := range msg.Content.Structured {
 			conv.Content.Structured = append(conv.Content.Structured, tokenizerTypes.ContentBlock{
-				Type:     block.Type,
-				Text:     block.Text,
-				ImageURL: tokenizerTypes.ImageBlock{URL: block.ImageURL.URL},
+				Type:       block.Type,
+				Text:       block.Text,
+				ImageURL:   tokenizerTypes.ImageBlock{URL: block.ImageURL.URL},
+				AudioURL:   tokenizerTypes.AudioURLBlock{URL: block.AudioURL.URL},
+				InputAudio: tokenizerTypes.AudioBlock{Data: block.InputAudio.Data, Format: block.InputAudio.Format},
 			})
 		}
 		conversation = append(conversation, conv)

--- a/pkg/epp/metadata/consts.go
+++ b/pkg/epp/metadata/consts.go
@@ -60,6 +60,12 @@ const (
 	VideoDurationHeaderKey = "x-llm-d-video-duration-seconds"
 	// VideoResolutionHeaderKey is the header key used to specify a request's video frame resolution as "WIDTHxHEIGHT".
 	VideoResolutionHeaderKey = "x-llm-d-video-resolution"
+	// AudioDurationHeaderKey is the header key used to specify a request's audio length in seconds.
+	AudioDurationHeaderKey = "x-llm-d-audio-duration-seconds"
+	// AudioSampleRateHeaderKey is the header key used to specify a request's audio sample rate in Hz.
+	AudioSampleRateHeaderKey = "x-llm-d-audio-sample-rate"
+	// AudioChannelsHeaderKey is the header key used to specify a request's audio channel count.
+	AudioChannelsHeaderKey = "x-llm-d-audio-channels"
 	// FlowQueueDurationHeaderKey is the response header carrying the time a request spent in flow control admission,
 	// as integer milliseconds. It is absent when flow control did not process the request.
 	FlowQueueDurationHeaderKey = "x-llm-d-flow-queue-duration-ms"

--- a/pkg/kvcache/tokenization/types/types.go
+++ b/pkg/kvcache/tokenization/types/types.go
@@ -27,11 +27,24 @@ type ImageBlock struct {
 	URL string `json:"url,omitempty"`
 }
 
+// AudioBlock represents audio data in a multimodal content block.
+type AudioBlock struct {
+	Data   string `json:"data,omitempty"`
+	Format string `json:"format,omitempty"`
+}
+
+// AudioURLBlock represents the audio_url field in a multimodal content block.
+type AudioURLBlock struct {
+	URL string `json:"url,omitempty"`
+}
+
 // ContentBlock represents a single part of a multimodal message.
 type ContentBlock struct {
-	Type     string     `json:"type"`
-	Text     string     `json:"text,omitempty"`
-	ImageURL ImageBlock `json:"image_url,omitempty"`
+	Type       string        `json:"type"`
+	Text       string        `json:"text,omitempty"`
+	ImageURL   ImageBlock    `json:"image_url,omitempty"`
+	AudioURL   AudioURLBlock `json:"audio_url,omitempty"`
+	InputAudio AudioBlock    `json:"input_audio,omitempty"`
 }
 
 // Content holds a message's content — either plain text or a list of multimodal blocks.
@@ -76,6 +89,12 @@ func (c Content) PlainText() string {
 		if block.Type == "text" {
 			sb.WriteString(block.Text)
 			sb.WriteString(" ")
+		} else if block.Type == "audio_url" || block.Type == "input_audio" || block.Type == "audio" {
+			// Include audio URL or placeholder for prefix caching
+			if block.AudioURL.URL != "" {
+				sb.WriteString(block.AudioURL.URL)
+				sb.WriteString(" ")
+			}
 		}
 	}
 	return sb.String()

--- a/pkg/kvcache/tokenization/types/types.go
+++ b/pkg/kvcache/tokenization/types/types.go
@@ -86,11 +86,11 @@ func (c Content) PlainText() string {
 	}
 	var sb strings.Builder
 	for _, block := range c.Structured {
-		if block.Type == "text" {
+		switch block.Type {
+		case "text":
 			sb.WriteString(block.Text)
 			sb.WriteString(" ")
-		} else if block.Type == "audio_url" || block.Type == "input_audio" || block.Type == "audio" {
-			// Include audio URL or placeholder for prefix caching
+		case "audio_url", "input_audio", "audio":
 			if block.AudioURL.URL != "" {
 				sb.WriteString(block.AudioURL.URL)
 				sb.WriteString(" ")


### PR DESCRIPTION
## Summary

Enable prefix-cache and token-load scorers to handle audio content in chat completions requests. Previously audio blocks were dropped during tokenization, making them invisible to routing decisions.

## Changes

- Add AudioBlock, AudioURLBlock types to kvcache tokenization types
- Add AudioURL field to ContentBlock in requesthandling types
- Update tokenizer to pass audio blocks through to kvcache types
- Add audioEstimator with dynamic/static modes for token estimation
- Update estimate backend to hash audio URL/data for prefix caching
- Update PlainText() to include audio URLs for text-based matching
- Add audio metadata headers (x-llm-d-audio-duration-seconds, etc.)

## Audio estimation

Uses mid-range compressed audio (~8000 bytes/sec) for base64 data, defaulting to 10-second duration for URL-based audio.

## Testing

- All existing tests pass
- Build compiles successfully