### PR TITLE
feat(coordinator): add pipeline amplification and media metrics

### DIFF
--- a/pkg/coordinator/metrics/cardinality.go
+++ b/pkg/coordinator/metrics/cardinality.go
@@ -40,3 +40,35 @@ func boundModel(modelName string) string {
 	}
 	return modelLabelLimiter.Bound(modelName)
 }
+
+// boundRoute maps a coordinator route name onto the closed set used as the
+// orchestration_overhead_seconds route label. Anything else becomes
+// RouteUnknown so a raw path cannot expand the time series set.
+func boundRoute(route string) string {
+	switch route {
+	case RouteChatCompletions, RouteCompletions, RouteGenerate:
+		return route
+	default:
+		return RouteUnknown
+	}
+}
+
+// boundMediaType maps a media-type name onto the closed set used as the
+// media_items label. Unknown values collapse to MediaTypeOther.
+func boundMediaType(mediaType string) string {
+	if mediaType == MediaTypeImage {
+		return MediaTypeImage
+	}
+	return MediaTypeOther
+}
+
+// boundDownloadResult maps a download outcome onto the closed set used as
+// the media_download_duration_seconds result label.
+func boundDownloadResult(result string) string {
+	switch result {
+	case DownloadResultSuccess, DownloadResultError, DownloadResultCancelled:
+		return result
+	default:
+		return DownloadResultError
+	}
+}

--- a/pkg/coordinator/metrics/cardinality_test.go
+++ b/pkg/coordinator/metrics/cardinality_test.go
@@ -27,3 +27,24 @@ func TestBoundModel_EmptyIsUnknown(t *testing.T) {
 	// a flood of empty-model requests can never exhaust the cap.
 	require.Equal(t, ModelUnknown, boundModel(""))
 }
+
+func TestBoundRoute_ClosedSet(t *testing.T) {
+	require.Equal(t, RouteChatCompletions, boundRoute(RouteChatCompletions))
+	require.Equal(t, RouteCompletions, boundRoute(RouteCompletions))
+	require.Equal(t, RouteGenerate, boundRoute(RouteGenerate))
+	require.Equal(t, RouteUnknown, boundRoute("/v1/chat/completions"))
+	require.Equal(t, RouteUnknown, boundRoute(""))
+}
+
+func TestBoundMediaType_ClosedSet(t *testing.T) {
+	require.Equal(t, MediaTypeImage, boundMediaType(MediaTypeImage))
+	require.Equal(t, MediaTypeOther, boundMediaType("image/png"))
+	require.Equal(t, MediaTypeOther, boundMediaType(""))
+}
+
+func TestBoundDownloadResult_ClosedSet(t *testing.T) {
+	require.Equal(t, DownloadResultSuccess, boundDownloadResult(DownloadResultSuccess))
+	require.Equal(t, DownloadResultError, boundDownloadResult(DownloadResultError))
+	require.Equal(t, DownloadResultCancelled, boundDownloadResult(DownloadResultCancelled))
+	require.Equal(t, DownloadResultError, boundDownloadResult("timeout"))
+}

--- a/pkg/coordinator/metrics/classify.go
+++ b/pkg/coordinator/metrics/classify.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"errors"
 	"net/http"
 )
@@ -58,4 +59,22 @@ func ClassifyErrorCode(err error, opts ClassifyOptions) string {
 		}
 	}
 	return ErrorCodeInternal
+}
+
+// ClassifyDownloadResult maps a media-download attempt onto the result label
+// for media_download_duration_seconds. A nil err is success. A canceled
+// request context (or an err that unwraps to context.Canceled) is cancelled.
+// Every other failure, including a client timeout that is not a parent
+// cancel, is error.
+func ClassifyDownloadResult(ctx context.Context, err error) string {
+	if err == nil {
+		return DownloadResultSuccess
+	}
+	if ctx != nil && ctx.Err() == context.Canceled {
+		return DownloadResultCancelled
+	}
+	if errors.Is(err, context.Canceled) {
+		return DownloadResultCancelled
+	}
+	return DownloadResultError
 }

--- a/pkg/coordinator/metrics/classify_test.go
+++ b/pkg/coordinator/metrics/classify_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -97,4 +98,17 @@ func TestClassifyErrorCode_NilOptionsSafe(t *testing.T) {
 	// A caller who forgets to wire options gets "internal" for every error
 	// rather than a nil-pointer panic.
 	require.Equal(t, ErrorCodeInternal, ClassifyErrorCode(errors.New("boom"), ClassifyOptions{}))
+}
+
+func TestClassifyDownloadResult(t *testing.T) {
+	ctx := context.Background()
+	require.Equal(t, DownloadResultSuccess, ClassifyDownloadResult(ctx, nil))
+	require.Equal(t, DownloadResultError, ClassifyDownloadResult(ctx, errors.New("500")))
+	require.Equal(t, DownloadResultError, ClassifyDownloadResult(ctx, context.DeadlineExceeded))
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.Equal(t, DownloadResultCancelled, ClassifyDownloadResult(canceled, context.Canceled))
+	require.Equal(t, DownloadResultCancelled, ClassifyDownloadResult(ctx, context.Canceled))
+	require.Equal(t, DownloadResultCancelled, ClassifyDownloadResult(canceled, errors.New("dial")))
 }

--- a/pkg/coordinator/metrics/llm_d_coordinator_metrics.go
+++ b/pkg/coordinator/metrics/llm_d_coordinator_metrics.go
@@ -175,11 +175,11 @@ var (
 // media_download_duration_seconds, which is one observation per download
 // attempt.
 var (
-	encodeFanoutSize = prometheus.NewHistogramVec(
+	encodeSubrequests = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: LLMDRouterCoordinatorSubsystem,
-			Name:      "encode_fanout_size",
-			Help:      metricsutil.HelpMsgWithStability("Number of Encode subrequests produced by one client request. Observed once per pipeline execution after fan-out size is known; 0 when Encode does not run or is skipped. Unit: subrequests.", compbasemetrics.ALPHA),
+			Name:      "encode_subrequests",
+			Help:      metricsutil.HelpMsgWithStability("Number of Encode subrequests produced by one client request. Observed once per pipeline execution after fan-out is known; 0 when Encode does not run or is skipped. Unit: subrequests.", compbasemetrics.ALPHA),
 			Buckets:   CountBuckets,
 		},
 		[]string{},
@@ -215,10 +215,10 @@ var (
 		resultLabel,
 	)
 
-	responseBytes = prometheus.NewHistogramVec(
+	responseSize = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: LLMDRouterCoordinatorSubsystem,
-			Name:      "response_bytes",
+			Name:      "response_size_bytes",
 			Help:      metricsutil.HelpMsgWithStability("Total bytes written to the client for one request, including partial writes on cancellation or disconnect. Observed once per client request. Unit: bytes.", compbasemetrics.ALPHA),
 			Buckets:   metricsutil.RequestSizeBuckets,
 		},

--- a/pkg/coordinator/metrics/llm_d_coordinator_metrics.go
+++ b/pkg/coordinator/metrics/llm_d_coordinator_metrics.go
@@ -169,3 +169,59 @@ var (
 		[]string{"result"},
 	)
 )
+
+// Per-request pipeline amplification, orchestration cost, media processing,
+// and outbound response size. Recorded once per client request except
+// media_download_duration_seconds, which is one observation per download
+// attempt.
+var (
+	encodeFanoutSize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: LLMDRouterCoordinatorSubsystem,
+			Name:      "encode_fanout_size",
+			Help:      metricsutil.HelpMsgWithStability("Number of Encode subrequests produced by one client request. Observed once per pipeline execution after fan-out size is known; 0 when Encode does not run or is skipped. Unit: subrequests.", compbasemetrics.ALPHA),
+			Buckets:   CountBuckets,
+		},
+		[]string{},
+	)
+
+	orchestrationOverhead = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: LLMDRouterCoordinatorSubsystem,
+			Name:      "orchestration_overhead_seconds",
+			Help:      metricsutil.HelpMsgWithStability("Coordinator wall time outside request parsing and pipeline step execution. Observed once per client request as max(0, total-parse-sum(steps)). Unit: seconds.", compbasemetrics.ALPHA),
+			Buckets:   metricsutil.GeneralLatencyBuckets,
+		},
+		routeLabel,
+	)
+
+	mediaItems = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: LLMDRouterCoordinatorSubsystem,
+			Name:      "media_items",
+			Help:      metricsutil.HelpMsgWithStability("Number of media items of one type found in one client request. Observed once per type after the request's media inventory is known. Unit: items.", compbasemetrics.ALPHA),
+			Buckets:   CountBuckets,
+		},
+		mediaTypeLabel,
+	)
+
+	mediaDownloadDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: LLMDRouterCoordinatorSubsystem,
+			Name:      "media_download_duration_seconds",
+			Help:      metricsutil.HelpMsgWithStability("Duration of one outbound media download attempt. Observed at the end of each HTTP fetch, including failed and cancelled attempts; data URIs are not downloads. Unit: seconds.", compbasemetrics.ALPHA),
+			Buckets:   metricsutil.GeneralLatencyBuckets,
+		},
+		resultLabel,
+	)
+
+	responseBytes = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: LLMDRouterCoordinatorSubsystem,
+			Name:      "response_bytes",
+			Help:      metricsutil.HelpMsgWithStability("Total bytes written to the client for one request, including partial writes on cancellation or disconnect. Observed once per client request. Unit: bytes.", compbasemetrics.ALPHA),
+			Buckets:   metricsutil.RequestSizeBuckets,
+		},
+		streamLabel,
+	)
+)

