### PR TITLE
fix(epp): move TokenizedPrompt to request attribute store (#1375)

### DIFF
--- a/pkg/epp/flowcontrol/benchmark/benchmark_test.go
+++ b/pkg/epp/flowcontrol/benchmark/benchmark_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	requesthandling "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 )
 
 // BenchmarkFlowController_PerformanceMatrix evaluates throughput across a matrix of variables.
@@ -346,8 +347,9 @@ func BenchmarkFlowController_FullPath(b *testing.B) {
 			//    detector reads to compute saturation.
 			infReq := &scheduling.InferenceRequest{
 				RequestID: reqID,
-				Body:      &requesthandling.InferenceRequestBody{TokenizedRequest: &requesthandling.TokenizedRequest{Prompts: []requesthandling.PromptTokens{{TokenIDs: benchTokenIDs}}}},
+				Body:      &requesthandling.InferenceRequestBody{},
 			}
+			infReq.PutAttribute(tokenizer.TokenizedPromptDataKey, &requesthandling.TokenizedRequest{Prompts: []requesthandling.PromptTokens{{TokenIDs: benchTokenIDs}}})
 			schedResult := &scheduling.SchedulingResult{ProfileResults: profileResults}
 			_ = h.producer.PreRequest(ctx, infReq, schedResult)
 

--- a/pkg/epp/flowcontrol/integration_test.go
+++ b/pkg/epp/flowcontrol/integration_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -86,10 +87,9 @@ func TestConcurrentSaturationReads(t *testing.T) {
 			schedEp := fwksched.NewEndpoint(pd.epMeta, datalayer.NewMetrics(), nil)
 			req := &fwksched.InferenceRequest{
 				RequestID: fmt.Sprintf("req-%d", i),
-				Body: &fwkrh.InferenceRequestBody{
-					TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 10)}}},
-				},
+				Body:      &fwkrh.InferenceRequestBody{},
 			}
+			req.PutAttribute(tokenizer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 10)}}})
 			result := &fwksched.SchedulingResult{
 				ProfileResults: map[string]*fwksched.ProfileRunResult{
 					"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},
@@ -163,10 +163,9 @@ func TestSaturationFullLoop(t *testing.T) {
 		schedEp := fwksched.NewEndpoint(pd.epMeta, datalayer.NewMetrics(), nil)
 		req := &fwksched.InferenceRequest{
 			RequestID: fmt.Sprintf("prefill-%d", i),
-			Body: &fwkrh.InferenceRequestBody{
-				TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 50)}}},
-			},
+			Body:      &fwkrh.InferenceRequestBody{},
 		}
+		req.PutAttribute(tokenizer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 50)}}})
 		result := &fwksched.SchedulingResult{
 			ProfileResults: map[string]*fwksched.ProfileRunResult{
 				"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},
@@ -452,10 +451,9 @@ func TestUsageLimitThresholdGatesDispatch(t *testing.T) {
 		schedEp := fwksched.NewEndpoint(pd.epMeta, datalayer.NewMetrics(), nil)
 		req := &fwksched.InferenceRequest{
 			RequestID: fmt.Sprintf("inflight-%d", i),
-			Body: &fwkrh.InferenceRequestBody{
-				TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 10)}}},
-			},
+			Body:      &fwkrh.InferenceRequestBody{},
 		}
+		req.PutAttribute(tokenizer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 10)}}})
 		result := &fwksched.SchedulingResult{
 			ProfileResults: map[string]*fwksched.ProfileRunResult{
 				"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},
@@ -1002,10 +1000,9 @@ func TestEndpointReregistrationSaturationAccuracy(t *testing.T) {
 	schedEp := fwksched.NewEndpoint(epMeta, datalayer.NewMetrics(), nil)
 	oldReq := &fwksched.InferenceRequest{
 		RequestID: "old-req",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 50)}}},
-		},
+		Body:      &fwkrh.InferenceRequestBody{},
 	}
+	oldReq.PutAttribute(tokenizer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 50)}}})
 	oldResult := &fwksched.SchedulingResult{
 		ProfileResults: map[string]*fwksched.ProfileRunResult{
 			"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},
@@ -1058,10 +1055,9 @@ func TestEndpointReregistrationSaturationAccuracy(t *testing.T) {
 	newSchedEp := fwksched.NewEndpoint(epMeta, datalayer.NewMetrics(), nil)
 	newReq := &fwksched.InferenceRequest{
 		RequestID: "new-req",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 50)}}},
-		},
+		Body:      &fwkrh.InferenceRequestBody{},
 	}
+	newReq.PutAttribute(tokenizer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 50)}}})
 	newResult := &fwksched.SchedulingResult{
 		ProfileResults: map[string]*fwksched.ProfileRunResult{
 			"decode": {TargetEndpoints: []fwksched.Endpoint{newSchedEp}},
@@ -1119,10 +1115,9 @@ func TestEndpointIdentityCollisionDuringPodReplacement(t *testing.T) {
 	schedEp := fwksched.NewEndpoint(epMeta, datalayer.NewMetrics(), nil)
 	req := &fwksched.InferenceRequest{
 		RequestID: "new-pod-req",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 50)}}},
-		},
+		Body:      &fwkrh.InferenceRequestBody{},
 	}
+	req.PutAttribute(tokenizer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 50)}}})
 	result := &fwksched.SchedulingResult{
 		ProfileResults: map[string]*fwksched.ProfileRunResult{
 			"decode": {TargetEndpoints: []fwksched.Endpoint{schedEp}},

--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -114,9 +114,6 @@ type InferenceRequestBody struct {
 	// If the payload is unmarshaled, we can perform advanced processing (like prefix cache aware routing).
 	// If it remains as raw bytes, such processing may not be supported.
 	Payload RequestPayload `json:"-"`
-	// TokenizedRequest contains parser-derived tokenization results when available.
-	// It is nil when the request was not already tokenized.
-	TokenizedRequest *TokenizedRequest `json:"-"`
 
 	// Stream indicates whether the request specifies a streaming response (e.g., via a stream field).
 	// This typically implies the model server's response will be streamed.

--- a/pkg/epp/framework/observability/multimodal/multimodal.go
+++ b/pkg/epp/framework/observability/multimodal/multimodal.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"go.opentelemetry.io/otel/attribute"
 
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
@@ -67,11 +68,18 @@ func Summary(req *scheduling.InferenceRequest) (modality string, hashCount int) 
 }
 
 func requestMMFeatures(req *scheduling.InferenceRequest) []fwkrh.MultiModalFeature {
-	if req == nil || req.Body == nil || req.Body.TokenizedRequest == nil {
+	if req == nil {
 		return nil
 	}
 	var features []fwkrh.MultiModalFeature
-	for _, p := range req.Body.TokenizedRequest.Prompts {
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](
+		req,
+		tokenizer.TokenizedPromptDataKey,
+	)
+	if !ok {
+		return nil
+	}
+	for _, p := range tp.Prompts {
 		features = append(features, p.MultiModalFeatures...)
 	}
 	return features

--- a/pkg/epp/framework/observability/multimodal/multimodal_test.go
+++ b/pkg/epp/framework/observability/multimodal/multimodal_test.go
@@ -19,6 +19,7 @@ package multimodal
 import (
 	"testing"
 
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/stretchr/testify/assert"
 
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
@@ -107,13 +108,13 @@ func TestSpanAttributes(t *testing.T) {
 }
 
 func requestWith(features ...fwkrh.MultiModalFeature) *scheduling.InferenceRequest {
-	return &scheduling.InferenceRequest{
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{
-					MultiModalFeatures: features,
-				}},
-			},
-		},
+	req := &scheduling.InferenceRequest{
+		Body: &fwkrh.InferenceRequestBody{},
 	}
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{
+			MultiModalFeatures: features,
+		}},
+	})
+	return req
 }

--- a/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/saturationdetector/concurrency/detector_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -807,10 +808,14 @@ func (f *liveSchedulingEndpoint) Clone() datalayer.AttributeMap { return f }
 // stays independent of the production in-flight token estimator's policy, which
 // derives output tokens from the outlen-bucket attribute rather than a fixed ratio.
 func simulatedTokenLoad(req *fwksched.InferenceRequest) int64 {
-	if req == nil || req.Body == nil || req.Body.TokenizedRequest == nil {
+	if req == nil {
 		return 0
 	}
-	input := int64(req.Body.TokenizedRequest.TokenCount())
+	tp, ok := fwksched.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, tokenizer.TokenizedPromptDataKey)
+	if !ok {
+		return 0
+	}
+	input := int64(tp.TokenCount())
 	// round(input * 1.5) via integer half-up, matching the numbers these tests assert.
 	return input + (input*3+1)/2
 }
@@ -818,12 +823,12 @@ func simulatedTokenLoad(req *fwksched.InferenceRequest) int64 {
 // makeTokenRequest builds a request with inputTokens tokenized input tokens.
 // simulatedTokenLoad then derives total tokens as inputTokens + round(inputTokens * 1.5).
 func makeTokenRequest(requestID string, inputTokens int) *fwksched.InferenceRequest {
-	return &fwksched.InferenceRequest{
+	req := &fwksched.InferenceRequest{
 		RequestID: requestID,
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, inputTokens)}}},
-		},
+		Body:      &fwkrh.InferenceRequestBody{},
 	}
