### PR TITLE
fix(epp): record encode-stage endpoint in multimodal encoder-cache

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/prerequest.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/prerequest.go
@@ -40,7 +40,7 @@ func (p *Producer) PreRequest(ctx context.Context, request *scheduling.Inference
 		return nil
 	}
 
-	targets := targetEndpoints(schedulingResult)
+	targets := p.targetEndpoints(schedulingResult)
 	if len(targets) == 0 {
 		logger.Info("No target endpoints found, skipping encoder-cache update")
 		return nil
@@ -65,13 +65,23 @@ func (p *Producer) PreRequest(ctx context.Context, request *scheduling.Inference
 	return nil
 }
 
-func targetEndpoints(schedulingResult *scheduling.SchedulingResult) []scheduling.Endpoint {
-	if schedulingResult == nil || schedulingResult.PrimaryProfileName == "" || schedulingResult.ProfileResults == nil {
+// targetEndpoints returns the endpoints that computed and hold the encoder cache
+// for the request. In disaggregated serving the encode profile selects those
+// pods; its target is recorded rather than the primary (decode) profile's, whose
+// pod does not hold the encoder cache. In aggregated serving no encode profile
+// runs and the primary profile's pod both encodes and serves.
+func (p *Producer) targetEndpoints(schedulingResult *scheduling.SchedulingResult) []scheduling.Endpoint {
+	if schedulingResult == nil || schedulingResult.ProfileResults == nil {
 		return nil
 	}
-	result := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName]
-	if result == nil {
+	if result := schedulingResult.ProfileResults[p.encodeProfile]; result != nil {
+		return result.TargetEndpoints
+	}
+	if schedulingResult.PrimaryProfileName == "" {
 		return nil
 	}
-	return result.TargetEndpoints
+	if result := schedulingResult.ProfileResults[schedulingResult.PrimaryProfileName]; result != nil {
+		return result.TargetEndpoints
+	}
+	return nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
@@ -51,6 +51,11 @@ const (
 
 	// bytesPerImage is the assumed memory per tracked image.
 	bytesPerImage = 2 * 1024 * 1024
+
+	// defaultEncodeProfile is the scheduling profile that selects encode-stage
+	// endpoints. It matches the disagg-profile-handler default and is
+	// overridable via the encodeProfile parameter.
+	defaultEncodeProfile = "encode"
 )
 
 var (
@@ -67,6 +72,11 @@ var (
 type Parameters struct {
 	// CacheSizeInMBPerServer is the per-endpoint LRU memory budget in mebibytes (MiB).
 	CacheSizeInMBPerServer int `json:"cacheSizeInMBPerServer"`
+
+	// EncodeProfile names the scheduling profile that selects encode-stage
+	// endpoints in disaggregated serving. Must match the profiles.encode value
+	// configured on disagg-profile-handler. Empty selects the default "encode".
+	EncodeProfile string `json:"encodeProfile,omitempty"`
 }
 
 // lruCapacityFromCacheSizeMB converts a MiB budget to a maximum LRU entry count.
@@ -100,14 +110,15 @@ func Factory(name string, rawParameters *json.Decoder, handle plugin.Handle) (pl
 // encoder-cache entries. Each pod has its own LRU cache of hashes, so eviction
 // is scoped per endpoint rather than global.
 type Producer struct {
-	typedName   plugin.TypedName
-	dk          plugin.DataKey
-	caches      map[string]*lru.Cache[string, struct{}]
-	cacheSize   int
-	pluginState *plugin.PluginState
-	podList     func() []k8stypes.NamespacedName
-	mutex       sync.RWMutex
-	wg          sync.WaitGroup
+	typedName     plugin.TypedName
+	dk            plugin.DataKey
+	caches        map[string]*lru.Cache[string, struct{}]
+	cacheSize     int
+	encodeProfile string
+	pluginState   *plugin.PluginState
+	podList       func() []k8stypes.NamespacedName
+	mutex         sync.RWMutex
+	wg            sync.WaitGroup
 }
 
 type requestState struct {
@@ -124,20 +135,25 @@ func (s *requestState) Clone() plugin.StateData {
 // New creates a Producer.
 func New(ctx context.Context, name string, params *Parameters, podList func() []k8stypes.NamespacedName) (*Producer, error) {
 	cacheSizeMB := 0
+	encodeProfile := defaultEncodeProfile
 	if params != nil {
 		cacheSizeMB = params.CacheSizeInMBPerServer
+		if params.EncodeProfile != "" {
+			encodeProfile = params.EncodeProfile
+		}
 	}
 	cacheSize := lruCapacityFromCacheSizeMB(cacheSizeMB)
 
 	registerEncoderCacheMetrics()
 
 	p := &Producer{
-		typedName:   plugin.TypedName{Type: ProducerType, Name: name},
-		dk:          attrmm.EncoderCacheMatchInfoKey.WithNonEmptyProducerName(name),
-		caches:      make(map[string]*lru.Cache[string, struct{}]),
-		cacheSize:   cacheSize,
-		pluginState: plugin.NewPluginState(ctx),
-		podList:     podList,
+		typedName:     plugin.TypedName{Type: ProducerType, Name: name},
+		dk:            attrmm.EncoderCacheMatchInfoKey.WithNonEmptyProducerName(name),
+		caches:        make(map[string]*lru.Cache[string, struct{}]),
+		cacheSize:     cacheSize,
+		encodeProfile: encodeProfile,
+		pluginState:   plugin.NewPluginState(ctx),
+		podList:       podList,
 	}
 	if podList != nil {
 		go p.cleanupLoop(ctx)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
@@ -146,6 +146,48 @@ func TestProduceMatchesMultiplePodsAndPreRequestUpdatesPlacement(t *testing.T) {
 	assert.Contains(t, cache["hash-c"], podC.String())
 }
 
+func TestPreRequestRecordsEncodeEndpointInDisaggregatedMode(t *testing.T) {
+	producer := newTestProducer(t, nil, nil)
+	encodePod := k8stypes.NamespacedName{Namespace: "default", Name: "encode-pod"}
+	decodePod := k8stypes.NamespacedName{Namespace: "default", Name: "decode-pod"}
+
+	request := requestWithHashes("req-1", map[string]int{"hash-a": 1})
+
+	require.NoError(t, producer.Produce(context.Background(), request,
+		[]scheduling.Endpoint{newEndpoint(encodePod), newEndpoint(decodePod)}))
+
+	result := &scheduling.SchedulingResult{
+		PrimaryProfileName: "decode",
+		ProfileResults: map[string]*scheduling.ProfileRunResult{
+			"decode": {TargetEndpoints: []scheduling.Endpoint{newEndpoint(decodePod)}},
+			"encode": {TargetEndpoints: []scheduling.Endpoint{newEndpoint(encodePod)}},
+		},
+	}
+
+	_ = producer.PreRequest(context.Background(), request, result)
+	producer.wg.Wait()
+
+	cache := producer.cacheSnapshot()
+	assert.Contains(t, cache["hash-a"], encodePod.String())
+	assert.NotContains(t, cache["hash-a"], decodePod.String())
+}
+
+func TestPreRequestFallsBackToPrimaryProfileWhenNoEncodeProfile(t *testing.T) {
+	producer := newTestProducer(t, nil, nil)
+	pod := k8stypes.NamespacedName{Namespace: "default", Name: "aggregated-pod"}
+
+	request := requestWithHashes("req-1", map[string]int{"hash-a": 1})
+
+	require.NoError(t, producer.Produce(context.Background(), request,
+		[]scheduling.Endpoint{newEndpoint(pod)}))
+
+	_ = producer.PreRequest(context.Background(), request, schedulingResult(newEndpoint(pod)))
+	producer.wg.Wait()
+
+	cache := producer.cacheSnapshot()
+	assert.Contains(t, cache["hash-a"], pod.String())
+}
+
 func TestLRUEviction(t *testing.T) {
 	producer := newTestProducer(t, &Parameters{CacheSizeInMBPerServer: 4}, nil)
 	endpoint := newEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "pod-a"})

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
@@ -188,6 +188,33 @@ func TestPreRequestFallsBackToPrimaryProfileWhenNoEncodeProfile(t *testing.T) {
 	assert.Contains(t, cache["hash-a"], pod.String())
 }
 
+func TestPreRequestCustomEncodeProfileParameter(t *testing.T) {
+	customProfileName := "my-custom-encode"
+	producer := newTestProducer(t, &Parameters{EncodeProfile: customProfileName}, nil)
+	encodePod := k8stypes.NamespacedName{Namespace: "default", Name: "encode-pod"}
+	decodePod := k8stypes.NamespacedName{Namespace: "default", Name: "decode-pod"}
+
+	request := requestWithHashes("req-1", map[string]int{"hash-x": 1})
+
+	require.NoError(t, producer.Produce(context.Background(), request,
+		[]scheduling.Endpoint{newEndpoint(encodePod), newEndpoint(decodePod)}))
+
+	result := &scheduling.SchedulingResult{
+		PrimaryProfileName: "decode",
+		ProfileResults: map[string]*scheduling.ProfileRunResult{
+			"decode":           {TargetEndpoints: []scheduling.Endpoint{newEndpoint(decodePod)}},
+			customProfileName:  {TargetEndpoints: []scheduling.Endpoint{newEndpoint(encodePod)}},
+		},
+	}
+
+	_ = producer.PreRequest(context.Background(), request, result)
+	producer.wg.Wait()
+
+	cache := producer.cacheSnapshot()
+	assert.Contains(t, cache["hash-x"], encodePod.String(), "custom encode profile pod should be recorded")
+	assert.NotContains(t, cache["hash-x"], decodePod.String(), "decode profile pod should not be recorded")
+}
+
 func TestLRUEviction(t *testing.T) {
 	producer := newTestProducer(t, &Parameters{CacheSizeInMBPerServer: 4}, nil)
 	endpoint := newEndpoint(k8stypes.NamespacedName{Namespace: "default", Name: "pod-a"})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

In encode-disaggregated (E/PD, E/P/D) serving, `mm-embeddings-cache-scorer` always scored 0 for every encode pod, so encoder-cache affinity never routed repeated media to the pod that already held the embedding, and `encoder_cache_hit_ratio` stayed at 0.

The `mm-embeddings-cache-producer` reads the per-pod LRU in `Produce()` (keyed by `endpoint.ID`, scoring encode pods) and writes it in `PreRequest()`. `PreRequest` recorded the endpoints from `ProfileResults[PrimaryProfileName]`, which `disagg-profile-handler` sets to the decode profile. So the producer stored decode-pod IDs while scoring queried encode-pod IDs: the keys never matched and affinity was always 0. Recording the decode pod also inflated `encoder_cache_hits_total`, which counts a hit for every pod in the LRU holding the hash even though decode pods do not hold the encoder cache.

This PR records the encode profile target endpoints instead, falling back to the primary profile when no encode profile ran (aggregated serving). The encode profile name is configurable via a new `encodeProfile` parameter (default `encode`) to match `disagg-profile-handler`.

Validated on a 1 encode-per-pod and 2 encode-pod E/PD deployment (Qwen2.5-VL-7B): with the fix, the first request scores 0 (cold), subsequent same-image requests score 1 on the encoding pod and 0 on the other, and all repeated requests route to that pod. `encoder_cache_hits_total` records only the encode pod.

**Which issue(s) this PR fixes**:
Fixes #2626

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Fixed multimodal encoder-cache affinity in encode-disaggregated (E/PD, E/P/D) serving. The mm-embeddings-cache-producer now records the encode-stage endpoint that holds the embeddings, rather than the decode endpoint, so repeated media routes to the pod that already encoded it. Adds an optional encodeProfile parameter (default "encode") to match the profiles.encode value on disagg-profile-handler.
```