### PR TITLE
chore(epp): remove dead nil check and fix comment typo in approx-prefix

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -181,9 +181,7 @@ func newDataProducer(ctx context.Context, name string, config config, handle plu
 		dk:          attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(name),
 	}
 
-	if handle != nil {
-		go p.CleanUpInactivePods(ctx, handle)
-	}
+	go p.CleanUpInactivePods(ctx, handle)
 
 	return p, nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
@@ -128,7 +128,7 @@ const (
 	// servers. Consider the llama3 8B model on a H100 80GB GPUs. The size of the model weight is
 	// about 16GB. The remaining HBM used for caching prefixes is 64GB. Each
 	// token is about 128KB in size, so we can cache 500K tokens. Using the default block size of 16
-	// in vLLM, we will have 250K / 16 = 31.25K blocks.
+	// in vLLM, we will have 500K / 16 = 31.25K blocks.
 	defaultLRUCapacityPerServer = 31250
 )
 


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind cleanup
**What this PR does / why we need it**:
* `newDataProducer` already returns an error when the handle is nil, so the condition is always true.
*  500K tokens at vLLM's default  block size of 16 gives 500K / 16 = 31.25K blocks;fix 250K to 500K.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
