### PR TITLE
approximateprefix: change block hash insertion order to tail-first

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer.go
@@ -69,13 +69,13 @@ func (i *indexer) Add(hashes []blockHash, pod server) {
 		lruForPod = newLRU
 	}
 
-	// Add to LRU (may evict)
-	for _, hash := range hashes {
+	// Insert hashes tail-first: matching is anchored at the first block, so
+	// the head is the most valuable entry and must stay cached longest; an
+	// oversized batch naturally keeps exactly its head. hashToPods is updated
+	// in the same iteration because the eviction callback can fire mid-batch.
+	for idx := len(hashes) - 1; idx >= 0; idx-- {
+		hash := hashes[idx]
 		lruForPod.Add(hash, struct{}{})
-	}
-
-	// Update hashToPods
-	for _, hash := range hashes {
 		podIDs := i.hashToPods[hash]
 		if podIDs == nil {
 			podIDs = make(podSet)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/indexer_test.go
@@ -50,6 +50,22 @@ func TestIndexer_AddAndGet(t *testing.T) {
 
 	servers = i.Get(blockHash(4))
 	assert.Empty(t, servers, "Cache should not contain non-existent hash")
+
+	// A batch larger than the capacity keeps its head: matching is anchored
+	// at the first block, and hashToPods must mirror the LRU membership.
+	i.Add([]blockHash{blockHash(4), blockHash(5), blockHash(6)}, pod)
+
+	assert.Equal(t, 2, i.podToLRU[pod.ServerID].Len(), "Cache size should stay at capacity after a batch add")
+	assert.NotEmpty(t, i.Get(blockHash(4)), "head hashes should remain cached")
+	assert.NotEmpty(t, i.Get(blockHash(5)), "head hashes should remain cached")
+	assert.Empty(t, i.Get(blockHash(6)), "hash truncated off the batch tail must not be reported as cached")
+	assert.Len(t, i.hashToPods, 2, "hashToPods should track exactly the LRU membership")
+
+	// Eviction pressure from a later batch strips the tail first: the head
+	// anchors all matching for the prompt and stays cached longest.
+	i.Add([]blockHash{blockHash(7)}, pod)
+	assert.NotEmpty(t, i.Get(blockHash(4)), "head hash should survive tail-first eviction")
+	assert.Empty(t, i.Get(blockHash(5)), "tail hash should be evicted before the head")
 }
 
 func TestIndexer_RemovePodAndEviction(t *testing.T) {
@@ -110,6 +126,13 @@ func TestIndexer_RemovePodAndEviction(t *testing.T) {
 
 	// Ensure hashToPods contains exactly indexerSize hashes (post-eviction and server2 removal)
 	assert.Len(t, i.hashToPods, indexerSize, "hashToPods should contain %d hashes after cleanup", indexerSize)
+
+	// RemovePod enumerates LRU keys to clean hashToPods, so the mirror must
+	// be exact for the cleanup to be complete.
+	i.Add([]blockHash{11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22}, server1) // 12 hashes > capacity 10
+	i.RemovePod(server1.ServerID)
+
+	assert.Empty(t, i.hashToPods, "hashToPods should be empty after removing the last pod")
 }
 
 func TestIndexer_ConcurrentAddRemovePod(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind feature
/kind bug
**What this PR does / why we need it**:

The routing-side prefix indexer mirrors each pod's block cache in an `LRU`. Matching is anchored at the first block — `matchLongestPrefix` walks from the head and stops at the first miss — so the **head is the most valuable entry**: once it is evicted, every later block of that prompt becomes unmatchable. The indexer has no access-time signal; insertion order is the only recency it controls. With head-first insertion the head was the oldest entry of every batch, so both in-batch overflow and later eviction pressure evicted the first block first, while the rest of the prompt — entries that could never match without it — kept occupying the `LRU` space.

This PR flips the write order: hashes are inserted **tail-first**, so the head stays most recent, eviction strips prefixes from the tail, and each pod's cached membership remains a contiguous head-prefix — the invariant the match-length counting implicitly assumes.

The indexer remains an approximation — it cannot observe engine-internal evictions — but keeping unmatchable hashes out of the `LRU` is still worth enforcing: **every entry held now represents capacity a pod can actually match against, and the derived block accounting (per-pod match lengths in `PrefixCacheMatchInfo`, the reported `LRU`-size metrics) tracks the real membership instead of dead entries.**

**Example: shared prefixes under eviction pressure**  
`golang-lru` re-adds an existing key by refreshing its recency (no eviction), and evicts the oldest entry when a new key exceeds capacity. With capacity 4:  
`Add(h1,h2,h3)`: insert h3, h2, h1 -> newest..oldest: h1 h2 h3  
`Add(h1,h2,h3,h4)`: insert h4, refresh h3, h2, h1 -> newest..oldest: h1 h2 h3 h4  
The next capacity pressure evicts h4 first: it is the tail block, inserted earliest and serving only the second prompt, while h1 anchors matching for both prompts sharing the prefix. The shared head survives longest, mirroring the shared KV blocks on the engine. With capacity 3 the same batch churns mid-insert but converges to exactly {h1,h2,h3} — the head.

**Side effect fixed: `hashToPods` desync on oversized batches**  
When the rare oversized batch does occur (hashes exceed the pod's `LRU` capacity), the old two-pass `Add` also corrupted the reverse index: the eviction callback's cleanup during the `LRU` pass was overwritten by the second registration pass, so `hashToPods` kept one stale entry per evicted hash — reporting blocks the pod no longer held, inflating match counts, and never reclaimed until the pod disappeared. `RemovePod` was affected in turn: it cleans up by enumerating `LRU` keys, so stale non-member hashes survived pod deletion.

This is why registration now happens in the same loop as insertion. The eviction callback fires synchronously inside `lru.Add`, so a second registration pass always runs against the `LRU`'s final membership and blindly re-registers every batch hash, dead or alive. Interleaving registration right after each insertion keeps the two structures consistent at every step of the loop: a hash evicted later in the batch removes an entry registered earlier, and a hash evicted before its own turn is never registered at all. The merge is also required by the tail-first order itself — a batch larger than the capacity now guarantees in-batch evictions, a situation the two-pass form cannot survive.

Default configurations are unaffected in practice (with accurate auto-tuned capacities a single prompt cannot exceed the pod's block capacity); the trigger is a small `lruCapacityPerServer`, including the auto-tune fallback when endpoint metrics are unavailable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
