### PR TITLE
fix(tokenizer): preserve render request key order - fixes #2641

### DIFF
--- a/pkg/epp/framework/interface/scheduling/types.go
+++ b/pkg/epp/framework/interface/scheduling/types.go
@@ -58,6 +58,8 @@ type InferenceRequest struct {
 	FairnessID string
 	// RequestSizeBytes is the size of the raw request body in bytes when available.
 	RequestSizeBytes int
+	// RawBody contains the request body exactly as received from the downstream proxy.
+	RawBody []byte
 	// SchedulingResult captures the scheduling decisions made during the cycle.
 	SchedulingResult *SchedulingResult
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
@@ -27,12 +27,19 @@ import (
 
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 )
 
 // tokenInputProducer turns a request body into a TokenizedRequest. Backends vary
 // in fidelity (render vs estimate); callers never branch on which produced it.
 type tokenInputProducer interface {
 	produce(ctx context.Context, body *fwkrh.InferenceRequestBody) (*fwkrh.TokenizedRequest, error)
+}
+
+// requestInputProducer is implemented by backends that need request metadata
+// in addition to the parsed body.
+type requestInputProducer interface {
+	produceRequest(ctx context.Context, request *scheduling.InferenceRequest) (*fwkrh.TokenizedRequest, error)
 }
 
 // timeoutAware is implemented by backends (and the tokenizers they wrap) whose
@@ -102,6 +109,30 @@ func warmupChat(imageURLs ...string) *fwkrh.InferenceRequestBody {
 // the pre-tokenized (Generate) passthrough.
 type renderBackend struct {
 	tk tokenizer
+}
+
+// produceRequest sends the original chat-completions JSON to vLLM when it is
+// also the body that will be forwarded downstream, preserving object key order.
+func (b renderBackend) produceRequest(ctx context.Context, request *scheduling.InferenceRequest) (*fwkrh.TokenizedRequest, error) {
+	body := request.Body
+	renderer, ok := b.tk.(*vllmHTTPRenderer)
+	if !ok || body.ChatCompletions == nil || body.Mutated || len(request.RawBody) == 0 ||
+		request.TargetModel != renderer.modelName || body.Model != renderer.modelName || body.Payload == nil {
+		return b.produce(ctx, body)
+	}
+
+	payload, ok := body.Payload.AsMap()
+	if !ok {
+		return b.produce(ctx, body)
+	}
+	tokenIDs, mmFeatures, err := renderer.postRawChatRender(ctx, request.RawBody, renderer.chatTimeout(payload))
+	if err != nil {
+		return nil, fmt.Errorf("tokenization failed: %w", err)
+	}
+	return &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{
+		TokenIDs:           tokenIDs,
+		MultiModalFeatures: convertMMFeaturesToUpstream(mmFeatures),
+	}}}, nil
 }
 
 func (b renderBackend) produce(ctx context.Context, body *fwkrh.InferenceRequestBody) (*fwkrh.TokenizedRequest, error) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -372,7 +372,13 @@ func (p *Plugin) Produce(ctx context.Context, request *scheduling.InferenceReque
 	}
 
 	ctx = withMMMetadata(ctx, parseMMMetadataHeaders(request.Headers))
