### PR TITLE
feat: emit OpenTelemetry structured JSON logs to stdout

### DIFF
--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	pflag.Parse()
 
-	logutil.InitSetupLogging()
+	logutil.InitSetupLogging("llm-d-coordinator")
 	log := ctrl.Log.WithName("coordinator")
 
 	log.Info("coordinator build", "commit-sha", version.CommitSHA, "build-ref", version.BuildRef)

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -212,7 +212,7 @@ func (r *Runner) WithCustomCollectors(collectors ...prometheus.Collector) *Runne
 
 func (r *Runner) Run(ctx context.Context) error {
 	// Setup a very basic logger in case command line argument parsing fails
-	logutil.InitSetupLogging()
+	logutil.InitSetupLogging("llm-d-epp")
 
 	setupLog.Info(r.eppExecutableName+" build", "commit-sha", version.CommitSHA, "build-ref", version.BuildRef)
 

--- a/pkg/common/observability/logging/logger.go
+++ b/pkg/common/observability/logging/logger.go
@@ -33,38 +33,16 @@ import (
 // level can be adjusted after the controller-runtime delegation is fulfilled.
 var atomicLevel = uberzap.NewAtomicLevelAt(zapcore.InfoLevel)
 
-// LevelEncoder maps negative Zap levels to human-readable names that match
-// the project's verbosity constants (VERBOSE=3, DEBUG=4, TRACE=5). Without
-// this, controller-runtime's zap bridge emits all V(n) calls as "debug" in
-// JSON output, which is misleading for V(1)-V(3) (verbose info).
+// LevelEncoder maps zap / logr verbosity levels to OTel severity_text.
 func LevelEncoder(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
-	if l >= 0 {
-		zapcore.LowercaseLevelEncoder(l, enc)
-		return
-	}
-
-	switch l {
-	case zapcore.Level(-1 * DEBUG): // V(4) -> "debug"
-		enc.AppendString("debug")
-	case zapcore.Level(-1 * TRACE): // V(5) -> "trace"
-		enc.AppendString("trace")
-	default:
-		if l >= zapcore.Level(-1*VERBOSE) { // V(1)-V(3) -> "info"
-			enc.AppendString("info")
-		} else { // V(6+) -> "trace"
-			enc.AppendString("trace")
-		}
-	}
+	enc.AppendString(SeverityText(l))
 }
 
-func InitSetupLogging() {
-	config := uberzap.NewProductionEncoderConfig()
-	config.EncodeLevel = LevelEncoder
-
-	logger := zap.New(
+func InitSetupLogging(serviceName string) {
+	logger := NewLogger(
+		serviceName,
 		zap.Level(atomicLevel),
 		zap.RawZapOpts(uberzap.AddCaller()),
-		zap.Encoder(zapcore.NewJSONEncoder(config)),
 	)
 	ctrl.SetLogger(logger)
 }

--- a/pkg/common/observability/logging/logger_test.go
+++ b/pkg/common/observability/logging/logger_test.go
@@ -40,47 +40,62 @@ func TestCustomLevelEncoder(t *testing.T) {
 		{
 			name:     "Standard Info (0)",
 			level:    zapcore.InfoLevel, // 0
-			expected: "info",
+			expected: "INFO",
 		},
 		{
 			name:     "Standard Warn (1)",
 			level:    zapcore.WarnLevel, // 1
-			expected: "warn",
+			expected: "WARN",
 		},
 		{
 			name:     "Standard Error (2)",
 			level:    zapcore.ErrorLevel, // 2
-			expected: "error",
+			expected: "ERROR",
+		},
+		{
+			name:     "DPanic (3)",
+			level:    zapcore.DPanicLevel,
+			expected: "DPANIC",
+		},
+		{
+			name:     "Panic (4)",
+			level:    zapcore.PanicLevel,
+			expected: "PANIC",
+		},
+		{
+			name:     "Fatal (5)",
+			level:    zapcore.FatalLevel,
+			expected: "FATAL",
 		},
 		{
 			name:     "V(1) (-1)",
 			level:    zapcore.Level(-1),
-			expected: "info",
+			expected: "INFO",
 		},
 		{
 			name:     "V(2) Default (-2)",
 			level:    zapcore.Level(-2),
-			expected: "info",
+			expected: "INFO",
 		},
 		{
 			name:     "Verbose (-3)",
 			level:    zapcore.Level(-3),
-			expected: "info",
+			expected: "INFO",
 		},
 		{
 			name:     "Debug (-4)",
 			level:    zapcore.Level(-4),
-			expected: "debug",
+			expected: "DEBUG",
 		},
 		{
 			name:     "Trace (-5)",
 			level:    zapcore.Level(-5),
-			expected: "trace",
+			expected: "TRACE",
 		},
 		{
 			name:     "Extremely Verbose (-6)",
 			level:    zapcore.Level(-6),
-			expected: "trace",
+			expected: "TRACE",
 		},
 	}
 

--- a/pkg/common/observability/logging/otel.go
+++ b/pkg/common/observability/logging/otel.go
@@ -1,0 +1,181 @@
+package logging
+
+import (
+	"context"
+	"os"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+const (
+	otelTimestampKey      = "timestamp"
+	otelSeverityTextKey   = "severity_text"
+	otelLoggerKey         = "logger"
+	otelCallerKey         = "caller"
+	otelBodyKey           = "body"
+	otelStacktraceKey     = "stacktrace"
+	otelServiceNameKey    = "service.name"
+	otelSeverityNumberKey = "severity_number"
+
+	severityTrace  = "TRACE"
+	severityDebug  = "DEBUG"
+	severityInfo   = "INFO"
+	severityWarn   = "WARN"
+	severityError  = "ERROR"
+	severityDPanic = "DPANIC"
+	severityPanic  = "PANIC"
+	severityFatal  = "FATAL"
+
+	severityNumberTrace  = 1
+	severityNumberDebug  = 5
+	severityNumberInfo   = 9
+	severityNumberWarn   = 13
+	severityNumberError  = 17
+	severityNumberDPanic = 18
+	severityNumberPanic  = 19
+	severityNumberFatal  = 21
+)
+
+// HTTPBodyKey identifies a log field containing an HTTP payload.
+const HTTPBodyKey = "http_body"
+
+// NewLogger returns a logger with OpenTelemetry field names and severity
+// fields. Additional options customize the logger for each service.
+func NewLogger(serviceName string, opts ...crzap.Opts) logr.Logger {
+	defaultOpts := []crzap.Opts{
+		crzap.WriteTo(os.Stdout),
+		crzap.Encoder(zapcore.NewJSONEncoder(EncoderConfig())),
+		crzap.RawZapOpts(
+			zap.WrapCore(WrapCore),
+			zap.Fields(zap.String(otelServiceNameKey, ServiceName(serviceName))),
+		),
+	}
+	return crzap.New(append(defaultOpts, opts...)...)
+}
+
+// NewLoggerWithOptions returns an OpenTelemetry logger configured from
+// controller-runtime logging options.
+func NewLoggerWithOptions(serviceName string, options *crzap.Options) logr.Logger {
+	configured := *options
+	if configured.DestWriter == nil {
+		configured.DestWriter = os.Stdout
+	}
+	configured.Encoder = zapcore.NewJSONEncoder(EncoderConfig())
+	configured.ZapOpts = append(append([]zap.Option(nil), configured.ZapOpts...),
+		zap.WrapCore(WrapCore),
+		zap.Fields(zap.String(otelServiceNameKey, ServiceName(serviceName))),
+	)
+	return crzap.New(crzap.UseFlagOptions(&configured))
+}
+
+// EncoderConfig returns a zap encoder config that emits OTel Logs Data Model
+// field names on stdout JSON records.
+func EncoderConfig() zapcore.EncoderConfig {
+	config := zap.NewProductionEncoderConfig()
+	config.TimeKey = otelTimestampKey
+	config.LevelKey = otelSeverityTextKey
+	config.NameKey = otelLoggerKey
+	config.CallerKey = otelCallerKey
+	config.MessageKey = otelBodyKey
+	config.StacktraceKey = otelStacktraceKey
+	config.EncodeTime = zapcore.RFC3339NanoTimeEncoder
+	config.EncodeLevel = LevelEncoder
+	return config
+}
+
+// SeverityText maps zap / logr verbosity levels to OTel severity_text.
+func SeverityText(l zapcore.Level) string {
+	if l >= 0 {
+		switch {
+		case l >= zapcore.FatalLevel:
+			return severityFatal
+		case l >= zapcore.PanicLevel:
+			return severityPanic
+		case l >= zapcore.DPanicLevel:
+			return severityDPanic
+		case l >= zapcore.ErrorLevel:
+			return severityError
+		case l >= zapcore.WarnLevel:
+			return severityWarn
+		default:
+			return severityInfo
+		}
+	}
+
+	switch l {
+	case zapcore.Level(-1 * DEBUG):
+		return severityDebug
+	case zapcore.Level(-1 * TRACE):
+		return severityTrace
+	default:
+		if l >= zapcore.Level(-1*VERBOSE) {
+			return severityInfo
+		}
+		return severityTrace
+	}
+}
+
+// SeverityNumber maps zap / logr verbosity levels to OTel severity_number.
+func SeverityNumber(l zapcore.Level) int {
+	switch SeverityText(l) {
+	case severityFatal:
+		return severityNumberFatal
+	case severityPanic:
+		return severityNumberPanic
+	case severityDPanic:
+		return severityNumberDPanic
+	case severityError:
+		return severityNumberError
+	case severityWarn:
+		return severityNumberWarn
+	case severityDebug:
+		return severityNumberDebug
+	case severityTrace:
+		return severityNumberTrace
+	default:
+		return severityNumberInfo
+	}
+}
+
+// ServiceName returns service.name from the OTel environment or fallback.
+func ServiceName(fallback string) string {
+	res, err := resource.New(context.Background(), resource.WithFromEnv())
+	if err == nil || res != nil {
+		if value, ok := res.Set().Value(attribute.Key(otelServiceNameKey)); ok {
+			if name := value.AsString(); name != "" {
+				return name
+			}
+		}
+	}
+	return fallback
+}
+
+// WrapCore adds severity_number to every log record.
+func WrapCore(c zapcore.Core) zapcore.Core {
+	return &otelCore{Core: c}
+}
+
+type otelCore struct {
+	zapcore.Core
+}
+
+func (c *otelCore) With(fields []zapcore.Field) zapcore.Core {
+	return &otelCore{Core: c.Core.With(fields)}
+}
+
+func (c *otelCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(ent.Level) {
+		return ce.AddCore(ent, c)
+	}
+	return ce
+}
+
+func (c *otelCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	fields = append(fields, zap.Int(otelSeverityNumberKey, SeverityNumber(ent.Level)))
+	return c.Core.Write(ent, fields)
+}

--- a/pkg/common/observability/logging/otel_test.go
+++ b/pkg/common/observability/logging/otel_test.go
@@ -1,0 +1,130 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestJSONRecordUsesOTelFields(t *testing.T) {
+	var buf bytes.Buffer
+	core := WrapCore(zapcore.NewCore(zapcore.NewJSONEncoder(EncoderConfig()), zapcore.AddSync(&buf), zapcore.InfoLevel))
+	zl := zap.New(core)
+	zl.Info("request assembled")
+	if err := zl.Sync(); err != nil {
+		t.Fatal(err)
+	}
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatal(err)
+	}
+	if rec["body"] != "request assembled" {
+		t.Errorf("body = %v, want request assembled", rec["body"])
+	}
+	if rec["severity_text"] != "INFO" {
+		t.Errorf("severity_text = %v, want INFO", rec["severity_text"])
+	}
+	if rec["severity_number"] != float64(9) {
+		t.Errorf("severity_number = %v, want 9", rec["severity_number"])
+	}
+	if rec["timestamp"] == nil || rec["timestamp"] == "" {
+		t.Error("timestamp missing")
+	}
+}
+
+func TestNewLoggerSeparatesBodyAndHTTPBody(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger(
+		"test-service",
+		crzap.WriteTo(&buf),
+		crzap.Level(zapcore.InfoLevel),
+	)
+	logger.Info("request body", HTTPBodyKey, `{"prompt":"hello"}`)
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatal(err)
+	}
+	if rec["body"] != "request body" {
+		t.Errorf("body = %v, want request body", rec["body"])
+	}
+	if rec[HTTPBodyKey] != `{"prompt":"hello"}` {
+		t.Errorf("%s = %v, want request payload", HTTPBodyKey, rec[HTTPBodyKey])
+	}
+	if rec["service.name"] != "test-service" {
+		t.Errorf("service.name = %v, want test-service", rec["service.name"])
+	}
+}
+
+func TestNewLoggerWithOptionsPreservesOTelConfiguration(t *testing.T) {
+	var buf bytes.Buffer
+	options := &crzap.Options{
+		DestWriter: &buf,
+		Level:      zapcore.InfoLevel,
+	}
+	logger := NewLoggerWithOptions("test-service", options)
+	logger.Info("request assembled")
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatal(err)
+	}
+	if rec["body"] != "request assembled" {
+		t.Errorf("body = %v, want request assembled", rec["body"])
+	}
+	if rec["severity_text"] != "INFO" {
+		t.Errorf("severity_text = %v, want INFO", rec["severity_text"])
+	}
+	if rec["service.name"] != "test-service" {
+		t.Errorf("service.name = %v, want test-service", rec["service.name"])
+	}
+}
+
+func TestServiceNameReadsOTelEnvironment(t *testing.T) {
+	tests := []struct {
+		name     string
+		service  string
+		attrs    string
+		fallback string
+		want     string
+	}{
+		{name: "fallback", fallback: "default", want: "default"},
+		{name: "resource attributes", attrs: "service.name=from-attrs", fallback: "default", want: "from-attrs"},
+		{name: "service name takes precedence", service: "from-service-name", attrs: "service.name=from-attrs", fallback: "default", want: "from-service-name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OTEL_SERVICE_NAME", tt.service)
+			t.Setenv("OTEL_RESOURCE_ATTRIBUTES", tt.attrs)
+			if got := ServiceName(tt.fallback); got != tt.want {
+				t.Errorf("ServiceName(%q) = %q, want %q", tt.fallback, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSeverityNumberPreservesZapFatalLevels(t *testing.T) {
+	tests := []struct {
+		name     string
+		level    zapcore.Level
+		expected int
+	}{
+		{name: "dpanic", level: zapcore.DPanicLevel, expected: severityNumberDPanic},
+		{name: "panic", level: zapcore.PanicLevel, expected: severityNumberPanic},
+		{name: "fatal", level: zapcore.FatalLevel, expected: severityNumberFatal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SeverityNumber(tt.level); got != tt.expected {
+				t.Errorf("SeverityNumber(%v) = %d, want %d", tt.level, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/coordinator/gateway/client.go
+++ b/pkg/coordinator/gateway/client.go
@@ -100,7 +100,7 @@ func (c *Client) Request(ctx context.Context, method, path string, body []byte, 
 	logger := log.FromContext(ctx).WithName("gateway")
 	if body != nil {
 		if v := logger.V(logutil.TRACE); v.Enabled() {
-			v.Info("request body", "method", method, "path", path, "headers", httplog.RedactedHeaders(req.Header), "body", RedactBody(body))
+			v.Info("request body", "method", method, "path", path, "headers", httplog.RedactedHeaders(req.Header), logutil.HTTPBodyKey, RedactBody(body))
 		}
 	}
 
@@ -117,7 +117,7 @@ func (c *Client) Request(ctx context.Context, method, path string, body []byte, 
 		if err != nil {
 			return nil, fmt.Errorf("reading response from gateway: %w", err)
 		}
-		v.Info("response body", "status", resp.StatusCode, "body", RedactBody(respBody))
+		v.Info("response body", "status", resp.StatusCode, logutil.HTTPBodyKey, RedactBody(respBody))
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 	}
 

--- a/pkg/coordinator/steps/decode_proxy.go
+++ b/pkg/coordinator/steps/decode_proxy.go
@@ -85,7 +85,7 @@ func newDecodeProxyRequest(ctx context.Context, logger logr.Logger, step string,
 	// the prefill and encode legs. Log the redacted body here so the decode leg's
 	// fields (min_tokens, max_tokens, ...) are observable at the same verbosity.
 	if v := logger.V(logutil.TRACE); v.Enabled() {
-		v.Info("request body", "method", "POST", "path", reqCtx.OriginalPath, "headers", httplog.RedactedHeaders(proxyReq.Header), "body", gateway.RedactBody(bodyBytes))
+		v.Info("request body", "method", "POST", "path", reqCtx.OriginalPath, "headers", httplog.RedactedHeaders(proxyReq.Header), logutil.HTTPBodyKey, gateway.RedactBody(bodyBytes))
 	}
 
 	return proxyReq, nil

--- a/pkg/sidecar/proxy/connector_mooncake.go
+++ b/pkg/sidecar/proxy/connector_mooncake.go
@@ -106,7 +106,7 @@ func (s *Server) handleMooncake(w http.ResponseWriter, r *http.Request, prefillP
 	// Guarded: stringifying the body allocates a copy per request even when
 	// TRACE is disabled.
 	if trace := s.logger.V(logging.TRACE); trace.Enabled() {
-		trace.Info("Prefill request", "body", string(prefillBody))
+		trace.Info("Prefill request", logging.HTTPBodyKey, string(prefillBody))
 	}
 
 	// Build decode request body
@@ -131,7 +131,7 @@ func (s *Server) handleMooncake(w http.ResponseWriter, r *http.Request, prefillP
 	}
 
 	if trace := s.logger.V(logging.TRACE); trace.Enabled() {
-		trace.Info("Decode request", "body", string(decodeBody))
+		trace.Info("Decode request", logging.HTTPBodyKey, string(decodeBody))
 	}
 
 	s.handleMooncakeConcurrentRequests(w, r, prefillBody, decodeBody, prefillPodHostPort, dpRank)

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -203,7 +203,7 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 	// Guarded: stringifying the body allocates a copy per request even when
 	// TRACE is disabled.
 	if trace := s.logger.V(logging.TRACE); trace.Enabled() {
-		trace.Info("Prefill request", "body", string(pbody))
+		trace.Info("Prefill request", logging.HTTPBodyKey, string(pbody))
 	}
 
 	// Retry on transient 5xx (502/503/504): these failures (e.g. connection
@@ -250,7 +250,7 @@ retryLoop:
 	if isHTTPError(pw.statusCode) {
 		s.logger.Error(fmt.Errorf("prefill returned %d", pw.statusCode), "prefill request failed",
 			"request_id", uuidStr,
-			"body", pw.buffer.String())
+			logging.HTTPBodyKey, pw.buffer.String())
 		prefillSpan.SetStatus(codes.Error, "prefill request failed")
 		prefillSpan.End()
 
@@ -425,7 +425,7 @@ retryLoop:
 	// 2. Forward to local decoder.
 
 	if trace := s.logger.V(logging.TRACE); trace.Enabled() {
-		trace.Info("sending request to decoder", "body", string(dbody))
+		trace.Info("sending request to decoder", logging.HTTPBodyKey, string(dbody))
 	}
 	decodeWriter, finalizeDecodeWriter := newCachedTokensResponseWriterWithFinalize(w, pCachedTokens, streamingEnabled)
 	dataParallelUsed := s.forwardDataParallel && s.dataParallelHandler(decodeWriter, dreq)
@@ -675,8 +675,8 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 	dreq.ContentLength = int64(len(dbody))
 
 	if trace := s.logger.V(logging.TRACE); trace.Enabled() {
-		trace.Info("concurrent-dispatch prefill request body", "body", string(pbody))
-		trace.Info("concurrent-dispatch decode request body", "body", string(dbody))
+		trace.Info("concurrent-dispatch prefill request body", logging.HTTPBodyKey, string(pbody))
+		trace.Info("concurrent-dispatch decode request body", logging.HTTPBodyKey, string(dbody))
 	}
 
 	// Decode writes into a deferred writer that buffers everything until we
@@ -705,7 +705,7 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 			prefillSpan.SetStatus(codes.Error, "prefill request failed")
 			cancel() // KV will never arrive -> abort decode instead of hanging
 			s.logger.Error(nil, "concurrent-dispatch prefill returned error status",
-				"status", pw.statusCode, "request_id", uuidStr, "body", pw.buffer.String())
+				"status", pw.statusCode, "request_id", uuidStr, logging.HTTPBodyKey, pw.buffer.String())
 		}
 	}()
 

--- a/pkg/sidecar/proxy/connector_p2p.go
+++ b/pkg/sidecar/proxy/connector_p2p.go
@@ -89,7 +89,7 @@ func (s *Server) handleP2P(w http.ResponseWriter, r *http.Request, prefillPodHos
 		return
 	}
 	if v := s.logger.V(logging.TRACE); v.Enabled() {
-		v.Info("prefill request body", "body", string(prefillBody))
+		v.Info("prefill request body", logging.HTTPBodyKey, string(prefillBody))
 	}
 
 	// Decode leg: pull KV from the prefiller's OffloadingConnector P2P tier. Original body
@@ -114,7 +114,7 @@ func (s *Server) handleP2P(w http.ResponseWriter, r *http.Request, prefillPodHos
 		return
 	}
 	if v := s.logger.V(logging.TRACE); v.Enabled() {
-		v.Info("decode request body", "body", string(decodeBody))
+		v.Info("decode request body", logging.HTTPBodyKey, string(decodeBody))
 	}
 
 	s.handleP2PSequentialRequests(w, r, prefillBody, decodeBody, prefillPodHostPort)
@@ -367,7 +367,7 @@ func (s *Server) decodeWithP2PSource(w http.ResponseWriter, r *http.Request, sou
 		return
 	}
 	if v := s.logger.V(logging.TRACE); v.Enabled() {
-		v.Info("decoder request body with p2p source", "body", string(newBody))
+		v.Info("decoder request body with p2p source", logging.HTTPBodyKey, string(newBody))
 	}
 
 	s.dispatchDecode(w, cloneRequestWithBody(r.Context(), r, newBody), requestData)

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -32,8 +32,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
-	uberzap "go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
@@ -693,15 +691,12 @@ func validatePortRange(startPort, rangeSize int) error {
 	return nil
 }
 
-// NewLogger returns a logger configured from the Options logging flags,
-// with a custom level encoder that maps verbosity levels to their semantic
-// names instead of always rendering V(n) as "debug".
+// NewLogger returns a logger configured from the Options logging flags with
+// OpenTelemetry field names and severity fields.
 func (opts *Options) NewLogger() logr.Logger {
-	config := uberzap.NewProductionEncoderConfig()
-	config.EncodeLevel = logutil.LevelEncoder
-	return zap.New(
-		zap.UseFlagOptions(&opts.loggingOptions),
-		zap.Encoder(zapcore.NewJSONEncoder(config)),
+	return logutil.NewLoggerWithOptions(
+		"llm-d-router-disagg-sidecar",
+		&opts.loggingOptions,
 	)
 }
 

--- a/test/coordinator/e2e/coordinator/coordinator_test.go
+++ b/test/coordinator/e2e/coordinator/coordinator_test.go
@@ -221,7 +221,7 @@ func verifyCoordinatorSteps(logs string, expectedSteps []string, expectedImages 
 
 	for _, step := range expectedSteps {
 		stepField := `"step":"` + step + `"`
-		gomega.Expect(logHasLine(logs, `"msg":"step complete"`, stepField)).To(gomega.BeTrue(),
+		gomega.Expect(logHasLine(logs, `"body":"step complete"`, stepField)).To(gomega.BeTrue(),
 			"coordinator logs have no 'step complete' entry for step %q", step)
 	}
 
@@ -236,15 +236,15 @@ func verifyCoordinatorSteps(logs string, expectedSteps []string, expectedImages 
 		// never sees, so the kv connector's "preparing decode kv params" trace,
 		// which always sets do_remote_prefill=true, is where the decode leg surfaces.
 		ginkgo.By("Verifying kv_transfer_params forwarded on the prefill request")
-		gomega.Expect(logHasLine(logs, `"msg":"request body"`, `"epp-profile":"prefill"`, `"kv_transfer_params"`)).To(gomega.BeTrue(),
+		gomega.Expect(logHasLine(logs, `"body":"request body"`, `"epp-profile":"prefill"`, `"kv_transfer_params"`)).To(gomega.BeTrue(),
 			"coordinator logs have no prefill request body carrying kv_transfer_params")
 
 		ginkgo.By("Verifying kv_transfer_params in the prefill response")
-		gomega.Expect(logHasLine(logs, `"msg":"response body"`, `"do_remote_prefill":true`)).To(gomega.BeTrue(),
+		gomega.Expect(logHasLine(logs, `"body":"response body"`, `"do_remote_prefill":true`)).To(gomega.BeTrue(),
 			"coordinator logs have no prefill response body carrying kv_transfer_params with do_remote_prefill=true")
 
 		ginkgo.By("Verifying kv_transfer_params on the decode leg")
-		gomega.Expect(logHasLine(logs, `"msg":"preparing decode kv params"`, `"do_remote_prefill":true`)).To(gomega.BeTrue(),
+		gomega.Expect(logHasLine(logs, `"body":"preparing decode kv params"`, `"do_remote_prefill":true`)).To(gomega.BeTrue(),
 			"coordinator logs have no decode kv_transfer_params with do_remote_prefill=true")
 	}
 
@@ -252,7 +252,7 @@ func verifyCoordinatorSteps(logs string, expectedSteps []string, expectedImages 
 		// The encode step fans out one sub-request per image; this marker is
 		// logged by the step itself, so it holds for any ec connector.
 		ginkgo.By("Verifying encode completed all image sub-requests")
-		gomega.Expect(logHasLine(logs, `"msg":"all sub-requests complete"`, fmt.Sprintf(`"count":%d`, expectedImages))).To(gomega.BeTrue(),
+		gomega.Expect(logHasLine(logs, `"body":"all sub-requests complete"`, fmt.Sprintf(`"count":%d`, expectedImages))).To(gomega.BeTrue(),
 			"coordinator logs missing 'all sub-requests complete' with count=%d", expectedImages)
 
 		if ecNIXL {
@@ -260,11 +260,11 @@ func verifyCoordinatorSteps(logs string, expectedSteps []string, expectedImages 
 			// ("merged encode response","total":N), then the merged set is carried
 			// on the prefill request body.
 			ginkgo.By("Verifying ec_transfer_params merged for all images")
-			gomega.Expect(logHasLine(logs, `"msg":"merged encode response"`, fmt.Sprintf(`"total":%d`, expectedImages))).To(gomega.BeTrue(),
+			gomega.Expect(logHasLine(logs, `"body":"merged encode response"`, fmt.Sprintf(`"total":%d`, expectedImages))).To(gomega.BeTrue(),
 				"coordinator logs missing merged encode response with total=%d", expectedImages)
 
 			ginkgo.By("Verifying ec_transfer_params forwarded on the prefill request")
-			gomega.Expect(logHasLine(logs, `"msg":"request body"`, `"epp-profile":"prefill"`, `"ec_transfer_params"`)).To(gomega.BeTrue(),
+			gomega.Expect(logHasLine(logs, `"body":"request body"`, `"epp-profile":"prefill"`, `"ec_transfer_params"`)).To(gomega.BeTrue(),
 				"coordinator logs have no prefill request body carrying ec_transfer_params")
 		}
 	}
@@ -385,7 +385,7 @@ func fetchCoordinatorLogs(nsName string) string {
 // on the coordinator running at log_level 5.
 func verifyTokenLimits(logs string, wantMin, wantMax int, capLegs []string) {
 	ginkgo.By("Verifying decode leg forwards the client min_tokens/max_tokens")
-	gomega.Expect(logHasLine(logs, `"msg":"request body"`, `"epp-profile":"decode"`,
+	gomega.Expect(logHasLine(logs, `"body":"request body"`, `"epp-profile":"decode"`,
 		fmt.Sprintf(`"min_tokens":%d`, wantMin), fmt.Sprintf(`"max_tokens":%d`, wantMax))).To(gomega.BeTrue(),
 		"coordinator logs have no decode request body carrying min_tokens=%d and max_tokens=%d", wantMin, wantMax)
 
@@ -393,11 +393,11 @@ func verifyTokenLimits(logs string, wantMin, wantMax int, capLegs []string) {
 		phaseField := `"epp-profile":"` + phase + `"`
 
 		ginkgo.By("Verifying " + phase + " leg caps max_tokens to 1")
-		gomega.Expect(logHasLine(logs, `"msg":"request body"`, phaseField, `"max_tokens":1`)).To(gomega.BeTrue(),
+		gomega.Expect(logHasLine(logs, `"body":"request body"`, phaseField, `"max_tokens":1`)).To(gomega.BeTrue(),
 			"coordinator logs have no %s request body carrying max_tokens=1", phase)
 
 		ginkgo.By("Verifying " + phase + " leg strips min_tokens")
-		gomega.Expect(logHasLine(logs, `"msg":"request body"`, phaseField, `"min_tokens"`)).To(gomega.BeFalse(),
+		gomega.Expect(logHasLine(logs, `"body":"request body"`, phaseField, `"min_tokens"`)).To(gomega.BeFalse(),
 			"%s request body must not carry min_tokens", phase)
 	}
 }
@@ -410,7 +410,7 @@ func verifyEncodeSkipped(nsName string) {
 	logs := fetchCoordinatorLogs(nsName)
 
 	ginkgo.By("Verifying encode was skipped for the generate request")
-	gomega.Expect(logHasLine(logs, `"msg":"skipping encode for generate request"`)).To(gomega.BeTrue(),
+	gomega.Expect(logHasLine(logs, `"body":"skipping encode for generate request"`)).To(gomega.BeTrue(),
 		"coordinator logs missing 'skipping encode for generate request'")
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
JSON logs currently use zap keys (`msg`, `level`). This emits the OpenTelemetry Logs Data Model on stdout (`body`, `severity_text`, `severity_number`, `timestamp`, `service.name`) and injects `trace_id`/`span_id` on the request path when a span is active, so collectors can correlate logs with traces.

 As an Inference Component Developer
 I want MaaS, llm-d EPP, KServe controllers, and vLLM to emit structured JSON logs to stdout adhering to the OpenTelemetry Logs Data Model and including trace_id and span_id

So that all inference log records are standardized, machine-parsable, and directly correlated with active distributed traces.

### Acceptance Criteria

Standardized JSON Schema: All four components (MaaS, llm-d EPP, KServe controllers, and vLLM) emit logs to stdout formatted as structured JSON conforming to the OpenTelemetry Logs Data Model.

Trace Context Injection: When a trace context is active, the logger automatically extracts and includes trace_id and span_id within the log payload.

Severity Mapping: Standardizes log levels (e.g., INFO, WARN, ERROR) to standard OTel severity representation.

**Which issue(s) this PR fixes**:
Related: https://redhat.atlassian.net/browse/RHOAIENG-83718

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
JSON logs use OpenTelemetry field names (`body`, `severity_text`, `severity_number`) and include `trace_id`/`span_id` when a trace is active. Collectors that match on `msg` need to match `body` instead.
```