### PR TITLE
fix: warn when refresh-metrics-interval exceeds metricsStalenessThres…

### DIFF
--- a/cmd/epp/runner/feature_gate_test.go
+++ b/cmd/epp/runner/feature_gate_test.go
@@ -143,7 +143,7 @@ featureGates:
 			}
 
 			ds := datastore.NewDatastore(ctx, r.setupMetricsCollection(opts))
-			eppConfig, err := r.parseConfigurationPhaseTwo(ctx, rawConfig, ds)
+			eppConfig, err := r.parseConfigurationPhaseTwo(ctx, rawConfig, ds, opts.RefreshMetricsInterval)
 			require.NoError(t, err)
 
 			endpointCandidates := contracts.EndpointCandidates(

--- a/cmd/epp/runner/multicluster_config_test.go
+++ b/cmd/epp/runner/multicluster_config_test.go
@@ -65,7 +65,7 @@ func TestMultiClusterConfigLoad(t *testing.T) {
 			require.NoError(t, err)
 
 			ds := datastore.NewDatastore(ctx, r.setupMetricsCollection(opts))
-			_, err = r.parseConfigurationPhaseTwo(ctx, rawConfig, ds)
+			_, err = r.parseConfigurationPhaseTwo(ctx, rawConfig, ds, opts.RefreshMetricsInterval)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
 				return

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -380,7 +380,7 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 		setupLog.Error(err, "Failed to setup datastore")
 		return nil, nil, err
 	}
-	eppConfig, err := r.parseConfigurationPhaseTwo(ctx, rawConfig, ds)
+	eppConfig, err := r.parseConfigurationPhaseTwo(ctx, rawConfig, ds, opts.RefreshMetricsInterval)
 	if err != nil {
 		setupLog.Error(err, "Failed to parse configuration")
 		return nil, nil, err
@@ -795,10 +795,12 @@ func makePodListFunc(ds datastore.Datastore) func() []types.NamespacedName {
 	}
 }
 
-func (r *Runner) parseConfigurationPhaseTwo(ctx context.Context, rawConfig *configapi.EndpointPickerConfig, ds datastore.Datastore) (*config.Config, error) {
+func (r *Runner) parseConfigurationPhaseTwo(ctx context.Context, rawConfig *configapi.EndpointPickerConfig, ds datastore.Datastore, refreshMetricsInterval time.Duration) (*config.Config, error) {
 	logger := log.FromContext(ctx)
 
-	handle := fwkplugin.NewEppHandle(ctx, makePodListFunc(ds), fwkplugin.WithMetricsRecorder(ctrlmetrics.Registry))
+	handle := fwkplugin.NewEppHandle(ctx, makePodListFunc(ds),
+		fwkplugin.WithMetricsRecorder(ctrlmetrics.Registry),
+		fwkplugin.WithRefreshMetricsInterval(refreshMetricsInterval))
 	r.PluginHandle = handle
 	cfg, err := loader.InstantiateAndConfigure(rawConfig, handle, logger)
 
@@ -1099,7 +1101,7 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 		"(InferenceModelRewrite, InferenceObjective reconciler, and any " +
 		"k8s-notification-source data layer plugins); see docs/discovery.md")
 
-	eppConfig, err := r.parseConfigurationPhaseTwo(ctx, rawConfig, ds)
+	eppConfig, err := r.parseConfigurationPhaseTwo(ctx, rawConfig, ds, opts.RefreshMetricsInterval)
 	if err != nil {
 		setupLog.Error(err, "Failed to parse configuration")
 		return err

--- a/pkg/epp/framework/interface/plugin/handle.go
+++ b/pkg/epp/framework/interface/plugin/handle.go
@@ -19,6 +19,7 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -44,6 +45,11 @@ type Handle interface {
 	// SetCrossReplicaSyncer makes the configured cross-replica syncer available
 	// to plugins through the handle.
 	SetCrossReplicaSyncer(Plugin)
+
+	// RefreshMetricsInterval returns the base polling tick configured by
+	// --refresh-metrics-interval, after the minimum-interval clamp. Data sources
+	// that set their own interval may poll less often than this. Zero when unset.
+	RefreshMetricsInterval() time.Duration
 }
 
 // HandlePlugins defines a set of APIs to work with instantiated plugins
@@ -68,9 +74,10 @@ type PodListFunc func() []types.NamespacedName
 type eppHandle struct {
 	ctx context.Context
 	HandlePlugins
-	podList            PodListFunc
-	metricsRecorder    MetricsRecorder
-	crossReplicaSyncer Plugin
+	podList                PodListFunc
+	metricsRecorder        MetricsRecorder
+	crossReplicaSyncer     Plugin
+	refreshMetricsInterval time.Duration
 }
 
 // Context returns a context the plugins can use, if they need one
@@ -130,6 +137,11 @@ func (h *eppHandle) SetCrossReplicaSyncer(syncer Plugin) {
 	h.crossReplicaSyncer = syncer
 }
 
+// RefreshMetricsInterval returns the data-layer polling cadence.
+func (h *eppHandle) RefreshMetricsInterval() time.Duration {
+	return h.refreshMetricsInterval
+}
+
 // HandleOption configures an eppHandle constructed via NewEppHandle.
 type HandleOption func(*eppHandle)
 
@@ -140,6 +152,14 @@ func WithMetricsRecorder(recorder MetricsRecorder) HandleOption {
 		if recorder != nil {
 			h.metricsRecorder = recorder
 		}
+	}
+}
+
+// WithRefreshMetricsInterval sets the base polling tick advertised to plugins
+// via Handle.RefreshMetricsInterval.
+func WithRefreshMetricsInterval(interval time.Duration) HandleOption {
+	return func(h *eppHandle) {
+		h.refreshMetricsInterval = interval
 	}
 }
 

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector.go
@@ -64,7 +64,15 @@ func UtilizationDetectorFactory(
 	if err != nil {
 		return nil, err
 	}
-	return NewDetector(name, *cfg, log.FromContext(handle.Context())), nil
+	logger := log.FromContext(handle.Context())
+	if refresh := handle.RefreshMetricsInterval(); refresh > cfg.MetricsStalenessThreshold {
+		logger.Info("Warning: refresh-metrics-interval exceeds metricsStalenessThreshold; "+
+			"metrics will be stale between polls",
+			"detector", name,
+			"refreshMetricsInterval", refresh.String(),
+			"metricsStalenessThreshold", cfg.MetricsStalenessThreshold.String())
+	}
+	return NewDetector(name, *cfg, logger), nil
 }
 
 var (

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization/detector_test.go
@@ -18,12 +18,14 @@ package utilization
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
@@ -559,4 +561,51 @@ func TestDetector_StaleEndpointObservabilityIgnore(t *testing.T) {
 
 	require.Equal(t, 1.0, staleGaugeValue(t, detectorName),
 		"the stale endpoint gauge must record under the ignore policy too")
+}
+
+// warnCountingSink records how many Info messages mention the staleness warning.
+type warnCountingSink struct {
+	warnings int
+}
+
+func (s *warnCountingSink) Init(logr.RuntimeInfo)          {}
+func (s *warnCountingSink) Enabled(int) bool               { return true }
+func (s *warnCountingSink) Error(error, string, ...any)    {}
+func (s *warnCountingSink) WithValues(...any) logr.LogSink { return s }
+func (s *warnCountingSink) WithName(string) logr.LogSink   { return s }
+
+func (s *warnCountingSink) Info(_ int, msg string, _ ...any) {
+	if strings.Contains(msg, "refresh-metrics-interval exceeds metricsStalenessThreshold") {
+		s.warnings++
+	}
+}
+
+// TestUtilizationDetectorFactory_StalenessWarning verifies the factory warns
+// only when the data-layer polling cadence exceeds the staleness threshold.
+func TestUtilizationDetectorFactory_StalenessWarning(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		refreshInterval time.Duration
+		wantWarnings    int
+	}{
+		{"interval exceeds threshold", DefaultMetricsStalenessThreshold + time.Second, 1},
+		{"interval equals threshold", DefaultMetricsStalenessThreshold, 0},
+		{"interval below threshold", DefaultMetricsStalenessThreshold - time.Millisecond, 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sink := &warnCountingSink{}
+			ctx := log.IntoContext(context.Background(), logr.New(sink))
+			handle := fwkplugin.NewEppHandle(ctx, nil, fwkplugin.WithRefreshMetricsInterval(tc.refreshInterval))
+
+			_, err := UtilizationDetectorFactory("test", nil, handle)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantWarnings, sink.warnings)
+		})
+	}
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -245,6 +246,10 @@ func (h *testHandle) CrossReplicaSyncer() plugin.Plugin {
 
 func (h *testHandle) SetCrossReplicaSyncer(syncer plugin.Plugin) {
 	h.crossReplicaSyncer = syncer
+}
+
+func (h *testHandle) RefreshMetricsInterval() time.Duration {
+	return 0
 }
 
 func (h *testHandle) PodList() []k8stypes.NamespacedName {

--- a/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/nohitlru/no_hit_lru_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -70,6 +71,10 @@ func (h *fakeHandle) CrossReplicaSyncer() plugin.Plugin {
 
 func (h *fakeHandle) SetCrossReplicaSyncer(syncer plugin.Plugin) {
 	h.crossReplicaSyncer = syncer
+}
+
+func (h *fakeHandle) RefreshMetricsInterval() time.Duration {
+	return 0
 }
 
 type stubPlugin struct {

--- a/test/utils/handle.go
+++ b/test/utils/handle.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"context"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/types"
@@ -52,6 +53,10 @@ func (h *testHandle) CrossReplicaSyncer() plugin.Plugin {
 
 func (h *testHandle) SetCrossReplicaSyncer(syncer plugin.Plugin) {
 	h.crossReplicaSyncer = syncer
+}
+
+func (h *testHandle) RefreshMetricsInterval() time.Duration {
+	return 0
 }
 
 type testHandlePlugins struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When `--refresh-metrics-interval` exceeds a saturation detector's `metricsStalenessThreshold`, endpoint metrics may become stale between polls. This can cause the detector to treat healthy endpoints as saturated, leading to backpressure and increased request latency.

This PR adds a startup warning that identifies the detector and both effective values, helping operators detect and correct the configuration before serving traffic.

**Which issue(s) this PR fixes**:
Fixes #2514

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Added a startup warning when `--refresh-metrics-interval` exceeds a saturation detector's `metricsStalenessThreshold`.
```