+	req.PutAttribute(tokenizer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, inputTokens)}}})
+	return req
 }
 
 // nilMetadataEndpoint simulates a freshly registered endpoint whose metadata

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -131,7 +131,7 @@ func (p *dataProducer) Produces() map[plugin.DataKey]any {
 // is configured.
 func (p *dataProducer) Consumes() plugin.DataDependencies {
 	return plugin.DataDependencies{
-		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: fwksched.TokenizedRequest{}},
+		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: (*fwksched.TokenizedRequest)(nil)},
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -50,11 +51,15 @@ func disableMinBlockSizeClamp(t *testing.T) {
 	t.Cleanup(func() { minBlockSizeTokens = prev })
 }
 
-// tokenizedBody returns a request body carrying only a tokenized prompt.
-func tokenizedBody(tokenIDs []uint32) *fwkrh.InferenceRequestBody {
-	return &fwkrh.InferenceRequestBody{
-		TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: tokenIDs}}},
+func inferenceRequest(targetModel string, tokenIDs []uint32) *fwksched.InferenceRequest {
+	req := &fwksched.InferenceRequest{
+		RequestID:   uuid.NewString(),
+		TargetModel: targetModel,
+		Body:        &fwkrh.InferenceRequestBody{},
 	}
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey,
+		&fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: tokenIDs}}})
+	return req
 }
 
 func TestProduce(t *testing.T) {
@@ -74,11 +79,7 @@ func TestProduce(t *testing.T) {
 	endpoints := []fwksched.Endpoint{endpoint1, endpoint2}
 
 	// First request to populate cache.
-	req1 := &fwksched.InferenceRequest{
-		RequestID:   uuid.NewString(),
-		TargetModel: "test-model1",
-		Body:        tokenizedBody([]uint32{1, 2}),
-	}
+	req1 := inferenceRequest("test-model1", []uint32{1, 2})
 
 	// We need to simulate the PreRequest logic since Produce only reads from the indexer.
 	// But first let's see if Produce correctly handles an empty indexer.
@@ -113,12 +114,7 @@ func TestPreRequest(t *testing.T) {
 		p, _ := newDataProducer(context.Background(), ApproxPrefixCachePluginType, config, testHandle())
 
 		endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1", Namespace: "default"}}, fwkdl.NewMetrics(), fwkdl.NewAttributes())
-		req1 := &fwksched.InferenceRequest{
-			RequestID:   uuid.NewString(),
-			TargetModel: "test-model1",
-			Body:        tokenizedBody([]uint32{1, 2}),
-		}
-
+		req1 := inferenceRequest("test-model1", []uint32{1, 2})
 		// 1. Produce data (this saves state)
 		_ = p.Produce(context.Background(), req1, []fwksched.Endpoint{endpoint1})
 
@@ -165,11 +161,7 @@ func TestPreRequest(t *testing.T) {
 		allHashes := make([][]blockHash, 0, len(tokenSets))
 
 		for _, tokenIDs := range tokenSets {
-			req := &fwksched.InferenceRequest{
-				RequestID:   uuid.NewString(),
-				TargetModel: "test-model1",
-				Body:        tokenizedBody(tokenIDs),
-			}
+			req := inferenceRequest("test-model1", tokenIDs)
 			_ = p.Produce(context.Background(), req, []fwksched.Endpoint{endpoint1})
 
 			res := &fwksched.SchedulingResult{
@@ -182,7 +174,6 @@ func TestPreRequest(t *testing.T) {
 			}
 			_ = p.PreRequest(context.Background(), req, res)
 			p.wg.Wait()
-
 			perPromptHashes := prefixhash.GetBlockHashes(context.Background(), req, config.BlockSizeTokens, defaultMaxPrefixBlocks)
 			allHashes = append(allHashes, perPromptHashes[0])
 		}
@@ -241,11 +232,7 @@ func TestPrefixPluginPartialPrefixMatch(t *testing.T) {
 	endpoints := []fwksched.Endpoint{endpoint1, endpoint2, endpoint3}
 
 	// First request: tokens [1, 2].
-	req1 := &fwksched.InferenceRequest{
-		RequestID:   uuid.NewString(),
-		TargetModel: "test-model1",
-		Body:        tokenizedBody([]uint32{1, 2}),
-	}
+	req1 := inferenceRequest("test-model1", []uint32{1, 2})
 	_ = p.Produce(context.Background(), req1, endpoints)
 	state, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	assert.Equal(t, 2, len(state.PerPromptHashes[0]))
@@ -262,11 +249,7 @@ func TestPrefixPluginPartialPrefixMatch(t *testing.T) {
 	p.wg.Wait()
 
 	// Second request shares the first token but diverges on the second.
-	req3 := &fwksched.InferenceRequest{
-		RequestID:   uuid.NewString(),
-		TargetModel: "test-model1",
-		Body:        tokenizedBody([]uint32{1, 3}),
-	}
+	req3 := inferenceRequest("test-model1", []uint32{1, 3})
 	_ = p.Produce(context.Background(), req3, endpoints)
 
 	key := attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(ApproxPrefixCachePluginType)
@@ -301,11 +284,7 @@ func TestPrefixPluginPrefixGrowth(t *testing.T) {
 	endpoints := []fwksched.Endpoint{endpoint1}
 
 	// First request with an initial token prefix.
-	req1 := &fwksched.InferenceRequest{
-		RequestID:   uuid.NewString(),
-		TargetModel: "test-model1",
-		Body:        tokenizedBody([]uint32{1, 2, 3, 4, 5, 6}),
-	}
+	req1 := inferenceRequest("test-model1", []uint32{1, 2, 3, 4, 5, 6})
 	_ = p.Produce(context.Background(), req1, endpoints)
 	state1, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	initialHashCount := len(state1.PerPromptHashes[0])
@@ -322,11 +301,7 @@ func TestPrefixPluginPrefixGrowth(t *testing.T) {
 	p.wg.Wait()
 
 	// Second request extends the first one's token prefix.
-	req2 := &fwksched.InferenceRequest{
-		RequestID:   uuid.NewString(),
-		TargetModel: "test-model1",
-		Body:        tokenizedBody([]uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}),
-	}
+	req2 := inferenceRequest("test-model1", []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12})
 	_ = p.Produce(context.Background(), req2, endpoints)
 	state2, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req2.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 	extendedHashCount := len(state2.PerPromptHashes[0])
@@ -356,12 +331,7 @@ func TestPrefixPluginAutoTune(t *testing.T) {
 	for i := range tokenIDs {
 		tokenIDs[i] = uint32(i + 1)
 	}
-	req := &fwksched.InferenceRequest{
-		RequestID:   uuid.NewString(),
-		TargetModel: "test-model",
-		Body:        tokenizedBody(tokenIDs),
-	}
-
+	req := inferenceRequest("test-model", tokenIDs)
 	config := config{
 		AutoTune:               true,
 		BlockSizeTokens:        256, // Should be ignored in favor of pod metrics (128)
@@ -406,12 +376,7 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 	)
 
 	// 4 token IDs = 4 blocks at blockSize 1, but should be capped to 2.
-	req := &fwksched.InferenceRequest{
-		RequestID:   uuid.NewString(),
-		TargetModel: "test-model",
-		Body:        tokenizedBody([]uint32{1, 2, 3, 4}),
-	}
-
+	req := inferenceRequest("test-model", []uint32{1, 2, 3, 4})
 	err = p.Produce(context.Background(), req, []fwksched.Endpoint{endpoint})
 	assert.NoError(t, err)
 
@@ -429,12 +394,7 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 	p2, err := newDataProducer(context.Background(), ApproxPrefixCachePluginType, cfg2, testHandle())
 	assert.NoError(t, err)
 
-	req2 := &fwksched.InferenceRequest{
-		RequestID:   uuid.NewString(),
-		TargetModel: "test-model",
-		Body:        tokenizedBody([]uint32{1, 2, 3, 4}),
-	}
-
+	req2 := inferenceRequest("test-model", []uint32{1, 2, 3, 4})
 	err = p2.Produce(context.Background(), req2, []fwksched.Endpoint{endpoint})
 	assert.NoError(t, err)
 
@@ -463,12 +423,7 @@ func TestMaxPrefixBothCapsZeroMatchesEverything(t *testing.T) {
 		fwkdl.NewMetrics(), fwkdl.NewAttributes(),
 	)
 
-	req := &fwksched.InferenceRequest{
-		RequestID:   uuid.NewString(),
-		TargetModel: "test-model",
-		Body:        tokenizedBody([]uint32{1, 2, 3, 4}),
-	}
-
+	req := inferenceRequest("test-model", []uint32{1, 2, 3, 4})
 	err = p.Produce(context.Background(), req, []fwksched.Endpoint{endpoint})
 	assert.NoError(t, err)
 
@@ -596,12 +551,7 @@ func BenchmarkPrefixPluginStress(b *testing.B) {
 				ID: k8stypes.NamespacedName{Name: "pod1"},
 			}, nil, fwkdl.NewAttributes())
 			endpoints := []fwksched.Endpoint{endpoint}
-			req := &fwksched.InferenceRequest{
-				RequestID:   uuid.NewString(),
-				TargetModel: "model-stress",
-				Body:        tokenizedBody(tokenIDs),
-			}
-
+			req := inferenceRequest("model-stress", tokenIDs)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_ = p.Produce(context.Background(), req, endpoints)
@@ -678,13 +628,11 @@ func TestProduce_MultiPrompt(t *testing.T) {
 	req := &fwksched.InferenceRequest{
 		RequestID:   uuid.NewString(),
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2, 3}}, {TokenIDs: []uint32{4, 5}}},
-			},
-		},
+		Body:        &fwkrh.InferenceRequestBody{},
 	}
-
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2, 3}}, {TokenIDs: []uint32{4, 5}}},
+	})
 	err = p.Produce(context.Background(), req, endpoints)
 	assert.NoError(t, err)
 
@@ -721,12 +669,11 @@ func TestMultiPromptMatchAggregation(t *testing.T) {
 	req1 := &fwksched.InferenceRequest{
 		RequestID:   uuid.NewString(),
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2, 3}}, {TokenIDs: []uint32{4, 5}}},
-			},
-		},
+		Body:        &fwkrh.InferenceRequestBody{},
 	}
+	req1.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2, 3}}, {TokenIDs: []uint32{4, 5}}},
+	})
 	_ = p.Produce(context.Background(), req1, endpoints)
 	_ = p.PreRequest(context.Background(), req1, &fwksched.SchedulingResult{
 		PrimaryProfileName: "default",
@@ -740,12 +687,11 @@ func TestMultiPromptMatchAggregation(t *testing.T) {
 	req2 := &fwksched.InferenceRequest{
 		RequestID:   uuid.NewString(),
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2, 3}}, {TokenIDs: []uint32{4, 5}}},
-			},
-		},
+		Body:        &fwkrh.InferenceRequestBody{},
 	}
+	req2.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2, 3}}, {TokenIDs: []uint32{4, 5}}},
+	})
 	_ = p.Produce(context.Background(), req2, endpoints)
 
 	key := attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(ApproxPrefixCachePluginType)
@@ -774,12 +720,11 @@ func TestMultiPromptPartialMatch(t *testing.T) {
 	req1 := &fwksched.InferenceRequest{
 		RequestID:   uuid.NewString(),
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2}}, {TokenIDs: []uint32{3, 4}}},
-			},
-		},
+		Body:        &fwkrh.InferenceRequestBody{},
 	}
+	req1.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2}}, {TokenIDs: []uint32{3, 4}}},
+	})
 	_ = p.Produce(context.Background(), req1, endpoints)
 	_ = p.PreRequest(context.Background(), req1, &fwksched.SchedulingResult{
 		PrimaryProfileName: "default",
@@ -793,12 +738,11 @@ func TestMultiPromptPartialMatch(t *testing.T) {
 	req2 := &fwksched.InferenceRequest{
 		RequestID:   uuid.NewString(),
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2}}, {TokenIDs: []uint32{5, 6}}},
-			},
-		},
+		Body:        &fwkrh.InferenceRequestBody{},
 	}
+	req2.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2}}, {TokenIDs: []uint32{5, 6}}}},
+	)
 	_ = p.Produce(context.Background(), req2, endpoints)
 
 	key := attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(ApproxPrefixCachePluginType)
@@ -825,12 +769,7 @@ func TestPrefixPluginTokenizedRequest(t *testing.T) {
 	endpoints := []fwksched.Endpoint{endpoint}
 
 	// 4 token IDs -> 4 blocks at blockSize 1.
-	req := &fwksched.InferenceRequest{
-		RequestID:   uuid.NewString(),
-		TargetModel: "test-model",
-		Body:        tokenizedBody([]uint32{10, 20, 30, 40}),
-	}
-
+	req := inferenceRequest("test-model", []uint32{10, 20, 30, 40})
 	err = p.Produce(context.Background(), req, endpoints)
 	assert.NoError(t, err)
 
@@ -864,17 +803,8 @@ func TestPrefixPluginMatchesSameTokens(t *testing.T) {
 
 	tokenIDs := []uint32{1, 2, 3, 4, 5, 6, 7, 8}
 
-	req1 := &fwksched.InferenceRequest{
-		RequestID:   uuid.NewString(),
-		TargetModel: "test-model",
-		Body:        tokenizedBody(tokenIDs),
-	}
-	req2 := &fwksched.InferenceRequest{
-		RequestID:   uuid.NewString(),
-		TargetModel: "test-model",
-		Body:        tokenizedBody(tokenIDs),
-	}
-
+	req1 := inferenceRequest("test-model", tokenIDs)
+	req2 := inferenceRequest("test-model", tokenIDs)
 	_ = p.Produce(context.Background(), req1, endpoints)
 	state1, _ := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req1.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin.go
@@ -77,7 +77,7 @@ func (p *dataProducer) Produces() map[plugin.DataKey]any {
 // before this producer and one is auto-created when none is configured.
 func (p *dataProducer) Consumes() plugin.DataDependencies {
 	return plugin.DataDependencies{
-		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: fwksched.TokenizedRequest{}},
+		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: (*fwksched.TokenizedRequest)(nil)},
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/burstprefix/plugin_test.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"testing"
 
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -30,11 +31,12 @@ import (
 )
 
 func tokenizedRequest(tokens []uint32) *fwksched.InferenceRequest {
-	return &fwksched.InferenceRequest{
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: tokens}}},
-		},
+	req := &fwksched.InferenceRequest{
+		Body: &fwkrh.InferenceRequestBody{},
 	}
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey,
+		&fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: tokens}}})
+	return req
 }
 
 // assignedReplica returns the name of the endpoint this producer steered the

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -709,7 +709,7 @@ func (p *InFlightLoadProducer) Produces() map[fwkplugin.DataKey]any {
 func (p *InFlightLoadProducer) Consumes() fwkplugin.DataDependencies {
 	return fwkplugin.DataDependencies{
 		Required: map[fwkplugin.DataKey]any{
-			tokenproducer.TokenizedPromptDataKey: fwksched.TokenizedRequest{},
+			tokenproducer.TokenizedPromptDataKey: (*fwksched.TokenizedRequest)(nil),
 		},
 		Optional: map[fwkplugin.DataKey]any{
 			p.prefixMatchInfoDK: attrprefix.PrefixCacheMatchInfo{},

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -635,14 +635,15 @@ func (f *stubSchedulingEndpoint) Keys() []fwkplugin.DataKey { return f.attr.Keys
 // matching a deployment where the outlen-bucket plugin is not enabled, hence the
 // UnknownOutputTokens output the counter-tracking tests expect.
 func makeTokenRequest(requestID string, inputTokens int) *fwksched.InferenceRequest {
-	return &fwksched.InferenceRequest{
+	req := &fwksched.InferenceRequest{
 		RequestID: requestID,
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, inputTokens)}},
-			},
-		},
+		Body:      &fwkrh.InferenceRequestBody{},
 	}
+	tp := fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, inputTokens)}},
+	}
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &tp)
+	return req
 }
 
 // TestInFlightLoadProducer_ExcludeOutputTokens_StartOfStreamRelease verifies that when

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator.go
@@ -17,7 +17,9 @@ limitations under the License.
 package inflightload
 
 import (
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestheader/outlenbucket"
 )
 
