### PR TITLE
feat(helm): support structured plugin config

### DIFF
--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -103,7 +103,7 @@ Since both charts use `routerlib` under the hood, all configurations and customi
 
 ### 1. EPP Core Configuration
 
-Core settings for the Endpoint Picker Proxy (EPP) container and pod, including scaling, images, command-line flags, custom environment variables, resources, and custom plugins configuration (`pluginsCustomConfig`).
+Core settings for the Endpoint Picker Proxy (EPP) container and pod, including scaling, images, command-line flags, custom environment variables, resources, and plugins configuration.
 
 > [!NOTE]
 > **High Availability (HA) Modes**:
@@ -132,7 +132,8 @@ Core settings for the Endpoint Picker Proxy (EPP) container and pod, including s
 | `router.epp.tolerations` | Tolerations for EPP pods. | `[]` |
 | `router.epp.resources` | EPP container resource requests and limits. | `requests.cpu: "8"`, `requests.memory: 8Gi`, `limits.memory: 16Gi` |
 | `router.epp.pluginsConfigFile` | EPP plugins configuration file name. | `default-plugins.yaml` |
-| `router.epp.pluginsCustomConfig` | Inline custom YAML configuration for EPP plugins. | `{}` |
+| `router.epp.pluginsConfig` | Structured EPP configuration rendered into `pluginsConfigFile`. | `{}` |
+| `router.epp.pluginsCustomConfig` | Additional raw ConfigMap entries keyed by file name. | `{}` |
 | `router.epp.volumes` | Extra volumes for EPP pod. | `[]` |
 | `router.epp.volumeMounts` | Extra volume mounts for EPP container. | `[]` |
 
