### PR TITLE
fix(metrics): read SGLang cache capacity from dedicated gauges

### DIFF
--- a/docs/plugin-metric-protocol.md
+++ b/docs/plugin-metric-protocol.md
@@ -67,7 +67,7 @@ If absent, the value is taken from the `approximate-prefix` plugin's `BlockSizeT
 | Model server | Metric | Label |
 | --- | --- | --- |
 | vLLM | `vllm:cache_config_info` | `block_size` |
-| SGLang | `sglang:cache_config_info` | `page_size` |
+| SGLang | `sglang:page_size` | — |
 | Triton TensorRT-LLM | `nv_trt_llm_kv_cache_block_metrics{kv_cache_block_type=tokens_per}` | — |
 | trtllm-serve | `trtllm_kv_cache_tokens_per_block` | — |
 
@@ -82,7 +82,7 @@ If absent, the value is taken from the `approximate-prefix` plugin's `LRUCapacit
 | Model server | Metric | Label |
 | --- | --- | --- |
 | vLLM | `vllm:cache_config_info` | `num_gpu_blocks` |
-| SGLang | `sglang:cache_config_info` | `num_pages` |
+| SGLang | `sglang:num_pages` | — |
 | Triton TensorRT-LLM | `nv_trt_llm_kv_cache_block_metrics{kv_cache_block_type=max}` | — |
 | trtllm-serve | `trtllm_kv_cache_max_blocks` | — |
 

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor.go
@@ -269,8 +269,8 @@ func populateLoRAMetrics(clone *fwkdl.Metrics, metric *dto.Metric, errs *[]error
 }
 
 // populateCacheInfoMetrics updates the metrics with cache info from the metric labels.