@@ -66,10 +68,14 @@ func NewSimpleTokenEstimator(maxOutput *int64) TokenEstimator {
 // EstimateInput returns the input token count read from the tokenized prompt,
 // or 0 when no tokenization is available.
 func (e *SimpleTokenEstimator) EstimateInput(request *fwksched.InferenceRequest) int64 {
-	if request == nil || request.Body == nil || request.Body.TokenizedRequest == nil {
+	if request == nil {
 		return 0
 	}
-	return int64(request.Body.TokenizedRequest.TokenCount())
+	tp, ok := fwksched.ReadRequestAttribute[*fwkrh.TokenizedRequest](request, tokenproducer.TokenizedPromptDataKey)
+	if !ok {
+		return 0
+	}
+	return int64(tp.TokenCount())
 }
 
 // EstimateOutputFromRequest returns the estimated output token count for a request

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/token_estimator_test.go
@@ -19,6 +19,7 @@ package inflightload
 import (
 	"testing"
 
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
@@ -29,13 +30,14 @@ import (
 
 // tokenizedRequest builds a request whose body carries a tokenized prompt of n tokens.
 func tokenizedRequest(n int) *fwksched.InferenceRequest {
-	return &fwksched.InferenceRequest{
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, n)}},
-			},
-		},
+	req := &fwksched.InferenceRequest{
+		Body: &fwkrh.InferenceRequestBody{},
 	}
+	tp := fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, n)}},
+	}
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &tp)
+	return req
 }
 
 // requestWithBucket builds a request whose outlen-bucket attribute is set (as the

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
@@ -255,7 +256,7 @@ func (p *Producer) Produces() map[plugin.DataKey]any {
 // is configured; multimodal features come from the tokenizer output.
 func (p *Producer) Consumes() plugin.DataDependencies {
 	return plugin.DataDependencies{
-		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedRequest{}},
+		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: (*scheduling.TokenizedRequest)(nil)},
 	}
 }
 
@@ -297,12 +298,19 @@ func (p *Producer) Produce(ctx context.Context, request *scheduling.InferenceReq
 // ExtractMMItems returns deterministic, unique multimodal encoder-cache items
 // derived from the tokenized prompt's multimodal features.
 func ExtractMMItems(request *scheduling.InferenceRequest) []attrmm.MatchItem {
-	if request == nil || request.Body == nil || request.Body.TokenizedRequest == nil {
+	if request == nil {
+		return nil
+	}
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](
+		request,
+		tokenproducer.TokenizedPromptDataKey,
+	)
+	if !ok {
 		return nil
 	}
 
 	itemsByHash := map[string]attrmm.MatchItem{}
-	for _, p := range request.Body.TokenizedRequest.Prompts {
+	for _, p := range tp.Prompts {
 		for _, feature := range p.MultiModalFeatures {
 			if feature.Hash == "" {
 				continue

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"testing"
 
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -56,19 +57,17 @@ func TestFactory(t *testing.T) {
 }
 
 func TestExtractMMItemsFromTokenizedRequest(t *testing.T) {
-	items := ExtractMMItems(&scheduling.InferenceRequest{
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{
-					MultiModalFeatures: []fwkrh.MultiModalFeature{
-						{Modality: fwkrh.ModalityImage, Hash: "image-a", Length: 576},
-						{Modality: fwkrh.ModalityImage, Hash: "image-b", Length: 0},
-						{Modality: fwkrh.ModalityImage, Hash: "image-a", Length: 144},
-					},
-				}},
+	req := &scheduling.InferenceRequest{Body: &fwkrh.InferenceRequestBody{}}
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{
+			MultiModalFeatures: []fwkrh.MultiModalFeature{
+				{Modality: fwkrh.ModalityImage, Hash: "image-a", Length: 576},
+				{Modality: fwkrh.ModalityImage, Hash: "image-b", Length: 0},
+				{Modality: fwkrh.ModalityImage, Hash: "image-a", Length: 144},
 			},
-		},
+		}},
 	})
+	items := ExtractMMItems(req)
 
 	assert.ElementsMatch(t, []attrmm.MatchItem{
 		{Hash: "image-a", Size: 1, Modality: string(fwkrh.ModalityImage)},
@@ -84,11 +83,11 @@ func TestExtractMMItemsNilTokenizedRequestReturnsNil(t *testing.T) {
 }
 
 func TestExtractMMItemsEmptyMultiModalFeaturesReturnsNil(t *testing.T) {
-	items := ExtractMMItems(&scheduling.InferenceRequest{
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{},
-		},
-	})
+	req := &scheduling.InferenceRequest{
+		Body: &fwkrh.InferenceRequestBody{},
+	}
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{})
+	items := ExtractMMItems(req)
 	assert.Nil(t, items)
 }
 
@@ -276,12 +275,12 @@ func requestWithHashes(requestID string, hashToWeight map[string]int) *schedulin
 	for hash, weight := range hashToWeight {
 		features = append(features, fwkrh.MultiModalFeature{Modality: fwkrh.ModalityImage, Hash: hash, Length: weight})
 	}
-	return &scheduling.InferenceRequest{
+	req := &scheduling.InferenceRequest{
 		RequestID: requestID,
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{MultiModalFeatures: features}}},
-		},
+		Body:      &fwkrh.InferenceRequestBody{},
 	}
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{MultiModalFeatures: features}}})
+	return req
 }
 
 func schedulingResult(target scheduling.Endpoint) *scheduling.SchedulingResult {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/blockkeys.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/blockkeys.go
@@ -40,11 +40,11 @@ type kvCacheIndexer interface {
 func computeBlockKeys(ctx context.Context, idx kvCacheIndexer,
 	request *scheduling.InferenceRequest, blockSizeTokens int,
 ) ([][]kvblock.BlockHash, []int, error) {
-	if request == nil || request.Body == nil {
+	if request == nil {
 		return nil, nil, nil
 	}
-	tp := request.Body.TokenizedRequest
-	if tp == nil || len(tp.Prompts) == 0 {
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](request, tokenizer.TokenizedPromptDataKey)
+	if !ok || len(tp.Prompts) == 0 {
 		return nil, nil, nil
 	}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -298,7 +298,7 @@ func (p *Producer) Produces() map[plugin.DataKey]any {
 // the data-layer DAG orders tokenization before this producer runs.
 func (p *Producer) Consumes() plugin.DataDependencies {
 	return plugin.DataDependencies{
-		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedRequest{}},
+		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: (*scheduling.TokenizedRequest)(nil)},
 	}
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/jellydator/ttlcache/v3"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/pkg/kvcache"
 	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-router/pkg/kvevents"
@@ -182,11 +183,9 @@ func TestProduce_UsesTokenizedRequest(t *testing.T) {
 	req := &scheduling.InferenceRequest{
 		RequestID:   "req-1",
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: tokens}}},
-		},
+		Body:        &fwkrh.InferenceRequestBody{},
 	}
-
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: tokens}}})
 	require.NoError(t, p.Produce(ctx, req, testEndpoints))
 	require.Equal(t, tokens, capturedTokens)
 
@@ -245,10 +244,10 @@ func TestProduce_EmptyTokenizedRequest_NoOp(t *testing.T) {
 		RequestID:   "req-3",
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
-			Completions:      &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "p"}},
-			TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{}}}},
+			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "p"}},
 		},
 	}
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{}}}})
 	require.NoError(t, p.Produce(ctx, req, testEndpoints))
 }
 
@@ -286,13 +285,11 @@ func TestProduce_MultiPromptEmptyBlockKeys_NoOp(t *testing.T) {
 	req := &scheduling.InferenceRequest{
 		RequestID:   "req-multi-empty",
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{TokenIDs: promptA}, {TokenIDs: promptB}},
-			},
-		},
+		Body:        &fwkrh.InferenceRequestBody{},
 	}
-
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{TokenIDs: promptA}, {TokenIDs: promptB}},
+	})
 	require.NoError(t, p.Produce(ctx, req, endpoints))
 	require.Equal(t, [][]uint32{promptA, promptB}, computeCalls)
 
@@ -344,13 +341,11 @@ func TestProduce_MultiPromptSkipsEmptyPromptKeys(t *testing.T) {
 	req := &scheduling.InferenceRequest{
 		RequestID:   "req-multi-mixed",
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{TokenIDs: shortPrompt}, {TokenIDs: fullPrompt}},
-			},
-		},
+		Body:        &fwkrh.InferenceRequestBody{},
 	}
-
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{TokenIDs: shortPrompt}, {TokenIDs: fullPrompt}},
+	})
 	require.NoError(t, p.Produce(ctx, req, endpoints))
 	require.Equal(t, [][]uint32{shortPrompt, fullPrompt}, computeCalls)
 	require.Equal(t, [][]kvblock.BlockHash{{wantKey}}, lookupCalls)
@@ -417,16 +412,14 @@ func TestProduce_WritesCachedBlocksByTier(t *testing.T) {
 	req := &scheduling.InferenceRequest{
 		RequestID:   "req-by-tier",
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{
-					{TokenIDs: promptA},
-					{TokenIDs: promptB},
-				},
-			},
-		},
+		Body:        &fwkrh.InferenceRequestBody{},
 	}
-
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{
+			{TokenIDs: promptA},
+			{TokenIDs: promptB},
+		},
+	})
 	require.NoError(t, p.Produce(ctx, req, endpoints))
 
 	raw, ok := endpoints[0].Get(attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName("test"))
@@ -485,18 +478,16 @@ func TestProduce_MMMatchUsesCachedBlocksNotWeightedScore(t *testing.T) {
 	req := &scheduling.InferenceRequest{
 		RequestID:   "req-mm-weighted",
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{
-					TokenIDs: tokens,
-					MultiModalFeatures: []fwkrh.MultiModalFeature{
-						{Modality: fwkrh.ModalityImage, Hash: "img", Offset: 48, Length: 16},
-					},
-				}},
-			},
-		},
+		Body:        &fwkrh.InferenceRequestBody{},
 	}
-
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{
+			TokenIDs: tokens,
+			MultiModalFeatures: []fwkrh.MultiModalFeature{
+				{Modality: fwkrh.ModalityImage, Hash: "img", Offset: 48, Length: 16},
+			},
+		}},
+	})
 	require.NoError(t, p.Produce(ctx, req, endpoints))
 
 	raw, ok := endpoints[0].Get(attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName("test"))
@@ -538,16 +529,14 @@ func TestProduce_PassesMMExtraFeatures(t *testing.T) {
 	req := &scheduling.InferenceRequest{
 		RequestID:   "req-mm",
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{
-					TokenIDs:           tokens,
-					MultiModalFeatures: []fwkrh.MultiModalFeature{{Modality: fwkrh.ModalityImage, Hash: "abc", Offset: 2, Length: 4}},
-				}},
-			},
-		},
+		Body:        &fwkrh.InferenceRequestBody{},
 	}
-
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{
+			TokenIDs:           tokens,
+			MultiModalFeatures: []fwkrh.MultiModalFeature{{Modality: fwkrh.ModalityImage, Hash: "abc", Offset: 2, Length: 4}},
+		}},
+	})
 	require.NoError(t, p.Produce(ctx, req, testEndpoints))
 	require.NotNil(t, captured)
 }
@@ -594,14 +583,12 @@ func TestProduce_FoldsCacheSalt(t *testing.T) {
 			req := &scheduling.InferenceRequest{
 				RequestID:   "req-salt",
 				TargetModel: "test-model",
-				Body: &fwkrh.InferenceRequestBody{
-					TokenizedRequest: &fwkrh.TokenizedRequest{
-						Prompts:   []fwkrh.PromptTokens{{TokenIDs: tokens, MultiModalFeatures: tc.mm}},
-						CacheSalt: "s3cr3t",
-					},
-				},
+				Body:        &fwkrh.InferenceRequestBody{},
 			}
-
+			req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
+				Prompts:   []fwkrh.PromptTokens{{TokenIDs: tokens, MultiModalFeatures: tc.mm}},
+				CacheSalt: "s3cr3t",
+			})
 			require.NoError(t, p.Produce(ctx, req, testEndpoints))
 			require.Len(t, captured, 1)
 			require.NotNil(t, captured[0])
@@ -631,11 +618,9 @@ func TestProduce_NoCacheSalt_NoExtraFeatures(t *testing.T) {
 	req := &scheduling.InferenceRequest{
 		RequestID:   "req-nosalt",
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: tokens}}},
-		},
+		Body:        &fwkrh.InferenceRequestBody{},
 	}
-
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: tokens}}})
 	require.NoError(t, p.Produce(ctx, req, testEndpoints))
 	require.Nil(t, captured)
 }
@@ -728,10 +713,9 @@ func TestNew_BlockSizeFlowsViaTokenProcessor(t *testing.T) {
 			req := &scheduling.InferenceRequest{
 				RequestID:   "r",
 				TargetModel: "m",
-				Body: &fwkrh.InferenceRequestBody{
-					TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: tokens}}},
-				},
+				Body:        &fwkrh.InferenceRequestBody{},
 			}
