### PR TITLE
feat(chart): support vLLM Rust renderer flavor for tokenizer sidecar

### DIFF
--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -381,20 +381,21 @@ router:
 
 Runs a tokenizer sidecar that EPP queries to tokenize incoming requests, enabling precise, token-count-aware routing policies (e.g., precise prefix-cache matching).
 
-The sidecar runs vLLM's `vllm launch render <modelName>` and exposes `/v1/completions/render` and `/v1/chat/completions/render` over loopback HTTP. Wire EPP to it via `router.epp.pluginsCustomConfig` with `type: token-producer` and `vllm:`.
+The sidecar runs vLLM's `vllm launch render <modelName>` (Python) or `vllm-rs render <modelName>` (Rust) and exposes `/v1/completions/render` and `/v1/chat/completions/render` over loopback HTTP. Wire EPP to it via `router.epp.pluginsCustomConfig` with `type: token-producer` and `vllm:`.
 
 #### Tokenizer Sidecar Parameters
 
 | **Parameter Name** | **Description** | **Default** |
 | :--- | :--- | :--- |
 | `router.tokenizer.enabled` | Enable the vLLM `/render` tokenizer sidecar in the EPP deployment. | `false` |
-| `router.tokenizer.modelName` | **REQUIRED** when enabled. Model name passed as the first positional arg to the sidecar's `vllm launch render` command. | `""` |
+| `router.tokenizer.flavor` | Renderer backend: `"python"` runs `vllm launch render`; `"rust"` runs `vllm-rs render` (requires an image containing `vllm-rs`). | `"python"` |
+| `router.tokenizer.modelName` | **REQUIRED** when enabled. Model name passed as the first positional arg to the sidecar's render command. | `""` |
 | `router.tokenizer.image.registry` | Tokenizer container image registry. | `docker.io` |
 | `router.tokenizer.image.repository` | Tokenizer container image repository. | `vllm/vllm-openai-cpu` |
 | `router.tokenizer.image.tag` | Tokenizer container image tag. | `v0.19.1` |
 | `router.tokenizer.image.pullPolicy` | Tokenizer container image pull policy. | `IfNotPresent` |
 | `router.tokenizer.port` | Container port the sidecar listens on. | `8000` |
-| `router.tokenizer.command` | Override container command. Empty renders `["vllm", "launch", "render"]`. | `[]` |
+| `router.tokenizer.command` | Override container command. Empty renders `["vllm", "launch", "render"]` for `"python"` flavor or `["vllm-rs", "render"]` for `"rust"` flavor. | `[]` |
 | `router.tokenizer.args` | Override container args. Empty renders `["<modelName>", "--port=<port>"]`. | `[]` |
 | `router.tokenizer.extraArgs` | Extra args appended to the tokenizer container after the default or overridden args. | `[]` |
 | `router.tokenizer.initContainers` | Pod-level init containers rendered when the tokenizer is enabled. | `[]` |

--- a/config/charts/routerlib/templates/_deployment.yaml
+++ b/config/charts/routerlib/templates/_deployment.yaml
@@ -224,12 +224,16 @@
         {{- if .Values.router.tokenizer.enabled }}
         {{- $tokenizer := .Values.router.tokenizer }}
         {{- $renderPort := $tokenizer.port | default 8000 | int }}
+        {{- $flavor := $tokenizer.flavor | default "python" | lower }}
         - name: vllm-render
           image: {{ $tokenizer.image.registry }}/{{ $tokenizer.image.repository }}:{{ $tokenizer.image.tag }}
           imagePullPolicy: {{ $tokenizer.image.pullPolicy | default "IfNotPresent" }}
           command:
           {{- if $tokenizer.command }}
           {{- toYaml $tokenizer.command | nindent 12 }}
+          {{- else if eq $flavor "rust" }}
+            - vllm-rs
+            - render
           {{- else }}
             - vllm
             - launch

--- a/config/charts/routerlib/templates/_helpers.tpl
+++ b/config/charts/routerlib/templates/_helpers.tpl
@@ -516,12 +516,18 @@ Helper to check if priorityRouting is enabled across chart contexts.
 {{- end -}}
 
 {{/*
-Tokenizer validations: require modelName for the render sidecar's command args.
+Tokenizer validations: require modelName and valid flavor for the render sidecar.
 */}}
 {{- define "llm-d-router.validations.epp.tokenizer" -}}
 {{- $tokenizer := .Values.router.tokenizer | default dict }}
