### PR TITLE
Fix KV event hash integer conversion

### DIFF
--- a/pkg/kvevents/engineadapter/common.go
+++ b/pkg/kvevents/engineadapter/common.go
@@ -51,16 +51,47 @@ func parseTopic(topic string) (string, string) {
 	return topic, ""
 }
 
-// getHashAsUint64 converts engine hash formats (uint64, int64, or []byte) to uint64.
-// This handles both legacy uint64 hashes and new []byte hashes by taking
-// the last 8 bytes and interpreting them as a big-endian integer.
+// getHashAsUint64 converts engine hash formats (any Go integer type or []byte)
+// to uint64. MessagePack may decode small Python int values into narrow Go
+// integer types (int8, uint8, etc.), so all integer widths are accepted.
+// Signed integer hashes must be non-negative. Byte hashes use the last 8
+// bytes, interpreted as a big-endian integer.
 func getHashAsUint64(raw any) (uint64, error) {
 	switch val := raw.(type) {
 	case uint64:
 		return val, nil
+	case uint:
+		return uint64(val), nil
+	case uint32:
+		return uint64(val), nil
+	case uint16:
+		return uint64(val), nil
+	case uint8:
+		return uint64(val), nil
+	case int:
+		if val < 0 {
+			return 0, fmt.Errorf("hash value is negative: %d", val)
+		}
+		return uint64(val), nil
+	case int32:
+		if val < 0 {
+			return 0, fmt.Errorf("hash value is negative: %d", val)
+		}
+		return uint64(val), nil
+	case int16:
+		if val < 0 {
+			return 0, fmt.Errorf("hash value is negative: %d", val)
+		}
+		return uint64(val), nil
+	case int8:
+		if val < 0 {
+			return 0, fmt.Errorf("hash value is negative: %d", val)
+		}
+		return uint64(val), nil
 	case int64:
-		// msgpack can decode small integers as int64
-		//nolint:gosec // int64 to uint64 conversion is safe here
+		if val < 0 {
+			return 0, fmt.Errorf("hash value is negative: %d", val)
+		}
 		return uint64(val), nil
 	case []byte:
 		if len(val) == 0 {

--- a/pkg/kvevents/engineadapter/common.go
+++ b/pkg/kvevents/engineadapter/common.go
@@ -54,8 +54,8 @@ func parseTopic(topic string) (string, string) {
 // getHashAsUint64 converts engine hash formats (any Go integer type or []byte)
 // to uint64. MessagePack may decode small Python int values into narrow Go
 // integer types (int8, uint8, etc.), so all integer widths are accepted.
-// Signed integer hashes must be non-negative. Byte hashes use the last 8
-// bytes, interpreted as a big-endian integer.
+// Signed integer hashes preserve their two's-complement bit pattern. Byte
+// hashes use the last 8 bytes, interpreted as a big-endian integer.
 func getHashAsUint64(raw any) (uint64, error) {
 	switch val := raw.(type) {
 	case uint64:
@@ -69,29 +69,19 @@ func getHashAsUint64(raw any) (uint64, error) {
 	case uint8:
 		return uint64(val), nil
 	case int:
-		if val < 0 {
-			return 0, fmt.Errorf("hash value is negative: %d", val)
-		}
+		//nolint:gosec // preserve the two's-complement bit pattern of signed hashes
 		return uint64(val), nil
 	case int32:
-		if val < 0 {
-			return 0, fmt.Errorf("hash value is negative: %d", val)
-		}
+		//nolint:gosec // preserve the two's-complement bit pattern of signed hashes
 		return uint64(val), nil
 	case int16:
-		if val < 0 {
-			return 0, fmt.Errorf("hash value is negative: %d", val)
-		}
+		//nolint:gosec // preserve the two's-complement bit pattern of signed hashes
 		return uint64(val), nil
 	case int8:
-		if val < 0 {
-			return 0, fmt.Errorf("hash value is negative: %d", val)
-		}
+		//nolint:gosec // preserve the two's-complement bit pattern of signed hashes
 		return uint64(val), nil
 	case int64:
-		if val < 0 {
-			return 0, fmt.Errorf("hash value is negative: %d", val)
-		}
+		//nolint:gosec // preserve the two's-complement bit pattern of signed hashes
 		return uint64(val), nil
 	case []byte:
 		if len(val) == 0 {

--- a/pkg/kvevents/engineadapter/common.go
+++ b/pkg/kvevents/engineadapter/common.go
@@ -51,25 +51,20 @@ func parseTopic(topic string) (string, string) {
 	return topic, ""
 }
 
-// getHashAsUint64 converts engine hash formats (any Go integer type or []byte)
-// to uint64. MessagePack may decode small Python int values into narrow Go
-// integer types (int8, uint8, etc.), so all integer widths are accepted.
+// getHashAsUint64 converts MessagePack integer types or []byte to uint64.
+// MessagePack may decode small Python int values into narrow Go integer types,
+// so all supported integer widths are accepted.
 // Signed integer hashes preserve their two's-complement bit pattern. Byte
 // hashes use the last 8 bytes, interpreted as a big-endian integer.
 func getHashAsUint64(raw any) (uint64, error) {
 	switch val := raw.(type) {
 	case uint64:
 		return val, nil
-	case uint:
-		return uint64(val), nil
 	case uint32:
 		return uint64(val), nil
 	case uint16:
 		return uint64(val), nil
 	case uint8:
-		return uint64(val), nil
-	case int:
-		//nolint:gosec // preserve the two's-complement bit pattern of signed hashes
 		return uint64(val), nil
 	case int32:
 		//nolint:gosec // preserve the two's-complement bit pattern of signed hashes

--- a/pkg/kvevents/engineadapter/common_test.go
+++ b/pkg/kvevents/engineadapter/common_test.go
@@ -71,21 +71,22 @@ func TestGetHashAsUint64(t *testing.T) {
 		})
 	}
 
-	negativeIntegers := []struct {
+	signedIntegers := []struct {
 		name string
 		raw  any
+		want uint64
 	}{
-		{name: "int64", raw: int64(-1)},
-		{name: "int", raw: int(-1)},
-		{name: "int32", raw: int32(-1)},
-		{name: "int16", raw: int16(-1)},
-		{name: "int8", raw: int8(-1)},
+		{name: "int64_negative", raw: int64(-1), want: ^uint64(0)},
+		{name: "int_negative", raw: int(-1), want: ^uint64(0)},
+		{name: "int32_negative", raw: int32(-1), want: ^uint64(0)},
+		{name: "int16_negative", raw: int16(-1), want: ^uint64(0)},
+		{name: "int8_negative", raw: int8(-1), want: ^uint64(0)},
 	}
-	for _, tt := range negativeIntegers {
-		t.Run("negative_"+tt.name, func(t *testing.T) {
+	for _, tt := range signedIntegers {
+		t.Run(tt.name, func(t *testing.T) {
 			result, err := getHashAsUint64(tt.raw)
-			require.ErrorContains(t, err, "hash value is negative")
-			assert.Zero(t, result)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 

--- a/pkg/kvevents/engineadapter/common_test.go
+++ b/pkg/kvevents/engineadapter/common_test.go
@@ -53,12 +53,10 @@ func TestGetHashAsUint64(t *testing.T) {
 		want uint64
 	}{
 		{name: "uint64", raw: uint64(42), want: 42},
-		{name: "uint", raw: uint(42), want: 42},
 		{name: "uint32", raw: uint32(42), want: 42},
 		{name: "uint16", raw: uint16(42), want: 42},
 		{name: "uint8", raw: uint8(42), want: 42},
 		{name: "int64", raw: int64(42), want: 42},
-		{name: "int", raw: int(42), want: 42},
 		{name: "int32", raw: int32(42), want: 42},
 		{name: "int16", raw: int16(42), want: 42},
 		{name: "int8", raw: int8(42), want: 42},
@@ -77,7 +75,6 @@ func TestGetHashAsUint64(t *testing.T) {
 		want uint64
 	}{
 		{name: "int64_negative", raw: int64(-1), want: ^uint64(0)},
-		{name: "int_negative", raw: int(-1), want: ^uint64(0)},
 		{name: "int32_negative", raw: int32(-1), want: ^uint64(0)},
 		{name: "int16_negative", raw: int16(-1), want: ^uint64(0)},
 		{name: "int8_negative", raw: int8(-1), want: ^uint64(0)},

--- a/pkg/kvevents/engineadapter/common_test.go
+++ b/pkg/kvevents/engineadapter/common_test.go
@@ -47,17 +47,47 @@ func TestParseTopic_Plain(t *testing.T) {
 
 // TestGetHashAsUint64 tests hash format conversions.
 func TestGetHashAsUint64(t *testing.T) {
-	t.Run("uint64", func(t *testing.T) {
-		result, err := getHashAsUint64(uint64(42))
-		require.NoError(t, err)
-		assert.Equal(t, uint64(42), result)
-	})
+	positiveIntegers := []struct {
+		name string
+		raw  any
+		want uint64
+	}{
+		{name: "uint64", raw: uint64(42), want: 42},
+		{name: "uint", raw: uint(42), want: 42},
+		{name: "uint32", raw: uint32(42), want: 42},
+		{name: "uint16", raw: uint16(42), want: 42},
+		{name: "uint8", raw: uint8(42), want: 42},
+		{name: "int64", raw: int64(42), want: 42},
+		{name: "int", raw: int(42), want: 42},
+		{name: "int32", raw: int32(42), want: 42},
+		{name: "int16", raw: int16(42), want: 42},
+		{name: "int8", raw: int8(42), want: 42},
+	}
+	for _, tt := range positiveIntegers {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := getHashAsUint64(tt.raw)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
 
-	t.Run("int64", func(t *testing.T) {
-		result, err := getHashAsUint64(int64(42))
-		require.NoError(t, err)
-		assert.Equal(t, uint64(42), result)
-	})
+	negativeIntegers := []struct {
+		name string
+		raw  any
+	}{
+		{name: "int64", raw: int64(-1)},
+		{name: "int", raw: int(-1)},
+		{name: "int32", raw: int32(-1)},
+		{name: "int16", raw: int16(-1)},
+		{name: "int8", raw: int8(-1)},
+	}
+	for _, tt := range negativeIntegers {
+		t.Run("negative_"+tt.name, func(t *testing.T) {
+			result, err := getHashAsUint64(tt.raw)
+			require.ErrorContains(t, err, "hash value is negative")
+			assert.Zero(t, result)
+		})
+	}
 
 	t.Run("bytes_8", func(t *testing.T) {
 		b := make([]byte, 8)

--- a/pkg/kvevents/engineadapter/sglang_adapter_test.go
+++ b/pkg/kvevents/engineadapter/sglang_adapter_test.go
@@ -123,6 +123,35 @@ func TestSGLangBlockStored_FullFields(t *testing.T) {
 	assert.Nil(t, blockStored.ExtraKeys)
 }
 
+// TestSGLangBlockStoredNegativeHashPreservesBits verifies the signed hash
+// representation emitted by SGLang survives adapter conversion.
+func TestSGLangBlockStoredNegativeHashPreservesBits(t *testing.T) {
+	adapter := NewSGLangAdapter()
+	hash := int64(-987654321987654321)
+	parentHash := int64(-1234567890123456789)
+
+	// MessagePack: ["BlockStored", [-987654321987654321],
+	// -1234567890123456789, [1], 1, nil, "GPU"].
+	rawEvent := []byte{
+		0x97, // array of 7
+		0xab, 'B', 'l', 'o', 'c', 'k', 'S', 't', 'o', 'r', 'e', 'd',
+		0x91, 0xd3, 0xf2, 0x4b, 0x25, 0xa0, 0x81, 0x0b, 0xed, 0x4f,
+		0xd3, 0xee, 0xdd, 0xef, 0x0b, 0x82, 0x16, 0x7e, 0xeb,
+		0x91, 0x01,
+		0x01,
+		0xc0,
+		0xa3, 'G', 'P', 'U',
+	}
+
+	event, err := decodeEvent(rawEvent, adapter.eventConverters)
+	require.NoError(t, err)
+
+	blockStored, ok := event.(*kvevents.BlockStoredEvent)
+	require.True(t, ok)
+	assert.Equal(t, []uint64{uint64(hash)}, blockStored.BlockHashes)
+	assert.Equal(t, uint64(parentHash), blockStored.ParentHash)
+}
+
 // TestSGLangBlockStored_7Fields tests decoding with 7 fields (no lora_name, no extra_keys).
 func TestSGLangBlockStored_7Fields(t *testing.T) {
 	adapter := NewSGLangAdapter()

--- a/pkg/kvevents/engineadapter/vllm_adapter_test.go
+++ b/pkg/kvevents/engineadapter/vllm_adapter_test.go
@@ -123,6 +123,33 @@ func TestVLLMBlockStored(t *testing.T) {
 	assert.Nil(t, blockStored.ExtraKeys)
 }
 
+// TestVLLMBlockStoredSmallIntegerHash verifies that a MessagePack fixed
+// integer hash is accepted by the vLLM event decoder.
+func TestVLLMBlockStoredSmallIntegerHash(t *testing.T) {
+	adapter := NewVLLMAdapter()
+
+	// MessagePack: ["BlockStored", [100], nil, [1], 1, nil, "gpu", nil, nil].
+	rawEvent := []byte{
+		0x99, // array of 9
+		0xab, 'B', 'l', 'o', 'c', 'k', 'S', 't', 'o', 'r', 'e', 'd',
+		0x91, 0x64, // block_hashes: [100] (positive fixint)
+		0xc0,       // parent_block_hash: nil
+		0x91, 0x01, // token_ids: [1]
+		0x01, // block_size: 1
+		0xc0, // lora_id: nil
+		0xa3, 'g', 'p', 'u',
+		0xc0, // lora_name: nil
+		0xc0, // extra_keys: nil
+	}
+
+	event, err := adapter.decodeVLLMEvent(rawEvent)
+	require.NoError(t, err)
+
+	blockStored, ok := event.(*kvevents.BlockStoredEvent)
+	require.True(t, ok)
+	assert.Equal(t, []uint64{100}, blockStored.BlockHashes)
+}
+
 // TestVLLMBlockStoredWithLora tests decoding a valid BlockStored event with LoRA.
 func TestVLLMBlockStoredWithLora(t *testing.T) {
 	adapter := NewVLLMAdapter()


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

The migrated KV event hash conversion in the router does not accept all integer types produced by MessagePack decoding. Valid narrow integer hashes can be rejected during event decoding.

This change accepts all integer widths produced by MessagePack interface decoding while preserving the existing signed-integer conversion semantics used by SGLang. Negative signed hashes retain their two's-complement bit pattern when represented as `uint64`. Existing `[]byte` hash parsing remains unchanged, including big-endian parsing and low 64-bit truncation.

The implementation follows the logic proposed in [llm-d/llm-d-kv-cache#671](https://github.com/llm-d/llm-d-kv-cache/pull/671), which addresses [llm-d/llm-d-kv-cache#662](https://github.com/llm-d/llm-d-kv-cache/issues/662).

The failure is conditional rather than guaranteed for every vLLM event. For example, a small hash such as `100` can be encoded as a MessagePack fixed integer and decoded by the router as Go `int8(100)`, which the decoder did not accept. Typical vLLM hashes are large 64-bit values and usually decode as `uint64`, so this remained a latent compatibility gap.

**Implementation notes**:

- The explicit type switch follows the existing `toInt()` pattern and keeps hash conversion semantics separate from integer fields such as `block_size`.
- Signed hash values preserve their two's-complement bit pattern during conversion for SGLang compatibility.
- The `[]byte` path remains unchanged.

**Implementation details**:

- The `getHashAsUint64` comment documents the narrow Go integer types that MessagePack can produce.
- The `nolint:gosec` directives are limited to intentional signed-to-unsigned conversions.
- A wire-level regression fixture encodes a small integer hash and exercises the full vLLM event decoder.
- A SGLang regression fixture verifies that negative signed hashes retain their bit patterns.

**Which issue(s) this PR fixes**:

Related to [llm-d/llm-d-kv-cache#662](https://github.com/llm-d/llm-d-kv-cache/issues/662).

**Test plan**:

- [x] Verify conversion of all supported signed and unsigned integer widths.
- [x] Verify negative signed hashes preserve their `uint64` bit patterns.
- [x] Decode a MessagePack fixed-integer `BlockStored` event through the vLLM adapter.
- [x] Decode a negative signed `BlockStored` hash through the SGLang adapter.
- [x] Run `go test ./pkg/kvevents/engineadapter`.
- [x] Run package-scoped `golangci-lint` with the repository configuration.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Fix KV event block hash conversion for narrow MessagePack integer types while preserving SGLang signed hash compatibility.
```