+			req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: tokens}}})
 			require.NoError(t, p.Produce(ctx, req, []scheduling.Endpoint{endpoint}))
 
 			raw, ok := endpoint.Get(attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(name))

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/dataproducer_hooks.go
@@ -171,7 +171,7 @@ func (pl *PredictedLatency) Consumes() plugin.DataDependencies {
 	required := map[plugin.DataKey]any{
 		pl.prefixMatchDataKey:                attrprefix.PrefixCacheMatchInfo{},
 		pl.inFlightLoadDataKey:               attrconcurrency.InFlightLoad{},
-		tokenproducer.TokenizedPromptDataKey: fwksched.TokenizedRequest{},
+		tokenproducer.TokenizedPromptDataKey: (*fwksched.TokenizedRequest)(nil),
 	}
 	// Required (not Optional) because only Required dependencies create DAG
 	// ordering edges; the encoder-cache producer must run before this plugin.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin.go
@@ -28,7 +28,9 @@ import (
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	latencypredictor "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -416,10 +418,9 @@ type predictedLatencyCtx struct {
 
 func newPredictedLatencyContext(request *fwksched.InferenceRequest) *predictedLatencyCtx {
 	inputTokenCount := 0
-	if request.Body != nil {
-		if tp := request.Body.TokenizedRequest; tp != nil {
-			inputTokenCount = tp.TokenCount()
-		}
+	tp, ok := fwksched.ReadRequestAttribute[*fwkrh.TokenizedRequest](request, tokenproducer.TokenizedPromptDataKey)
+	if ok {
+		inputTokenCount = tp.TokenCount()
 	}
 	return &predictedLatencyCtx{
 		schedulingRequest:              *request,

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/plugin_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/jellydator/ttlcache/v3"
 	latencypredictor "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/latencypredictorclient"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
@@ -147,7 +148,6 @@ func createTestInferenceRequest(reqID string, ttftSLO, tpotSLO float64) *fwksche
 		Completions: &fwkrh.CompletionsRequest{
 			Prompt: fwkrh.Prompt{Raw: "test prompt"},
 		},
-		TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 2)}}},
 	})
 }
 
@@ -159,7 +159,6 @@ func createTestChatCompletionsInferenceRequest(reqID string, ttftSLO, tpotSLO fl
 				{Role: "user", Content: fwkrh.Content{Raw: "Tell me a joke."}},
 			},
 		},
-		TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 8)}}},
 	})
 }
 
@@ -172,11 +171,12 @@ func createTestInferenceRequestWithBody(reqID string, ttftSLO, tpotSLO float64, 
 	if tpotSLO > 0 {
 		headers[metadata.TPOTSLOHeaderKey] = fmt.Sprintf("%f", tpotSLO)
 	}
-
-	return &fwksched.InferenceRequest{
+	req := &fwksched.InferenceRequest{
 		Headers: headers,
 		Body:    body,
 	}
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 2)}}})
+	return req
 }
 
 func TestParseSLOHeaders(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency/requestcontrol_hooks_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/jellydator/ttlcache/v3"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -104,14 +105,14 @@ func TestNewPredictedLatencyContext_ChatCompletionsPrompt(t *testing.T) {
 	ctx := newPredictedLatencyContext(request)
 
 	assert.NotNil(t, ctx)
-	assert.Equal(t, 8, ctx.inputTokenCount)
+	assert.Equal(t, 2, ctx.inputTokenCount)
 }
 
 func TestNewPredictedLatencyContext_GenerateUsesTokenIDCount(t *testing.T) {
 	request := createTestInferenceRequestWithBody("test-generate", 1.0, 0.05, &fwkrh.InferenceRequestBody{
-		Generate:         &fwkrh.GenerateRequest{TokenIDs: []uint32{1, 2, 3, 4, 5}},
-		TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 5)}}},
+		Generate: &fwkrh.GenerateRequest{TokenIDs: []uint32{1, 2, 3, 4, 5}},
 	})
+	request.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 5)}}})
 	ctx := newPredictedLatencyContext(request)
 
 	assert.NotNil(t, ctx)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing.go
@@ -30,6 +30,7 @@ import (
 
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 )
 
 // BlockHash is a hash of a block of request data.
@@ -56,16 +57,16 @@ func (b HashBlock) Hash() uint64 {
 // independently so cross-prompt block adjacency is avoided. The first block
 // hash of every prompt includes the model name and cache salt (if provided).
 // For subsequent blocks, the hash is calculated as: hash(block i content, hash(i-1)).
-// It requires request.Body.TokenizedRequest to be populated by a token-producer backend.
+// It requires the token producer to populate TokenizedPromptDataKey.
 func GetBlockHashes(ctx context.Context, request *scheduling.InferenceRequest, blockSizeTokens int, maxPrefixBlocks int) [][]BlockHash {
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
-	if request == nil || request.Body == nil {
-		loggerDebug.Info("Request or request data is nil, skipping hashing")
+	if request == nil {
+		loggerDebug.Info("Request is nil, skipping hashing")
 		return nil
 	}
 
-	tp := request.Body.TokenizedRequest
-	if tp == nil || tp.TokenCount() == 0 {
+	tp, ok := scheduling.ReadRequestAttribute[*scheduling.TokenizedRequest](request, tokenproducer.TokenizedPromptDataKey)
+	if !ok || tp.TokenCount() == 0 {
 		loggerDebug.Info("TokenizedRequest is empty, skipping hashing")
 		return nil
 	}
@@ -73,7 +74,7 @@ func GetBlockHashes(ctx context.Context, request *scheduling.InferenceRequest, b
 	var result [][]BlockHash
 	for _, p := range tp.Prompts {
 		seq := getKVCacheBlocksFromTokens(p.TokenIDs, blockSizeTokens)
-		hashes := computeBlockHashes(seq, request, maxPrefixBlocks)
+		hashes := computeBlockHashes(seq, request.TargetModel, tp.CacheSalt, maxPrefixBlocks)
 		if len(hashes) > 0 {
 			result = append(result, hashes)
 		}
@@ -86,13 +87,13 @@ func GetBlockHashes(ctx context.Context, request *scheduling.InferenceRequest, b
 }
 
 // computeBlockHashes calculates the hash for content blocks.
-func computeBlockHashes(seq iter.Seq[HashBlock], request *scheduling.InferenceRequest, maxPrefixBlocks int) []BlockHash {
+func computeBlockHashes(seq iter.Seq[HashBlock], targetModel, cacheSalt string, maxPrefixBlocks int) []BlockHash {
 	var blockHashes []BlockHash
 
 	h := xxhash.New()
 	// Different models should have different hashes even with the same body.
-	_, _ = h.Write([]byte(request.TargetModel))
-	if cacheSalt := request.Body.TokenizedRequest.CacheSalt; cacheSalt != "" {
+	_, _ = h.Write([]byte(targetModel))
+	if cacheSalt != "" {
 		_, _ = h.Write([]byte(cacheSalt))
 	}
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing_test.go
@@ -25,6 +25,7 @@ import (
 
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 )
 
 // testMaxPrefixBlocks is a cap large enough not to truncate any prompt in
@@ -82,43 +83,29 @@ func TestGetKVCacheBlocksFromTokens(t *testing.T) {
 func TestGetBlockHashes(t *testing.T) {
 	tests := []struct {
 		name            string
-		request         *fwksched.InferenceRequest
+		targetModel     string
+		tokenized       *fwkrh.TokenizedRequest
 		blockSizeTokens int
 		expectedBlocks  int
 	}{
 		{
 			name: "TokenizedRequest",
-			request: &fwksched.InferenceRequest{
-				Body: &fwkrh.InferenceRequestBody{
-					TokenizedRequest: &fwkrh.TokenizedRequest{
-						Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}}},
-					},
+			tokenized: &fwkrh.TokenizedRequest{
+				Prompts: []fwkrh.PromptTokens{
+					{TokenIDs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 				},
 			},
 			blockSizeTokens: 4,
 			expectedBlocks:  3,
 		},
 		{
-			name: "MissingTokenizedRequest",
-			request: &fwksched.InferenceRequest{
-				Body: &fwkrh.InferenceRequestBody{},
-			},
+			name:            "MissingTokenizedRequest",
 			blockSizeTokens: 4,
 			expectedBlocks:  0,
 		},
 		{
-			name: "EmptyTokenIDs",
-			request: &fwksched.InferenceRequest{
-				Body: &fwkrh.InferenceRequestBody{
-					TokenizedRequest: &fwkrh.TokenizedRequest{},
-				},
-			},
-			blockSizeTokens: 4,
-			expectedBlocks:  0,
-		},
-		{
-			name:            "NilRequest",
-			request:         nil,
+			name:            "EmptyTokenIDs",
+			tokenized:       &fwkrh.TokenizedRequest{},
 			blockSizeTokens: 4,
 			expectedBlocks:  0,
 		},
@@ -126,7 +113,8 @@ func TestGetBlockHashes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			perPromptHashes := GetBlockHashes(context.Background(), tt.request, tt.blockSizeTokens, testMaxPrefixBlocks)
+			request := tokenizedRequest(tt.targetModel, tt.tokenized)
+			perPromptHashes := GetBlockHashes(context.Background(), request, tt.blockSizeTokens, testMaxPrefixBlocks)
 			totalBlocks := 0
 			for _, ph := range perPromptHashes {
 				totalBlocks += len(ph)
@@ -137,21 +125,16 @@ func TestGetBlockHashes(t *testing.T) {
 }
 
 func TestGetBlockHashesCacheSalt(t *testing.T) {
-	body := func(salt string) *fwkrh.InferenceRequestBody {
-		return &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts:   []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2, 3, 4}}},
-				CacheSalt: salt,
-			},
-		}
+	req := func(salt string) *fwksched.InferenceRequest {
+		return tokenizedRequest("m", &fwkrh.TokenizedRequest{
+			Prompts:   []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2, 3, 4}}},
+			CacheSalt: salt,
+		})
 	}
-
-	noSalt := GetBlockHashes(context.Background(), &fwksched.InferenceRequest{
-		TargetModel: "m", Body: body(""),
-	}, 2, testMaxPrefixBlocks)
-	salted := GetBlockHashes(context.Background(), &fwksched.InferenceRequest{
-		TargetModel: "m", Body: body("salt"),
-	}, 2, testMaxPrefixBlocks)
+	noSaltReq := req("")
+	noSalt := GetBlockHashes(context.Background(), noSaltReq, 2, testMaxPrefixBlocks)
+	saltReq := req("salt")
+	salted := GetBlockHashes(context.Background(), saltReq, 2, testMaxPrefixBlocks)
 
 	assert.Equal(t, len(noSalt), len(salted))
 	assert.NotEqual(t, noSalt, salted, "cache salt must change the block hashes")
@@ -190,15 +173,9 @@ func TestGetBlockHashes_MultiPrompt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := &fwksched.InferenceRequest{
-				TargetModel: "model",
-				Body: &fwkrh.InferenceRequestBody{
-					TokenizedRequest: &fwkrh.TokenizedRequest{
-						Prompts: tt.prompts,
-					},
-				},
-			}
-			result := GetBlockHashes(context.Background(), request, tt.blockSizeTokens, testMaxPrefixBlocks)
+			result := GetBlockHashes(context.Background(), tokenizedRequest("model", &fwkrh.TokenizedRequest{
+				Prompts: tt.prompts,
+			}), tt.blockSizeTokens, testMaxPrefixBlocks)
 			assert.Equal(t, tt.expectedPrompts, len(result))
 			for i, expected := range tt.expectedBlocksPerPrompt {
 				assert.Equal(t, expected, len(result[i]), "prompt %d block count", i)
@@ -208,25 +185,12 @@ func TestGetBlockHashes_MultiPrompt(t *testing.T) {
 }
 
 func TestGetBlockHashes_MultiPromptHashIndependence(t *testing.T) {
-	multiPrompt := &fwksched.InferenceRequest{
-		TargetModel: "model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2}}, {TokenIDs: []uint32{3, 4}}},
-			},
-		},
-	}
-	singlePrompt := &fwksched.InferenceRequest{
-		TargetModel: "model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2, 3, 4}}},
-			},
-		},
-	}
-
-	multi := GetBlockHashes(context.Background(), multiPrompt, 2, testMaxPrefixBlocks)
-	single := GetBlockHashes(context.Background(), singlePrompt, 2, testMaxPrefixBlocks)
+	multi := GetBlockHashes(context.Background(), tokenizedRequest("model", &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2}}, {TokenIDs: []uint32{3, 4}}},
+	}), 2, testMaxPrefixBlocks)
+	single := GetBlockHashes(context.Background(), tokenizedRequest("model", &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2, 3, 4}}},
+	}), 2, testMaxPrefixBlocks)
 
 	assert.Equal(t, 2, len(multi), "multi-prompt should produce 2 inner slices")
 	assert.Equal(t, 1, len(single), "single-prompt should produce 1 inner slice")
@@ -240,6 +204,14 @@ func TestGetBlockHashes_MultiPromptHashIndependence(t *testing.T) {
 	// split prevents.
 	assert.NotEqual(t, multi[1][0], single[0][1],
 		"second prompt must start its own hash chain, not chain from the first prompt")
+}
+
+func tokenizedRequest(targetModel string, tokenized *fwkrh.TokenizedRequest) *fwksched.InferenceRequest {
+	request := &fwksched.InferenceRequest{TargetModel: targetModel}
+	if tokenized != nil {
+		request.PutAttribute(tokenproducer.TokenizedPromptDataKey, tokenized)
+	}
+	return request
 }
 
 func TestKVCacheBlock_Hash(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package tokenizer provides a DataProducer plugin that tokenizes the request
-// prompt and publishes the result on InferenceRequestBody.TokenizedRequest for
+// prompt and publishes the result on per-request TokenizedPrompt attribute for
 // downstream consumers (scorers, filters, other data producers).
 package tokenizer
 
@@ -313,7 +313,7 @@ func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) 
 	p := &Plugin{
 		typedName: plugin.TypedName{Type: PluginType, Name: name},
 		backend:   backend,
-		dk:        TokenizedPromptDataKey.WithNonEmptyProducerName(name),
+		dk:        TokenizedPromptDataKey,
 	}
 	if w, ok := backend.(warmer); ok {
 		go w.warmup(ctx)
@@ -322,7 +322,7 @@ func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) 
 }
 
 // Plugin tokenizes the prompt in the incoming request and writes the result to
