### PR TITLE
fix(chart): allow overriding the EPP Deployment strategy so multi-replica EPP can satisfy helm --wait

### DIFF
--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -112,12 +112,75 @@ Core settings for the Endpoint Picker Proxy (EPP) container and pod, including s
 > *   **Active-Active Mode**: You can explicitly disable leader-election by passing `ha-enable-leader-election: false` under `router.epp.flags`. In this mode, all replicas process traffic concurrently.
 >     *   *Warning*: In active-active mode, you **must only use active-active compatible plugins**—specifically plugins that pull real-time metrics/state dynamically from the backend model servers (such as the precise prefix cache, queue, and KV-cache utilization scorers). Avoid plugins that rely on local in-memory routing state, as this state is not synchronized across replicas.
 
+##### Multi-replica EPP and Helm `--wait`
+
+In active-passive mode only the elected leader passes its readiness probe; standby
+replicas answer the `readiness` gRPC service with `NOT_SERVING` on purpose, so they
+never become Service endpoints. That is deliberate, but it means the EPP Deployment
+settles at `readyReplicas: 1` out of `replicas: N`.
+
+With the default `Recreate` strategy, Kubernetes forces `maxUnavailable` to `0`, so
+the Deployment reports `Available=False` / `MinimumReplicasUnavailable` and never
+becomes available. Anything that gates on Deployment availability blocks:
+
+```console
+$ helm install my-release . --set router.epp.replicas=2 --wait --timeout 4m
+Error: INSTALLATION FAILED: resource Deployment/.../my-release-epp not ready.
+status: InProgress, message: Available: 1/2
+```
+
+With Flux, the `HelmRelease` stays `pending-upgrade` until its timeout and then
+rolls back, and while it is pending no further EPP configuration change can start
+a new upgrade.
+
+Pick whichever of these fits your tooling:
+
+**1. Let Helm treat the standbys as expected-unavailable** (Helm 3 and Flux only)
+
+```yaml
+router:
+  epp:
+    replicas: 2
+    deploymentStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 1   # must cover the standby replicas, i.e. >= replicas - 1
+        maxSurge: 0
+```
+
+Helm 3 computes readiness as `readyReplicas >= replicas - maxUnavailable`, so the
+release converges as soon as the leader is ready. Standbys remain `NotReady` and
+stay out of the Service, so no traffic reaches them before they are elected.
+
+> [!IMPORTANT]
+> This does **not** help Helm 4, which uses `kstatus`. `kstatus` compares
+> `availableReplicas` against `spec.replicas` directly and ignores `maxUnavailable`,
+> so a multi-replica EPP still reports `Available: 1/2` there. Use option 2 on Helm 4.
+>
+> Moving off `Recreate` also changes upgrade behaviour: during a rollout the old
+> leader holds the lease until it is terminated, so a new replica cannot become
+> ready until the lease expires. Keep `maxSurge: 0` so the rollout does not stall
+> waiting on a surge replica that can never be elected.
+
+**2. Do not gate on Deployment availability**
+
+Install without `--wait` (Flux: `spec.install.disableWait` and
+`spec.upgrade.disableWait`), then gate on what actually indicates a serving EPP --
+an elected leader and a Ready Service endpoint:
+
+```bash
+kubectl wait --for=jsonpath='{.subsets[0].addresses[0].ip}' \
+  endpoints/<release>-epp -n <namespace> --timeout=5m
+```
+
+
 #### EPP Core Configuration Parameters
 
 | **Parameter Name** | **Description** | **Default** |
 | :--- | :--- | :--- |
 | `router.epp.parsers` | List of request parser types for EPP. Options: `[openai-parser, anthropic-parser, vllmgrpc-parser, vllmhttp-parser, passthrough-parser]`. Empty for auto-selection. | `[]` |
 | `router.epp.replicas` | Number of EPP replicas. Set > 1 to enable multi-replica EPP. | `1` |
+| `router.epp.deploymentStrategy` | Overrides the EPP Deployment's `spec.strategy`. See [Multi-replica EPP and Helm `--wait`](#multi-replica-epp-and-helm---wait). | `{type: Recreate}` |
 | `router.epp.extProcPort` | Port EPP uses for external processing gRPC communication. | `9002` |
 | `router.epp.image.registry` | EPP container image registry. | `ghcr.io/llm-d` |
 | `router.epp.image.repository` | EPP container image repository. | `llm-d-router-endpoint-picker` |

--- a/config/charts/routerlib/templates/_deployment.yaml
+++ b/config/charts/routerlib/templates/_deployment.yaml
@@ -336,13 +336,21 @@ metadata:
 spec:
   replicas: {{ .Values.router.epp.replicas | default 1 }}
   strategy:
+    {{- with .Values.router.epp.deploymentStrategy }}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
     # The current recommended EPP deployment pattern is to have a single active replica. This ensures
     # optimal performance of the stateful operations such prefix cache aware scorer.
     # The Recreate strategy the old replica is killed immediately, and allow the new replica(s) to
     # quickly take over. This is particularly important in the high availability set up with leader
     # election, as the rolling update strategy would prevent the old leader being killed because
     # otherwise the maxUnavailable would be 100%.