-{{- if and (dig "enabled" false $tokenizer) (not (dig "modelName" "" $tokenizer)) }}
+{{- if (dig "enabled" false $tokenizer) }}
+{{- if not (dig "modelName" "" $tokenizer) }}
 {{- fail ".Values.router.tokenizer.modelName is required when the tokenizer is enabled." }}
+{{- end }}
+{{- $flavor := dig "flavor" "python" $tokenizer | lower }}
+{{- if not (or (eq $flavor "python") (eq $flavor "rust")) }}
+{{- fail (printf ".Values.router.tokenizer.flavor must be one of [python, rust], got %q" (dig "flavor" "" $tokenizer)) }}
+{{- end }}
 {{- end }}
 {{- end -}}
 

--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -95,12 +95,16 @@ epp:
 proxy:
   enabled: false    
 
-# Tokenizer sidecar. Runs vLLM's `vllm launch render <modelName>` and exposes
-# `/render` over loopback HTTP to EPP. modelName is passed as the first
+# Tokenizer sidecar. Runs vLLM's `vllm launch render <modelName>` (Python) or
+# `vllm-rs render <modelName>` (Rust) and exposes `/v1/completions/render` and
+# `/v1/chat/completions/render` over loopback HTTP to EPP. modelName is passed as the first
 # positional arg to the render command (required when enabled). EPP is wired to
 # the sidecar via `router.epp.pluginsCustomConfig`.
+# When flavor is "rust", router.tokenizer.image must be set to an image containing the vllm-rs binary.
 tokenizer:
   enabled: false
+  # Backend renderer flavor: "python" (default, runs vllm launch render) or "rust" (runs vllm-rs render; requires an image that includes vllm-rs).
+  flavor: "python"
   modelName: ""
   image:
     registry: docker.io

--- a/hack/verify-helm.sh
+++ b/hack/verify-helm.sh
@@ -65,6 +65,8 @@ test_cases_llm_d_router_gateway["basic"]="--set router.modelServers.matchLabels.
 test_cases_llm_d_router_gateway["gke-provider"]="--set provider.name=gke --set router.modelServers.matchLabels.app=llm-instance-gateway"
 test_cases_llm_d_router_gateway["multiple-replicas"]="--set router.replicas=3 --set router.modelServers.matchLabels.app=llm-instance-gateway"
 test_cases_llm_d_router_gateway["latency-predictor"]="--set router.latencyPredictor.enabled=true --set router.modelServers.matchLabels.app=llm-instance-gateway"
+test_cases_llm_d_router_gateway["tokenizer-python"]="--set router.modelServers.matchLabels.app=llm-instance-gateway --set router.tokenizer.enabled=true --set router.tokenizer.modelName=test-model"
+test_cases_llm_d_router_gateway["tokenizer-rust"]="--set router.modelServers.matchLabels.app=llm-instance-gateway --set router.tokenizer.enabled=true --set router.tokenizer.flavor=rust --set router.tokenizer.modelName=test-model"
 
 # Run the install command in case this script runs from a different bash
 # source (such as in the verify-all script)
@@ -100,6 +102,19 @@ for key in "${!test_cases_llm_d_router_gateway[@]}"; do
   if [ "${key}" == "triton" ]; then
     if ! grep -q "passthrough-parser" "${output_dir}/llm-d-router-gateway/templates/inferenceextension.yaml"; then
       echo "Validation failed: passthrough-parser not found in rendered output for test: ${key}"
+      exit 1
+    fi
+  fi
+
+  if [ "${key}" == "tokenizer-rust" ]; then
+    if ! grep -q "vllm-rs" "${output_dir}/llm-d-router-gateway/templates/epp.yaml"; then
+      echo "Validation failed: vllm-rs not found in rendered output for test: ${key}"
+      exit 1
+    fi
+  fi
+  if [ "${key}" == "tokenizer-python" ]; then
+    if ! grep -q "vllm" "${output_dir}/llm-d-router-gateway/templates/epp.yaml" || ! grep -q "launch" "${output_dir}/llm-d-router-gateway/templates/epp.yaml"; then
+      echo "Validation failed: vllm launch not found in rendered output for test: ${key}"
       exit 1
     fi
   fi
