### PR TITLE
Fix: Scope Endpoint Metric Cleanup by Namespace and Producer

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -351,9 +351,14 @@ func (p *InFlightLoadProducer) Extract(ctx context.Context, event datalayer.Endp
 			break
 		}
 		p.registeredEndpoints.Delete(id)
-		endpointName, _ := splitNamespacedName(event.Endpoint.GetMetadata().ID.String())
-		inflightTokens.DeletePartialMatch(prometheus.Labels{"endpoint_name": endpointName})
-		inflightRequests.DeletePartialMatch(prometheus.Labels{"endpoint_name": endpointName})
+		endpointName, namespace := splitNamespacedName(event.Endpoint.GetMetadata().ID.String())
+		labels := prometheus.Labels{
+			"endpoint_name": endpointName,
+			"namespace":     namespace,
+			"producer_name": p.typedName.Name,
+		}
+		inflightTokens.DeletePartialMatch(labels)
+		inflightRequests.DeletePartialMatch(labels)
 		p.DeleteEndpoint(id)
 		log.FromContext(ctx).V(logutil.DEFAULT).Info("Cleaned up in-flight load for deleted endpoint", "endpoint", id)
 	case datalayer.EventAddOrUpdate:

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -264,7 +264,7 @@ func TestInFlightLoadProducer_NotificationCleanup(t *testing.T) {
 	require.Equal(t, int64(0), producer.tokenTracker.get(endpointID))
 }
 
-func TestInFlightLoadProducer_DeleteEndpointPrunesMetricSeries(t *testing.T) {
+func TestInFlightLoadProducer_DeleteEndpointPrunesOnlyMatchingMetricSeries(t *testing.T) {
 	inflightRequests.Reset()
 	inflightTokens.Reset()
 
@@ -274,8 +274,12 @@ func TestInFlightLoadProducer_DeleteEndpointPrunesMetricSeries(t *testing.T) {
 
 	inflightTokens.WithLabelValues(endpointName, "default", producer.typedName.Name, "fairness-id", "1").Add(1000)
 	inflightRequests.WithLabelValues(endpointName, "default", producer.typedName.Name, "fairness-id", "1").Inc()
+	inflightTokens.WithLabelValues(endpointName, "other", producer.typedName.Name, "fairness-id", "1").Add(2000)
+	inflightRequests.WithLabelValues(endpointName, "other", producer.typedName.Name, "fairness-id", "1").Add(2)
+	inflightTokens.WithLabelValues(endpointName, "default", "other-producer", "fairness-id", "1").Add(3000)
+	inflightRequests.WithLabelValues(endpointName, "default", "other-producer", "fairness-id", "1").Add(3)
 
-	require.Equal(t, 1, promtestutil.CollectAndCount(inflightTokens))
+	require.Equal(t, 3, promtestutil.CollectAndCount(inflightTokens))
 
 	err := producer.Extract(ctx, datalayer.EndpointEvent{
 		Type:     datalayer.EventDelete,
@@ -283,8 +287,21 @@ func TestInFlightLoadProducer_DeleteEndpointPrunesMetricSeries(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, 0, promtestutil.CollectAndCount(inflightTokens))
-	require.Equal(t, 0, promtestutil.CollectAndCount(inflightRequests))
+	expectedTokens := `
+# HELP llm_d_epp_inflight_tokens [ALPHA] Current number of in-flight tokens per endpoint (uncached prompt tokens, optionally plus estimated output), as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_tokens gauge
+llm_d_epp_inflight_tokens{endpoint_name="deleted-endpoint",fairness_id="fairness-id",namespace="default",priority="1",producer_name="other-producer"} 3000
+llm_d_epp_inflight_tokens{endpoint_name="deleted-endpoint",fairness_id="fairness-id",namespace="other",priority="1",producer_name="inflight-load-producer"} 2000
+`
+	require.NoError(t, promtestutil.CollectAndCompare(inflightTokens, strings.NewReader(expectedTokens), "llm_d_epp_inflight_tokens"))
+
+	expectedRequests := `
+# HELP llm_d_epp_inflight_requests [ALPHA] Current number of in-flight requests per endpoint, as tracked by the in-flight load producer.
+# TYPE llm_d_epp_inflight_requests gauge
+llm_d_epp_inflight_requests{endpoint_name="deleted-endpoint",fairness_id="fairness-id",namespace="default",priority="1",producer_name="other-producer"} 3
+llm_d_epp_inflight_requests{endpoint_name="deleted-endpoint",fairness_id="fairness-id",namespace="other",priority="1",producer_name="inflight-load-producer"} 2
+`
+	require.NoError(t, promtestutil.CollectAndCompare(inflightRequests, strings.NewReader(expectedRequests), "llm_d_epp_inflight_requests"))
 }
 
 func TestInFlightLoadProducer_DumpState(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

EPP uses following Prometheus metrics to track real-time load for each endpoint:
• llm_d_epp_inflight_requests
• llm_d_epp_inflight_tokens

When an inference endpoint is removed because of scale-down, rolling update, or another lifecycle event, EPP deletes its corresponding Prometheus time series.

In the default `Kubernetes discovery` mode, one EPP watches endpoints only in its configured InferencePool namespace. Therefore, same-named Pods from different Kubernetes namespaces are not managed by same EPP instance in this mode.

However, `file-based discovery` mode supports configuring multiple endpoints with same name in different namespaces under one EPP instance. For example:

```
endpoints:
- name: model-a
  namespace: team-a
  address: 10.0.0.21
  port: "8000"

- name: model-a
  namespace: team-b
  address: 10.0.1.21
  port: "8000"
```

If namespaces are used to isolate tenants or workloads, these endpoints can represent different tenant or workload domains.

Current metric cleanup logic matches only `endpoint_name` and does not include `namespace`. When `team-a/model-a` is deleted, existing code also incorrectly deletes metrics belonging to `team-b/model-a`, even though that endpoint is still running.

Therefore, metric cleanup must filter by `endpoint_name`, `namespace`, and `producer_name` to delete only time series owned by removed endpoint.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Scope Endpoint Metric Cleanup by Namespace and Producer
```
