### PR TITLE
fix(epp): Add check for unpopulated load attributes for TTFT load gate

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
@@ -63,9 +63,11 @@ Can be instantiated multiple times with different thresholds (e.g., 0.99 for glo
   `inFlightTokens / peakPrefillThroughput * 1000` (ms) when `ttftSource` is
   `prefillThroughput` (default), or comes from the latency predictor when `ttftSource`
   is `latencyPredictor`
-- If no endpoints have the TTFT source attribute (`LatencyPredictionInfo` or `InFlightLoad`),
-  the TTFT load gate is skipped. If no endpoints have `PrefixCacheMatchInfo`, all prefix
-  scores default to 0 and no endpoints pass the affinity threshold, so all are kept (no-op)
+- If either the sticky or non-sticky set has no endpoint with the TTFT source attribute
+  (`LatencyPredictionInfo` or `InFlightLoad`), the TTFT load gate is skipped and the sticky
+  set is kept; the `missing_signal` outcome is recorded. If no endpoints have
+  `PrefixCacheMatchInfo`, all prefix scores default to 0 and no endpoints pass the affinity
+  threshold, so all are kept (no-op)
 
 ## Composition requirements
 
@@ -110,7 +112,7 @@ documents the strategy and its calibration.
 ## Config
 
 | Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
+| ----------- | ------ | ---------- | --------- | ------------- |
 | `affinityThreshold` | `float64` | No | `0.80` | Prefix cache score threshold for stickiness |
 | `explorationProbability` | `float64` | No | `0` | Probability of skipping the gate |
 | `maxTTFTPenaltyMs` | `float64` | No | `18000` | Max TTFT penalty (ms) before breaking stickiness. 0 = always stick |
@@ -130,6 +132,7 @@ to `latencyPredictor` to source TTFT from the latency predictor instead.
 - Reads `LatencyPredictionInfo` for the TTFT load gate when `ttftSource` is `latencyPredictor` (from `predicted-latency-producer`)
 
 **Configuration Example:**
+
 ```yaml
 plugins:
   - type: prefix-cache-affinity-filter

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/README.md
@@ -112,7 +112,7 @@ documents the strategy and its calibration.
 ## Config
 
 | Parameter | Type | Required | Default | Description |
-| ----------- | ------ | ---------- | --------- | ------------- |
+|-----------|------|----------|---------|-------------|
 | `affinityThreshold` | `float64` | No | `0.80` | Prefix cache score threshold for stickiness |
 | `explorationProbability` | `float64` | No | `0` | Probability of skipping the gate |
 | `maxTTFTPenaltyMs` | `float64` | No | `18000` | Max TTFT penalty (ms) before breaking stickiness. 0 = always stick |
@@ -132,7 +132,6 @@ to `latencyPredictor` to source TTFT from the latency predictor instead.
 - Reads `LatencyPredictionInfo` for the TTFT load gate when `ttftSource` is `latencyPredictor` (from `predicted-latency-producer`)
 
 **Configuration Example:**
-
 ```yaml
 plugins:
   - type: prefix-cache-affinity-filter

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/metrics.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/metrics.go
@@ -43,7 +43,7 @@ const (
 	// outcomeNotApplicable: the filter had nothing to decide (a single
 	// candidate, or the affinity threshold disabled).
 	outcomeNotApplicable = "not_applicable"
-	// outcomeMisingSignal: Either side of the TTFT comparison lacked the configured attribute
+	// outcomeMissingSignal: Either side of the TTFT comparison lacked the configured attribute
 	// gate skipped and sticky set kept
 	outcomeMissingSignal = "missing_signal"
 )

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/metrics.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/metrics.go
@@ -43,6 +43,9 @@ const (
 	// outcomeNotApplicable: the filter had nothing to decide (a single
 	// candidate, or the affinity threshold disabled).
 	outcomeNotApplicable = "not_applicable"
+	// outcomeMisingSignal: Either side of the TTFT comparison lacked the configured attribute
+	// gate skipped and sticky set kept
+	outcomeMissingSignal = "missing_signal"
 )
 
 var filterDecisions = prometheus.NewCounterVec(

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/metrics_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/metrics_test.go
@@ -92,7 +92,7 @@ func TestFilterRecordsDecisionOutcome(t *testing.T) {
 		},
 	}
 
-	allOutcomes := []string{outcomeSticky, outcomeNoMatch, outcomeLoadOverride, outcomeExploration, outcomeNotApplicable}
+	allOutcomes := []string{outcomeSticky, outcomeNoMatch, outcomeLoadOverride, outcomeExploration, outcomeNotApplicable, outcomeMissingSignal}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/metrics_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/metrics_test.go
@@ -84,6 +84,12 @@ func TestFilterRecordsDecisionOutcome(t *testing.T) {
 			input:   []fwksched.Endpoint{makeEndpoint("a", 90, 500, 0), makeEndpoint("b", 10, 50, 0)},
 			outcome: outcomeLoadOverride,
 		},
+		{
+			name:    "missing signal keeps sticky",
+			config:  Config{AffinityThreshold: 0.80, MaxTTFTPenaltyMs: 100, TTFTSource: TTFTSourceLatencyPredictor},
+			input:   []fwksched.Endpoint{makeEndpoint("a", 90, -1, 0), makeEndpoint("b", 10, 50, 0)},
+			outcome: outcomeMissingSignal,
+		},
 	}
 
 	allOutcomes := []string{outcomeSticky, outcomeNoMatch, outcomeLoadOverride, outcomeExploration, outcomeNotApplicable}

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -300,8 +300,7 @@ func (p *Plugin) bestTTFT(endpoints []fwksched.Endpoint) (float64, bool) {
 // endpointTTFT returns the predicted TTFT (ms) for an endpoint, either from the
 // latency predictor or estimated from in-flight tokens and peak prefill
 // throughput. Endpoints missing the required attribute contribute no signal:
-// MaxFloat64 on the predictor path (never the fastest), 0 in-flight tokens on
-// the throughput path (no observed load). Returns the ttft and false if predictiond data was missing.
+// the function returns false and the endpoint is excluded from the bestTTFT calculation.
 func (p *Plugin) endpointTTFT(ep fwksched.Endpoint) (float64, bool) {
 	if p.config.usesLatencyPredictor() {
 		if raw, ok := ep.Get(p.latencyPredictionInfoDataKey); ok {
@@ -317,8 +316,8 @@ func (p *Plugin) endpointTTFT(ep fwksched.Endpoint) (float64, bool) {
 	return float64(tokens) / p.config.PeakPrefillThroughput * 1000, true
 }
 
-// inFlightTokens returns an endpoint's in-flight token count, or 0 when the
-// attribute is absent (no observed load).
+// inFlightTokens returns an endpoint's in-flight token count. If the attribute is
+// absent, it returns ok=false so the caller can treat the signal as missing.
 func (p *Plugin) inFlightTokens(ep fwksched.Endpoint) (int64, bool) {
 	if raw, ok := ep.Get(p.inFlightLoadDataKey); ok {
 		if load, ok := raw.(*attrconcurrency.InFlightLoad); ok && load != nil {

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -230,8 +230,14 @@ func (p *Plugin) Filter(ctx context.Context, request *fwksched.InferenceRequest,
 
 	// TTFT load gate: break stickiness if sticky endpoints are too slow.
 	if p.config.MaxTTFTPenaltyMs > 0 && len(nonSticky) > 0 {
-		bestStickyTTFT := p.bestTTFT(sticky)
-		bestNonStickyTTFT := p.bestTTFT(nonSticky)
+		bestStickyTTFT, stickyOk := p.bestTTFT(sticky)
+		bestNonStickyTTFT, nonStickyOk := p.bestTTFT(nonSticky)
+		if !stickyOk || !nonStickyOk {
+			logger.V(logutil.DEBUG).Info("PrefixCacheAffinityFilter: TTFT load gate skipped, missing signal",
+				"stickyObserved", stickyOk, "nonStickyObserved", nonStickyOk)
+			recordDecision(p.typedName.Name, outcomeMissingSignal)
+			return sticky
+		}
 		penalty := bestStickyTTFT - bestNonStickyTTFT
 		span.SetAttributes(semconv.LLMDEPPFilterTTFTPenaltyMs(penalty))
 		if penalty > p.config.MaxTTFTPenaltyMs {
@@ -279,39 +285,45 @@ func (p *Plugin) prefixCacheScore(ep fwksched.Endpoint) float64 {
 }
 
 // bestTTFT returns the lowest per-endpoint TTFT (ms) across endpoints.
-func (p *Plugin) bestTTFT(endpoints []fwksched.Endpoint) float64 {
+func (p *Plugin) bestTTFT(endpoints []fwksched.Endpoint) (float64, bool) {
 	best := math.MaxFloat64
+	found := false
 	for _, ep := range endpoints {
-		if ttft := p.endpointTTFT(ep); ttft < best {
+		if ttft, ok := p.endpointTTFT(ep); ok && ttft < best {
 			best = ttft
+			found = true
 		}
 	}
-	return best
+	return best, found
 }
 
 // endpointTTFT returns the predicted TTFT (ms) for an endpoint, either from the
 // latency predictor or estimated from in-flight tokens and peak prefill
 // throughput. Endpoints missing the required attribute contribute no signal:
 // MaxFloat64 on the predictor path (never the fastest), 0 in-flight tokens on
-// the throughput path (no observed load).
-func (p *Plugin) endpointTTFT(ep fwksched.Endpoint) float64 {
+// the throughput path (no observed load). Returns the ttft and false if predictiond data was missing.
+func (p *Plugin) endpointTTFT(ep fwksched.Endpoint) (float64, bool) {
 	if p.config.usesLatencyPredictor() {
 		if raw, ok := ep.Get(p.latencyPredictionInfoDataKey); ok {
 			info := raw.(*attrlatency.LatencyPredictionInfo)
-			return info.TTFT()
+			return info.TTFT(), true
 		}
-		return math.MaxFloat64
+		return math.MaxFloat64, false
 	}
-	return float64(p.inFlightTokens(ep)) / p.config.PeakPrefillThroughput * 1000
+	tokens, ok := p.inFlightTokens(ep)
+	if !ok {
+		return 0, false
+	}
+	return float64(tokens) / p.config.PeakPrefillThroughput * 1000, true
 }
 
 // inFlightTokens returns an endpoint's in-flight token count, or 0 when the
 // attribute is absent (no observed load).
-func (p *Plugin) inFlightTokens(ep fwksched.Endpoint) int64 {
+func (p *Plugin) inFlightTokens(ep fwksched.Endpoint) (int64, bool) {
 	if raw, ok := ep.Get(p.inFlightLoadDataKey); ok {
 		if load, ok := raw.(*attrconcurrency.InFlightLoad); ok && load != nil {
-			return load.Tokens
+			return load.Tokens, true
 		}
 	}
-	return 0
+	return 0, false
 }

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
@@ -153,6 +153,61 @@ func TestFilter_ExplorationProbability(t *testing.T) {
 	assert.Equal(t, 2, len(result), "epsilon=1.0 should always skip gate")
 }
 
+func TestFilter_StickyMissingSignalPredictor(t *testing.T) {
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, MaxTTFTPenaltyMs: 100, TTFTSource: TTFTSourceLatencyPredictor})
+	endpoints := []fwksched.Endpoint{
+		makeEndpoint("a", 90, -1, 0),
+		makeEndpoint("b", 10, 50, 0),
+	}
+	result := p.Filter(context.Background(), nil, endpoints)
+	assert.Equal(t, 1, len(result), "missing sticky signal should keep sticky set")
+	assert.Equal(t, "a", result[0].GetMetadata().ID.Name)
+}
+
+func TestFilter_NonStickyMissingSignalPredictor(t *testing.T) {
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, MaxTTFTPenaltyMs: 100, TTFTSource: TTFTSourceLatencyPredictor})
+	endpoints := []fwksched.Endpoint{
+		makeEndpoint("a", 90, 5000, 0),
+		makeEndpoint("b", 10, -1, 0),
+	}
+	result := p.Filter(context.Background(), nil, endpoints)
+	assert.Equal(t, 1, len(result), "missing non-sticky signal should keep sticky set")
+	assert.Equal(t, "a", result[0].GetMetadata().ID.Name)
+}
+
+func TestFilter_NonStickyMissingSignalThroughput(t *testing.T) {
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, MaxTTFTPenaltyMs: 100, TTFTSource: TTFTSourcePrefillThroughput, PeakPrefillThroughput: 1000})
+	endpoints := []fwksched.Endpoint{
+		makeEndpoint("a", 90, -1, 500),
+		makeEndpoint("b", 10, -1, -1),
+	}
+	result := p.Filter(context.Background(), nil, endpoints)
+	assert.Equal(t, 1, len(result), "missing non-sticky signal should keep sticky set")
+	assert.Equal(t, "a", result[0].GetMetadata().ID.Name)
+}
+
+func TestFilter_StickyMissingSignalThroughput(t *testing.T) {
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, MaxTTFTPenaltyMs: 100, TTFTSource: TTFTSourcePrefillThroughput, PeakPrefillThroughput: 1000})
+	endpoints := []fwksched.Endpoint{
+		makeEndpoint("a", 90, -1, -1),
+		makeEndpoint("b", 10, -1, 50),
+	}
+	result := p.Filter(context.Background(), nil, endpoints)
+	assert.Equal(t, 1, len(result), "missing sticky signal should keep sticky set")
+	assert.Equal(t, "a", result[0].GetMetadata().ID.Name)
+}
+
+func TestFilter_MissingSignalBothPredictor(t *testing.T) {
+	p := newTestPlugin(Config{AffinityThreshold: 0.80, MaxTTFTPenaltyMs: 100, TTFTSource: TTFTSourceLatencyPredictor})
+	endpoints := []fwksched.Endpoint{
+		makeEndpoint("a", 90, -1, 0),
+		makeEndpoint("b", 10, -1, 0),
+	}
+	result := p.Filter(context.Background(), nil, endpoints)
+	assert.Equal(t, 1, len(result), "both sides missing should keep sticky set")
+	assert.Equal(t, "a", result[0].GetMetadata().ID.Name)
+}
+
 func TestConsumes_ConditionalAttributes(t *testing.T) {
 	// Gate disabled: neither TTFT source is consumed.
 	p := newTestPlugin(Config{MaxTTFTPenaltyMs: 0})


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**: 

Previously, with the prefix-cache-affinity-filter, the load gate compared loaded values against defaults that would cause the paths to fail in opposite directions. When endpoints (whether sticky or not) were missing certain attributes such as `LatencyPredictionInfo` or `InFlightLoad.Tokens` the substituted value would be arbitrarily 0 or `MaxFloat64` causing the gate to unwillingly fire or not fire.

The implementation changes the TTFT and inFlightToken computation functions to return booleans to determine if the computation is ok or not. If not ok (meaning there was no data), the endpoint is excluded from the bestTTFT calculation. If there was no data from either sticky/non-sticky set, then default to the sticky set. When there is missing data causing a failure toward stickiness, a `missing_signal` count is incremented. 

Tests were added as well as an adjustment to the README to note this behavior.

Fixes https://github.com/llm-d/llm-d-router/issues/2650


**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