-// InferenceRequestBody.TokenizedRequest for downstream DataProducer / scoring plugins.
+// per-request TokenizedPrompt attribute for downstream DataProducer / scoring plugins.
 type Plugin struct {
 	typedName plugin.TypedName
 	backend   tokenInputProducer
@@ -342,7 +342,7 @@ func (p *Plugin) TypedName() plugin.TypedName {
 
 // Produces returns the data keys this plugin produces.
 func (p *Plugin) Produces() map[plugin.DataKey]any {
-	return map[plugin.DataKey]any{p.dk: fwkrh.TokenizedRequest{}}
+	return map[plugin.DataKey]any{p.dk: (*fwkrh.TokenizedRequest)(nil)}
 }
 
 // ProduceTimeout surfaces the backend's render timeout when it manages one, so
@@ -356,19 +356,11 @@ func (p *Plugin) ProduceTimeout() time.Duration {
 }
 
 // Produce derives the request's TokenizedRequest via the configured backend and
-// stores it on the body. Skips when one is already present; errors propagate to
-// the Director, which logs and continues.
+// stores it in the per-request attribute store. Errors propagate to the
+// Director, which logs and continues.
 func (p *Plugin) Produce(ctx context.Context, request *scheduling.InferenceRequest, _ []scheduling.Endpoint) error {
 	if request.Body == nil {
 		return errors.New("request body is nil")
-	}
-	if request.Body.TokenizedRequest != nil {
-		// A parser (e.g. vLLM gRPC) may pre-populate tokens without a salt;
-		// ensure cache-salt isolation still applies on the skip path.
-		if request.Body.TokenizedRequest.CacheSalt == "" {
-			request.Body.TokenizedRequest.CacheSalt = CacheSaltFromBody(request.Body)
-		}
-		return nil
 	}
 
 	ctx = withMMMetadata(ctx, parseMMMetadataHeaders(request.Headers))
@@ -380,7 +372,7 @@ func (p *Plugin) Produce(ctx context.Context, request *scheduling.InferenceReque
 		return nil
 	}
 	tp.CacheSalt = CacheSaltFromBody(request.Body)
-	request.Body.TokenizedRequest = tp
+	request.PutAttribute(p.dk, tp)
 	return nil
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer_test.go
@@ -52,6 +52,7 @@ func newTestPlugin(tok tokenizer) *Plugin {
 	return &Plugin{
 		typedName: plugin.TypedName{Type: PluginType, Name: "test"},
 		backend:   renderBackend{tk: tok},
+		dk:        TokenizedPromptDataKey,
 	}
 }
 
@@ -75,6 +76,15 @@ func TestProduceTimeout(t *testing.T) {
 
 	// A render backend whose tokenizer manages no timeout (e.g. UDS) keeps the default.
 	assert.Zero(t, newTestPlugin(&mockTokenizer{}).ProduceTimeout())
+}
+
+// The tokenizer must publish under the bare TokenizedPromptDataKey regardless of
+// its instance name; every consumer reads that key, not a name-suffixed one.
+func TestNewPlugin_PublishesUnderBareKey(t *testing.T) {
+	ctx := context.Background()
+	p, err := NewPlugin(ctx, "custom-name", &tokenizerPluginConfig{Estimate: &estimateConfig{}})
+	require.NoError(t, err)
+	assert.Equal(t, TokenizedPromptDataKey, p.dk)
 }
 
 func TestPluginFactory_Validation(t *testing.T) {
@@ -142,7 +152,7 @@ func TestPluginFactory_Validation(t *testing.T) {
 	}
 }
 
-func TestProduce_PopulatesTokenizedRequest(t *testing.T) {
+func TestProduce_PublishesTokenizedPrompt(t *testing.T) {
 	mm := &tokenization.MultiModalFeatures{
 		MMHashes: map[string][]string{"image": {"hash-a", "hash-b"}},
 		MMPlaceholders: map[string][]kvblock.PlaceholderRange{
@@ -155,7 +165,6 @@ func TestProduce_PopulatesTokenizedRequest(t *testing.T) {
 		},
 	}
 	p := newTestPlugin(tok)
-
 	req := &scheduling.InferenceRequest{
 		Body: &fwkrh.InferenceRequestBody{
 			ChatCompletions: &fwkrh.ChatCompletionsRequest{
@@ -165,47 +174,17 @@ func TestProduce_PopulatesTokenizedRequest(t *testing.T) {
 		},
 	}
 	require.NoError(t, p.Produce(context.Background(), req, nil))
-	require.NotNil(t, req.Body.TokenizedRequest)
-	assert.Equal(t, []uint32{1, 2, 3, 4}, req.Body.TokenizedRequest.Prompts[0].TokenIDs)
-	require.Len(t, req.Body.TokenizedRequest.Prompts, 1)
-	require.Len(t, req.Body.TokenizedRequest.Prompts[0].MultiModalFeatures, 2)
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, TokenizedPromptDataKey)
+	assert.True(t, ok)
+	assert.Equal(t, []uint32{1, 2, 3, 4}, tp.Prompts[0].TokenIDs)
+	require.Len(t, tp.Prompts, 1)
+	require.Len(t, tp.Prompts[0].MultiModalFeatures, 2)
 
-	assert.Equal(t, 3, req.Body.TokenizedRequest.Prompts[0].MultiModalFeatures[0].Offset)
-	assert.Equal(t, "hash-a", req.Body.TokenizedRequest.Prompts[0].MultiModalFeatures[0].Hash)
-	assert.Equal(t, 20, req.Body.TokenizedRequest.Prompts[0].MultiModalFeatures[1].Offset)
-	assert.Equal(t, "hash-b", req.Body.TokenizedRequest.Prompts[0].MultiModalFeatures[1].Hash)
-	assert.Equal(t, fwkrh.ModalityImage, req.Body.TokenizedRequest.Prompts[0].MultiModalFeatures[0].Modality)
-}
-
-func TestProduce_SkipsWhenAlreadyPopulated(t *testing.T) {
-	existing := &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{42}}}}
-	p := newTestPlugin(&mockTokenizer{})
-	req := &scheduling.InferenceRequest{
-		Body: &fwkrh.InferenceRequestBody{TokenizedRequest: existing},
-	}
-	require.NoError(t, p.Produce(context.Background(), req, nil))
-	assert.Same(t, existing, req.Body.TokenizedRequest)
-}
-
-func TestProduce_SetsCacheSaltOnSkipPath(t *testing.T) {
-	tok := &mockTokenizer{
-		renderChatFunc: func(fwkrh.RequestPayload) ([]uint32, *tokenization.MultiModalFeatures, error) {
-			t.Fatal("backend must not run on the skip path")
-			return nil, nil, nil
-		},
-	}
-	existing := &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{1, 2, 3}}}}
-	p := newTestPlugin(tok)
-	req := &scheduling.InferenceRequest{
-		Body: &fwkrh.InferenceRequestBody{
-			ChatCompletions:  &fwkrh.ChatCompletionsRequest{CacheSalt: "tenant-x"},
-			TokenizedRequest: existing,
-		},
-	}
-	require.NoError(t, p.Produce(context.Background(), req, nil))
-	assert.Same(t, existing, req.Body.TokenizedRequest)
-	assert.Equal(t, "tenant-x", req.Body.TokenizedRequest.CacheSalt)
-	assert.Equal(t, []uint32{1, 2, 3}, req.Body.TokenizedRequest.Prompts[0].TokenIDs)
+	assert.Equal(t, 3, tp.Prompts[0].MultiModalFeatures[0].Offset)
+	assert.Equal(t, "hash-a", tp.Prompts[0].MultiModalFeatures[0].Hash)
+	assert.Equal(t, 20, tp.Prompts[0].MultiModalFeatures[1].Offset)
+	assert.Equal(t, "hash-b", tp.Prompts[0].MultiModalFeatures[1].Hash)
+	assert.Equal(t, fwkrh.ModalityImage, tp.Prompts[0].MultiModalFeatures[0].Modality)
 }
 
 func TestRenderBackend_CompletionsTokenIDsPassthrough(t *testing.T) {
@@ -300,7 +279,8 @@ func TestProduce_TokenizerError(t *testing.T) {
 	err := p.Produce(context.Background(), req, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tokenization failed")
-	assert.Nil(t, req.Body.TokenizedRequest)
+	_, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, TokenizedPromptDataKey)
+	assert.False(t, ok)
 }
 
 func TestProduce_UnsupportedBodyType(t *testing.T) {
@@ -313,7 +293,8 @@ func TestProduce_UnsupportedBodyType(t *testing.T) {
 	err := p.Produce(context.Background(), req, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported request body type")
-	assert.Nil(t, req.Body.TokenizedRequest)
+	_, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, TokenizedPromptDataKey)
+	assert.False(t, ok)
 }
 
 func TestProduce_GenerateUsesPreTokenizedIDs(t *testing.T) {
@@ -329,7 +310,6 @@ func TestProduce_GenerateUsesPreTokenizedIDs(t *testing.T) {
 		},
 	}
 	p := newTestPlugin(tok)
-
 	tokenIDs := []uint32{1, 2, 3, 4, 5}
 	req := &scheduling.InferenceRequest{
 		Body: &fwkrh.InferenceRequestBody{
@@ -340,9 +320,10 @@ func TestProduce_GenerateUsesPreTokenizedIDs(t *testing.T) {
 	}
 
 	require.NoError(t, p.Produce(context.Background(), req, nil))
-	require.NotNil(t, req.Body.TokenizedRequest)
-	assert.Equal(t, tokenIDs, req.Body.TokenizedRequest.Prompts[0].TokenIDs)
-	assert.Nil(t, req.Body.TokenizedRequest.Prompts[0].MultiModalFeatures)
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, TokenizedPromptDataKey)
+	assert.True(t, ok)
+	assert.Equal(t, tokenIDs, tp.Prompts[0].TokenIDs)
+	assert.Nil(t, tp.Prompts[0].MultiModalFeatures)
 }
 
 func TestProduce_GenerateFlattensFeatures(t *testing.T) {
@@ -359,7 +340,6 @@ func TestProduce_GenerateFlattensFeatures(t *testing.T) {
 		},
 	}
 	p := newTestPlugin(tok)
-
 	tokenIDs := []uint32{151644, 872, 198, 3838, 374, 279, 6722}
 	req := &scheduling.InferenceRequest{
 		Body: &fwkrh.InferenceRequestBody{
@@ -381,14 +361,15 @@ func TestProduce_GenerateFlattensFeatures(t *testing.T) {
 	}
 
 	require.NoError(t, p.Produce(context.Background(), req, nil))
-	require.NotNil(t, req.Body.TokenizedRequest)
-	assert.Equal(t, tokenIDs, req.Body.TokenizedRequest.Prompts[0].TokenIDs)
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, TokenizedPromptDataKey)
+	assert.True(t, ok)
+	assert.Equal(t, tokenIDs, tp.Prompts[0].TokenIDs)
 	assert.Equal(t,
 		[]fwkrh.MultiModalFeature{
 			{Modality: fwkrh.ModalityImage, Hash: "abc123hash", Offset: 1, Length: 3},
 			{Modality: fwkrh.ModalityImage, Hash: "def456hash", Offset: 4, Length: 3},
 		},
-		req.Body.TokenizedRequest.Prompts[0].MultiModalFeatures,
+		tp.Prompts[0].MultiModalFeatures,
 	)
 }
 
@@ -469,7 +450,6 @@ func TestProduce_StringArrayPrompt(t *testing.T) {
 		},
 	}
 	p := newTestPlugin(tok)
-
 	req := &scheduling.InferenceRequest{
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
@@ -478,10 +458,11 @@ func TestProduce_StringArrayPrompt(t *testing.T) {
 		},
 	}
 	require.NoError(t, p.Produce(context.Background(), req, nil))
-	require.NotNil(t, req.Body.TokenizedRequest)
-	require.Len(t, req.Body.TokenizedRequest.Prompts, 2)
-	assert.Equal(t, []uint32{10, 20, 30}, req.Body.TokenizedRequest.Prompts[0].TokenIDs)
-	assert.Equal(t, []uint32{40, 50}, req.Body.TokenizedRequest.Prompts[1].TokenIDs)
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, TokenizedPromptDataKey)
+	assert.True(t, ok)
+	require.Len(t, tp.Prompts, 2)
+	assert.Equal(t, []uint32{10, 20, 30}, tp.Prompts[0].TokenIDs)
+	assert.Equal(t, []uint32{40, 50}, tp.Prompts[1].TokenIDs)
 }
 
 func TestProduce_StringArrayPromptRenderError(t *testing.T) {
@@ -502,7 +483,8 @@ func TestProduce_StringArrayPromptRenderError(t *testing.T) {
 	err := p.Produce(context.Background(), req, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tokenization failed")
-	assert.Nil(t, req.Body.TokenizedRequest)
+	_, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, TokenizedPromptDataKey)
+	assert.False(t, ok)
 }
 
 func TestProduce_StringArrayPromptDoesNotPublishEmptyTokenResult(t *testing.T) {
@@ -521,7 +503,8 @@ func TestProduce_StringArrayPromptDoesNotPublishEmptyTokenResult(t *testing.T) {
 		},
 	}
 	require.NoError(t, p.Produce(context.Background(), req, nil))
-	assert.Nil(t, req.Body.TokenizedRequest)
+	_, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, TokenizedPromptDataKey)
+	assert.False(t, ok)
 }
 
 func TestProduce_SinglePromptSetsPrompts(t *testing.T) {
@@ -531,7 +514,6 @@ func TestProduce_SinglePromptSetsPrompts(t *testing.T) {
 		},
 	}
 	p := newTestPlugin(tok)
