### PR TITLE
fix: IPv6 address in remaining endpoint

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor.go
@@ -19,6 +19,8 @@ package preciseprefixcache
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -72,10 +74,10 @@ func (p *Producer) ensureSubscriber(ctx context.Context, meta *fwkdl.EndpointMet
 	}
 	endpointKey := meta.ID.String()
 	port := p.kvEventsConfig.PodDiscoveryConfig.SocketPort + meta.GetRankIndex()
-	zmqEndpoint := fmt.Sprintf("tcp://%s:%d", meta.Address, port)
+	zmqEndpoint := "tcp://" + net.JoinHostPort(meta.Address, strconv.Itoa(port))
 	replayEndpoint := ""
 	if replayPort := p.kvEventsConfig.PodDiscoveryConfig.EffectiveReplayPort(); replayPort > 0 {
-		replayEndpoint = fmt.Sprintf("tcp://%s:%d", meta.Address, replayPort+meta.GetRankIndex())
+		replayEndpoint = "tcp://" + net.JoinHostPort(meta.Address, strconv.Itoa(replayPort+meta.GetRankIndex()))
 	}
 	sourceEndpoint := fmt.Sprintf("%s:%s", meta.Address, meta.Port)
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/extractor_test.go
@@ -170,6 +170,8 @@ func TestProducer_ExtractEndpoint_OffsetsZMQPortByRankIndex(t *testing.T) {
 		{name: "pod-a-rank-0", address: "10.0.0.1", rank: 0, wantZMQ: "tcp://10.0.0.1:5557"},
 		{name: "pod-a-rank-1", address: "10.0.0.1", rank: 1, wantZMQ: "tcp://10.0.0.1:5558"},
 		{name: "pod-a-rank-2", address: "10.0.0.1", rank: 2, wantZMQ: "tcp://10.0.0.1:5559"},
+		{name: "pod-v6-rank-0", address: "fd00::1", rank: 0, wantZMQ: "tcp://[fd00::1]:5557"},
+		{name: "pod-v6-rank-1", address: "fd00::1", rank: 1, wantZMQ: "tcp://[fd00::1]:5558"},
 	}
 
 	for _, ep := range endpoints {
@@ -220,6 +222,32 @@ func TestProducer_EnsureSubscriber_PassesServingEndpoint(t *testing.T) {
 	assert.Equal(t, []string{"ns/pod-a-rank-3"}, subscribers.ids)
 	assert.Equal(t, []string{"10.0.0.1:8003"}, subscribers.sourceEndpoints)
 	assert.Equal(t, []string{"tcp://10.0.0.1:5560"}, subscribers.endpoints)
+}
+
+// IPv6 addresses must be bracketed in the zmq endpoint.
+func TestProducer_EnsureSubscriber_IPv6BracketsEndpoint(t *testing.T) {
+	cfg := kvevents.DefaultConfig()
+	cfg.DiscoverPods = true
+	cfg.PodDiscoveryConfig = kvevents.DefaultPodReconcilerConfig()
+	cfg.PodDiscoveryConfig.SocketPort = 5557
+
+	subscribers := &fakeSubscriberManager{}
+	p := &Producer{
+		typedName:          plugin.TypedName{Type: PluginType, Name: PluginType},
+		subscribersManager: subscribers,
+		kvEventsConfig:     cfg,
+		subscriberCtx:      context.Background(),
+	}
+
+	require.NoError(t, p.ensureSubscriber(context.Background(), &fwkdl.EndpointMetadata{
+		ID:        k8stypes.NamespacedName{Namespace: "ns", Name: "pod-v6"},
+		Address:   "fd00::1",
+		Port:      "8080",
+		RankIndex: 0,
+	}))
+
+	assert.Equal(t, []string{"tcp://[fd00::1]:5557"}, subscribers.endpoints)
+	assert.Equal(t, []string{"fd00::1:8080"}, subscribers.sourceEndpoints)
 }
 
 // RankIndex=0 must dial the base SocketPort unchanged.

--- a/pkg/sidecar/proxy/connector_mooncake.go
+++ b/pkg/sidecar/proxy/connector_mooncake.go
@@ -22,7 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -57,7 +59,7 @@ func (s *Server) handleMooncake(w http.ResponseWriter, r *http.Request, prefillP
 		return
 	}
 
-	bootstrapAddr := fmt.Sprintf("http://%s:%d", extractHost(prefillPodHostPort), s.config.MooncakeBootstrapPort)
+	bootstrapAddr := "http://" + net.JoinHostPort(extractHost(prefillPodHostPort), strconv.Itoa(s.config.MooncakeBootstrapPort))
 
 	engineMap, err := s.getMooncakeEngineMap(r.Context(), prefillPodHostPort, bootstrapAddr)
 	if err != nil {

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -586,7 +586,7 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 	completionRequest[requestFieldKVTransferParams] = map[string]any{
 		requestFieldDoRemotePrefill: true,
 		requestFieldDoRemoteDecode:  false,
-		requestFieldRemoteEngineID:  fmt.Sprintf("%s:%d", prefillHost, s.config.MoRIIOPrefillHandshakePort),
+		requestFieldRemoteEngineID:  net.JoinHostPort(prefillHost, strconv.Itoa(s.config.MoRIIOPrefillHandshakePort)),
 		// Empty (not nil) since decode allocates its own blocks in WRITE mode.
 		requestFieldRemoteBlockIDs:       []any{},
 		requestFieldRemoteHost:           prefillHost,

--- a/pkg/sidecar/proxy/connector_test.go
+++ b/pkg/sidecar/proxy/connector_test.go
@@ -21,9 +21,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 
 	. "github.com/onsi/ginkgo/v2" // nolint:revive
 	. "github.com/onsi/gomega"    // nolint:revive
@@ -200,6 +202,30 @@ var _ = Describe("Common Connector tests", func() {
 			})
 		})
 	}
+})
+
+var _ = Describe("IPv6 endpoint address construction", func() {
+	DescribeTable("mooncake bootstrapAddr brackets IPv6 host",
+		func(prefillHostPort string, port int, want string) {
+			got := "http://" + net.JoinHostPort(extractHost(prefillHostPort), strconv.Itoa(port))
+			Expect(got).To(Equal(want))
+		},
+		Entry("IPv4", "10.0.0.1:8080", 9090, "http://10.0.0.1:9090"),
+		Entry("IPv6", "[fd00::1]:8080", 9090, "http://[fd00::1]:9090"),
+	)
+
+	DescribeTable("nixlv2 remoteEngineID brackets IPv6 host",
+		func(prefillPodHostPort string, handshakePort int, want string) {
+			host, _, err := net.SplitHostPort(prefillPodHostPort)
+			if err != nil {
+				host = prefillPodHostPort
+			}
+			got := net.JoinHostPort(host, strconv.Itoa(handshakePort))
+			Expect(got).To(Equal(want))
+		},
+		Entry("IPv4", "10.0.0.1:8080", 61000, "10.0.0.1:61000"),
+		Entry("IPv6", "[fd00::2]:8080", 61000, "[fd00::2]:61000"),
+	)
 })
 
 func sidecarConnectionTestSetup(connector string) *sidecarTestInfo {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
- follow up what we have done in https://github.com/llm-d/llm-d-router/pull/2607 but cover other cases.
- use net.JoinHostPort in the prefix-cache extractor (zmq/replay endpoints), the Mooncake bootstrap address,and the NIXLv2 WRITE-mode remote engine ID.
- keep internal cache identifiers unchanged to preserve compatibility during route rupgrades.


**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