-// blockSizeLabelName and numBlocksLabelName allow engines to use different label names
-// (e.g. SGLang uses "page_size" and "num_pages" instead of "block_size" and "num_gpu_blocks").
+// blockSizeLabelName and numBlocksLabelName allow engines to carry the values under
+// label names other than "block_size" and "num_gpu_blocks".
 func populateCacheInfoMetrics(clone *fwkdl.Metrics, metric *dto.Metric, blockSizeLabelName, numBlocksLabelName string, errs *[]error) {
 	clone.CacheBlockSize = 0
 	clone.CachePrefixMatchUnit = 0

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/extractor_test.go
@@ -307,13 +307,15 @@ func TestBackwardCompatibility(t *testing.T) {
 func TestCacheInfoLabelAliasing(t *testing.T) {
 	ctx := context.Background()
 
-	// SGLang uses "page_size" and "num_pages" instead of "block_size" and "num_gpu_blocks"
+	// An engine config aliases the cache-info label names when the engine
+	// carries block size and block count under something other than
+	// "block_size" and "num_gpu_blocks".
 	registry := NewMappingRegistry()
 	mapping, err := NewMappingFromConfig(MappingConfig{
-		Queue:               "sglang:num_queue_reqs",
-		Running:             "sglang:num_running_reqs",
-		KVUsage:             "sglang:token_usage",
-		CacheInfo:           "sglang:cache_config_info",
+		Queue:               "myengine:num_queue_reqs",
+		Running:             "myengine:num_running_reqs",
+		KVUsage:             "myengine:token_usage",
+		CacheInfo:           "myengine:cache_config_info",
 		CacheBlockSizeLabel: "page_size",
 		CacheNumBlocksLabel: "num_pages",
 	})
@@ -327,7 +329,7 @@ func TestCacheInfoLabelAliasing(t *testing.T) {
 	extractor, _ := NewCoreMetricsExtractor(registry, "")
 
 	data := sourcemetrics.PrometheusMetricMap{
-		"sglang:cache_config_info": &dto.MetricFamily{
+		"myengine:cache_config_info": &dto.MetricFamily{
 			Type: dto.MetricType_GAUGE.Enum(),
 			Metric: []*dto.Metric{
 				{

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/factories.go
@@ -56,10 +56,10 @@ type (
 		// Defaults to "num_gpu_blocks" if empty.
 		CacheNumBlocksLabelName string `json:"cacheNumBlocksLabelName,omitempty"`
 		// CacheBlockSizeSpec defines the metric specification string for retrieving block size directly
-		// as a gauge value (alternative to CacheInfoSpec labels). Used by engines like Triton TRT-LLM.
+		// as a gauge value (alternative to CacheInfoSpec labels).
 		CacheBlockSizeSpec string `json:"cacheBlockSizeSpec,omitempty"`
 		// CacheNumBlocksSpec defines the metric specification string for retrieving num GPU blocks directly
-		// as a gauge value (alternative to CacheInfoSpec labels). Used by engines like Triton TRT-LLM.
+		// as a gauge value (alternative to CacheInfoSpec labels).
 		CacheNumBlocksSpec string `json:"cacheNumBlocksSpec,omitempty"`
 		// CustomMetrics defines engine-specific scalar metrics to extract as endpoint attributes.
 		CustomMetrics []customMetricConfigParams `json:"customMetrics,omitempty"`
@@ -97,14 +97,14 @@ var defaultEngineConfigs = []engineConfigParams{
 		CacheInfoSpec:       "vllm:cache_config_info",
 	},
 	{
-		Name:                    "sglang",
-		QueuedRequestsSpec:      "sglang:num_queue_reqs",
-		RunningRequestsSpec:     "sglang:num_running_reqs",
-		KVUsageSpec:             "sglang:token_usage",
-		LoRASpec:                "",
-		CacheInfoSpec:           "sglang:cache_config_info",
-		CacheBlockSizeLabelName: "page_size",
-		CacheNumBlocksLabelName: "num_pages",
+		Name:                "sglang",
+		QueuedRequestsSpec:  "sglang:num_queue_reqs",
+		RunningRequestsSpec: "sglang:num_running_reqs",
+		KVUsageSpec:         "sglang:token_usage",
+		LoRASpec:            "",
+		CacheInfoSpec:       "",
+		CacheBlockSizeSpec:  "sglang:page_size",
+		CacheNumBlocksSpec:  "sglang:num_pages",
 	},
 	{
 		Name:                "trtllm-serve",

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/mapping.go
@@ -30,7 +30,7 @@ type Mapping struct {
 	KVCacheUtilization   *Spec
 	LoraRequestInfo      *LoRASpec
 	// CacheInfo is used for info-style gauge metrics where block_size and
-	// num_gpu_blocks are exposed as label values (e.g. vLLM, trtllm-serve, SGLang).
+	// num_gpu_blocks are exposed as label values.
 	CacheInfo *Spec
 	// CacheBlockSizeLabel and CacheNumBlocksLabel allow engines to use different
 	// label names for the CacheInfo metric. If empty, defaults to "block_size"
@@ -38,8 +38,7 @@ type Mapping struct {
 	CacheBlockSizeLabel string
 	CacheNumBlocksLabel string
 	// CacheBlockSize and CacheNumBlocks are used for engines that expose cache
-	// config as separate gauge values rather than labels on an info metric
-	// (e.g. Triton TRT-LLM).
+	// config as separate gauge values rather than labels on an info metric.
 	CacheBlockSize *Spec
 	CacheNumBlocks *Spec
 	CustomMetrics  []CustomMetric

--- a/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
+++ b/pkg/epp/framework/plugins/datalayer/extractor/metrics/metrics_extraction_from_config_test.go
@@ -545,3 +545,40 @@ func TestMetricsExtractionMultipleExtractors(t *testing.T) {
 	assert.Equal(t, 8, mB.MaxActiveModels, "extractor B: MaxActiveModels")
 	assert.Contains(t, mB.ActiveModels, "adapter-x", "extractor B: ActiveModels")
 }
+
+// TestMetricsExtractionSGLangDefaultConfig verifies that the built-in SGLang
+// engine config reads cache capacity from the dedicated sglang:page_size and
+// sglang:num_pages gauges, and that a payload carrying no cache-config info
+// gauge extracts without error.
+func TestMetricsExtractionSGLangDefaultConfig(t *testing.T) {
+	srv := createMockServer([]MetricMock{
+		{Name: "sglang:num_queue_reqs", Value: 6},
+		{Name: "sglang:num_running_reqs", Value: 2},
+		{Name: "sglang:token_usage", Value: 0.42},
+		{Name: "sglang:page_size", Value: 64},
+		{Name: "sglang:num_pages", Value: 11147},
+	})
+	defer srv.Close()
+
+	p, err := buildPipeline(t, srv.URL, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ep := newEndpointAt(mustHost(t, srv.URL), map[string]string{
+		DefaultEngineTypeLabelKey: "sglang",
+	})
+
+	// Drive Poll + Extract directly: the dispatcher swallows extractor errors
+	// into DataLayerExtractErrorsTotal, and a spurious per-scrape error is
+	// part of what this test guards against.
+	data, err := p.source.Poll(ctx, ep)
+	require.NoError(t, err)
+	require.NoError(t, p.ext.Extract(ctx, fwkdl.PollInput[sourcemetrics.PrometheusMetricMap]{Payload: data, Endpoint: ep}))
+
+	m := ep.GetMetrics()
+	assert.Equal(t, 6, m.WaitingQueueSize, "WaitingQueueSize")
+	assert.Equal(t, 2, m.RunningRequestsSize, "RunningRequestsSize")
+	assert.InDelta(t, 0.42, m.KVCacheUsagePercent, 0.001, "KVCacheUsagePercent")
+	assert.Equal(t, 64, m.CacheBlockSize, "CacheBlockSize")
+	assert.Equal(t, 11147, m.CacheNumBlocks, "CacheNumBlocks")
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

SGLang exposes KV cache capacity as two dedicated gauges: `sglang:page_size` ("KV cache page size in tokens") and `sglang:num_pages` ("Number of KV cache pages"). The built-in `sglang` engine config instead reads both from labels on
`sglang:cache_config_info`, a metric SGLang does not emit; sgl-project/sglang#24197 replaced that info gauge with the dedicated ones.

On an SGLang pool this has two effects:

- `CacheBlockSize` and `CacheNumBlocks` stay at 0, so `approximate-prefix` auto-tuning falls back to the configured `BlockSizeTokens` and `LRUCapacityPerServer` rather than sizing the index from the endpoint.
- Every scrape of every SGLang endpoint fails with `metric family "sglang:cache_config_info" not found`, which increments `datalayer_extract_errors_total` and logs at DEBUG. The counter is keyed by source and extractor type with no metric name, so this pins it non-zero and masks unrelated extraction failures.

The `sglang` config now reads the two gauges through the existing `cacheBlockSizeSpec` / `cacheNumBlocksSpec` direct-gauge path, which `trtllm-serve` and `triton-tensorrt-llm` already use, and leaves `cacheInfoSpec` empty. No new extraction plumbing.

Declaring `cacheInfoSpec` alongside the gauges would keep both metric shapes working, but the absent family would then bump `datalayer_extract_errors_total` on every scrape against either SGLang version, so the built-in config targets the emitted metrics only. An operator running a build that still emits `sglang:cache_config_info` can restore the label mapping with an `engineConfigs` entry named `sglang`, which replaces the built-in one wholesale:

```yaml
type: core-metrics-extractor
parameters:
  engineConfigs:
    - name: "sglang"
      queuedRequestsSpec: "sglang:num_queue_reqs"
      runningRequestsSpec: "sglang:num_running_reqs"
      kvUsageSpec: "sglang:token_usage"
      loraSpec: ""
      cacheInfoSpec: "sglang:cache_config_info"
      cacheBlockSizeLabelName: "page_size"
      cacheNumBlocksLabelName: "num_pages"
```

**Which issue(s) this PR fixes**:

Fixes #2294

**Test plan**:

- [x] Added coverage for the built-in SGLang engine config reading cache block size and block count from the dedicated gauges, and extracting without error when no cache-config info gauge is present. The test fails on the previous mapping with `metric family "sglang:cache_config_info" not found`.
- [x] `make test-unit-epp`
- [x] `make lint`
- [x] Verified on a kind cluster against an endpoint labeled `llm-d.ai/engine-type: sglang` serving the current SGLang metric set: the EPP records `CacheBlockSize: 64` and `CacheNumBlocks: 11147` from `sglang:page_size` and `sglang:num_pages`, and `datalayer_extract_errors_total` stays unset where the previous mapping incremented it on every scrape. vLLM endpoints on the same pool continue to resolve cache capacity from `vllm:cache_config_info` labels.

**Release note**:

```release-note
Fix KV cache capacity metadata for SGLang endpoints, which is read from the `sglang:page_size` and `sglang:num_pages` metrics. Current SGLang releases do not emit `sglang:cache_config_info`, so approximate prefix cache auto-tuning fell back to its configured defaults and each scrape of an SGLang endpoint recorded a data layer extraction error.
```
