### PR TITLE
docs: document that endpoint discovery honours custom pod readinessGates

### DIFF
--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Pod readiness in Kubernetes discovery](#pod-readiness-in-kubernetes-discovery)
 - [Architecture](#architecture)
 - [The EndpointDiscovery Interface](#the-endpointdiscovery-interface)
   - [EndpointDiscovery](#endpointdiscovery)
@@ -42,6 +43,52 @@ When a discovery plugin is configured:
   datastore via `DiscoveryNotifier`.
 - All scheduling, request control, and metrics collection behaviour is
   unchanged.
+
+---
+
+## Pod readiness in Kubernetes discovery
+
+In the default Kubernetes mode the EPP admits a pod into the routing pool only
+when the pod's aggregate **`Ready`** condition is `True` (see
+`pkg/epp/util/pod/pod.go`). A pod whose `Ready` condition is `False` or
+`Unknown`, or that has a deletion timestamp, is removed from the datastore and
+receives no traffic.
+
+Reading the aggregate `Ready` condition means custom
+[pod readiness gates](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-readiness-gate)
+are honoured without any additional EPP configuration. The kubelet computes
+`Ready` as `ContainersReady` **AND** every condition listed in
+`spec.readinessGates`, so an unsatisfied gate holds the pod out of the routing
+pool even when its container probes already pass:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: vllm          # selected by the InferencePool
+spec:
+  readinessGates:
+    - conditionType: "custom.orchestrator.io/serving"
+```
+
+Until an external controller patches `custom.orchestrator.io/serving` to
+`True` on the pod's status, the pod reports:
+
+```text
+Ready=False
+ContainersReady=True
+```
+
+and the EPP does not route to it. Once the condition flips to `True`, the
+kubelet sets `Ready=True` and the pod joins the pool on the next reconcile.
+
+This is a **fail-closed** contract, which is what makes readiness gates useful
+for out-of-band lifecycle managers -- checkpoint restorers, warm-up agents, and
+dynamic weight loaders -- that need to hold traffic back until work that the
+container probes cannot observe has finished. Note that a gated pod still shows
+`1/1` in `kubectl get pods`, because that column counts ready *containers*; the
+`Ready` **condition** is the one the EPP reads.
 
 ---
 

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -83,12 +83,8 @@ ContainersReady=True
 and the EPP does not route to it. Once the condition flips to `True`, the
 kubelet sets `Ready=True` and the pod joins the pool on the next reconcile.
 
-This is a **fail-closed** contract, which is what makes readiness gates useful
-for out-of-band lifecycle managers -- checkpoint restorers, warm-up agents, and
-dynamic weight loaders -- that need to hold traffic back until work that the
-container probes cannot observe has finished. Note that a gated pod still shows
-`1/1` in `kubectl get pods`, because that column counts ready *containers*; the
-`Ready` **condition** is the one the EPP reads.
+Note that a gated pod still shows `1/1` in `kubectl get pods`: that column counts
+ready *containers*, while the EPP reads the `Ready` condition.
 
 ---
 

--- a/pkg/epp/util/pod/pod_test.go
+++ b/pkg/epp/util/pod/pod_test.go
@@ -112,6 +112,59 @@ func TestIsPodReady(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "Pod with an unsatisfied readiness gate",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "custom.orchestrator.io/serving"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.ContainersReady,
+							Status: corev1.ConditionTrue,
+						},
+						// The kubelet ANDs every readiness gate into PodReady, so an
+						// unsatisfied gate holds PodReady at False even though the
+						// containers themselves are ready.
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Pod with a satisfied readiness gate",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					ReadinessGates: []corev1.PodReadinessGate{
+						{ConditionType: "custom.orchestrator.io/serving"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   "custom.orchestrator.io/serving",
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type:   corev1.ContainersReady,
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/epp/util/pod/pod_test.go
+++ b/pkg/epp/util/pod/pod_test.go
@@ -126,9 +126,6 @@ func TestIsPodReady(t *testing.T) {
 							Type:   corev1.ContainersReady,
 							Status: corev1.ConditionTrue,
 						},
-						// The kubelet ANDs every readiness gate into PodReady, so an
-						// unsatisfied gate holds PodReady at False even though the
-						// containers themselves are ready.
 						{
 							Type:   corev1.PodReady,
 							Status: corev1.ConditionFalse,


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The issue asks whether the router honours custom pod `readinessGates`, and notes
"the router may already support this; I just couldn't find any documentation."

It does, and it already behaves exactly as requested. Every readiness decision in
the EPP goes through `podutil.IsPodReady` (`pkg/epp/util/pod/pod.go`), which reads
the pod's **aggregate `Ready` condition**. The kubelet computes `Ready` as
`ContainersReady` AND every condition listed in `spec.readinessGates`, so an
unsatisfied gate holds the pod out of the routing pool with no EPP configuration
required, fail-closed. The same is true of the other two readiness call sites
(`pkg/epp/datastore/datastore.go`, the topology extractor).

So the gap was purely that this was never written down. This PR:

1. Documents the contract in `docs/discovery.md`, including the detail that a
   gated pod still shows `1/1` in `kubectl get pods` (that column counts ready
   *containers*, not the `Ready` condition) -- which is the thing that makes this
   confusing to verify by hand.
2. Adds `IsPodReady` cases for a satisfied and an unsatisfied readiness gate, so
   the behaviour is pinned rather than incidental.

The unsatisfied-gate case has teeth: switching `IsPodReady` from `corev1.PodReady`
to `corev1.ContainersReady` fails it.

```console
$ go test ./pkg/epp/util/pod/...      # with that regression introduced
--- FAIL: TestIsPodReady/Pod_with_an_unsatisfied_readiness_gate
FAIL
```

**Verification** (OpenShift 4.21 / k8s v1.32, live EPP against an InferencePool):

Two pods labelled for the pool, one with `readinessGates: [custom.orchestrator.io/serving]`:

```console
$ oc get pod vllm-gated -o jsonpath='...'      $ oc get pod vllm-ungated -o jsonpath='...'
Ready=False                                     Ready=True
ContainersReady=True                            ContainersReady=True
```

The EPP admitted only the ungated pod:

```json
{"msg":"Pod added","name":"vllm-ungated"}
```

Patching the gate condition to `True` flipped `Ready=True`, and the EPP picked the
pod up on the next reconcile:

```json
{"msg":"Pod added","name":"vllm-gated"}
```

This also covers the use cases in the issue -- checkpoint restorers, out-of-band
warm-up agents, dynamic weight loaders -- and the [llm-d/llm-d#2365](https://github.com/llm-d/llm-d/issues/2365)
Snapshot Orchestrator integration it references.

If maintainers would rather also see this asserted end-to-end against a live pool,
I'm happy to add an integration test; I kept the PR to docs plus a unit-level pin
since the behaviour itself needs no change.

**Which issue(s) this PR fixes**:

Fixes #2541

**Release note**:
```release-note
NONE
```
