### PR TITLE
fix(kind): forward Prometheus host port

### DIFF
--- a/Makefile.kind.mk
+++ b/Makefile.kind.mk
@@ -2,6 +2,9 @@
 
 KIND_CLUSTER_NAME ?= $(PROJECT_NAME)-dev
 KIND_GATEWAY_HOST_PORT ?= 30080
+# KIND_PROM_HOST_PORT is the documented Make variable. Fall back to
+# PROM_HOST_PORT so direct callers keep working through this target.
+KIND_PROM_HOST_PORT ?= $(PROM_HOST_PORT)
 
 .PHONY: image-kind
 image-kind: ## Reload the EPP and SideCar images into the kind cluster $(KIND_CLUSTER_NAME)
@@ -15,6 +18,7 @@ env-dev-kind: image-build image-pull ## Run under kind ($(KIND_CLUSTER_NAME))
 	else \
 		CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
 		GATEWAY_HOST_PORT=$(KIND_GATEWAY_HOST_PORT) \
+		PROM_HOST_PORT="$(KIND_PROM_HOST_PORT)" \
 		IMAGE_REGISTRY=$(IMAGE_REGISTRY) \
 		./scripts/kind-dev-env.sh; \
 	fi

--- a/Makefile.kind.mk
+++ b/Makefile.kind.mk
@@ -2,9 +2,7 @@
 
 KIND_CLUSTER_NAME ?= $(PROJECT_NAME)-dev
 KIND_GATEWAY_HOST_PORT ?= 30080
-# KIND_PROM_HOST_PORT is the documented Make variable. Fall back to
-# PROM_HOST_PORT so direct callers keep working through this target.
-KIND_PROM_HOST_PORT ?= $(PROM_HOST_PORT)
+KIND_PROM_HOST_PORT ?= 30090
 
 .PHONY: image-kind
 image-kind: ## Reload the EPP and SideCar images into the kind cluster $(KIND_CLUSTER_NAME)


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind bug

**What this PR does / why we need it**:

`DEVELOPMENT.md` documents `PROM_ENABLED=true KIND_PROM_HOST_PORT=30091 make env-dev-kind`, but the `env-dev-kind` target did not forward `KIND_PROM_HOST_PORT` to `scripts/kind-dev-env.sh`. The script therefore used its default host port, `30090`.

This change forwards `KIND_PROM_HOST_PORT` as `PROM_HOST_PORT`. The Prometheus service NodePort remains `30090`, and direct invocations using `PROM_HOST_PORT` remain supported.

This is a development-only fix. It does not change production deployments, request routing, or the in-cluster Prometheus port. It lets local Kind users select an available host port when `30090` is already in use, while preserving the existing default.

**Which issue(s) this PR fixes**:
Related to #790

**Local before/after verification**:

Command:

```bash
PROM_ENABLED=true KIND_PROM_HOST_PORT=30091 make --no-print-directory -n env-dev-kind
```

Before this change, the generated command omitted `PROM_HOST_PORT`:

```text
CLUSTER_NAME=llm-d-router-dev \
GATEWAY_HOST_PORT=30080 \
IMAGE_REGISTRY=ghcr.io/llm-d \
./scripts/kind-dev-env.sh; \
```

After this change, the generated command forwards the requested port:

```text
CLUSTER_NAME=llm-d-router-dev \
GATEWAY_HOST_PORT=30080 \
PROM_HOST_PORT="30091" \
IMAGE_REGISTRY=ghcr.io/llm-d \
./scripts/kind-dev-env.sh; \
```

No Kind cluster was created during the comparison.

**Release note** _(write `NONE` if no user-facing change)_: 
```release-note
Fix the Prometheus host-port override for the Kind development environment.
```
