### PR TITLE
fix(lora-affinity): correct ActiveModels docs and remove wrong capacity

### DIFF
--- a/pkg/epp/framework/interface/datalayer/metrics.go
+++ b/pkg/epp/framework/interface/datalayer/metrics.go
@@ -24,10 +24,12 @@ import (
 
 // Metrics holds the latest metrics snapshot scraped from a pod.
 type Metrics struct {
-	// ActiveModels is a set of models(including LoRA adapters) that are currently cached to GPU.
-	ActiveModels  map[string]int
+	// ActiveModels tracks adapters with running requests (not GPU residency).
+	// Idle adapters loaded on GPU but with no in-flight requests do not appear.
+	ActiveModels map[string]int
+	// WaitingModels tracks adapters with queued-but-not-yet-running requests.
 	WaitingModels map[string]int
-	// MaxActiveModels is the maximum number of models that can be loaded to GPU.
+	// MaxActiveModels is the maximum number of adapters the model server can load (max_lora).
 	MaxActiveModels         int
 	RunningRequestsSize     int
 	WaitingQueueSize        int

--- a/pkg/epp/framework/interface/datalayer/metrics.go
+++ b/pkg/epp/framework/interface/datalayer/metrics.go
@@ -24,10 +24,11 @@ import (
 
 // Metrics holds the latest metrics snapshot scraped from a pod.
 type Metrics struct {
-	// ActiveModels tracks adapters with running requests (not GPU residency).
-	// Idle adapters loaded on GPU but with no in-flight requests do not appear.
+	// ActiveModels holds only adapters that have at least one running or queued request.
 	ActiveModels map[string]int
-	// WaitingModels tracks adapters with queued-but-not-yet-running requests.
+	// WaitingModels is intended to track adapters with only queued requests,
+	// but current vLLM populates it with the same adapters as in ActiveModels.
+	// Not useful until vLLM replaces it with a residency signal.
 	WaitingModels map[string]int
 	// MaxActiveModels is the maximum number of adapters the model server can load (max_lora).
 	MaxActiveModels         int

--- a/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity.go
@@ -83,23 +83,19 @@ func (s *LoraAffinityScorer) WithName(name string) *LoraAffinityScorer {
 func (s *LoraAffinityScorer) Score(_ context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
 	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 
-	// Assign a score to each endpoint for loading the target adapter.
+	// Score by whether the target adapter has active or waiting requests on each endpoint.
 	for _, endpoint := range endpoints {
 		_, active := endpoint.GetMetrics().ActiveModels[request.TargetModel]
 		_, waiting := endpoint.GetMetrics().WaitingModels[request.TargetModel]
 
-		// Determine the model server's suitability score based on adapter load status and capacity.
 		switch {
-		// Ideal: The adapter is already active on this model server.
+		// Ideal: the adapter is already active on this model server.
 		case active:
 			scores[endpoint] = 1.0
-		// Good: The model server has capacity to load at least one more adapter.
-		case len(endpoint.GetMetrics().ActiveModels)+len(endpoint.GetMetrics().WaitingModels) < endpoint.GetMetrics().MaxActiveModels:
-			scores[endpoint] = 0.8
-		// Moderate: The adapter is already in the queue to be loaded on this model server.
+		// Moderate: the adapter has queued requests on this model server.
 		case waiting:
-			scores[endpoint] = 0.6
-		// Unsuitable: The model server has reached its maximum capacity and cannot load the adapter.
+			scores[endpoint] = 0.8
+		// No signal: the adapter has no request activity on this model server.
 		default:
 			scores[endpoint] = 0.0
 		}

--- a/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity.go
@@ -83,19 +83,30 @@ func (s *LoraAffinityScorer) WithName(name string) *LoraAffinityScorer {
 func (s *LoraAffinityScorer) Score(_ context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
 	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 
-	// Score by whether the target adapter has active or waiting requests on each endpoint.
 	for _, endpoint := range endpoints {
-		_, active := endpoint.GetMetrics().ActiveModels[request.TargetModel]
-		_, waiting := endpoint.GetMetrics().WaitingModels[request.TargetModel]
+		m := endpoint.GetMetrics()
+		_, active := m.ActiveModels[request.TargetModel]
+		_, waiting := m.WaitingModels[request.TargetModel]
+
+		// ActiveModels and WaitingModels share the same source in current vLLM,
+		// so take the union to count each adapter once. This may change later if
+		// vLLM adds native support.
+		unionCount := len(m.ActiveModels)
+		for k := range m.WaitingModels {
+			if _, ok := m.ActiveModels[k]; !ok {
+				unionCount++
+			}
+		}
 
 		switch {
-		// Ideal: the adapter is already active on this model server.
 		case active:
 			scores[endpoint] = 1.0
-		// Moderate: the adapter has queued requests on this model server.
-		case waiting:
+		case unionCount < m.MaxActiveModels:
 			scores[endpoint] = 0.8
-		// No signal: the adapter has no request activity on this model server.
+		// Unreachable against current vLLM (waiting implies active), but
+		// reachable with the simulator and future backends.
+		case waiting:
+			scores[endpoint] = 0.6
 		default:
 			scores[endpoint] = 0.0
 		}

--- a/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity_test.go
@@ -63,11 +63,11 @@ func TestLoraAffinityScorer(t *testing.T) {
 					}, nil),
 			},
 			expectedScoresEndpoint: map[string]float64{
-				"pod1": 0.6,
+				"pod1": 0.8,
 			},
 		},
 		{
-			name:    "Endpoints have no space for new model",
+			name:    "Target model not active or waiting",
 			request: &fwksched.InferenceRequest{TargetModel: "active-model-1"},
 			endpoints: []fwksched.Endpoint{
 				fwksched.NewEndpoint(
@@ -133,8 +133,8 @@ func TestLoraAffinityScorer(t *testing.T) {
 			expectedScoresEndpoint: map[string]float64{
 				"pod1": 1.0,
 				"pod2": 0.8,
-				"pod3": 0.8,
-				"pod4": 0.6,
+				"pod3": 0.0,
+				"pod4": 0.8,
 				"pod5": 0.0,
 			},
 		},

--- a/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/loraaffinity/lora_affinity_test.go
@@ -51,7 +51,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 			},
 		},
 		{
-			name:    "Target model is waiting",
+			name:    "Target model is waiting, adapter slots saturated",
 			request: &fwksched.InferenceRequest{TargetModel: "active-model-1"},
 			endpoints: []fwksched.Endpoint{
 				fwksched.NewEndpoint(
@@ -63,7 +63,7 @@ func TestLoraAffinityScorer(t *testing.T) {
 					}, nil),
 			},
 			expectedScoresEndpoint: map[string]float64{
-				"pod1": 0.8,
+				"pod1": 0.6,
 			},
 		},
 		{
@@ -133,9 +133,49 @@ func TestLoraAffinityScorer(t *testing.T) {
 			expectedScoresEndpoint: map[string]float64{
 				"pod1": 1.0,
 				"pod2": 0.8,
-				"pod3": 0.0,
-				"pod4": 0.8,
+				"pod3": 0.8,
+				"pod4": 0.6,
 				"pod5": 0.0,
+			},
+		},
+		{
+			name:    "vLLM-shaped: target in both maps scores active",
+			request: &fwksched.InferenceRequest{TargetModel: "adapter-a"},
+			endpoints: []fwksched.Endpoint{
+				fwksched.NewEndpoint(
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}},
+					&fwkdl.Metrics{
+						ActiveModels:    map[string]int{"adapter-a": 1, "adapter-b": 1},
+						WaitingModels:   map[string]int{"adapter-a": 1, "adapter-b": 1},
+						MaxActiveModels: 4,
+					}, nil),
+			},
+			expectedScoresEndpoint: map[string]float64{
+				"pod1": 1.0,
+			},
+		},
+		{
+			name:    "vLLM-shaped: target not in maps, capacity available vs saturated",
+			request: &fwksched.InferenceRequest{TargetModel: "target-adapter"},
+			endpoints: []fwksched.Endpoint{
+				fwksched.NewEndpoint(
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}},
+					&fwkdl.Metrics{
+						ActiveModels:    map[string]int{"adapter-a": 1, "adapter-b": 1},
+						WaitingModels:   map[string]int{"adapter-a": 1, "adapter-b": 1},
+						MaxActiveModels: 4,
+					}, nil),
+				fwksched.NewEndpoint(
+					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}},
+					&fwkdl.Metrics{
+						ActiveModels:    map[string]int{"adapter-a": 1, "adapter-b": 1, "adapter-c": 1, "adapter-d": 1},
+						WaitingModels:   map[string]int{"adapter-a": 1, "adapter-b": 1, "adapter-c": 1, "adapter-d": 1},
+						MaxActiveModels: 4,
+					}, nil),
+			},
+			expectedScoresEndpoint: map[string]float64{
+				"pod1": 0.8,
+				"pod2": 0.0,
 			},
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
- ActiveModels and WaitingModels carry the same adapter set against current vLLM. The capacity branch compared `len(active)+len(waiting) `against `max_lora`, double-counting every adapter and reporting saturation at half the actual limit.
- Replace the sum with a union count of distinct adapters across both maps. Keep the original score tiers (1.0/0.8/0.6/0.0) unchanged.
- Update doc comments to reflect that `WaitingModels` is not yet distinguishable from ActiveModels in vLLM.

**Which issue(s) this PR fixes**:
Fixes #2605

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```


cc [atantawi](https://github.com/atantawi)