### PR TITLE
Add Bob as request lifecycle code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,15 @@
 # auto-requested for review on their paths.
 *                                                                         @llm-d/router-maintainers
 
+# Request control and handling
+/pkg/epp/handlers/                                                        @zetxqx @llm-d/router-maintainers
+/pkg/epp/requestcontrol/                                                  @zetxqx @llm-d/router-maintainers
+/pkg/epp/framework/common/request/                                        @zetxqx @llm-d/router-maintainers
+/pkg/epp/framework/interface/requestcontrol/                              @zetxqx @llm-d/router-maintainers
+/pkg/epp/framework/plugins/requestcontrol/                                @zetxqx @llm-d/router-maintainers
+/pkg/epp/framework/interface/requesthandling/                             @zetxqx @llm-d/router-maintainers
+/pkg/epp/framework/plugins/requesthandling/                               @zetxqx @llm-d/router-maintainers
+
 # Flow control framework + plugins
 /pkg/epp/flowcontrol/                                                     @LukeAVanDrie @RishabhSaini @llm-d/router-maintainers
 /pkg/epp/framework/interface/flowcontrol/                                 @LukeAVanDrie @RishabhSaini @llm-d/router-maintainers
@@ -47,10 +56,6 @@
 # KV-cache subsystem — indexer, KV-block index, KV-events
 /pkg/kvcache/                                                              @vMaroon @liu-cong @hyeongyun0916 @yankay @sagearc @llm-d/router-maintainers
 /pkg/kvevents/                                                             @vMaroon @liu-cong @hyeongyun0916 @yankay @sagearc @llm-d/router-maintainers
-
-# Request handling
-/pkg/epp/framework/interface/requesthandling/                             @zetxqx @llm-d/router-maintainers
-/pkg/epp/framework/plugins/requesthandling/                               @zetxqx @llm-d/router-maintainers
 
 # Coordinator
 /cmd/coordinator/                                                         @roytman @llm-d/router-maintainers


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adds @zetxqx as a code owner for the built-in request handling and request control packages, their framework interfaces and plugins, and shared framework request helpers.

The general request-control rule precedes the existing subsystem-specific rules, so latency prediction, prefix cache, and tokenization retain their specialized owners.

**Which issue(s) this PR fixes**:

None.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