+    #
+    # With replicas > 1 this also means the Deployment never reports Available=True,
+    # because standby replicas stay NotReady by design. Set router.epp.deploymentStrategy
+    # if that blocks your tooling; see "Multi-replica EPP and Helm --wait" in the chart README.
     type: Recreate
+    {{- end }}
   selector:
     matchLabels:
       {{- include "llm-d-router.selectorLabels" . | nindent 6 }}

--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -5,6 +5,22 @@ clusterDomain: cluster.local
 
 epp:
   replicas: 1
+
+  # Overrides the EPP Deployment's spec.strategy. Unset means `type: Recreate`,
+  # which is the recommended default for the stateful single-active-replica pattern.
+  #
+  # With replicas > 1 the chart enables leader election, and standby replicas stay
+  # NotReady by design, so a `Recreate` Deployment never reports Available=True and
+  # `helm --wait` blocks until it times out. Setting a RollingUpdate strategy whose
+  # maxUnavailable covers the standbys lets Helm consider the release ready while
+  # keeping standbys out of the Service (they are still NotReady, so they are not
+  # Endpoints). See "Multi-replica EPP and Helm --wait" in the chart README.
+  #
+  # deploymentStrategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxUnavailable: 1
+  #     maxSurge: 0
   image:
     registry: ghcr.io/llm-d
     repository: llm-d-router-endpoint-picker


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

With `router.epp.replicas > 1` the chart enables leader election. Only the leader
passes its readiness probe; standbys answer the `readiness` gRPC service with
`NOT_SERVING` by design, so they never become Service endpoints. The EPP
Deployment therefore settles at `readyReplicas: 1` of `N`.

Because the chart pins `strategy: Recreate`, Kubernetes forces `maxUnavailable`
to `0`, so the Deployment reports `Available=False` / `MinimumReplicasUnavailable`
permanently. Anything gating on Deployment availability blocks: `helm --wait`
times out, and a Flux `HelmRelease` stays `pending-upgrade` until its timeout and
then rolls back -- and while it is pending, no further EPP change can start a new
upgrade.

This adds `router.epp.deploymentStrategy`, which overrides the Deployment's
`spec.strategy`. **The default is unchanged** (`Recreate`), so this is a no-op for
existing deployments. Operators whose tooling gates on availability can set a
RollingUpdate strategy whose `maxUnavailable` covers the standbys.

Per the issue's constraint, this does not let standbys receive traffic: they stay
`NotReady`, so they remain out of the Service endpoints.

**Verification** (OpenShift 4.21 / k8s v1.32, 2 EPP replicas):

Before, on the unmodified chart:

```console
$ helm install epp-ha . -n epp-ha-repro --set router.epp.replicas=2 --wait --timeout 4m
Error: INSTALLATION FAILED: resource Deployment/epp-ha-repro/epp-ha-epp not ready.
status: InProgress, message: Available: 1/2
context deadline exceeded          # after the full 4m

$ oc get deploy epp-ha-epp -o jsonpath='...'
ready=1 available=1 unavailable=1
Available=False MinimumReplicasUnavailable
```

After, with `deploymentStrategy: {type: RollingUpdate, rollingUpdate: {maxUnavailable: 1, maxSurge: 0}}`:

```console
$ helm install epp-fix . -n epp-verify -f fix-values.yaml --wait --timeout 4m
STATUS: deployed                   # 12 seconds

$ oc get deploy epp-fix-epp -o jsonpath='...'
ready=1/2 available=1
Available=True MinimumReplicasAvailable

$ oc get endpoints epp-fix-epp    # standby 10.130.2.244 is absent
NAME          ENDPOINTS
epp-fix-epp   10.128.11.117:9090,10.128.11.117:9002
```

Rendering is unchanged when the value is unset, and `helm lint` passes for both
the gateway and standalone charts.

**One caveat worth flagging for reviewers**: this remedy works on Helm 3 and Flux,
which compute readiness as `readyReplicas >= replicas - maxUnavailable`. It does
**not** help Helm 4, which uses `kstatus`; `kstatus` compares `availableReplicas`
against `spec.replicas` directly and ignores `maxUnavailable`. I verified both:
Helm 3.21.4 succeeds, Helm 4.1.1 still reports `Available: 1/2`. Helm 4 users need
the second documented option (do not gate on Deployment availability; gate on the
Service endpoint instead).

Fully closing the gap on Helm 4 would mean making standbys `Ready` while keeping
them out of the Service -- e.g. a leader-only label on the pod with the Service
selecting on it. That is an EPP-side change with RBAC implications, so I left it
out of this PR; happy to follow up if maintainers want that direction.

**Which issue(s) this PR fixes**:

Fixes #2568

**Release note**:
```release-note
Added `router.epp.deploymentStrategy` to override the EPP Deployment's update strategy. The default remains `Recreate`. Multi-replica EPP deployments that must satisfy `helm --wait` or Flux can now set a RollingUpdate strategy whose `maxUnavailable` covers the intentionally-NotReady standby replicas.
```