-	tp, err := p.backend.produce(ctx, request.Body)
+	var tp *fwkrh.TokenizedRequest
+	var err error
+	if requestProducer, ok := p.backend.(requestInputProducer); ok {
+		tp, err = requestProducer.produceRequest(ctx, request)
+	} else {
+		tp, err = p.backend.produce(ctx, request.Body)
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -180,6 +180,14 @@ func (r *vllmHTTPRenderer) postChatRender(ctx context.Context, body any, timeout
 	return resp.TokenIDs, toKVCacheMM(resp.Features), nil
 }
 
+func (r *vllmHTTPRenderer) postRawChatRender(ctx context.Context, body []byte, timeout time.Duration) ([]uint32, *tokenization.MultiModalFeatures, error) {
+	var resp renderResponse
+	if err := r.postJSONPayload(ctx, chatRenderPath, body, timeout, &resp); err != nil {
+		return nil, nil, err
+	}
+	return resp.TokenIDs, toKVCacheMM(resp.Features), nil
+}
+
 func (r *vllmHTTPRenderer) chatTimeout(payload fwkrh.PayloadMap) time.Duration {
 	messages, ok := payload["messages"].([]any)
 	if !ok {
@@ -349,7 +357,10 @@ func (r *vllmHTTPRenderer) postJSON(ctx context.Context, path string, body any, 
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)
 	}
+	return r.postJSONPayload(ctx, path, payload, timeout, out)
+}
 
+func (r *vllmHTTPRenderer) postJSONPayload(ctx context.Context, path string, payload []byte, timeout time.Duration, out any) error {
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
@@ -248,6 +248,96 @@ func TestProduce_ChatCompletionsVLLMHTTPUsesRawPayload(t *testing.T) {
 	assert.Equal(t, testHTTPModel, sent["model"])
 }
 
+func TestProduce_ChatCompletionsVLLMHTTPPreservesRequestBodyOrder(t *testing.T) {
+	srv, captured := httpFixture(t, nil, renderResponse{TokenIDs: []uint32{9, 10}})
+	defer srv.Close()
+
+	rawBody := []byte(`{
+  "model": "test-model",
+  "messages": [{"role": "user", "content": "hello"}],
+  "tools": [{"type": "function", "function": {"name": "lookup", "parameters": {
+    "type": "object",
+    "properties": {"zeta": {"type": "string", "description": "last"}, "alpha": {"type": "string", "description": "first"}}
+  }}}]
+}`)
+	var payload fwkrh.PayloadMap
+	require.NoError(t, json.Unmarshal(rawBody, &payload))
+	req := &scheduling.InferenceRequest{
+		TargetModel: testHTTPModel,
+		RawBody:     rawBody,
+		Body: &fwkrh.InferenceRequestBody{
+			ChatCompletions: &fwkrh.ChatCompletionsRequest{
+				Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Raw: "hello"}}},
+			},
+			Payload: payload,
+			Model:   testHTTPModel,
+		},
+	}
+
+	p := newTestPlugin(newHTTPRenderer(t, srv))
+	require.NoError(t, p.Produce(context.Background(), req, nil))
+	assert.Equal(t, rawBody, captured.chat)
+}
+
+func TestProduce_ChatCompletionsVLLMHTTPUsesMutatedPayload(t *testing.T) {
+	srv, captured := httpFixture(t, nil, renderResponse{TokenIDs: []uint32{9, 10}})
+	defer srv.Close()
+
+	rawBody := []byte(`{"model":"client-model","messages":[{"role":"user","content":"hello"}]}`)
+	payload := fwkrh.PayloadMap{
+		"model":    testHTTPModel,
+		"messages": []any{map[string]any{"role": "user", "content": "hello"}},
+	}
+	req := &scheduling.InferenceRequest{
+		TargetModel: testHTTPModel,
+		RawBody:     rawBody,
+		Body: &fwkrh.InferenceRequestBody{
+			ChatCompletions: &fwkrh.ChatCompletionsRequest{
+				Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Raw: "hello"}}},
+			},
+			Payload: payload,
+			Mutated: true,
+		},
+	}
+
+	p := newTestPlugin(newHTTPRenderer(t, srv))
+	require.NoError(t, p.Produce(context.Background(), req, nil))
+	want, err := payload.Marshal()
+	require.NoError(t, err)
+	assert.Equal(t, want, captured.chat)
+	assert.NotEqual(t, rawBody, captured.chat)
+}
+
+func TestProduce_ChatCompletionsVLLMHTTPUsesPayloadWhenModelDiffers(t *testing.T) {
+	srv, captured := httpFixture(t, nil, renderResponse{TokenIDs: []uint32{9, 10}})
+	defer srv.Close()
+
+	rawBody := []byte(`{"model":"client-model","messages":[{"role":"user","content":"hello"}]}`)
+	payload := fwkrh.PayloadMap{
+		"model":    "client-model",
+		"messages": []any{map[string]any{"role": "user", "content": "hello"}},
+	}
+	req := &scheduling.InferenceRequest{
+		TargetModel: testHTTPModel,
+		RawBody:     rawBody,
+		Body: &fwkrh.InferenceRequestBody{
+			ChatCompletions: &fwkrh.ChatCompletionsRequest{
+				Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Raw: "hello"}}},
+			},
+			Payload: payload,
+			Model:   "client-model",
+		},
+	}
+
+	p := newTestPlugin(newHTTPRenderer(t, srv))
+	require.NoError(t, p.Produce(context.Background(), req, nil))
+	assert.NotEqual(t, rawBody, captured.chat)
+
+	var sent fwkrh.PayloadMap
+	require.NoError(t, json.Unmarshal(captured.chat, &sent))
+	assert.Equal(t, testHTTPModel, sent["model"])
+}
+
 // TestProduce_MessagesVLLMHTTPFullAgenticTurn covers the complete production
 // path from a parsed Anthropic request through the rebuilt OpenAI-shaped
 // payload sent to vLLM's chat render endpoint.

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -227,6 +227,7 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 		RequestID:        reqCtx.Request.Headers[reqcommon.RequestIDHeaderKey],
 		TargetModel:      reqCtx.TargetModelName,
 		Body:             inferenceRequestBody,
+		RawBody:          reqCtx.Request.RawBody,
 		Headers:          reqCtx.Request.Headers,
 		FairnessID:       fairnessID,
 		Objectives:       requestObjectives,

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -1191,6 +1191,9 @@ func TestDirector_HandleRequest(t *testing.T) {
 				}
 
 				assert.NoError(t, err, "HandleRequest() returned unexpected error")
+				require.NotNil(t, returnedReqCtx.SchedulingRequest, "SchedulingRequest should be populated")
+				assert.Equal(t, originalRawBody, returnedReqCtx.SchedulingRequest.RawBody,
+					"SchedulingRequest.RawBody should contain the original request bytes")
 
 				if test.wantReqCtx != nil {
 					assert.Equal(t, test.wantReqCtx.ObjectiveKey, returnedReqCtx.ObjectiveKey, "reqCtx.Model mismatch")


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

**What this PR does / why we need it**:

Fixes #2641, which seemingly breaks precise KV cache as the `/render` code path marshals and unmarshals the raw body, potentially leading to llm-d index seeing different token ID's than those received via ZMQ messages.

Tentative solutuion through which we check if EPP has not mutated the body, and if so, we use the `rawBody` directly to call `/render`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
#2641
Fixes #


**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