-
 	req := &scheduling.InferenceRequest{
 		Body: &fwkrh.InferenceRequestBody{
 			Completions: &fwkrh.CompletionsRequest{
@@ -540,8 +522,9 @@ func TestProduce_SinglePromptSetsPrompts(t *testing.T) {
 		},
 	}
 	require.NoError(t, p.Produce(context.Background(), req, nil))
-	require.NotNil(t, req.Body.TokenizedRequest)
-	assert.Equal(t, []fwkrh.PromptTokens{{TokenIDs: []uint32{10, 20, 30}}}, req.Body.TokenizedRequest.Prompts)
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, TokenizedPromptDataKey)
+	assert.True(t, ok)
+	assert.Equal(t, []fwkrh.PromptTokens{{TokenIDs: []uint32{10, 20, 30}}}, tp.Prompts)
 }
 
 func TestChatCompletionsToRenderChatRequest_MultimodalContent(t *testing.T) {
@@ -878,7 +861,6 @@ func TestProduce_MessagesRequest(t *testing.T) {
 		},
 	}
 	p := newTestPlugin(tok)
-
 	// Payload holds the raw request body; RenderChat must receive the converted
 	// /render body, not that raw payload.
 	req := &scheduling.InferenceRequest{
@@ -893,9 +875,11 @@ func TestProduce_MessagesRequest(t *testing.T) {
 			},
 		},
 	}
+
 	require.NoError(t, p.Produce(context.Background(), req, nil))
-	require.NotNil(t, req.Body.TokenizedRequest)
-	assert.Equal(t, []fwkrh.PromptTokens{{TokenIDs: wantTokens}}, req.Body.TokenizedRequest.Prompts)
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, TokenizedPromptDataKey)
+	assert.True(t, ok)
+	assert.Equal(t, []fwkrh.PromptTokens{{TokenIDs: wantTokens}}, tp.Prompts)
 
 	pm, ok := gotPayload.AsMap()
 	require.True(t, ok, "RenderChat payload must be a map")

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
@@ -105,8 +105,9 @@ func TestProduce_CompletionsVLLMHTTPUsesRawPayload(t *testing.T) {
 
 	p := newTestPlugin(newHTTPRenderer(t, srv))
 	require.NoError(t, p.Produce(context.Background(), req, nil))
-	require.NotNil(t, req.Body.TokenizedRequest)
-	assert.Equal(t, []uint32{4, 5}, req.Body.TokenizedRequest.Prompts[0].TokenIDs)
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, p.dk)
+	assert.True(t, ok)
+	assert.Equal(t, []uint32{4, 5}, tp.Prompts[0].TokenIDs)
 
 	var sent map[string]any
 	require.NoError(t, json.Unmarshal(cap.completions, &sent))
@@ -238,8 +239,9 @@ func TestProduce_ChatCompletionsVLLMHTTPUsesRawPayload(t *testing.T) {
 
 	p := newTestPlugin(newHTTPRenderer(t, srv))
 	require.NoError(t, p.Produce(context.Background(), req, nil))
-	require.NotNil(t, req.Body.TokenizedRequest)
-	assert.Equal(t, []uint32{9, 10}, req.Body.TokenizedRequest.Prompts[0].TokenIDs)
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, p.dk)
+	assert.True(t, ok)
+	assert.Equal(t, []uint32{9, 10}, tp.Prompts[0].TokenIDs)
 
 	var sent map[string]any
 	require.NoError(t, json.Unmarshal(cap.chat, &sent))
@@ -280,8 +282,9 @@ func TestProduce_MessagesVLLMHTTPFullAgenticTurn(t *testing.T) {
 
 	p := newTestPlugin(newHTTPRenderer(t, srv))
 	require.NoError(t, p.Produce(context.Background(), req, nil))
-	require.NotNil(t, req.Body.TokenizedRequest)
-	assert.Equal(t, []uint32{11, 12, 13}, req.Body.TokenizedRequest.Prompts[0].TokenIDs)
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, p.dk)
+	assert.True(t, ok)
+	assert.Equal(t, []uint32{11, 12, 13}, tp.Prompts[0].TokenIDs)
 
 	var sent struct {
 		Model    string           `json:"model"`

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
+	"github.com/llm-d/llm-d-router/pkg/kvcache/tokenization"
 	"google.golang.org/protobuf/proto"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	v1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
@@ -219,16 +221,11 @@ func convertToInferenceRequestBody(pbReq *pb.GenerateRequest) (*fwkrh.InferenceR
 		copiedTokenIDsInt := make([]uint32, len(inputIDs))
 		copy(copiedTokenIDsInt, inputIDs)
 		body = &fwkrh.InferenceRequestBody{
-			Completions: &fwkrh.CompletionsRequest{
-				Prompt: fwkrh.Prompt{TokenIDs: [][]uint32{copiedTokenIDsInt}},
+			Generate: &fwkrh.GenerateRequest{
+				TokenIDs: copiedTokenIDsInt,
+				Features: convertMultiModalFeatures(pbReq.GetMmInputs()),
 			},
 			Payload: fwkrh.PayloadProto{Message: pbReq},
-			TokenizedRequest: &fwkrh.TokenizedRequest{
-				Prompts: []fwkrh.PromptTokens{{
-					TokenIDs:           copiedTokenIDsInt,
-					MultiModalFeatures: convertMultiModalFeatures(pbReq.GetMmInputs()),
-				}},
-			},
 		}
 	default:
 		return nil, errors.New("not supported request inputType")
@@ -242,7 +239,7 @@ func convertToInferenceRequestBody(pbReq *pb.GenerateRequest) (*fwkrh.InferenceR
 	return body, nil
 }
 
-func convertMultiModalFeatures(mmInputs *pb.MultimodalInputs) []fwkrh.MultiModalFeature {
+func convertMultiModalFeatures(mmInputs *pb.MultimodalInputs) *tokenization.MultiModalFeatures {
 	if mmInputs == nil {
 		return nil
 	}
@@ -252,27 +249,31 @@ func convertMultiModalFeatures(mmInputs *pb.MultimodalInputs) []fwkrh.MultiModal
 		return nil
 	}
 
-	hashes := mmInputs.GetMmHashes()
-	features := make([]fwkrh.MultiModalFeature, 0, len(placeholders))
+	ranges := make([]kvblock.PlaceholderRange, len(placeholders))
 	for i, placeholder := range placeholders {
-		hash := ""
-		if i < len(hashes) {
-			hash = hashes[i]
+		if placeholder == nil {
+			continue
 		}
-
-		feature := fwkrh.MultiModalFeature{
-			Modality: fwkrh.ModalityImage,
-			Hash:     hash,
+		ranges[i] = kvblock.PlaceholderRange{
+			Offset: int(placeholder.GetOffset()),
+			Length: int(placeholder.GetLength()),
 		}
-		if placeholder != nil {
-			feature.Offset = int(placeholder.GetOffset())
-			feature.Length = int(placeholder.GetLength())
-		}
-
-		features = append(features, feature)
 	}
 
-	return features
+	// Keep one hash entry per placeholder. Missing hashes are represented by
+	// empty strings so downstream conversion does not drop placeholder ranges.
+	hashes := make([]string, len(placeholders))
+	copy(hashes, mmInputs.GetMmHashes())
+
+	modality := string(fwkrh.ModalityImage)
+	return &tokenization.MultiModalFeatures{
+		MMHashes: map[string][]string{
+			modality: hashes,
+		},
+		MMPlaceholders: map[string][]kvblock.PlaceholderRange{
+			modality: ranges,
+		},
+	}
 }
 
 func convertEmbedToInferenceRequestBody(pbReq *pb.EmbedRequest) (*fwkrh.InferenceRequestBody, error) {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/vllmgrpc_test.go
@@ -30,6 +30,8 @@ import (
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	pb "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc/api/gen"
+	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
+	"github.com/llm-d/llm-d-router/pkg/kvcache/tokenization"
 )
 
 // helper function to simulate the gRPC payload framing
@@ -125,10 +127,8 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
-				Completions: &fwkrh.CompletionsRequest{
-					Prompt: fwkrh.Prompt{
-						TokenIDs: [][]uint32{{11, 12, 13}},
-					},
+				Generate: &fwkrh.GenerateRequest{
+					TokenIDs: []uint32{11, 12, 13},
 				},
 				Payload: fwkrh.PayloadProto{
 					Message: &pb.GenerateRequest{
@@ -139,9 +139,6 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 							},
 						},
 					}},
-				TokenizedRequest: &fwkrh.TokenizedRequest{
-					Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{11, 12, 13}}},
-				},
 			},
 		},
 		{
@@ -163,8 +160,19 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
-				Completions: &fwkrh.CompletionsRequest{
-					Prompt: fwkrh.Prompt{TokenIDs: [][]uint32{{101, 102, 103, 104, 105}}},
+				Generate: &fwkrh.GenerateRequest{
+					TokenIDs: []uint32{101, 102, 103, 104, 105},
+					Features: &tokenization.MultiModalFeatures{
+						MMHashes: map[string][]string{
+							"image": {"hash-a", "hash-b"},
+						},
+						MMPlaceholders: map[string][]kvblock.PlaceholderRange{
+							"image": {
+								{Offset: 1, Length: 2},
+								{Offset: 4, Length: 1},
+							},
+						},
+					},
 				},
 				Payload: fwkrh.PayloadProto{
 					Message: &pb.GenerateRequest{
@@ -182,15 +190,6 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 							MmHashes: []string{"hash-a", "hash-b"},
 						},
 					},
-				},
-				TokenizedRequest: &fwkrh.TokenizedRequest{
-					Prompts: []fwkrh.PromptTokens{{
-						TokenIDs: []uint32{101, 102, 103, 104, 105},
-						MultiModalFeatures: []fwkrh.MultiModalFeature{
-							{Modality: fwkrh.ModalityImage, Hash: "hash-a", Offset: 1, Length: 2},
-							{Modality: fwkrh.ModalityImage, Hash: "hash-b", Offset: 4, Length: 1},
-						},
-					}},
 				},
 			},
 		},
@@ -213,8 +212,19 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 			},
 			headers: map[string]string{":path": "/vllm.grpc.engine.VllmEngine/Generate"},
 			want: &fwkrh.InferenceRequestBody{
-				Completions: &fwkrh.CompletionsRequest{
-					Prompt: fwkrh.Prompt{TokenIDs: [][]uint32{{201, 202, 203, 204}}},
+				Generate: &fwkrh.GenerateRequest{
+					TokenIDs: []uint32{201, 202, 203, 204},
+					Features: &tokenization.MultiModalFeatures{
+						MMHashes: map[string][]string{
+							"image": {"hash-only", ""},
+						},
+						MMPlaceholders: map[string][]kvblock.PlaceholderRange{
+							"image": {
+								{Offset: 0, Length: 1},
+								{Offset: 2, Length: 2},
+							},
+						},
+					},
 				},
 				Payload: fwkrh.PayloadProto{
 					Message: &pb.GenerateRequest{
@@ -232,15 +242,6 @@ func TestVllmGRPCParser_ParseRequest(t *testing.T) {
 							MmHashes: []string{"hash-only"},
 						},
 					},
-				},
-				TokenizedRequest: &fwkrh.TokenizedRequest{
-					Prompts: []fwkrh.PromptTokens{{
-						TokenIDs: []uint32{201, 202, 203, 204},
-						MultiModalFeatures: []fwkrh.MultiModalFeature{
-							{Modality: fwkrh.ModalityImage, Hash: "hash-only", Offset: 0, Length: 1},
-							{Modality: fwkrh.ModalityImage, Hash: "", Offset: 2, Length: 2},
-						},
-					}},
 				},
 			},
 		},

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/always_disagg_mm_decider.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/always_disagg_mm_decider.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 )
 
 const (
@@ -47,4 +48,12 @@ func (d *AlwaysDisaggMultimodalDecider) WithName(name string) *AlwaysDisaggMulti
 
 func (d *AlwaysDisaggMultimodalDecider) disaggregate(_ context.Context, request *scheduling.InferenceRequest, _ scheduling.Endpoint) bool {
 	return hasMultimodalContent(request)
+}
+
+func (d *AlwaysDisaggMultimodalDecider) Consumes() plugin.DataDependencies {
+	return plugin.DataDependencies{
+		Required: map[plugin.DataKey]any{
+			tokenproducer.TokenizedPromptDataKey: (*scheduling.TokenizedRequest)(nil),
+		},
+	}
 }

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler.go
@@ -252,7 +252,7 @@ func (h *Handler) Consumes() plugin.DataDependencies {
 	return plugin.DataDependencies{
 		Required: map[plugin.DataKey]any{
 			prefixMatchInfoDK:                    attrprefix.PrefixCacheMatchInfo{},
-			tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedRequest{},
+			tokenproducer.TokenizedPromptDataKey: (*scheduling.TokenizedRequest)(nil),
 		},
 	}
 }

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/disagg_profile_handler_test.go
@@ -73,12 +73,14 @@ func profileNames(m map[string]scheduling.SchedulerProfile) []string {
 // carries len(prompt)/averageCharactersPerToken token IDs, which the decider reads
 // as the input token count.
 func completionsRequest(prompt string) *scheduling.InferenceRequest {
-	return &scheduling.InferenceRequest{
+	req := &scheduling.InferenceRequest{
 		Body: &fwkrh.InferenceRequestBody{
-			Completions:      &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: prompt}},
-			TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, len(prompt)/averageCharactersPerToken)}}},
+			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: prompt}},
 		},
 	}
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
+		Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, len(prompt)/averageCharactersPerToken)}}})
+	return req
 }
 
 // chatRequest builds a chat-completions InferenceRequest, populating the