@@ -146,6 +161,8 @@ test_cases_llm_d_router_standalone["agentgateway"]="--set router.proxy.proxyType
 test_cases_llm_d_router_standalone["proxy-service"]="--set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set router.proxy.mode=service --set router.proxy.replicas=3"
 test_cases_llm_d_router_standalone["agentgateway-service"]="--set router.proxy.proxyType=agentgateway --set router.proxy.mode=service --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set 'router.modelServers.targetPorts[0].number=8000'"
 test_cases_llm_d_router_standalone["triton"]="--set router.modelServers.type=triton --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false"
+test_cases_llm_d_router_standalone["tokenizer-python"]="--set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set router.tokenizer.enabled=true --set router.tokenizer.modelName=test-model"
+test_cases_llm_d_router_standalone["tokenizer-rust"]="--set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set router.tokenizer.enabled=true --set router.tokenizer.flavor=rust --set router.tokenizer.modelName=test-model"
 
 
 echo "Processing dependencies for llm-d-router-standalone chart..."
@@ -172,6 +189,18 @@ for key in "${!test_cases_llm_d_router_standalone[@]}"; do
   if [ $? -ne 0 ]; then
     echo "Kubectl validation failed for test: ${key}"
     exit 1
+  fi
+  if [ "${key}" == "tokenizer-rust" ]; then
+    if ! grep -q "vllm-rs" "${output_dir}/llm-d-router-standalone/templates/epp.yaml"; then
+      echo "Validation failed: vllm-rs not found in rendered output for test: ${key}"
+      exit 1
+    fi
+  fi
+  if [ "${key}" == "tokenizer-python" ]; then
+    if ! grep -q "vllm" "${output_dir}/llm-d-router-standalone/templates/epp.yaml" || ! grep -q "launch" "${output_dir}/llm-d-router-standalone/templates/epp.yaml"; then
+      echo "Validation failed: vllm launch not found in rendered output for test: ${key}"
+      exit 1
+    fi
   fi
   echo "Test case ${key} passed validation."
 done
@@ -237,6 +266,13 @@ invalid_priority_routing_health_checking_command="${HELM} template ${SCRIPT_ROOT
 echo "Executing: ${invalid_priority_routing_health_checking_command}"
 if eval "${invalid_priority_routing_health_checking_command}"; then
   echo "Helm template unexpectedly succeeded for non-boolean router.epp.flags.health-checking with priority routing"
+  exit 1
+fi
+
+invalid_tokenizer_flavor_command="${HELM} template ${SCRIPT_ROOT}/config/charts/llm-d-router-standalone --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set router.tokenizer.enabled=true --set router.tokenizer.modelName=test-model --set router.tokenizer.flavor=invalid >/dev/null"
+echo "Executing: ${invalid_tokenizer_flavor_command}"
+if eval "${invalid_tokenizer_flavor_command}"; then
+  echo "Helm template unexpectedly succeeded for invalid router.tokenizer.flavor"
   exit 1
 fi
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -102,7 +102,8 @@ continues; downstream scorers fall back to their own paths.
 
 The plugin calls `POST {http}/v1/completions/render` and
 `POST {http}/v1/chat/completions/render`, both of which are exposed by
-`vllm serve <model>` and by the GPU-less `vllm launch render <model>`.
+`vllm serve <model>`, the Python-based GPU-less `vllm launch render <model>`,
+and the standalone Rust renderer `vllm-rs render <model>`.
 Any reachable HTTP endpoint serving the same model the scheduler tokenizes
 for will work — sidecar in the EPP pod (loopback) or a dedicated Service
 shared by multiple EPP replicas. When the inbound request carries an
