### PR TITLE
docs: describe file discovery validation behavior

### DIFF
--- a/pkg/epp/framework/plugins/datalayer/discovery/file/README.md
+++ b/pkg/epp/framework/plugins/datalayer/discovery/file/README.md
@@ -18,17 +18,18 @@ datastore on each change.
 ## How It Works
 
 - **Initial load.** On `Start`, the file is read once. Each entry is
-  validated (address must be a parseable IP, port must be in `[1, 65535]`)
-  and applied via `notifier.Upsert`. Per-entry validation errors are logged
-  and the entry is skipped; file-level problems (open, parse, size > 1 MiB)
-  abort startup.
+  validated (address must be a literal IPv4 address, port must be in
+  `[1, 65535]`). Valid entries are applied via `notifier.Upsert`, and the
+  loader returns all validation errors together. Any validation error, or a
+  file-level problem (open, parse, size > 1 MiB), aborts startup and leaves the
+  discovery plugin not ready.
 - **Reload (optional).** When `watchFile: true`, fsnotify Write / Create /
   Remove events trigger a reload. After an atomic rename or ConfigMap-style
   symlink swap (which destroys the inode being watched), the watcher is
-  re-attached so subsequent changes still fire. Reload semantics match the
-  initial load: invalid entries are logged and skipped, valid entries are
-  applied. Endpoints present in the previous load but absent from the new
-  one are deleted via `notifier.Delete`.
+  re-attached so subsequent changes still fire. Invalid entries are logged
+  and skipped, valid entries are applied, and endpoints absent from the valid
+  entries are deleted via `notifier.Delete`. A reload error does not stop the
+  plugin.
 - **Readiness.** The plugin closes its `Ready()` channel after the first
   successful load so callers can gate request-serving components on the
   datastore being populated.
@@ -100,8 +101,8 @@ endpoints:
   and `InferenceObjective` reconcilers do not run, and any
   `k8s-notification-source` plugin in the data layer config will not bind.
   The runner emits a startup log naming the inactive features.
-- A single bad entry on initial load is logged and skipped, not fatal. If
-  the entire file is not readable or fails to parse, startup fails.
+- Any invalid address or port causes the initial load to fail. An unreadable,
+  oversized, or malformed file also causes startup to fail.
 
 ## Related Documentation
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The file discovery README describes initial-load validation errors as non-fatal and says reload validation matches initial-load behavior. The implementation aborts startup after collecting initial-load validation errors, while reloads skip invalid entries and continue running.

Describe the initial-load and reload behavior separately, and clarify that endpoint addresses must be literal IPv4 addresses.

**Which issue(s) this PR fixes**:

None.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
