### PR TITLE
Add Nili as P2P routing code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,6 +28,10 @@
 # Proxy sidecar
 /cmd/pd-sidecar/                                                          @roytman @llm-d/router-maintainers
 /pkg/sidecar/                                                             @roytman @llm-d/router-maintainers
+/pkg/sidecar/proxy/*p2p*                                                  @nilig @roytman @llm-d/router-maintainers
+
+# P2P request routing
+/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/          @nilig @llm-d/router-maintainers
 
 # SLO + latency-prediction subsystem
 /pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier/             @kaushikmitr @llm-d/router-maintainers


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adds @nilig as a code owner for the P2P source producer and P2P-specific sidecar implementation and tests. The existing sidecar owner remains on the sidecar paths.

**Which issue(s) this PR fixes**:

None.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