@@ -206,6 +207,53 @@ router:
     - name: model-volume
       emptyDir: {}
 ```
+
+#### Structured Plugins Configuration
+
+Use `router.epp.pluginsConfig` to share an EPP configuration across Helm values files.
+It provides the complete contents of `pluginsConfigFile`; it does not inherit plugins
+from the chart's built-in configurations. An empty map leaves the built-in files unchanged.
+
+For example, `base-values.yaml` defines the plugins and scheduling profiles:
+
+```yaml
+router:
+  modelServers:
+    matchLabels:
+      app: vllm
+  epp:
+    pluginsConfigFile: custom-plugins.yaml
+    pluginsConfig:
+      apiVersion: llm-d.ai/v1alpha1
+      kind: EndpointPickerConfig
+      plugins:
+        - type: queue-scorer
+      schedulingProfiles:
+        - name: default
+          plugins:
+            - pluginRef: queue-scorer
+```
+
+An overlay, `feature-gates.yaml`, sets the feature gates:
+
+```yaml
+router:
+  epp:
+    pluginsConfig:
+      featureGates:
+        - flowControl
+```
+
+```shell
+helm template router config/charts/llm-d-router-gateway \
+  -f base-values.yaml -f feature-gates.yaml
+```
+
+Helm merges maps across values files and replaces lists as a whole. The overlay
+preserves the base plugins and profiles, but replaces any base `featureGates` list.
+YAML comments are not retained in the rendered structured configuration.
+`pluginsCustomConfig` can provide other raw configuration files alongside it.
+Defining the same filename through both settings is an error.
 
 ---
 

--- a/config/charts/routerlib/templates/_config.yaml
+++ b/config/charts/routerlib/templates/_config.yaml
@@ -1,10 +1,20 @@
 {{- define "llm-d-epp.config" -}}
+{{- $pluginsConfig := .Values.router.epp.pluginsConfig | default dict }}
+{{- if not (kindIs "map" $pluginsConfig) }}
+{{- fail "router.epp.pluginsConfig must be a map" }}
+{{- end }}
+{{- $pluginsConfigFile := .Values.router.epp.pluginsConfigFile | default "default-plugins.yaml" }}
+{{- $pluginsCustomConfig := .Values.router.epp.pluginsCustomConfig | default dict }}
+{{- if and $pluginsConfig (hasKey $pluginsCustomConfig $pluginsConfigFile) }}
+{{- fail (printf "router.epp.pluginsConfig and router.epp.pluginsCustomConfig cannot both define %q" $pluginsConfigFile) }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "llm-d-router.name" . }}
   namespace: {{ .Release.Namespace }}
 data:
+  {{- if or (not $pluginsConfig) (ne $pluginsConfigFile "default-plugins.yaml") }}
   default-plugins.yaml: |
     {{- $modelServerProtocol := .Values.router.modelServers.protocol | default "http" }}
     {{- $modelServerType := .Values.router.modelServers.type | default "vllm" }}
@@ -86,6 +96,8 @@ data:
       - pluginRef: {{ $p }}
       {{- end }}
     {{- end }}
+  {{- end }}
+  {{- if or (not $pluginsConfig) (ne $pluginsConfigFile "payload-agnostic.yaml") }}
   payload-agnostic.yaml: |
     # Request-format agnostic routing. Use this when the request format is
     # unknown or unsupported, so the EPP cannot rely on scorers that read the
@@ -110,8 +122,13 @@ data:
         weight: 1
       - pluginRef: session-affinity-scorer
         weight: 1
-  {{- if .Values.router.epp.pluginsCustomConfig }}
-  {{- .Values.router.epp.pluginsCustomConfig | toYaml | nindent 2 }}
+  {{- end }}
+  {{- if $pluginsConfig }}
+  {{ $pluginsConfigFile | quote }}: |
+  {{- $pluginsConfig | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $pluginsCustomConfig }}
+  {{- $pluginsCustomConfig | toYaml | nindent 2 }}
   {{- end }}
   
 ---

--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -37,6 +37,10 @@ epp:
   env: []
   
   pluginsConfigFile: "default-plugins.yaml"
+  # Structured EPP configuration rendered into pluginsConfigFile. Maps merge
+  # across values files; lists are replaced according to Helm's merge rules.
+  pluginsConfig: {}
+  # Additional raw ConfigMap entries keyed by file name.
   pluginsCustomConfig: {}
   
   # Define additional container ports

--- a/hack/testdata/plugins-config-base.yaml
+++ b/hack/testdata/plugins-config-base.yaml
@@ -1,0 +1,22 @@
+router:
+  modelServers:
+    matchLabels:
+      app: llm-instance-gateway
+  epp:
+    pluginsConfigFile: structured-plugins.yaml
+    pluginsCustomConfig:
+      extra-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+    pluginsConfig:
+      apiVersion: llm-d.ai/v1alpha1
+      kind: EndpointPickerConfig
+      featureGates:
+        - flowControl=false
+      plugins:
+        - type: queue-scorer
+        - type: kv-cache-utilization-scorer
+      schedulingProfiles:
+        - name: default
+          plugins:
+            - pluginRef: queue-scorer

--- a/hack/testdata/plugins-config-expected.yaml
+++ b/hack/testdata/plugins-config-expected.yaml
@@ -1,0 +1,11 @@
+apiVersion: llm-d.ai/v1alpha1
+featureGates:
+- flowControl
+kind: EndpointPickerConfig
+plugins:
+- type: queue-scorer
+- type: kv-cache-utilization-scorer
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: queue-scorer

--- a/hack/testdata/plugins-config-overlay.yaml
+++ b/hack/testdata/plugins-config-overlay.yaml
@@ -1,0 +1,5 @@
+router:
+  epp:
+    pluginsConfig:
+      featureGates:
+        - flowControl

--- a/hack/verify-helm.sh
+++ b/hack/verify-helm.sh
@@ -236,6 +236,11 @@ if ! grep -q -- '--secure-serving=false' "${flag_render_output}"; then
   exit 1
 fi
 
+if ! HELM="${HELM}" bash "${SCRIPT_ROOT}/hack/verify-plugins-config.sh"; then
+  echo "Structured plugins configuration validation failed"
+  exit 1
+fi
+
 echo "Verifying llm-d-router-standalone agentgateway renders plaintext EPP and custom listener ports..."
 agentgateway_render_output="${TEMP_DIR}/llm-d-router-standalone-agentgateway-render.yaml"
 agentgateway_render_command="${HELM} template ${SCRIPT_ROOT}/config/charts/llm-d-router-standalone --set router.proxy.proxyType=agentgateway --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set 'router.modelServers.targetPorts[0].number=8000' --set 'router.extraServicePorts[0].name=http' --set 'router.extraServicePorts[0].port=9000' --set 'router.extraServicePorts[0].protocol=TCP' --set 'router.extraServicePorts[0].targetPort=http' > ${agentgateway_render_output}"

--- a/hack/verify-plugins-config.sh
+++ b/hack/verify-plugins-config.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+HELM="${HELM:-${SCRIPT_ROOT}/bin/helm}"
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TEMP_DIR}"' EXIT
+
+# Compare the selected ConfigMap literal, excluding the other plugin files.
+extract_config() {
+  local file=$1 key=$2
+  awk -v key="${key}" '
+    $0 == "  " key ": |" || $0 == "  \"" key "\": |" { found++; active=1; next }
+    active && /^    / { sub(/^    /, ""); print; next }
+    active { active=0 }
+    END {
+      if (found != 1) {
+        print "Expected one ConfigMap entry for " key ", found " (found+0) > "/dev/stderr"
+        exit 1
+      }
+    }
+  ' "${file}"
+}
+
+assert_config_equal() {
+  extract_config "$1" "$3" > "${TEMP_DIR}/expected.yaml"
+  extract_config "$2" "$3" > "${TEMP_DIR}/actual.yaml"
+  diff -u "${TEMP_DIR}/expected.yaml" "${TEMP_DIR}/actual.yaml"
+}
+
+for chart in llm-d-router-gateway llm-d-router-standalone; do
+  echo "Verifying structured plugins configuration for ${chart}..."
+  chart_path="${SCRIPT_ROOT}/config/charts/${chart}"
+  args=(--set router.modelServers.matchLabels.app=llm-instance-gateway)
+  if [[ ${chart} == llm-d-router-standalone ]]; then
+    args+=(--set router.inferencePool.create=false)
+  fi
+  "${HELM}" dependency build "${chart_path}"
+  baseline="${TEMP_DIR}/${chart}-baseline.yaml"
+  output="${TEMP_DIR}/${chart}-render.yaml"
+  "${HELM}" template plugins-test "${chart_path}" "${args[@]}" > "${baseline}"
+
+  for empty in '{}' null; do
+    "${HELM}" template plugins-test "${chart_path}" "${args[@]}" \
+      --set-json "router.epp.pluginsConfig=${empty}" > "${output}"
+    diff -u "${baseline}" "${output}"
+  done
+
+  values=(-f "${SCRIPT_ROOT}/hack/testdata/plugins-config-base.yaml"
+          -f "${SCRIPT_ROOT}/hack/testdata/plugins-config-overlay.yaml")
+  for filename in structured-plugins.yaml default-plugins.yaml payload-agnostic.yaml; do
+    "${HELM}" template plugins-test "${chart_path}" "${values[@]}" "${args[@]}" \
+      --set "router.epp.pluginsConfigFile=${filename}" > "${output}"
+    extract_config "${output}" "${filename}" > "${TEMP_DIR}/actual.yaml"
+    diff -u "${SCRIPT_ROOT}/hack/testdata/plugins-config-expected.yaml" "${TEMP_DIR}/actual.yaml"
+    grep -Fq -- "\"/config/${filename}\"" "${output}"
+    extract_config "${output}" extra-plugins.yaml > "${TEMP_DIR}/raw.yaml"
+    diff -u <(printf 'apiVersion: llm-d.ai/v1alpha1\nkind: EndpointPickerConfig\n') "${TEMP_DIR}/raw.yaml"
+    for builtin in default-plugins.yaml payload-agnostic.yaml; do
+      if [[ ${filename} != "${builtin}" ]]; then
+        assert_config_equal "${baseline}" "${output}" "${builtin}"
+      fi
+    done
+
+    if "${HELM}" template plugins-test "${chart_path}" "${values[@]}" "${args[@]}" \
+      --set "router.epp.pluginsConfigFile=${filename}" \
+      --set-string "router.epp.pluginsCustomConfig.${filename//./\\.}=conflict" \
+      > "${output}" 2> "${TEMP_DIR}/error.log"; then
+      echo "Accepted conflicting pluginsConfig and pluginsCustomConfig for ${filename}"
+      exit 1
+    fi
+    grep -Fq -- "router.epp.pluginsConfig and router.epp.pluginsCustomConfig cannot both define \"${filename}\"" "${TEMP_DIR}/error.log"
+  done
+
+  "${HELM}" template plugins-test "${chart_path}" "${values[@]}" "${args[@]}" \
+    --set-json 'router.epp.pluginsConfig.plugins=[{"type":"queue-scorer"}]' > "${output}"
+  extract_config "${output}" structured-plugins.yaml > "${TEMP_DIR}/actual.yaml"
+  grep -Fxq -- '- type: queue-scorer' "${TEMP_DIR}/actual.yaml"
+  if grep -Fq -- 'kv-cache-utilization-scorer' "${TEMP_DIR}/actual.yaml"; then
+    echo "Plugin lists were merged instead of replaced"
+    exit 1
+  fi
+
+  "${HELM}" template plugins-test "${chart_path}" "${values[@]}" "${args[@]}" \
+    --set router.epp.pluginsConfig=null \
+    --set router.epp.pluginsConfigFile=extra-plugins.yaml > "${output}"
+  for builtin in default-plugins.yaml payload-agnostic.yaml; do
+    assert_config_equal "${baseline}" "${output}" "${builtin}"
+  done
+  extract_config "${output}" extra-plugins.yaml > "${TEMP_DIR}/raw.yaml"
+  diff -u <(printf 'apiVersion: llm-d.ai/v1alpha1\nkind: EndpointPickerConfig\n') "${TEMP_DIR}/raw.yaml"
+  grep -Fq -- '"/config/extra-plugins.yaml"' "${output}"
+
+  for invalid in '"raw YAML"' '[{"type":"queue-scorer"}]'; do
+    if "${HELM}" template plugins-test "${chart_path}" "${args[@]}" \
+      --set-json "router.epp.pluginsConfig=${invalid}" > "${output}" 2> "${TEMP_DIR}/error.log"; then
+      echo "Accepted non-map pluginsConfig: ${invalid}"
+      exit 1
+    fi
+    grep -Fq -- 'router.epp.pluginsConfig must be a map' "${TEMP_DIR}/error.log"
+  done
+  echo "Structured plugins configuration checks passed for ${chart}."
+done


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Implements option (b) from #2358. `router.epp.pluginsConfig` accepts a structured EPP configuration and renders it into `pluginsConfigFile`. A feature-gate overlay can share the plugins and scheduling profiles defined in a base values file.

An empty configuration preserves the built-in files. Existing `pluginsCustomConfig` entries remain supported; using both settings for the same filename produces an error. The documentation explains that structured configuration supplies a complete file and that Helm replaces lists when merging values files.

The chart regression checks run for both the gateway and standalone variants:

- [x] A feature-gate overlay preserves base plugins and scheduling profiles; list overrides replace the base list.
- [x] Custom and built-in filenames produce one configuration entry and match the EPP configuration-file argument.
- [x] Empty configuration and raw custom files preserve the built-in output.
- [x] Conflicting filenames and non-map structured configuration produce errors.

Validation: `make verify-helm-charts`, strict Helm lint with subcharts, `make presubmit`, and `go test -race -count=1 ./pkg/epp/config/loader` passed with Go 1.26.7. Presubmit ran inside the prepared builder container with `BUILDER_RUN="sh -c"` and `-o image-build-builder` to avoid nesting builder containers. Eight legacy rendering cases matched upstream byte-for-byte. The regression failed on unmodified upstream before passing with the feature.

**Which issue(s) this PR fixes**:

Fixes #2358. Option (a) was merged in #2388.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The Helm charts support router.epp.pluginsConfig for structured EPP configuration that can be layered across Helm values files.
```
