### PR TITLE
fix(epp): reject negative maxPrefixBlocksToMatch config

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -149,6 +149,9 @@ func newDataProducer(ctx context.Context, name string, config config, handle plu
 	if config.MaxPrefixTokensToMatch < 0 {
 		return nil, fmt.Errorf("invalid configuration: MaxPrefixTokensToMatch must be >= 0 (current value: %d)", config.MaxPrefixTokensToMatch)
 	}
+	if config.MaxPrefixBlocksToMatch < 0 {
+		return nil, fmt.Errorf("invalid configuration: MaxPrefixBlocksToMatch must be >= 0 (current value: %d)", config.MaxPrefixBlocksToMatch)
+	}
 	if handle == nil {
 		return nil, errors.New("plugin handle is required")
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -213,6 +213,10 @@ func TestDataProducerValidation(t *testing.T) {
 	}, {
 		AutoTune:        false,
 		BlockSizeTokens: 0,
+	}, {
+		AutoTune:               false,
+		BlockSizeTokens:        1,
+		MaxPrefixBlocksToMatch: -1,
 	}}
 
 	for _, config := range validConfigs {


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind bug

**What this PR does / why we need it**:
A negative maxPrefixBlocksToMatch was silently accepted by the approx-prefix-cache data producer.
[resolveMaxBlocks](https://github.com/llm-d/llm-d-router/blob/ebc59e514b58eed1e6af796225f5786a3700a715/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go#L374) returned the negative value, and block hashing broke on the first block (count >=maxPrefixBlocks), so every request produced zero prefix hashes — prefix-cache matching was disabled with no error or log.

This PR rejects the value at plugin construction, mirroring the existing maxPrefixTokensToMatch check.

https://github.com/llm-d/llm-d-router/blob/ebc59e514b58eed1e6af796225f5786a3700a715/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go#L374-L378

->

https://github.com/llm-d/llm-d-router/blob/ebc59e514b58eed1e6af796225f5786a3700a715/pkg/epp/framework/plugins/requestcontrol/dataproducer/prefixhash/hashing.go#L102-L105

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