@@ -104,10 +106,11 @@ func chatRequest(hasImage, hasVideo, hasAudio bool) *scheduling.InferenceRequest
 			Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Structured: blocks}}},
 		},
 	}
+	req := &scheduling.InferenceRequest{Body: body}
 	if len(features) > 0 {
-		body.TokenizedRequest = &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{MultiModalFeatures: features}}}
+		req.PutAttribute(tokenproducer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{MultiModalFeatures: features}}})
 	}
-	return &scheduling.InferenceRequest{Body: body}
+	return req
 }
 
 // withPrompt adds a completions body to a chat request and sets the input token
@@ -115,15 +118,17 @@ func chatRequest(hasImage, hasVideo, hasAudio bool) *scheduling.InferenceRequest
 // any existing multimodal features.
 func withPrompt(req *scheduling.InferenceRequest, prompt string) *scheduling.InferenceRequest {
 	req.Body.Completions = &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: prompt}}
-	if req.Body.TokenizedRequest == nil {
-		req.Body.TokenizedRequest = &fwkrh.TokenizedRequest{}
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, tokenproducer.TokenizedPromptDataKey)
+	if !ok {
+		tp = &fwkrh.TokenizedRequest{}
 	}
 	tokenIDs := make([]uint32, len(prompt)/averageCharactersPerToken)
-	if len(req.Body.TokenizedRequest.Prompts) > 0 {
-		req.Body.TokenizedRequest.Prompts[0].TokenIDs = tokenIDs
+	if len(tp.Prompts) > 0 {
+		tp.Prompts[0].TokenIDs = tokenIDs
 	} else {
-		req.Body.TokenizedRequest.Prompts = []fwkrh.PromptTokens{{TokenIDs: tokenIDs}}
+		tp.Prompts = []fwkrh.PromptTokens{{TokenIDs: tokenIDs}}
 	}
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey, tp)
 	return req
 }
 
@@ -173,31 +178,31 @@ func (m *mockPDDecider) disaggregate(_ context.Context, _ *scheduling.InferenceR
 
 func TestHasMultimodalContent(t *testing.T) {
 	tests := []struct {
-		name     string
-		req      *scheduling.InferenceRequest
-		expected bool
+		name      string
+		req       *scheduling.InferenceRequest
+		tokenized *fwkrh.TokenizedRequest
+		expected  bool
 	}{
-		{"nil request", nil, false},
-		{"nil body", &scheduling.InferenceRequest{Body: nil}, false},
-		{"nil tokenized prompt", &scheduling.InferenceRequest{Body: &fwkrh.InferenceRequestBody{}}, false},
-		{"empty multimodal features", &scheduling.InferenceRequest{
-			Body: &fwkrh.InferenceRequestBody{TokenizedRequest: &fwkrh.TokenizedRequest{}},
-		}, false},
-		{"text only", chatRequest(false, false, false), false},
-		{"image", chatRequest(true, false, false), true},
-		{"video", chatRequest(false, true, false), true},
-		{"audio", chatRequest(false, false, true), true},
+		{"nil request", nil, nil, false},
+		{"nil body", &scheduling.InferenceRequest{Body: nil}, nil, false},
+		{"nil tokenized prompt", &scheduling.InferenceRequest{Body: &fwkrh.InferenceRequestBody{}}, nil, false},
+		{"empty multimodal features", &scheduling.InferenceRequest{}, &fwkrh.TokenizedRequest{}, false},
+		{"text only", chatRequest(false, false, false), nil, false},
+		{"image", chatRequest(true, false, false), nil, true},
+		{"video", chatRequest(false, true, false), nil, true},
+		{"audio", chatRequest(false, false, true), nil, true},
 		{"feature present", &scheduling.InferenceRequest{
-			Body: &fwkrh.InferenceRequestBody{
-				TokenizedRequest: &fwkrh.TokenizedRequest{
-					Prompts: []fwkrh.PromptTokens{{MultiModalFeatures: []fwkrh.MultiModalFeature{{Modality: fwkrh.ModalityImage}}}},
-				},
-			},
+			Body: &fwkrh.InferenceRequestBody{},
+		}, &fwkrh.TokenizedRequest{
+			Prompts: []fwkrh.PromptTokens{{MultiModalFeatures: []fwkrh.MultiModalFeature{{Modality: fwkrh.ModalityImage}}}},
 		}, true},
-		{"all types", chatRequest(true, true, true), true},
+		{"all types", chatRequest(true, true, true), nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.tokenized != nil {
+				tt.req.PutAttribute(tokenproducer.TokenizedPromptDataKey, tt.tokenized)
+			}
 			assert.Equal(t, tt.expected, hasMultimodalContent(tt.req))
 		})
 	}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/multimodal_helpers.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/multimodal_helpers.go
@@ -2,16 +2,21 @@ package disagg
 
 import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 )
 
 // hasMultimodalContent reports whether the tokenized prompt carries any
 // multimodal features. Detection is protocol-agnostic: it relies on the
 // token-producer plugin having populated PromptTokens.MultiModalFeatures.
 func hasMultimodalContent(request *scheduling.InferenceRequest) bool {
-	if request == nil || request.Body == nil || request.Body.TokenizedRequest == nil {
+	if request == nil {
 		return false
 	}
-	for _, p := range request.Body.TokenizedRequest.Prompts {
+	tp, ok := scheduling.ReadRequestAttribute[*scheduling.TokenizedRequest](request, tokenproducer.TokenizedPromptDataKey)
+	if !ok {
+		return false
+	}
+	for _, p := range tp.Prompts {
 		if len(p.MultiModalFeatures) > 0 {
 			return true
 		}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider.go
@@ -150,7 +150,7 @@ func (d *PrefixBasedPDDecider) Consumes() plugin.DataDependencies {
 	return plugin.DataDependencies{
 		Required: map[plugin.DataKey]any{
 			d.prefixMatchInfoDK:                  attrprefix.PrefixCacheMatchInfo{},
-			tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedRequest{},
+			tokenproducer.TokenizedPromptDataKey: (*scheduling.TokenizedRequest)(nil),
 		},
 	}
 }
@@ -271,12 +271,11 @@ func (d *PrefixBasedPDDecider) computeNeedsRemotePrefill(ctx context.Context, re
 	}
 	prefixInfoRaw, ok := endpoint.Get(d.prefixMatchInfoDK)
 	if !ok || prefixInfoRaw == nil {
-		return false, fmt.Errorf("unable to read prefix cache state for %s", d.prefixMatchInfoDK)
+		return false, errors.New("unable to read prefix cache state")
 	}
 	info, ok := prefixInfoRaw.(*attrprefix.PrefixCacheMatchInfo)
 	if !ok {
-		return false, fmt.Errorf("prefix cache match info from %s has unexpected type: %T",
-			d.prefixMatchInfoDK, prefixInfoRaw)
+		return false, fmt.Errorf("prefix cache match info has unexpected type: %T", prefixInfoRaw)
 	}
 	hitPrefixTokens := info.CachedBlockCount() * info.BlockSizeTokens()
 	nonCachedTokens := inputTokens - hitPrefixTokens
@@ -291,11 +290,15 @@ func (d *PrefixBasedPDDecider) computeNeedsRemotePrefill(ctx context.Context, re
 // in PreRequest and disaggregate surfaces the tokenizer failure in the log
 // rather than silently treating an untokenized request as zero-length input.
 func getUserInputLenInTokens(request *scheduling.InferenceRequest) (int, error) {
-	if request == nil || request.Body == nil {
+	if request == nil {
 		return 0, errors.New("request or request body is nil")
 	}
-	if request.Body.TokenizedRequest == nil {
+	tp, ok := scheduling.ReadRequestAttribute[*scheduling.TokenizedRequest](
+		request,
+		tokenproducer.TokenizedPromptDataKey,
+	)
+	if !ok {
 		return 0, errors.New("prompt not tokenized")
 	}
-	return request.Body.TokenizedRequest.TokenCount(), nil
+	return tp.TokenCount(), nil
 }

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/prefix_based_pd_decider_test.go
@@ -67,10 +67,12 @@ func makeRequestWithTokens(tokens int) *scheduling.InferenceRequest {
 // withTokens sets the tokenized prompt to carry n token IDs, which the decider reads
 // as the input token count. Any existing tokenized prompt is preserved.
 func withTokens(req *scheduling.InferenceRequest, n int) *scheduling.InferenceRequest {
-	if req.Body.TokenizedRequest == nil {
-		req.Body.TokenizedRequest = &fwkrh.TokenizedRequest{}
+	_, ok := req.GetAttribute(tokenproducer.TokenizedPromptDataKey)
+	if !ok {
+		tp := &fwkrh.TokenizedRequest{}
+		tp.Prompts = []fwkrh.PromptTokens{{TokenIDs: make([]uint32, n)}}
+		req.PutAttribute(tokenproducer.TokenizedPromptDataKey, tp)
 	}
-	req.Body.TokenizedRequest.Prompts = []fwkrh.PromptTokens{{TokenIDs: make([]uint32, n)}}
 	return req
 }
 
@@ -114,16 +116,15 @@ func TestGetUserInputLenInTokens(t *testing.T) {
 		},
 		{
 			name: "completions string array prompt",
-			req: &scheduling.InferenceRequest{
+			req: withTokens(&scheduling.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
 					Completions: &fwkrh.CompletionsRequest{
 						Prompt: fwkrh.Prompt{
 							Strings: []string{"hello world", "foo bar baz"},
 						},
 					},
-					TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 5)}}},
 				},
-			},
+			}, 5),
 			want: 5,
 		},
 		{
@@ -161,12 +162,11 @@ func TestGetUserInputLenInTokens(t *testing.T) {
 		},
 		{
 			name: "generate request returns exact token count",
-			req: &scheduling.InferenceRequest{
+			req: withTokens(&scheduling.InferenceRequest{
 				Body: &fwkrh.InferenceRequestBody{
-					Generate:         &fwkrh.GenerateRequest{TokenIDs: []uint32{1, 2, 3, 4, 5, 6, 7}},
-					TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, 7)}}},
+					Generate: &fwkrh.GenerateRequest{TokenIDs: []uint32{1, 2, 3, 4, 5, 6, 7}},
 				},
-			},
+			}, 7),
 			want: 7,
 		},
 	}

--- a/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/scheduler_test.go
+++ b/pkg/epp/framework/plugins/scheduling/profilehandler/disagg/scheduler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
+	tokenproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/stretchr/testify/assert"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log" // Import config for thresholds
@@ -36,14 +37,20 @@ const (
 	averageCharactersPerToken = 4
 )
 
-// completionsBody builds a completions request body whose tokenized prompt carries
+// inferenceRequest builds a completions request body whose tokenized prompt carries
 // len(prompt)/averageCharactersPerToken token IDs, which the decider reads as
 // the input token count.
-func completionsBody(prompt string) *fwkrh.InferenceRequestBody {
-	return &fwkrh.InferenceRequestBody{
-		Completions:      &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: prompt}},
-		TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, len(prompt)/averageCharactersPerToken)}}},
+func inferenceRequest(model, prompt string) *fwksched.InferenceRequest {
+	req := &fwksched.InferenceRequest{
+		RequestID:   uuid.NewString(),
+		TargetModel: model,
+		Body: &fwkrh.InferenceRequestBody{
+			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: prompt}},
+		},
 	}
+	req.PutAttribute(tokenproducer.TokenizedPromptDataKey,
+		&fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: make([]uint32, len(prompt)/averageCharactersPerToken)}}})
+	return req
 }
 
 // Tests the scheduler expected behavior.