--- a/pkg/coordinator/metrics/metrics.go
+++ b/pkg/coordinator/metrics/metrics.go
@@ -107,7 +107,7 @@ const (
 	DownloadResultCancelled = "cancelled"
 )
 
-// Stream label values for response_bytes. Fixed boolean-like strings, not
+// Stream label values for response_size_bytes. Fixed boolean-like strings, not
 // the request's raw stream field.
 const (
 	StreamTrue  = "true"
@@ -164,11 +164,11 @@ func allCollectors() []resettableCollector {
 		upstreamRequestDuration,
 		executionPathTotal,
 		conditionalDecodeProbesTotal,
-		encodeFanoutSize,
+		encodeSubrequests,
 		orchestrationOverhead,
 		mediaItems,
 		mediaDownloadDuration,
-		responseBytes,
+		responseSize,
 	}
 }
 

--- a/pkg/coordinator/metrics/metrics.go
+++ b/pkg/coordinator/metrics/metrics.go
@@ -83,10 +83,49 @@ const (
 	ProbeResultTransportError = "transport_error"
 )
 
+// Route label values for orchestration_overhead_seconds. These name the
+// coordinator's registered inference routes, not the raw URL path.
+const (
+	RouteChatCompletions = "chat_completions"
+	RouteCompletions     = "completions"
+	RouteGenerate        = "generate"
+	RouteUnknown         = "unknown"
+)
+
+// MediaType label values for media_items. The coordinator currently
+// inventories image parts only; any other type is collapsed to other so the
+// label set stays bounded.
+const (
+	MediaTypeImage = "image"
+	MediaTypeOther = "other"
+)
+
+// Download result label values for media_download_duration_seconds.
+const (
+	DownloadResultSuccess   = "success"
+	DownloadResultError     = "error"
+	DownloadResultCancelled = "cancelled"
+)
+
+// Stream label values for response_bytes. Fixed boolean-like strings, not
+// the request's raw stream field.
+const (
+	StreamTrue  = "true"
+	StreamFalse = "false"
+)
+
+// CountBuckets is a small-integer histogram ladder for per-request counts
+// (encode fan-out, media item inventory).
+var CountBuckets = []float64{0, 1, 2, 4, 8, 16, 32, 64, 128, 256}
+
 var (
-	modelLabel    = []string{"model_name"}
-	stepLabel     = []string{"step"}
-	upstreamLabel = []string{"upstream"}
+	modelLabel     = []string{"model_name"}
+	stepLabel      = []string{"step"}
+	upstreamLabel  = []string{"upstream"}
+	routeLabel     = []string{"route"}
+	mediaTypeLabel = []string{"media_type"}
+	resultLabel    = []string{"result"}
+	streamLabel    = []string{"stream"}
 )
 
 // withLabel returns a fresh slice of base followed by extra. It allocates a
@@ -125,6 +164,11 @@ func allCollectors() []resettableCollector {
 		upstreamRequestDuration,
 		executionPathTotal,
 		conditionalDecodeProbesTotal,
+		encodeFanoutSize,
+		orchestrationOverhead,
+		mediaItems,
+		mediaDownloadDuration,
+		responseBytes,
 	}
 }
 

--- a/pkg/coordinator/metrics/metrics_test.go
+++ b/pkg/coordinator/metrics/metrics_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -181,4 +182,58 @@ func TestExecutionPathAndProbes_Records(t *testing.T) {
 	require.InDelta(t, 1.0,
 		promtestutil.ToFloat64(conditionalDecodeProbesTotal.WithLabelValues(ProbeResultTransportError)), 1e-9,
 	)
+}
+
+func TestPipelineAmplificationFamily_Records(t *testing.T) {
+	Reset()
+	RecordEncodeFanoutSize(0)
+	RecordEncodeFanoutSize(3)
+	RecordOrchestrationOverhead(RouteChatCompletions, 40*time.Millisecond)
+	RecordOrchestrationOverhead("/raw/path", -time.Second)
+	RecordMediaItems(MediaTypeImage, 2)
+	RecordMediaItems("image/png", 1)
+	RecordMediaDownloadDuration(DownloadResultSuccess, 10*time.Millisecond)
+	RecordMediaDownloadDuration(DownloadResultError, 5*time.Millisecond)
+	RecordMediaDownloadDuration(DownloadResultCancelled, time.Millisecond)
+	RecordMediaDownloadDuration("timeout", time.Millisecond)
+	RecordResponseBytes(true, 512)
+	RecordResponseBytes(false, 64)
+
+	require.InDelta(t, 2.0, histogramSampleCount(t, encodeFanoutSize, nil), 1e-9)
+	require.InDelta(t, 3.0, histogramSampleSum(t, encodeFanoutSize, nil), 1e-9)
+
+	require.InDelta(t, 1.0, histogramSampleCount(t, orchestrationOverhead, []string{RouteChatCompletions}), 1e-9)
+	require.InDelta(t, 1.0, histogramSampleCount(t, orchestrationOverhead, []string{RouteUnknown}), 1e-9)
+	require.InDelta(t, 0.0, histogramSampleSum(t, orchestrationOverhead, []string{RouteUnknown}), 1e-9)
+
+	require.InDelta(t, 1.0, histogramSampleCount(t, mediaItems, []string{MediaTypeImage}), 1e-9)
+	require.InDelta(t, 2.0, histogramSampleSum(t, mediaItems, []string{MediaTypeImage}), 1e-9)
+	require.InDelta(t, 1.0, histogramSampleCount(t, mediaItems, []string{MediaTypeOther}), 1e-9)
+
+	require.InDelta(t, 1.0, histogramSampleCount(t, mediaDownloadDuration, []string{DownloadResultSuccess}), 1e-9)
+	require.InDelta(t, 2.0, histogramSampleCount(t, mediaDownloadDuration, []string{DownloadResultError}), 1e-9)
+	require.InDelta(t, 1.0, histogramSampleCount(t, mediaDownloadDuration, []string{DownloadResultCancelled}), 1e-9)
+
+	require.InDelta(t, 1.0, histogramSampleCount(t, responseBytes, []string{StreamTrue}), 1e-9)
+	require.InDelta(t, 512.0, histogramSampleSum(t, responseBytes, []string{StreamTrue}), 1e-9)
+	require.InDelta(t, 1.0, histogramSampleCount(t, responseBytes, []string{StreamFalse}), 1e-9)
+	require.InDelta(t, 64.0, histogramSampleSum(t, responseBytes, []string{StreamFalse}), 1e-9)
+}
+
+func histogramSampleCount(t *testing.T, hv *prometheus.HistogramVec, labels []string) float64 {
+	t.Helper()
+	m, err := hv.GetMetricWithLabelValues(labels...)
+	require.NoError(t, err)
+	pb := &dto.Metric{}
+	require.NoError(t, m.(prometheus.Metric).Write(pb))
+	return float64(pb.GetHistogram().GetSampleCount())
+}
+
+func histogramSampleSum(t *testing.T, hv *prometheus.HistogramVec, labels []string) float64 {
+	t.Helper()
+	m, err := hv.GetMetricWithLabelValues(labels...)
+	require.NoError(t, err)
+	pb := &dto.Metric{}
+	require.NoError(t, m.(prometheus.Metric).Write(pb))
+	return pb.GetHistogram().GetSampleSum()
 }