@@ -112,11 +113,19 @@ sends no `Authorization` header, so against such an endpoint it is skipped
 and the first request pays the cold-start cost.
 
 ```yaml
-# EPP pod spec
+# EPP pod spec (Python renderer)
 containers:
 - name: vllm-render
   image: vllm/vllm-openai:latest          # any image shipping `vllm launch render`
   command: ["vllm", "launch", "render"]
+  args: ["${MODEL_NAME}", "--port=8000"]
+  ports: [{name: render-http, containerPort: 8000}]
+  readinessProbe: {httpGet: {path: /health, port: 8000}, periodSeconds: 5}
+
+# EPP pod spec (Rust renderer, ~40x lighter image)
+- name: vllm-render
+  image: vllm/vllm-rs:latest              # image shipping `vllm-rs render`
+  command: ["vllm-rs", "render"]
   args: ["${MODEL_NAME}", "--port=8000"]
   ports: [{name: render-http, containerPort: 8000}]
   readinessProbe: {httpGet: {path: /health, port: 8000}, periodSeconds: 5}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -228,7 +228,7 @@ func (r *vllmHTTPRenderer) Render(ctx context.Context, payload fwkrh.RequestPayl
 	}
 	// Shallow copy is sufficient because only the top-level model field is stamped in.
 	body := maps.Clone(pm)
-	body["model"] = r.modelName // `vllm launch render` requires the base model name
+	body["model"] = r.modelName // `vllm launch render` and `vllm-rs render` require the base model name
 	return r.postCompletionsRender(ctx, body)
 }
 
@@ -256,7 +256,7 @@ func (r *vllmHTTPRenderer) RenderChat(ctx context.Context, payload fwkrh.Request
 	}
 	// Shallow copy is sufficient because only the top-level model field is stamped in.
 	body := maps.Clone(pm)
-	body["model"] = r.modelName // `vllm launch render` requires the base model name
+	body["model"] = r.modelName // `vllm launch render` and `vllm-rs render` require the base model name
 	return r.postChatRender(ctx, body, r.chatTimeout(pm))
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
@@ -727,3 +727,34 @@ func TestVLLMHTTPRenderer_RenderSpanName(t *testing.T) {
 		assert.Equal(t, "tokenize_render /v1/completions/render", s.Name)
 	}
 }
+
+// TestVLLMHTTPRenderer_RustStandaloneRenderer verifies compatibility with the
+// response shapes produced by the standalone Rust renderer (`vllm-rs render`).
+// The Rust renderer returns {"token_ids": [...]} without multimodal features.
+func TestVLLMHTTPRenderer_RustStandaloneRenderer(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(chatRenderPath, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"token_ids":[101, 2054, 2003, 1037, 3231, 102]}`))
+	})
+	mux.HandleFunc(completionsRenderPath, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[{"token_ids":[101, 2054, 2003, 1037, 3231, 102]}]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	r := newHTTPRenderer(t, srv)
+
+	chatTokens, features, err := r.RenderChat(context.Background(), fwkrh.PayloadMap{
+		"messages": []any{map[string]any{"role": "user", "content": "hello world"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []uint32{101, 2054, 2003, 1037, 3231, 102}, chatTokens)
+	assert.Nil(t, features)
+
+	compTokens, offsets, err := r.Render(context.Background(), fwkrh.PayloadMap{
+		"prompt": "hello world",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, [][]uint32{{101, 2054, 2003, 1037, 3231, 102}}, compTokens)
+	assert.Nil(t, offsets)
+}


### PR DESCRIPTION
**What type of PR is this?**
    /kind feature

**What this PR does / why we need it**:
  Adds `router.tokenizer.flavor` to configure the tokenizer sidecar backend in the Helm charts.

    - Set `router.tokenizer.flavor: "python"` (default) to run `vllm launch render`.
    - Set `router.tokenizer.flavor: "rust"` to run the standalone `vllm-rs render` binary (~40x lighter image and 10x–14x
  higher preprocessing throughput).

 Key changes:
    - `_deployment.yaml`: Sets default container command to `["vllm-rs", "render"]` when `flavor` is `"rust"`, while
  retaining `["vllm", "launch", "render"]` for `"python"`. User-defined `command` overrides still take precedence.
    - `_helpers.tpl`: Adds validation enforcing that `flavor` must be either `"python"` or `"rust"`.
    - `config/charts/README.md` & `pkg/.../tokenizer/README.md`: Documents the new `flavor` setting and deployment
  configurations.
    - `hack/verify-helm.sh`: Adds positive verification test cases for `tokenizer-python` and `tokenizer-rust`, along
  with negative tests rejecting invalid flavors.
    - `vllm_http_test.go`: Adds `TestVLLMHTTPRenderer_RustStandaloneRenderer` verifying wire-format compatibility with
  the Rust renderer response shape.

**Which issue(s) this PR fixes**:
  Fixes #2440

**Release note** _(write `NONE` if no user-facing change)_:
    Support vLLM Rust renderer flavor (`router.tokenizer.flavor: "rust"`) in Helm charts for tokenizer sidecars.