### PR TITLE
docs(epp): add affinity filter composition requirements

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
@@ -72,7 +72,8 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
 The filter narrows the candidate set or leaves it unchanged; the routing decision is made
 by the scorers and picker that run after it. When the TTFT load gate breaks stickiness, the
 filter keeps all endpoints, and the request moves off the sticky set only if downstream
-scoring prefers the less-loaded endpoints.
+scoring prefers the less-loaded endpoints. Nothing tells the scorers that a break happened;
+they apply the same weights to whatever candidates arrive.
 
 Scorers running after this filter must not include a separately weighted prefix-affinity
 scorer. Each scorer's output is clamped to [0, 1] before weighting, so the other scorers can
@@ -85,7 +86,11 @@ at or above loadWeightSum / affinityThreshold no zero-match endpoint can beat an
 endpoint outright (at exact equality a tie, resolved at random, remains possible). The break
 still moves requests to partially warm endpoints inside the bound, so a weighted
 `prefix-cache-scorer` with `max-score-picker` attenuates the gate in proportion to the prefix
-weight, up to full inertness for cold endpoints.
+weight, up to full inertness for cold endpoints. Breaks are counted by
+`llm_d_epp_prefix_cache_affinity_filter_decisions_total` with `outcome="load_override"`. A
+break that changed no routing decision shows as that counter climbing while the sticky
+endpoint's queue depth and TTFT hold; there is no counter for a break that left the request
+on the same endpoint.
 
 Excluding a weighted prefix scorer does not remove affinity from the post-break decision.
 The recommended load scorers count uncached tokens (the endpoint's uncached tokens in flight

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
@@ -22,7 +22,7 @@ candidates (no-op).
 The `prefix-cache-scorer` plugin scores endpoints by prefix cache hit ratio. It works with
 any picker, but the choice of picker creates a trade-off:
 
-- **With `max-picker`** (the default): the scorer consistently picks the single
+- **With `max-score-picker`** (the default): the scorer consistently picks the single
   highest-scoring endpoint, which maximizes cache hits but causes **hot-spotting** — many
   concurrent requests with similar prompts all land on the same endpoint, overloading it and
   degrading TTFT.
@@ -66,6 +66,33 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
 - If no endpoints have the TTFT source attribute (`LatencyPredictionInfo` or `InFlightLoad`),
   the TTFT load gate is skipped. If no endpoints have `PrefixCacheMatchInfo`, all prefix
   scores default to 0 and no endpoints pass the affinity threshold, so all are kept (no-op)
+
+## Composition requirements
+
+The filter narrows or widens the candidate set; the routing decision is made by the scorers
+and picker that run after it. When the TTFT load gate breaks stickiness, the filter keeps
+all endpoints, and the request moves off the sticky set only if downstream scoring prefers
+the less-loaded endpoints.
+
+Scorers running after this filter must score on load only. Each scorer's output is clamped
+to [0, 1] before weighting, so load scorers can favor a non-sticky endpoint by at most the
+sum of their weights, while a prefix-affinity scorer penalizes it by its weight times the
+prefix cache score difference. The break can therefore move a request only to endpoints
+whose prefix cache score is within loadWeightSum / prefixWeight of the sticky endpoint's.
+A prefix weight at or above the load weight sum lets a zero-match endpoint at best tie a
+fully matched sticky one; at or above loadWeightSum / affinityThreshold the gate cannot
+move any request. Combining this filter with a weighted `prefix-cache-scorer` and
+`max-score-picker` leaves the gate inert whenever the sticky endpoint holds a full match.
+
+Recommended compositions pair the filter with a single load scorer and `max-score-picker`:
+`token-load-scorer` for prefill-bound workloads, `active-request-scorer` for decode-bound
+workloads. `weighted-random-picker` spreads requests across the sticky set rather than
+concentrating them on the top-scored endpoint; the picker choice does not affect the
+load-only requirement on scorers. The
+[optimized-baseline guide](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline)
+ships the prefill-bound composition, and the
+[Sticky Until Saturated post](https://llm-d.ai/blog/sticky-until-saturated-token-aware-routing)
+documents the strategy and its calibration.
 
 ## Config
 

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
@@ -69,26 +69,34 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
 
 ## Composition requirements
 
-The filter narrows or widens the candidate set; the routing decision is made by the scorers
-and picker that run after it. When the TTFT load gate breaks stickiness, the filter keeps
-all endpoints, and the request moves off the sticky set only if downstream scoring prefers
-the less-loaded endpoints.
+The filter narrows the candidate set or leaves it unchanged; the routing decision is made
+by the scorers and picker that run after it. When the TTFT load gate breaks stickiness, the
+filter keeps all endpoints, and the request moves off the sticky set only if downstream
+scoring prefers the less-loaded endpoints.
 
-Scorers running after this filter must score on load only. Each scorer's output is clamped
-to [0, 1] before weighting, so load scorers can favor a non-sticky endpoint by at most the
-sum of their weights, while a prefix-affinity scorer penalizes it by its weight times the
-prefix cache score difference. The break can therefore move a request only to endpoints
-whose prefix cache score is within loadWeightSum / prefixWeight of the sticky endpoint's.
-A prefix weight at or above the load weight sum lets a zero-match endpoint at best tie a
-fully matched sticky one; at or above loadWeightSum / affinityThreshold the gate cannot
-move any request. Combining this filter with a weighted `prefix-cache-scorer` and
-`max-score-picker` leaves the gate inert whenever the sticky endpoint holds a full match.
+Scorers running after this filter must not include a separately weighted prefix-affinity
+scorer. Each scorer's output is clamped to [0, 1] before weighting, so the other scorers can
+favor a non-sticky endpoint by at most the sum of their weights (loadWeightSum), while a
+prefix-affinity scorer penalizes it by its weight (prefixWeight) times the prefix cache
+score difference. The break can therefore move a request only to endpoints whose prefix
+cache score is within loadWeightSum / prefixWeight of the sticky endpoint's. A prefix weight
+at or above loadWeightSum lets a zero-match endpoint at best tie a fully matched sticky one;
+at or above loadWeightSum / affinityThreshold no zero-match endpoint can beat any sticky
+endpoint outright (at exact equality a tie, resolved at random, remains possible). The break
+still moves requests to partially warm endpoints inside the bound, so a weighted
+`prefix-cache-scorer` with `max-score-picker` attenuates the gate in proportion to the prefix
+weight, up to full inertness for cold endpoints.
+
+Excluding a weighted prefix scorer does not remove affinity from the post-break decision.
+The recommended load scorers count uncached tokens (the endpoint's uncached tokens in flight
+plus the tokens of this request the endpoint has not cached), so cache warmth lowers a
+request's cost on a warm endpoint in the same units as the load it is compared against.
 
 Recommended compositions pair the filter with a single load scorer and `max-score-picker`:
 `token-load-scorer` for prefill-bound workloads, `active-request-scorer` for decode-bound
 workloads. `weighted-random-picker` spreads requests across the sticky set rather than
 concentrating them on the top-scored endpoint; the picker choice does not affect the
-load-only requirement on scorers. The
+scorer requirement. The
 [optimized-baseline guide](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline)
 ships the prefill-bound composition, and the
 [Sticky Until Saturated post](https://llm-d.ai/blog/sticky-until-saturated-token-aware-routing)


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds a composition-requirements section to the `prefix-cache-affinity-filter` README.

The TTFT load gate's break keeps all endpoints; whether a request moves off the sticky set is decided by the scorers and picker that run after the filter. Scorer outputs are clamped to [0, 1] before weighting (`pkg/epp/scheduling/scheduler_profile.go`), which bounds how far in prefix cache score a break can move a request by the ratio of the load scorers' weight sum to the prefix scorer's weight. A prefix weight at or above the load weight sum makes the gate unable to move a request off a fully matched sticky endpoint; at or above the load weight sum divided by `affinityThreshold` it cannot move any request. No documentation stated this requirement. The inert composition is reachable by adding the filter to a weighted-blend profile (weighted `prefix-cache-scorer` + load scorers + `max-score-picker`), and the filter does not require a prefix scorer in the profile (the default `approx-prefix-cache` producer supplies `PrefixCacheMatchInfo`), so nothing structural prevents it.

The new section states the load-only requirement on downstream scorers with the weight arithmetic, names the inert composition, lists the recommended compositions (`token-load-scorer` prefill-bound, `active-request-scorer` decode-bound, with `max-score-picker`), notes that the picker choice is orthogonal to the scorer requirement, and links the optimized-baseline guide and the Sticky Until Saturated post. Also corrects a stale picker name in the same file (`max-picker` to `max-score-picker`).

Possible follow-up outside this repo: the llm-d guides that ship this filter (optimized-baseline and related) state the recommended composition but not the constraint; a one-line note there would cover users editing guide values files directly.

**Which issue(s) this PR fixes**:

None.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