--- a/pkg/coordinator/metrics/metrics_test.go
+++ b/pkg/coordinator/metrics/metrics_test.go
@@ -186,8 +186,8 @@ func TestExecutionPathAndProbes_Records(t *testing.T) {
 
 func TestPipelineAmplificationFamily_Records(t *testing.T) {
 	Reset()
-	RecordEncodeFanoutSize(0)
-	RecordEncodeFanoutSize(3)
+	RecordEncodeSubrequests(0)
+	RecordEncodeSubrequests(3)
 	RecordOrchestrationOverhead(RouteChatCompletions, 40*time.Millisecond)
 	RecordOrchestrationOverhead("/raw/path", -time.Second)
 	RecordMediaItems(MediaTypeImage, 2)
@@ -196,11 +196,11 @@ func TestPipelineAmplificationFamily_Records(t *testing.T) {
 	RecordMediaDownloadDuration(DownloadResultError, 5*time.Millisecond)
 	RecordMediaDownloadDuration(DownloadResultCancelled, time.Millisecond)
 	RecordMediaDownloadDuration("timeout", time.Millisecond)
-	RecordResponseBytes(true, 512)
-	RecordResponseBytes(false, 64)
+	RecordResponseSize(true, 512)
+	RecordResponseSize(false, 64)
 
-	require.InDelta(t, 2.0, histogramSampleCount(t, encodeFanoutSize, nil), 1e-9)
-	require.InDelta(t, 3.0, histogramSampleSum(t, encodeFanoutSize, nil), 1e-9)
+	require.InDelta(t, 2.0, histogramSampleCount(t, encodeSubrequests, nil), 1e-9)
+	require.InDelta(t, 3.0, histogramSampleSum(t, encodeSubrequests, nil), 1e-9)
 
 	require.InDelta(t, 1.0, histogramSampleCount(t, orchestrationOverhead, []string{RouteChatCompletions}), 1e-9)
 	require.InDelta(t, 1.0, histogramSampleCount(t, orchestrationOverhead, []string{RouteUnknown}), 1e-9)
@@ -214,10 +214,10 @@ func TestPipelineAmplificationFamily_Records(t *testing.T) {
 	require.InDelta(t, 2.0, histogramSampleCount(t, mediaDownloadDuration, []string{DownloadResultError}), 1e-9)
 	require.InDelta(t, 1.0, histogramSampleCount(t, mediaDownloadDuration, []string{DownloadResultCancelled}), 1e-9)
 
-	require.InDelta(t, 1.0, histogramSampleCount(t, responseBytes, []string{StreamTrue}), 1e-9)
-	require.InDelta(t, 512.0, histogramSampleSum(t, responseBytes, []string{StreamTrue}), 1e-9)
-	require.InDelta(t, 1.0, histogramSampleCount(t, responseBytes, []string{StreamFalse}), 1e-9)
-	require.InDelta(t, 64.0, histogramSampleSum(t, responseBytes, []string{StreamFalse}), 1e-9)
+	require.InDelta(t, 1.0, histogramSampleCount(t, responseSize, []string{StreamTrue}), 1e-9)
+	require.InDelta(t, 512.0, histogramSampleSum(t, responseSize, []string{StreamTrue}), 1e-9)
+	require.InDelta(t, 1.0, histogramSampleCount(t, responseSize, []string{StreamFalse}), 1e-9)
+	require.InDelta(t, 64.0, histogramSampleSum(t, responseSize, []string{StreamFalse}), 1e-9)
 }
 
 func histogramSampleCount(t *testing.T, hv *prometheus.HistogramVec, labels []string) float64 {

--- a/pkg/coordinator/metrics/record.go
+++ b/pkg/coordinator/metrics/record.go
@@ -99,3 +99,44 @@ func IncExecutionPath(modelName, path string) {
 func IncConditionalDecodeProbes(result string) {
 	conditionalDecodeProbesTotal.WithLabelValues(result).Inc()
 }
+
+// RecordEncodeFanoutSize observes the number of Encode subrequests for one
+// client request, including zero when Encode does not run.
+func RecordEncodeFanoutSize(n int) {
+	encodeFanoutSize.WithLabelValues().Observe(float64(n))
+}
+
+// RecordOrchestrationOverhead observes coordinator wall time outside parse
+// and pipeline step execution for one client request. Negative values are
+// recorded as zero so clock-resolution jitter cannot emit a negative sample.
+func RecordOrchestrationOverhead(route string, d time.Duration) {
+	if d < 0 {
+		d = 0
+	}
+	orchestrationOverhead.WithLabelValues(boundRoute(route)).Observe(d.Seconds())
+}
+
+// RecordMediaItems observes the number of media items of one type found in
+// one client request.
+func RecordMediaItems(mediaType string, n int) {
+	mediaItems.WithLabelValues(boundMediaType(mediaType)).Observe(float64(n))
+}
+
+// RecordMediaDownloadDuration observes the duration of one media download
+// attempt.
+func RecordMediaDownloadDuration(result string, d time.Duration) {
+	mediaDownloadDuration.WithLabelValues(boundDownloadResult(result)).Observe(d.Seconds())
+}
+
+// RecordResponseBytes observes the number of bytes written to the client for
+// one request. stream must be a bounded StreamTrue / StreamFalse value.
+func RecordResponseBytes(stream bool, bytes int) {
+	responseBytes.WithLabelValues(streamLabelValue(stream)).Observe(float64(bytes))
+}
+
+func streamLabelValue(stream bool) string {
+	if stream {
+		return StreamTrue
+	}
+	return StreamFalse
+}

--- a/pkg/coordinator/metrics/record.go
+++ b/pkg/coordinator/metrics/record.go
@@ -100,10 +100,10 @@ func IncConditionalDecodeProbes(result string) {
 	conditionalDecodeProbesTotal.WithLabelValues(result).Inc()
 }
 
-// RecordEncodeFanoutSize observes the number of Encode subrequests for one
+// RecordEncodeSubrequests observes the number of Encode subrequests for one
 // client request, including zero when Encode does not run.
-func RecordEncodeFanoutSize(n int) {
-	encodeFanoutSize.WithLabelValues().Observe(float64(n))
+func RecordEncodeSubrequests(n int) {
+	encodeSubrequests.WithLabelValues().Observe(float64(n))
 }
 
 // RecordOrchestrationOverhead observes coordinator wall time outside parse
@@ -128,10 +128,10 @@ func RecordMediaDownloadDuration(result string, d time.Duration) {
 	mediaDownloadDuration.WithLabelValues(boundDownloadResult(result)).Observe(d.Seconds())
 }
 
-// RecordResponseBytes observes the number of bytes written to the client for
+// RecordResponseSize observes the number of bytes written to the client for
 // one request. stream must be a bounded StreamTrue / StreamFalse value.
-func RecordResponseBytes(stream bool, bytes int) {
-	responseBytes.WithLabelValues(streamLabelValue(stream)).Observe(float64(bytes))
+func RecordResponseSize(stream bool, bytes int) {
+	responseSize.WithLabelValues(streamLabelValue(stream)).Observe(float64(bytes))
 }
 
 func streamLabelValue(stream bool) string {

--- a/pkg/coordinator/pipeline/context.go
+++ b/pkg/coordinator/pipeline/context.go
@@ -73,6 +73,14 @@ type RequestContext struct {
 	// request body before the pipeline ran. Execute reports it as the first
 	// entry in the step-timing summary.
 	ParseDuration time.Duration
+	// StepDuration is the sum of per-step wall times recorded by Execute.
+	// The handler subtracts ParseDuration and StepDuration from end-to-end
+	// latency to observe orchestration_overhead_seconds.
+	StepDuration time.Duration
+	// EncodeFanout is the number of Encode subrequests this request produced.
+	// EncodeStep sets it once fan-out size is known; 0 means Encode did not
+	// run, was skipped, or found no multimodal entries.
+	EncodeFanout int
 
 	TokenIDs          []int
 	MultimodalEntries []MultimodalEntry

--- a/pkg/coordinator/pipeline/pipeline.go
+++ b/pkg/coordinator/pipeline/pipeline.go
@@ -122,6 +122,7 @@ func (p *Pipeline) Execute(ctx context.Context, reqCtx *RequestContext) error {
 		if executed["render"] {
 			coordmetrics.RecordRequestInputTokens(reqCtx.Model, len(reqCtx.TokenIDs))
 		}
+		coordmetrics.RecordEncodeFanoutSize(reqCtx.EncodeFanout)
 	}()
 
 	for idx, step := range p.steps {
@@ -165,6 +166,7 @@ func (p *Pipeline) runStep(
 		d := time.Since(start)
 		coordmetrics.RecordStepDuration(name, d)
 		coordmetrics.DecStepRunning(name)
+		reqCtx.StepDuration += d
 		timings[idx] = stepTiming{name: name, duration: d}
 		if r := recover(); r != nil {
 			coordmetrics.IncStepErrorTotal(name, coordmetrics.ErrorCodeInternal)

--- a/pkg/coordinator/pipeline/pipeline.go
+++ b/pkg/coordinator/pipeline/pipeline.go
@@ -122,7 +122,7 @@ func (p *Pipeline) Execute(ctx context.Context, reqCtx *RequestContext) error {
 		if executed["render"] {
 			coordmetrics.RecordRequestInputTokens(reqCtx.Model, len(reqCtx.TokenIDs))
 		}
-		coordmetrics.RecordEncodeFanoutSize(reqCtx.EncodeFanout)
+		coordmetrics.RecordEncodeSubrequests(reqCtx.EncodeFanout)
 	}()
 
 	for idx, step := range p.steps {

--- a/pkg/coordinator/pipeline/pipeline_test.go
+++ b/pkg/coordinator/pipeline/pipeline_test.go
@@ -530,8 +530,8 @@ func TestExecute_RecordsEncodeFanoutIncludingZero(t *testing.T) {
 	if err := New(steps).Execute(context.Background(), &RequestContext{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	require.Equal(t, uint64(1), histogramSampleCount(t, reg, "llm_d_coordinator_encode_fanout_size", nil))
-	require.InDelta(t, 0.0, histogramSampleSum(t, reg, "llm_d_coordinator_encode_fanout_size", nil), 1e-9)
+	require.Equal(t, uint64(1), histogramSampleCount(t, reg, "llm_d_coordinator_encode_subrequests", nil))
+	require.InDelta(t, 0.0, histogramSampleSum(t, reg, "llm_d_coordinator_encode_subrequests", nil), 1e-9)
 
 	reg = newMetricsRegistry(t)
 	steps = []Step{
@@ -544,8 +544,8 @@ func TestExecute_RecordsEncodeFanoutIncludingZero(t *testing.T) {
 	if err := New(steps).Execute(context.Background(), &RequestContext{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	require.Equal(t, uint64(1), histogramSampleCount(t, reg, "llm_d_coordinator_encode_fanout_size", nil))
-	require.InDelta(t, 3.0, histogramSampleSum(t, reg, "llm_d_coordinator_encode_fanout_size", nil), 1e-9)
+	require.Equal(t, uint64(1), histogramSampleCount(t, reg, "llm_d_coordinator_encode_subrequests", nil))
+	require.InDelta(t, 3.0, histogramSampleSum(t, reg, "llm_d_coordinator_encode_subrequests", nil), 1e-9)
 }
 
 func TestExecute_AccumulatesStepDuration(t *testing.T) {

--- a/pkg/coordinator/pipeline/pipeline_test.go
+++ b/pkg/coordinator/pipeline/pipeline_test.go
@@ -465,3 +465,99 @@ func mustGauge(t *testing.T, reg *prometheus.Registry, name string, labels map[s
 	t.Fatalf("gauge %s%v not present", name, labels)
 	return 0
 }
+
+func histogramSampleCount(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) uint64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			got := map[string]string{}
+			for _, l := range m.GetLabel() {
+				got[l.GetName()] = l.GetValue()
+			}
+			match := true
+			for k, v := range labels {
+				if got[k] != v {
+					match = false
+					break
+				}
+			}
+			if match {
+				return m.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	return 0
+}
+
+func histogramSampleSum(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) float64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			got := map[string]string{}
+			for _, l := range m.GetLabel() {
+				got[l.GetName()] = l.GetValue()
+			}
+			match := true
+			for k, v := range labels {
+				if got[k] != v {
+					match = false
+					break
+				}
+			}
+			if match {
+				return m.GetHistogram().GetSampleSum()
+			}
+		}
+	}
+	return 0
+}
+
+func TestExecute_RecordsEncodeFanoutIncludingZero(t *testing.T) {
+	reg := newMetricsRegistry(t)
+	steps := []Step{
+		&mockStep{name: "decode", fn: func(_ context.Context, _ *RequestContext) error { return nil }},
+	}
+	if err := New(steps).Execute(context.Background(), &RequestContext{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	require.Equal(t, uint64(1), histogramSampleCount(t, reg, "llm_d_coordinator_encode_fanout_size", nil))
+	require.InDelta(t, 0.0, histogramSampleSum(t, reg, "llm_d_coordinator_encode_fanout_size", nil), 1e-9)
+
+	reg = newMetricsRegistry(t)
+	steps = []Step{
+		&mockStep{name: "encode", fn: func(_ context.Context, rc *RequestContext) error {
+			rc.EncodeFanout = 3
+			return nil
+		}},
+		&mockStep{name: "decode", fn: func(_ context.Context, _ *RequestContext) error { return nil }},
+	}
+	if err := New(steps).Execute(context.Background(), &RequestContext{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	require.Equal(t, uint64(1), histogramSampleCount(t, reg, "llm_d_coordinator_encode_fanout_size", nil))
+	require.InDelta(t, 3.0, histogramSampleSum(t, reg, "llm_d_coordinator_encode_fanout_size", nil), 1e-9)
+}
+
+func TestExecute_AccumulatesStepDuration(t *testing.T) {
+	reqCtx := &RequestContext{}
+	steps := []Step{
+		&mockStep{name: "render", fn: func(_ context.Context, _ *RequestContext) error { return nil }},
+		&mockStep{name: "decode", fn: func(_ context.Context, _ *RequestContext) error { return nil }},
+	}
+	if err := New(steps).Execute(context.Background(), reqCtx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reqCtx.StepDuration <= 0 {
+		t.Fatalf("expected StepDuration > 0, got %s", reqCtx.StepDuration)
+	}
+}

--- a/pkg/coordinator/server/counting_writer.go
+++ b/pkg/coordinator/server/counting_writer.go
@@ -19,7 +19,7 @@ package server
 import "net/http"
 
 // countingResponseWriter counts bytes written to the client so
-// response_bytes can include partial writes on cancellation or disconnect.
+// response_size_bytes can include partial writes on cancellation or disconnect.
 type countingResponseWriter struct {
 	http.ResponseWriter
 	n int

--- a/pkg/coordinator/server/counting_writer.go
+++ b/pkg/coordinator/server/counting_writer.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import "net/http"
+
+// countingResponseWriter counts bytes written to the client so
+// response_bytes can include partial writes on cancellation or disconnect.
+type countingResponseWriter struct {
+	http.ResponseWriter
+	n int
+}
+
+func newCountingResponseWriter(w http.ResponseWriter) *countingResponseWriter {
+	return &countingResponseWriter{ResponseWriter: w}
+}
+
+func (w *countingResponseWriter) Write(p []byte) (int, error) {
+	n, err := w.ResponseWriter.Write(p)
+	w.n += n
+	return n, err
+}
+
+func (w *countingResponseWriter) BytesWritten() int { return w.n }
+
+func (w *countingResponseWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+func (w *countingResponseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/pkg/coordinator/server/counting_writer_test.go
+++ b/pkg/coordinator/server/counting_writer_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCountingResponseWriter_CountsPartialWrites(t *testing.T) {
+	rec := httptest.NewRecorder()
+	cw := newCountingResponseWriter(rec)
+	n, err := cw.Write([]byte("hello"))
+	if err != nil || n != 5 {
+		t.Fatalf("Write = %d, %v", n, err)
+	}
+	n, err = cw.Write([]byte("!"))
+	if err != nil || n != 1 {
+		t.Fatalf("Write = %d, %v", n, err)
+	}
+	if cw.BytesWritten() != 6 {
+		t.Fatalf("BytesWritten = %d, want 6", cw.BytesWritten())
+	}
+}
+
+type failingWriter struct {
+	http.ResponseWriter
+	failAfter int
+	wrote     int
+}
+
+func (w *failingWriter) Write(p []byte) (int, error) {
+	remain := w.failAfter - w.wrote
+	if remain <= 0 {
+		return 0, errors.New("client disconnected")
+	}
+	if len(p) > remain {
+		n, _ := w.ResponseWriter.Write(p[:remain])
+		w.wrote += n
+		return n, errors.New("client disconnected")
+	}
+	n, err := w.ResponseWriter.Write(p)
+	w.wrote += n
+	return n, err
+}
+
+func TestCountingResponseWriter_CountsPartialWriteOnError(t *testing.T) {
+	inner := &failingWriter{ResponseWriter: httptest.NewRecorder(), failAfter: 3}
+	cw := newCountingResponseWriter(inner)
+	n, err := cw.Write([]byte("abcdef"))
+	if err == nil {
+		t.Fatal("expected write error")
+	}
+	if n != 3 {
+		t.Fatalf("partial n = %d, want 3", n)
+	}
+	if cw.BytesWritten() != 3 {
+		t.Fatalf("BytesWritten = %d, want 3", cw.BytesWritten())
+	}
+}

--- a/pkg/coordinator/server/handlers.go
+++ b/pkg/coordinator/server/handlers.go
@@ -33,6 +33,7 @@ import (
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 
 	"github.com/llm-d/llm-d-router/pkg/coordinator/config"
+	"github.com/llm-d/llm-d-router/pkg/coordinator/gateway"
 	coordmetrics "github.com/llm-d/llm-d-router/pkg/coordinator/metrics"
 	"github.com/llm-d/llm-d-router/pkg/coordinator/pipeline"
 )
@@ -46,6 +47,8 @@ var validRequestID = regexp.MustCompile(`^[a-zA-Z0-9\-]{1,128}$`)
 
 func (s *Server) handleInference(w http.ResponseWriter, r *http.Request) {
 	receivedAt := time.Now()
+	cw := newCountingResponseWriter(w)
+	route := inferenceRoute(r.URL.Path)
 	// model is the raw name from the request body, or "" when the client
 	// omitted it. Metric emitters normalize "" to ModelUnknown via
 	// boundModel; the pipeline sees the raw value so upstream requests
@@ -64,6 +67,9 @@ func (s *Server) handleInference(w http.ResponseWriter, r *http.Request) {
 	// branches land here with the full length. Success lands here with the
 	// parsed model.
 	var body []byte
+	var parseDuration time.Duration
+	var stream bool
+	var reqCtx *pipeline.RequestContext
 	defer func() {
 		// A pipeline panic bypasses the err-branch call to IncRequestErrorTotal
 		// below; recovering here records the panic under error_code=internal
@@ -75,6 +81,12 @@ func (s *Server) handleInference(w http.ResponseWriter, r *http.Request) {
 		coordmetrics.IncRequestTotal(model)
 		coordmetrics.RecordRequestDuration(model, time.Since(receivedAt))
 		coordmetrics.RecordRequestSize(model, len(body))
+		stepDuration := time.Duration(0)
+		if reqCtx != nil {
+			stepDuration = reqCtx.StepDuration
+		}
+		coordmetrics.RecordOrchestrationOverhead(route, time.Since(receivedAt)-parseDuration-stepDuration)
+		coordmetrics.RecordResponseBytes(stream, cw.BytesWritten())
 		coordmetrics.DecRequestRunning(inflightModel)
 		if r != nil {
 			panic(r)
@@ -84,31 +96,34 @@ func (s *Server) handleInference(w http.ResponseWriter, r *http.Request) {
 	parseStart := time.Now()
 	var err error
 	body, err = io.ReadAll(io.LimitReader(r.Body, s.maxRequestBodySize*config.BytesPerMB+1))
+	parseDuration = time.Since(parseStart)
 	if err != nil {
 		coordmetrics.IncRequestErrorTotal(model, coordmetrics.ErrorCodeBadRequest)
-		http.Error(w, "failed to read request body", http.StatusBadRequest)
+		http.Error(cw, "failed to read request body", http.StatusBadRequest)
 		return
 	}
 	if int64(len(body)) > s.maxRequestBodySize*config.BytesPerMB {
 		coordmetrics.IncRequestErrorTotal(model, coordmetrics.ErrorCodeBadRequest)
-		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		http.Error(cw, "request body too large", http.StatusRequestEntityTooLarge)
 		return
 	}
 
 	var parsed map[string]any
 	if err := json.Unmarshal(body, &parsed); err != nil {
+		parseDuration = time.Since(parseStart)
 		coordmetrics.IncRequestErrorTotal(model, coordmetrics.ErrorCodeBadRequest)
-		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		http.Error(cw, "invalid JSON body", http.StatusBadRequest)
 		return
 	}
 	if parsed == nil {
+		parseDuration = time.Since(parseStart)
 		coordmetrics.IncRequestErrorTotal(model, coordmetrics.ErrorCodeBadRequest)
-		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		http.Error(cw, "invalid JSON body", http.StatusBadRequest)
 		return
 	}
-	parseDuration := time.Since(parseStart)
+	parseDuration = time.Since(parseStart)
 
-	stream, _ := parsed[reqcommon.FieldStream].(bool)
+	stream, _ = parsed[reqcommon.FieldStream].(bool)
 	if m, ok := parsed["model"].(string); ok && m != "" {
 		model = m
 	}
@@ -125,7 +140,7 @@ func (s *Server) handleInference(w http.ResponseWriter, r *http.Request) {
 		requestID = uuid.New().String()
 	}
 
-	reqCtx := &pipeline.RequestContext{
+	reqCtx = &pipeline.RequestContext{
 		RequestID:        requestID,
 		OriginalPath:     r.URL.Path,
 		OriginalHeaders:  r.Header.Clone(),
@@ -134,7 +149,7 @@ func (s *Server) handleInference(w http.ResponseWriter, r *http.Request) {
 		Model:            model,
 		Stream:           stream,
 		KVTransferParams: make(map[string]any),
-		ResponseWriter:   w,
+		ResponseWriter:   cw,
 		ParseDuration:    parseDuration,
 	}
 
@@ -169,7 +184,22 @@ func (s *Server) handleInference(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		status, msg := classifyPipelineError(err, reqCtx.RequestID)
-		http.Error(w, msg, status)
+		http.Error(cw, msg, status)
+	}
+}
+
+// inferenceRoute maps an inbound path onto the bounded route label used by
+// orchestration_overhead_seconds.
+func inferenceRoute(path string) string {
+	switch path {
+	case gateway.PathChatCompletions:
+		return coordmetrics.RouteChatCompletions
+	case gateway.PathCompletions:
+		return coordmetrics.RouteCompletions
+	case gateway.DefaultGeneratePath:
+		return coordmetrics.RouteGenerate
+	default:
+		return coordmetrics.RouteUnknown
 	}
 }
 

--- a/pkg/coordinator/server/handlers.go
+++ b/pkg/coordinator/server/handlers.go
@@ -86,7 +86,7 @@ func (s *Server) handleInference(w http.ResponseWriter, r *http.Request) {
 			stepDuration = reqCtx.StepDuration
 		}
 		coordmetrics.RecordOrchestrationOverhead(route, time.Since(receivedAt)-parseDuration-stepDuration)
-		coordmetrics.RecordResponseBytes(stream, cw.BytesWritten())
+		coordmetrics.RecordResponseSize(stream, cw.BytesWritten())
 		coordmetrics.DecRequestRunning(inflightModel)
 		if r != nil {
 			panic(r)

--- a/pkg/coordinator/server/handlers_test.go
+++ b/pkg/coordinator/server/handlers_test.go
@@ -742,3 +742,68 @@ func TestRoutesRegistered_MethodMismatchReturns405(t *testing.T) {
 		t.Fatalf("expected 405 for GET on POST-only %s, got %d", gateway.PathChatCompletions, rec.Code)
 	}
 }
+
+func TestHandleInference_RecordsOrchestrationOverheadAndResponseBytes(t *testing.T) {
+	reg := newMetricsRegistry(t)
+	rec := postInference(t, newTestServer(nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	if hc := histogramCount(t, reg, "llm_d_coordinator_orchestration_overhead_seconds", map[string]string{"route": coordmetrics.RouteChatCompletions}); hc != 1 {
+		t.Fatalf("expected 1 orchestration_overhead_seconds observation, got %d", hc)
+	}
+	if hc := histogramCount(t, reg, "llm_d_coordinator_response_bytes", map[string]string{"stream": coordmetrics.StreamFalse}); hc != 1 {
+		t.Fatalf("expected 1 response_bytes observation, got %d", hc)
+	}
+	if hs := histogramSum(t, reg, "llm_d_coordinator_response_bytes", map[string]string{"stream": coordmetrics.StreamFalse}); hs != 0 {
+		t.Fatalf("expected 0 response bytes on a silent success path, got %v", hs)
+	}
+}
+
+func TestHandleInference_ResponseBytesCountsStreamedAndErrorBodies(t *testing.T) {
+	reg := newMetricsRegistry(t)
+	const streamedBody = "partial streamed body"
+	step := stubStep{name: "decode", fn: func(_ context.Context, rc *pipeline.RequestContext) error {
+		_, _ = rc.ResponseWriter.Write([]byte(streamedBody))
+		return &pipeline.UpstreamStreamedError{Step: "decode", StatusCode: http.StatusInternalServerError}
+	}}
+	p := pipeline.New([]pipeline.Step{step})
+	srv, err := New(config.ServerConfig{}, p, gateway.NewWithTransport(nil, stubGatewayURL))
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, gateway.PathChatCompletions, strings.NewReader(`{"model":"m","stream":true}`))
+	rec := httptest.NewRecorder()
+	srv.handleInference(rec, req)
+	require.Equal(t, streamedBody, rec.Body.String())
+
+	if hc := histogramCount(t, reg, "llm_d_coordinator_response_bytes", map[string]string{"stream": coordmetrics.StreamTrue}); hc != 1 {
+		t.Fatalf("expected 1 streaming response_bytes observation, got %d", hc)
+	}
+	if hs := histogramSum(t, reg, "llm_d_coordinator_response_bytes", map[string]string{"stream": coordmetrics.StreamTrue}); hs != float64(len(streamedBody)) {
+		t.Fatalf("expected streamed length %d, got %v", len(streamedBody), hs)
+	}
+}
+
+func TestHandleInference_ErrorPathRecordsResponseBytes(t *testing.T) {
+	reg := newMetricsRegistry(t)
+	req := httptest.NewRequest(http.MethodPost, gateway.PathCompletions, strings.NewReader("not-json"))
+	rec := httptest.NewRecorder()
+	newTestServer(nil).handleInference(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	if hc := histogramCount(t, reg, "llm_d_coordinator_orchestration_overhead_seconds", map[string]string{"route": coordmetrics.RouteCompletions}); hc != 1 {
+		t.Fatalf("expected 1 orchestration_overhead_seconds observation on completions, got %d", hc)
+	}
+	if hc := histogramCount(t, reg, "llm_d_coordinator_response_bytes", map[string]string{"stream": coordmetrics.StreamFalse}); hc != 1 {
+		t.Fatalf("expected 1 response_bytes observation on parse error, got %d", hc)
+	}
+	if hs := histogramSum(t, reg, "llm_d_coordinator_response_bytes", map[string]string{"stream": coordmetrics.StreamFalse}); hs <= 0 {
+		t.Fatalf("expected error body bytes > 0, got %v", hs)
+	}
+}
+
+func TestInferenceRoute(t *testing.T) {
+	require.Equal(t, coordmetrics.RouteChatCompletions, inferenceRoute(gateway.PathChatCompletions))
+	require.Equal(t, coordmetrics.RouteCompletions, inferenceRoute(gateway.PathCompletions))
+	require.Equal(t, coordmetrics.RouteGenerate, inferenceRoute(gateway.DefaultGeneratePath))
+	require.Equal(t, coordmetrics.RouteUnknown, inferenceRoute("/other"))
+}

--- a/pkg/coordinator/server/handlers_test.go
+++ b/pkg/coordinator/server/handlers_test.go
@@ -751,10 +751,10 @@ func TestHandleInference_RecordsOrchestrationOverheadAndResponseBytes(t *testing
 	if hc := histogramCount(t, reg, "llm_d_coordinator_orchestration_overhead_seconds", map[string]string{"route": coordmetrics.RouteChatCompletions}); hc != 1 {
 		t.Fatalf("expected 1 orchestration_overhead_seconds observation, got %d", hc)
 	}
-	if hc := histogramCount(t, reg, "llm_d_coordinator_response_bytes", map[string]string{"stream": coordmetrics.StreamFalse}); hc != 1 {
-		t.Fatalf("expected 1 response_bytes observation, got %d", hc)
+	if hc := histogramCount(t, reg, "llm_d_coordinator_response_size_bytes", map[string]string{"stream": coordmetrics.StreamFalse}); hc != 1 {
+		t.Fatalf("expected 1 response_size_bytes observation, got %d", hc)
 	}
-	if hs := histogramSum(t, reg, "llm_d_coordinator_response_bytes", map[string]string{"stream": coordmetrics.StreamFalse}); hs != 0 {
+	if hs := histogramSum(t, reg, "llm_d_coordinator_response_size_bytes", map[string]string{"stream": coordmetrics.StreamFalse}); hs != 0 {
 		t.Fatalf("expected 0 response bytes on a silent success path, got %v", hs)
 	}
 }
@@ -775,10 +775,10 @@ func TestHandleInference_ResponseBytesCountsStreamedAndErrorBodies(t *testing.T)
 	srv.handleInference(rec, req)
 	require.Equal(t, streamedBody, rec.Body.String())
 
-	if hc := histogramCount(t, reg, "llm_d_coordinator_response_bytes", map[string]string{"stream": coordmetrics.StreamTrue}); hc != 1 {
-		t.Fatalf("expected 1 streaming response_bytes observation, got %d", hc)
+	if hc := histogramCount(t, reg, "llm_d_coordinator_response_size_bytes", map[string]string{"stream": coordmetrics.StreamTrue}); hc != 1 {
+		t.Fatalf("expected 1 streaming response_size_bytes observation, got %d", hc)
 	}
-	if hs := histogramSum(t, reg, "llm_d_coordinator_response_bytes", map[string]string{"stream": coordmetrics.StreamTrue}); hs != float64(len(streamedBody)) {
+	if hs := histogramSum(t, reg, "llm_d_coordinator_response_size_bytes", map[string]string{"stream": coordmetrics.StreamTrue}); hs != float64(len(streamedBody)) {
 		t.Fatalf("expected streamed length %d, got %v", len(streamedBody), hs)
 	}
 }
@@ -793,10 +793,10 @@ func TestHandleInference_ErrorPathRecordsResponseBytes(t *testing.T) {
 	if hc := histogramCount(t, reg, "llm_d_coordinator_orchestration_overhead_seconds", map[string]string{"route": coordmetrics.RouteCompletions}); hc != 1 {
 		t.Fatalf("expected 1 orchestration_overhead_seconds observation on completions, got %d", hc)
 	}
-	if hc := histogramCount(t, reg, "llm_d_coordinator_response_bytes", map[string]string{"stream": coordmetrics.StreamFalse}); hc != 1 {
-		t.Fatalf("expected 1 response_bytes observation on parse error, got %d", hc)
+	if hc := histogramCount(t, reg, "llm_d_coordinator_response_size_bytes", map[string]string{"stream": coordmetrics.StreamFalse}); hc != 1 {
+		t.Fatalf("expected 1 response_size_bytes observation on parse error, got %d", hc)
 	}
-	if hs := histogramSum(t, reg, "llm_d_coordinator_response_bytes", map[string]string{"stream": coordmetrics.StreamFalse}); hs <= 0 {
+	if hs := histogramSum(t, reg, "llm_d_coordinator_response_size_bytes", map[string]string{"stream": coordmetrics.StreamFalse}); hs <= 0 {
 		t.Fatalf("expected error body bytes > 0, got %v", hs)
 	}
 }

--- a/pkg/coordinator/steps/encode.go
+++ b/pkg/coordinator/steps/encode.go
@@ -100,6 +100,8 @@ func (s *EncodeStep) Execute(ctx context.Context, reqCtx *pipeline.RequestContex
 		return nil
 	}
 
+	reqCtx.EncodeFanout = len(reqCtx.MultimodalEntries)
+
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(s.maxParallel)
 

--- a/pkg/coordinator/steps/encode_test.go
+++ b/pkg/coordinator/steps/encode_test.go
@@ -117,6 +117,9 @@ func TestEncodeStep_ParallelFanOut(t *testing.T) {
 	if int(requestCount.Load()) != 3 {
 		t.Fatalf("expected 3 gateway requests, got %d", requestCount.Load())
 	}
+	if reqCtx.EncodeFanout != 3 {
+		t.Fatalf("expected EncodeFanout=3, got %d", reqCtx.EncodeFanout)
+	}
 	if len(reqCtx.ECTransferParams) != 3 {
 		t.Fatalf("expected 3 ec_transfer_params entries, got %d", len(reqCtx.ECTransferParams))
 	}
@@ -237,6 +240,9 @@ func TestEncodeStep_PartialFailure(t *testing.T) {
 	err := step.Execute(context.Background(), reqCtx)
 	if err == nil {
 		t.Fatal("expected error when one encode fails")
+	}
+	if reqCtx.EncodeFanout != 3 {
+		t.Fatalf("expected EncodeFanout=3 on partial failure, got %d", reqCtx.EncodeFanout)
 	}
 }
 
@@ -439,6 +445,9 @@ func TestEncodeStep_TextOnly(t *testing.T) {
 	if gatewayCallCount != 0 {
 		t.Fatalf("expected no gateway calls for text-only request, got %d", gatewayCallCount)
 	}
+	if reqCtx.EncodeFanout != 0 {
+		t.Fatalf("expected EncodeFanout=0 for text-only request, got %d", reqCtx.EncodeFanout)
+	}
 	if reqCtx.ECTransferParams != nil {
 		t.Fatalf("expected nil ECTransferParams for text-only request, got %v", reqCtx.ECTransferParams)
 	}
@@ -477,6 +486,9 @@ func TestEncodeStep_SkipsForGenerate(t *testing.T) {
 	}
 	if gatewayCallCount != 0 {
 		t.Fatalf("expected no gateway calls for generate request, got %d", gatewayCallCount)
+	}
+	if reqCtx.EncodeFanout != 0 {
+		t.Fatalf("expected EncodeFanout=0 for generate skip, got %d", reqCtx.EncodeFanout)
 	}
 	if reqCtx.ECTransferParams != nil {
 		t.Fatalf("expected nil ECTransferParams for generate request, got %v", reqCtx.ECTransferParams)

--- a/pkg/coordinator/steps/render.go
+++ b/pkg/coordinator/steps/render.go
@@ -185,6 +185,8 @@ func (s *RenderStep) executeGenerate(ctx context.Context, reqCtx *pipeline.Reque
 	}
 	reqCtx.MultimodalEntries = entries
 
+	coordmetrics.RecordMediaItems(coordmetrics.MediaTypeImage, len(entries))
+
 	logger.V(logutil.DEFAULT).Info("complete", "token_ids_len", len(tokenIDs), "images", len(entries))
 	return nil
 }

--- a/pkg/coordinator/steps/render_test.go
+++ b/pkg/coordinator/steps/render_test.go
@@ -678,3 +678,35 @@ func TestRenderStep_GenerateFormat_MissingTokenIDs(t *testing.T) {
 		t.Errorf("expected ErrBadRequest, got %v", err)
 	}
 }
+
+func TestRenderStep_GenerateFormat_RecordsMediaItems(t *testing.T) {
+	reg := newStepMetricsRegistry(t)
+	step, err := NewRenderStep(nil, map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reqCtx := &pipeline.RequestContext{
+		OriginalPath: gateway.DefaultGeneratePath,
+		Body: map[string]any{
+			"model":     "test-model",
+			"token_ids": []any{float64(1), float64(32000), float64(32000), float64(3), float64(41000), float64(41000), float64(2)},
+			"features": map[string]any{
+				"mm_hashes": map[string]any{"image": []any{"abc123", "def456"}},
+				"mm_placeholders": map[string]any{"image": []any{
+					map[string]any{"offset": float64(1), "length": float64(2)},
+					map[string]any{"offset": float64(4), "length": float64(2)},
+				}},
+				"kwargs_data": map[string]any{"image": []any{"dGVuc29yMA==", "dGVuc29yMQ=="}},
+			},
+		},
+	}
+	if err := step.Execute(context.Background(), reqCtx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stepHistogramCount(t, reg, "llm_d_coordinator_media_items", map[string]string{"media_type": "image"}) != 1 {
+		t.Fatal("expected 1 media_items observation")
+	}
+	if sum := stepHistogramSum(t, reg, "llm_d_coordinator_media_items", map[string]string{"media_type": "image"}); sum != 2 {
+		t.Fatalf("expected media_items sum 2, got %v", sum)
+	}
+}

--- a/pkg/coordinator/steps/replace_media_urls.go
+++ b/pkg/coordinator/steps/replace_media_urls.go
@@ -175,6 +175,8 @@ func (s *ReplaceMediaURLsStep) Execute(ctx context.Context, reqCtx *pipeline.Req
 		}
 	}
 
+	coordmetrics.RecordMediaItems(coordmetrics.MediaTypeImage, len(imageURLs))
+
 	if len(imageURLs) == 0 {
 		return nil
 	}
@@ -251,7 +253,12 @@ func appendMultimodalEntry(reqCtx *pipeline.RequestContext, contentType, b64 str
 	})
 }
 
-func (s *ReplaceMediaURLsStep) download(ctx context.Context, rawURL string) ([]byte, string, error) {
+func (s *ReplaceMediaURLsStep) download(ctx context.Context, rawURL string) (data []byte, contentType string, err error) {
+	start := time.Now()
+	defer func() {
+		coordmetrics.RecordMediaDownloadDuration(coordmetrics.ClassifyDownloadResult(ctx, err), time.Since(start))
+	}()
+
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, "", fmt.Errorf("invalid URL: %w: %w", err, pipeline.ErrBadRequest)
@@ -284,14 +291,14 @@ func (s *ReplaceMediaURLsStep) download(ctx context.Context, rawURL string) ([]b
 		return nil, "", fmt.Errorf("response too large: Content-Length %d exceeds max %d: %w", resp.ContentLength, s.maxDownloadSize, pipeline.ErrBadRequest)
 	}
 
-	data, err := io.ReadAll(io.LimitReader(resp.Body, s.maxDownloadSize+1))
+	data, err = io.ReadAll(io.LimitReader(resp.Body, s.maxDownloadSize+1))
 	if err != nil {
 		return nil, "", err
 	}
 	if int64(len(data)) > s.maxDownloadSize {
 		return nil, "", fmt.Errorf("response too large: body exceeds max %d: %w", s.maxDownloadSize, pipeline.ErrBadRequest)
 	}
-	contentType := resp.Header.Get("Content-Type")
+	contentType = resp.Header.Get("Content-Type")
 	if contentType == "" {
 		contentType = defaultContentType
 	}

--- a/pkg/coordinator/steps/replace_media_urls_test.go
+++ b/pkg/coordinator/steps/replace_media_urls_test.go
@@ -28,7 +28,11 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
 	"github.com/llm-d/llm-d-router/pkg/coordinator/config"
+	coordmetrics "github.com/llm-d/llm-d-router/pkg/coordinator/metrics"
 	"github.com/llm-d/llm-d-router/pkg/coordinator/pipeline"
 )
 
@@ -1136,4 +1140,218 @@ func TestReplaceMediaURLsStep_CancelledContextSkipsDataURIParse(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
+}
+
+func newStepMetricsRegistry(t *testing.T) *prometheus.Registry {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	require.NoError(t, coordmetrics.Register(reg))
+	coordmetrics.Reset()
+	return reg
+}
+
+func stepHistogramCount(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) uint64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			got := map[string]string{}
+			for _, l := range m.GetLabel() {
+				got[l.GetName()] = l.GetValue()
+			}
+			match := true
+			for k, v := range labels {
+				if got[k] != v {
+					match = false
+					break
+				}
+			}
+			if match {
+				return m.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	return 0
+}
+
+func stepHistogramSum(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) float64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			got := map[string]string{}
+			for _, l := range m.GetLabel() {
+				got[l.GetName()] = l.GetValue()
+			}
+			match := true
+			for k, v := range labels {
+				if got[k] != v {
+					match = false
+					break
+				}
+			}
+			if match {
+				return m.GetHistogram().GetSampleSum()
+			}
+		}
+	}
+	return 0
+}
+
+func TestReplaceMediaURLsStep_RecordsMediaItemsAndDownloadSuccess(t *testing.T) {
+	reg := newStepMetricsRegistry(t)
+	imageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte("jpeg-bytes"))
+	}))
+	defer imageServer.Close()
+
+	step := newLoopbackStep(t, map[string]any{"download_timeout": "5s"})
+	reqCtx := &pipeline.RequestContext{
+		Body: map[string]any{
+			"messages": []any{
+				map[string]any{
+					"role": "user",
+					"content": []any{
+						map[string]any{"type": "text", "text": "describe this"},
+						map[string]any{
+							"type":      "image_url",
+							"image_url": map[string]any{"url": imageServer.URL + "/photo.jpg"},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := step.Execute(context.Background(), reqCtx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	require.Equal(t, uint64(1), stepHistogramCount(t, reg, "llm_d_coordinator_media_items", map[string]string{"media_type": coordmetrics.MediaTypeImage}))
+	require.InDelta(t, 1.0, stepHistogramSum(t, reg, "llm_d_coordinator_media_items", map[string]string{"media_type": coordmetrics.MediaTypeImage}), 1e-9)
+	require.Equal(t, uint64(1), stepHistogramCount(t, reg, "llm_d_coordinator_media_download_duration_seconds", map[string]string{"result": coordmetrics.DownloadResultSuccess}))
+}
+
+func TestReplaceMediaURLsStep_RecordsDownloadError(t *testing.T) {
+	reg := newStepMetricsRegistry(t)
+	imageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer imageServer.Close()
+
+	step := newLoopbackStep(t, map[string]any{"download_timeout": "5s"})
+	reqCtx := &pipeline.RequestContext{
+		Body: map[string]any{
+			"messages": []any{
+				map[string]any{
+					"role": "user",
+					"content": []any{
+						map[string]any{
+							"type":      "image_url",
+							"image_url": map[string]any{"url": imageServer.URL + "/photo.jpg"},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := step.Execute(context.Background(), reqCtx); err == nil {
+		t.Fatal("expected download error")
+	}
+	require.Equal(t, uint64(1), stepHistogramCount(t, reg, "llm_d_coordinator_media_items", map[string]string{"media_type": coordmetrics.MediaTypeImage}))
+	require.Equal(t, uint64(1), stepHistogramCount(t, reg, "llm_d_coordinator_media_download_duration_seconds", map[string]string{"result": coordmetrics.DownloadResultError}))
+}
+
+func TestReplaceMediaURLsStep_RecordsDownloadCancelled(t *testing.T) {
+	reg := newStepMetricsRegistry(t)
+	started := make(chan struct{})
+	block := make(chan struct{})
+	imageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-block
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer imageServer.Close()
+
+	step := newLoopbackStep(t, map[string]any{"download_timeout": "5s"})
+	ctx, cancel := context.WithCancel(context.Background())
+	reqCtx := &pipeline.RequestContext{
+		Body: map[string]any{
+			"messages": []any{
+				map[string]any{
+					"role": "user",
+					"content": []any{
+						map[string]any{
+							"type":      "image_url",
+							"image_url": map[string]any{"url": imageServer.URL + "/photo.jpg"},
+						},
+					},
+				},
+			},
+		},
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- step.Execute(ctx, reqCtx)
+	}()
+	<-started
+	cancel()
+	err := <-done
+	close(block)
+	if err == nil {
+		t.Fatal("expected cancellation error")
+	}
+	require.Equal(t, uint64(1), stepHistogramCount(t, reg, "llm_d_coordinator_media_download_duration_seconds", map[string]string{"result": coordmetrics.DownloadResultCancelled}))
+}
+
+func TestReplaceMediaURLsStep_DataURIDoesNotRecordDownloadDuration(t *testing.T) {
+	reg := newStepMetricsRegistry(t)
+	step, _ := NewReplaceMediaURLsStep(nil, map[string]any{})
+	reqCtx := &pipeline.RequestContext{
+		Body: map[string]any{
+			"messages": []any{
+				map[string]any{
+					"role": "user",
+					"content": []any{
+						map[string]any{
+							"type":      "image_url",
+							"image_url": map[string]any{"url": "data:image/png;base64,AAAA"},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := step.Execute(context.Background(), reqCtx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	require.Equal(t, uint64(1), stepHistogramCount(t, reg, "llm_d_coordinator_media_items", map[string]string{"media_type": coordmetrics.MediaTypeImage}))
+	require.Zero(t, stepHistogramCount(t, reg, "llm_d_coordinator_media_download_duration_seconds", map[string]string{"result": coordmetrics.DownloadResultSuccess}))
+}
+
+func TestReplaceMediaURLsStep_NoImagesRecordsZero(t *testing.T) {
+	reg := newStepMetricsRegistry(t)
+	step, _ := NewReplaceMediaURLsStep(nil, map[string]any{})
+	reqCtx := &pipeline.RequestContext{
+		Body: map[string]any{
+			"messages": []any{
+				map[string]any{
+					"role":    "user",
+					"content": []any{map[string]any{"type": "text", "text": "hi"}},
+				},
+			},
+		},
+	}
+	if err := step.Execute(context.Background(), reqCtx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	require.Equal(t, uint64(1), stepHistogramCount(t, reg, "llm_d_coordinator_media_items", map[string]string{"media_type": coordmetrics.MediaTypeImage}))
+	require.InDelta(t, 0.0, stepHistogramSum(t, reg, "llm_d_coordinator_media_items", map[string]string{"media_type": coordmetrics.MediaTypeImage}), 1e-9)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Extends the native Coordinator Prometheus instrumentation from #2435 with the pipeline amplification and media metrics scoped in #2482. Reuses the same `llm_d_coordinator` registry, `/metrics` endpoint, record helpers, and cardinality-bounded labels. Does not duplicate series already covered by #2435 (`request_*`, `step_*`, `upstream_*`, `execution_path_total`, etc.).

Adds five histograms:
- `llm_d_coordinator_encode_fanout_size` — Encode subrequests per client request (including 0)
- `llm_d_coordinator_orchestration_overhead_seconds{route}` — wall time outside parse + pipeline steps
- `llm_d_coordinator_media_items{media_type}` — media count per bounded type
- `llm_d_coordinator_media_download_duration_seconds{result}` — per HTTP download attempt
- `llm_d_coordinator_response_bytes{stream}` — bytes written to the client, including partial writes

**Which issue(s) this PR fixes**:
Fixes #2482
Part of #2276

**Release note**:
```release-note
Coordinator Prometheus metrics now include encode fan-out size, orchestration overhead, media item counts, media download duration, and response bytes written to the client.
```

## Test plan
- [x] Unit tests for the five new histograms and observation points (metrics, pipeline, handlers, encode, replace-media-urls, render)
- [x] Local smoke against mock gateway/media: scrape `/metrics` and confirm all five series have samples under mixed text/image traffic