@@ -118,22 +125,14 @@ func TestPDSchedule(t *testing.T) {
 		err      bool
 	}{
 		{
-			name: "no candidate endpoints",
-			req: &fwksched.InferenceRequest{
-				RequestID:   uuid.NewString(),
-				TargetModel: "any-model",
-				Body:        completionsBody("12345678901"),
-			},
+			name:  "no candidate endpoints",
+			req:   inferenceRequest("any-model", "12345678901"),
 			input: []fwksched.Endpoint{},
 			err:   true,
 		},
 		{
 			name: "one decode endpoint, long prompt, no prefill endpoint available",
-			req: &fwksched.InferenceRequest{
-				RequestID:   uuid.NewString(),
-				TargetModel: "critical",
-				Body:        completionsBody("12345678901"),
-			},
+			req:  inferenceRequest("critical", "12345678901"),
 			// The long, uncached prompt makes the decider pick the prefill profile,
 			// but no Prefill-role endpoint is present: the request must fail rather
 			// than silently complete decode-only.
@@ -142,22 +141,14 @@ func TestPDSchedule(t *testing.T) {
 		},
 		{
 			name: "one prefill endpoint, long prompt",
-			req: &fwksched.InferenceRequest{
-				RequestID:   uuid.NewString(),
-				TargetModel: "critical",
-				Body:        completionsBody("12345678901"),
-			},
+			req:  inferenceRequest("critical", "12345678901"),
 			// no Decode endpoint
 			input: []fwksched.Endpoint{endpoint1},
 			err:   true,
 		},
 		{
 			name: "1P1D - long prompt",
-			req: &fwksched.InferenceRequest{
-				RequestID:   uuid.NewString(),
-				TargetModel: "critical",
-				Body:        completionsBody("12345678906"),
-			},
+			req:  inferenceRequest("critical", "12345678906"),
 			// endpoint2 will be picked in the decode profile result, endpoint1 will be in the prefill profile result
 			input:    []fwksched.Endpoint{endpoint1, endpoint2},
 			wantRes:  prefillDecodeResult,
@@ -165,11 +156,7 @@ func TestPDSchedule(t *testing.T) {
 		},
 		{
 			name: "1P1Dshort",
-			req: &fwksched.InferenceRequest{
-				RequestID:   uuid.NewString(),
-				TargetModel: "critical",
-				Body:        completionsBody("12345"),
-			},
+			req:  inferenceRequest("critical", "12345"),
 			// endpoint2 will be picked because it is the decode endpoint, endpoint1 shouldn't be picked,
 			// because the prompt is too short
 			input:    []fwksched.Endpoint{endpoint1, endpoint2},
@@ -177,12 +164,8 @@ func TestPDSchedule(t *testing.T) {
 			wantRes2: decodeResult,
 		},
 		{
-			name: "TestRolesWithNoDecode",
-			req: &fwksched.InferenceRequest{
-				RequestID:   uuid.NewString(),
-				TargetModel: "critical",
-				Body:        completionsBody("12345678901"),
-			},
+			name:  "TestRolesWithNoDecode",
+			req:   inferenceRequest("critical", "12345678901"),
 			input: []fwksched.Endpoint{endpoint1, noRoleEndpoint1},
 			wantRes: &fwksched.SchedulingResult{
 				ProfileResults: map[string]*fwksched.ProfileRunResult{
@@ -206,11 +189,7 @@ func TestPDSchedule(t *testing.T) {
 		},
 		{
 			name: "1P2D - long prompt",
-			req: &fwksched.InferenceRequest{
-				RequestID:   uuid.NewString(),
-				TargetModel: "critical",
-				Body:        completionsBody("1234567890123456789012345678901234567890"),
-			},
+			req:  inferenceRequest("critical", "1234567890123456789012345678901234567890"),
 			// endpoint2 will be picked in the decode profile result cause it has higher score than noRoleEndpoint1
 			// endpoint1 will be in the prefill profile result
 			input:    []fwksched.Endpoint{endpoint1, endpoint2, noRoleEndpoint1},
@@ -357,11 +336,7 @@ func TestPDSchedule_PrefillFirst(t *testing.T) {
 	})
 	scheduler := scheduling.NewSchedulerWithConfig(schedulerConfig)
 
-	req := &fwksched.InferenceRequest{
-		RequestID:   uuid.NewString(),
-		TargetModel: "critical",
-		Body:        completionsBody("12345678906"),
-	}
+	req := inferenceRequest("critical", "12345678906")
 	input := []fwksched.Endpoint{endpoint1, endpoint2}
 
 	got, err := scheduler.Schedule(ctx, req, input)

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware.go
@@ -80,7 +80,7 @@ func NewContextLengthAware(name string, params *contextLengthAwareParameters) *C
 // If filtering is enabled, endpoints that don't support the request's context length are filtered out.
 // Additionally, it scores endpoints based on how well their context length ranges match the request.
 //
-// The context length is the token count from InferenceRequestBody.TokenizedRequest as
+// The context length is the token count from per-request TokenizedPrompt attribute as
 // populated by the tokenizer DataProducer plugin. When tokens are not available it is
 // treated as 0 (unknown).
 type ContextLengthAware struct {
@@ -108,7 +108,7 @@ func (p *ContextLengthAware) WithName(name string) *ContextLengthAware {
 // configured; the context length is the token count it provides.
 func (p *ContextLengthAware) Consumes() plugin.DataDependencies {
 	return plugin.DataDependencies{
-		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: scheduling.TokenizedRequest{}},
+		Required: map[plugin.DataKey]any{tokenproducer.TokenizedPromptDataKey: (*scheduling.TokenizedRequest)(nil)},
 	}
 }
 
@@ -200,13 +200,21 @@ func (p *ContextLengthAware) Category() scheduling.ScorerCategory {
 }
 
 // getContextLength returns the context length (token count) for the request, read solely
-// from InferenceRequestBody.TokenizedRequest as populated by the tokenizer DataProducer
+// from per-request TokenizedPrompt attribute as populated by the tokenizer DataProducer
 // plugin. When tokens are unavailable it returns 0 (unknown).
 func getContextLength(request *scheduling.InferenceRequest) int {
-	if request == nil || request.Body == nil || request.Body.TokenizedRequest == nil {
+	if request == nil {
 		return 0
 	}
-	return request.Body.TokenizedRequest.TokenCount()
+	tp, ok := scheduling.ReadRequestAttribute[*scheduling.TokenizedRequest](
+		request,
+		tokenproducer.TokenizedPromptDataKey,
+	)
+	if !ok {
+		return 0
+	}
+
+	return tp.TokenCount()
 }
 
 // parseContextRange parses a label value into a single context range.

--- a/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware/context_length_aware_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -241,7 +242,7 @@ func TestCalculateRangeScoreFallback(t *testing.T) {
 	})
 }
 
-// TokenizedRequest tests — plugin reads tokens from InferenceRequestBody.TokenizedRequest
+// TokenizedRequest tests — plugin reads tokens from per-request TokenizedPrompt attribute
 // as populated by the tokenizer DataProducer plugin.
 
 func TestContextLengthAwareWithTokenizedRequestOnRequest(t *testing.T) {
@@ -272,11 +273,9 @@ func TestContextLengthAwareWithTokenizedRequestOnRequest(t *testing.T) {
 	request := &scheduling.InferenceRequest{
 		RequestID:   "test-request",
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: tokenIDs}}},
-		},
+		Body:        &fwkrh.InferenceRequestBody{},
 	}
-
+	request.PutAttribute(tokenizer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: tokenIDs}}})
 	filteredEndpoints := plugin.Filter(ctx, request, endpoints)
 	assert.Equal(t, 1, len(filteredEndpoints))
 	assert.Equal(t, "tight-match", filteredEndpoints[0].GetMetadata().ID.Name)

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/legacy_producer.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/legacy_producer.go
@@ -109,7 +109,8 @@ func needsLegacyTokenization(request *scheduling.InferenceRequest) bool {
 	if request == nil || request.Body == nil {
 		return false
 	}
-	if tp := request.Body.TokenizedRequest; tp != nil && tp.TokenCount() > 0 {
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](request, tokenizer.TokenizedPromptDataKey)
+	if ok && tp.TokenCount() > 0 {
 		return false
 	}
 	return request.Body.Completions != nil || request.Body.ChatCompletions != nil
@@ -132,13 +133,13 @@ func (lp *legacyProducer) tokenizeRequest(request *scheduling.InferenceRequest) 
 		return
 	}
 
-	request.Body.TokenizedRequest = &fwkrh.TokenizedRequest{
+	request.PutAttribute(tokenizer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{
 		Prompts: []fwkrh.PromptTokens{{
 			TokenIDs:           tokens,
 			MultiModalFeatures: flattenMMFeatures(mmFeatures),
 		}},
 		CacheSalt: tokenizer.CacheSaltFromBody(request.Body),
-	}
+	})
 }
 
 // flattenMMFeatures regroups the kvcache map-shaped multimodal metadata

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/precise_prefix_cache_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
 	"github.com/llm-d/llm-d-router/pkg/kvcache/tokenization"
 	tokenizerTypes "github.com/llm-d/llm-d-router/pkg/kvcache/tokenization/types"
 	"github.com/prometheus/client_golang/prometheus"
@@ -214,7 +215,7 @@ func TestLegacyProducer_ConsumesDropsTokenizedRequestWhenPoolSet(t *testing.T) {
 
 // When a completions prompt arrives without TokenizedRequest and the pool
 // is set, Produce must route the prompt through the pool and stash the
-// resulting tokens on request.Body.TokenizedRequest.
+// resulting tokens in the request attribute store.
 func TestLegacyProducer_TokenizesCompletionPromptViaPool(t *testing.T) {
 	ctx := utils.NewTestContext(t)
 	handle := fwkplugin.NewEppHandle(ctx, nil,
@@ -241,11 +242,12 @@ func TestLegacyProducer_TokenizesCompletionPromptViaPool(t *testing.T) {
 
 	assert.Equal(t, 1, stub.calls)
 	assert.Equal(t, "hello world", stub.lastRaw)
-	require.NotNil(t, req.Body.TokenizedRequest)
-	assert.Equal(t, []uint32{1, 2, 3}, req.Body.TokenizedRequest.Prompts[0].TokenIDs)
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, tokenizer.TokenizedPromptDataKey)
+	assert.True(t, ok)
+	assert.Equal(t, []uint32{1, 2, 3}, tp.Prompts[0].TokenIDs)
 	// Wrapper-owned tokenization must still carry the cache salt so precise
 	// keys stay isolated on this path.
-	assert.Equal(t, "leg-salt", req.Body.TokenizedRequest.CacheSalt)
+	assert.Equal(t, "leg-salt", tp.CacheSalt)
 }
 
 // End-to-end: tokens from the pool flow into the embedded producer, get
@@ -314,12 +316,14 @@ func TestLegacyProducer_KeepsExistingTokenizedRequest(t *testing.T) {
 
 	req := &scheduling.InferenceRequest{
 		Body: &fwkrh.InferenceRequestBody{
-			TokenizedRequest: &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{5, 5, 5}}}},
-			Completions:      &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "should not tokenize"}},
+			Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "should not tokenize"}},
 		},
 	}
+	req.PutAttribute(tokenizer.TokenizedPromptDataKey, &fwkrh.TokenizedRequest{Prompts: []fwkrh.PromptTokens{{TokenIDs: []uint32{5, 5, 5}}}})
 	require.NoError(t, lp.Produce(ctx, req, nil))
 
 	assert.Equal(t, 0, stub.calls, "pool must not be called when tokens already present")
-	assert.Equal(t, []uint32{5, 5, 5}, req.Body.TokenizedRequest.Prompts[0].TokenIDs)
+	tp, ok := scheduling.ReadRequestAttribute[*fwkrh.TokenizedRequest](req, tokenizer.TokenizedPromptDataKey)
+	assert.True(t, ok)
+	assert.Equal(t, []uint32{5, 5, 5}, tp.Prompts[0].TokenIDs)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Moves TokenizedRequest out of InferenceRequestBody and stores it in the per-request attribute store under TokenizedPromptDataKey.

TokenizedPromptDataKey was already used to declare producer/consumer dependencies, while the actual tokenized prompt was still stored and accessed through InferenceRequestBody.TokenizedRequest. This made the declared dependency graph and the runtime data flow use two different mechanisms for the same data.

This PR aligns them by:

- publishing tokenized prompts from token-producer through the request attribute store;
- migrating request-control, scheduling, flow-control, and observability consumers to read the tokenized prompt from request attributes;
- removing InferenceRequestBody.TokenizedRequest;
- keeping protocol-level pre-tokenized input in the parsed request body and letting token-producer normalize it into the shared TokenizedRequest;
- updating the vLLM gRPC parser to use the existing GenerateRequest representation for pre-tokenized generate input and multimodal metadata;
- using the canonical TokenizedPromptDataKey consistently for production and consumption;
- updating affected tests and fixtures to use the new request-attribute contract.

This removes the previous hidden body mutation path and avoids maintaining multiple sources of truth for tokenized prompt state.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1375 

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
