### PR TITLE
feat: add custom TLS support for vLLM render endpoint

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -26,9 +26,11 @@ Backend selection:
   config whose plugins consume `TokenizedPrompt` (prefix cache, context-length,
   P/D routing) without declaring a `token-producer`.
 - **`vllm`** (or `modelName`): calls vLLM's `/v1/completions/render` and
-  `/v1/chat/completions/render` over plain HTTP (TLS is not supported). Future
-  protocol fields (e.g. `grpc`) can be added alongside `url` under the same
-  `vllm` block.
+  `/v1/chat/completions/render` over HTTP or HTTPS. TLS is driven by the URL
+  scheme (`https://`). For in-cluster endpoints using self-signed or private CA
+  certificates, configure `vllm.caCertPath` to trust the CA, and optionally
+  `vllm.clientCertPath`/`vllm.clientKeyPath` for mTLS. Future protocol fields
+  (e.g. `grpc`) can be added alongside `url` under the same `vllm` block.
 - **`udsTokenizerConfig`**: deprecated gRPC-over-UDS sidecar (see warning below).
 
 > [!WARNING]
@@ -46,12 +48,16 @@ Backend selection:
 
 ## Config
 
-| Parameter        | Default                 | Description                                                       |
-| ---------------- | ----------------------- | ----------------------------------------------------------------- |
-| `modelName`      | – (required for `vllm`) | Model whose tokenizer should be loaded / sent in render requests. |
-| `vllm.url`       | `http://localhost:8000` | Base URL of the vLLM render endpoint (no trailing slash).         |
-| `vllm.timeout`   | `5s`                    | Per-request timeout for text-only requests.                       |
-| `vllm.mmTimeout` | `30s`                   | Per-request timeout for multimodal requests.                      |
+| Parameter                  | Default                 | Description                                                                  |
+| -------------------------- | ----------------------- | ---------------------------------------------------------------------------- |
+| `modelName`                | – (required for `vllm`) | Model whose tokenizer should be loaded / sent in render requests.            |
+| `vllm.url`                 | `http://localhost:8000` | Base URL of the vLLM render endpoint (no trailing slash).                    |
+| `vllm.timeout`             | `5s`                    | Per-request timeout for text-only requests.                                  |
+| `vllm.mmTimeout`           | `30s`                   | Per-request timeout for multimodal requests.                                 |
+| `vllm.caCertPath`          | system CA pool          | PEM CA bundle for verifying the render endpoint when using `https://`.       |
+| `vllm.clientCertPath`      | –                       | Client certificate for mTLS with the render endpoint; requires `clientKeyPath`. |
+| `vllm.clientKeyPath`       | –                       | Client private key for mTLS; requires `clientCertPath`.                      |
+| `vllm.insecureSkipVerify`  | `false`                 | Skip server certificate verification when using `https://`; `caCertPath` is ignored when set. |
 
 The `estimate` backend tunes multimodal image placeholder estimation (empty uses
 the defaults below):
@@ -137,6 +143,31 @@ Plugin config — dedicated render Service:
     modelName: "${MODEL_NAME}"
     vllm:
       url: "http://vllm-render.default.svc.cluster.local:8000"
+```
+
+Plugin config — dedicated render Service with TLS:
+
+```yaml
+- type: token-producer
+  parameters:
+    modelName: "${MODEL_NAME}"
+    vllm:
+      url: "https://vllm-render.default.svc.cluster.local:8000"
+      caCertPath: "/path/to/ca.crt"
+```
+
+The render endpoint must also be serving TLS. When using `vllm launch render`,
+pass `--ssl-certfile` and `--ssl-keyfile` so the process listens over HTTPS:
+
+```yaml
+containers:
+- name: vllm-render
+  command: ["vllm", "launch", "render"]
+  args:
+    - "${MODEL_NAME}"
+    - "--port=8000"
+    - "--ssl-certfile=/path/to/tls.crt"
+    - "--ssl-keyfile=/path/to/tls.key"
 ```
 
 A complete sample config that pairs this with `precise-prefix-cache-producer` and `prefix-cache-scorer` is at [`deploy/config/sim-epp-tokenizer-vllm-http-config.yaml`](../../../../../../../deploy/config/sim-epp-tokenizer-vllm-http-config.yaml).

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -20,12 +20,14 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"maps"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -69,6 +71,18 @@ type vllmConfig struct {
 	// MMTimeout is the per-request timeout for multimodal requests
 	// (image download/processing). Defaults to 30s.
 	MMTimeout string `json:"mmTimeout,omitempty"`
+	// CACertPath is a PEM CA bundle used to verify the render endpoint's
+	// server certificate when the URL scheme is https. When empty, the
+	// system CA pool is used.
+	CACertPath string `json:"caCertPath,omitempty"`
+	// ClientCertPath and ClientKeyPath present a client certificate for
+	// mTLS with the render endpoint. Both must be set together.
+	ClientCertPath string `json:"clientCertPath,omitempty"`
+	ClientKeyPath  string `json:"clientKeyPath,omitempty"`
+	// InsecureSkipVerify disables verification of the render endpoint's
+	// server certificate. Use for self-signed certificates in development
+	// or when the cluster manages its own PKI.
+	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
 }
 
 // vllmHTTPRenderer implements the tokenizer interface by calling vLLM's
@@ -94,8 +108,12 @@ func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, 
 	if err != nil {
 		return nil, fmt.Errorf("invalid 'mmTimeout': %w", err)
 	}
+	transport, err := newRenderTransport(cfg)
+	if err != nil {
+		return nil, err
+	}
 	return &vllmHTTPRenderer{
-		client: &http.Client{Transport: otelhttp.NewTransport(newRenderTransport(), otelhttp.WithSpanNameFormatter(
+		client: &http.Client{Transport: otelhttp.NewTransport(transport, otelhttp.WithSpanNameFormatter(
 			// Name the outbound span after the render route instead of the
 			// transport's default "HTTP POST" so traces identify render calls.
 			func(_ string, r *http.Request) string { return "tokenize_render " + r.URL.Path },
@@ -110,8 +128,10 @@ func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, 
 // newRenderTransport returns an http.Transport tuned for the render endpoint:
 // HTTP/2 is disabled (vLLM doesn't support it) and the idle-connection pool
 // is sized for the in-pod sidecar case while still being reasonable for a
-// dedicated render Service.
-func newRenderTransport() *http.Transport {
+// dedicated render Service. When the config carries TLS fields (caCertPath,
+// clientCertPath/clientKeyPath, insecureSkipVerify), the transport is
+// configured for https.
+func newRenderTransport(cfg *vllmConfig) (*http.Transport, error) {
 	t := http.DefaultTransport.(*http.Transport).Clone()
 	t.MaxIdleConns = 0
 	t.MaxIdleConnsPerHost = 16
@@ -120,7 +140,44 @@ func newRenderTransport() *http.Transport {
 	// not enough — clearing TLSNextProto prevents ALPN-negotiated h2 too.
 	t.ForceAttemptHTTP2 = false
 	t.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
-	return t
+
+	if cfg.hasTLS() {
+		tlsCfg, err := renderTLSConfig(cfg)
+		if err != nil {
+			return nil, err
+		}
+		t.TLSClientConfig = tlsCfg
+	}
+	return t, nil
+}
+
+func (c *vllmConfig) hasTLS() bool {
+	return c.InsecureSkipVerify || c.CACertPath != "" || c.ClientCertPath != "" || c.ClientKeyPath != ""
+}
+
+func renderTLSConfig(cfg *vllmConfig) (*tls.Config, error) {
+	tc := &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify} //nolint:gosec
+
+	if !cfg.InsecureSkipVerify && cfg.CACertPath != "" {
+		pem, err := os.ReadFile(cfg.CACertPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading render CA cert %s: %w", cfg.CACertPath, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("no valid CA certs in %s", cfg.CACertPath)
+		}
+		tc.RootCAs = pool
+	}
+
+	if cfg.ClientCertPath != "" || cfg.ClientKeyPath != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.ClientCertPath, cfg.ClientKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("loading render client cert: %w", err)
+		}
+		tc.Certificates = []tls.Certificate{cert}
+	}
+	return tc, nil
 }
 
 func parseHTTPDuration(s string, def time.Duration) (time.Duration, error) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
@@ -18,10 +18,19 @@ package tokenizer
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"io"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -432,6 +441,119 @@ func TestVLLMHTTPRenderer_ChatTimeoutRawMessages(t *testing.T) {
 		json.RawMessage(`{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,abc"}}]}`),
 	}}
 	assert.Equal(t, 30*time.Second, r.chatTimeout(multimodal))
+}
+
+func TestVLLMHTTPRenderer_TLSInsecureSkipVerify(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]renderResponse{{TokenIDs: []uint32{1, 2}}})
+	}))
+	defer srv.Close()
+
+	r, err := newVLLMHTTPRenderer(&vllmConfig{
+		URL:                srv.URL,
+		InsecureSkipVerify: true,
+	}, testHTTPModel)
+	require.NoError(t, err)
+
+	tokenIDs, _, err := r.Render(context.Background(), fwkrh.PayloadMap{"prompt": "hello"})
+	require.NoError(t, err)
+	assert.Equal(t, [][]uint32{{1, 2}}, tokenIDs)
+}
+
+func TestVLLMHTTPRenderer_TLSWithCACert(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]renderResponse{{TokenIDs: []uint32{3, 4}}})
+	}))
+	defer srv.Close()
+
+	caFile := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(caFile, encodeCertPEM(srv.Certificate()), 0o600))
+
+	r, err := newVLLMHTTPRenderer(&vllmConfig{
+		URL:        srv.URL,
+		CACertPath: caFile,
+	}, testHTTPModel)
+	require.NoError(t, err)
+
+	tokenIDs, _, err := r.Render(context.Background(), fwkrh.PayloadMap{"prompt": "hello"})
+	require.NoError(t, err)
+	assert.Equal(t, [][]uint32{{3, 4}}, tokenIDs)
+}
+
+func TestVLLMHTTPRenderer_TLSWithMTLS(t *testing.T) {
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]renderResponse{{TokenIDs: []uint32{5, 6}}})
+	}))
+	srv.TLS = &tls.Config{
+		ClientAuth: tls.RequireAnyClientCert,
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	dir := t.TempDir()
+	clientCert, clientKey := generateTestCert(t, dir)
+
+	r, err := newVLLMHTTPRenderer(&vllmConfig{
+		URL:                srv.URL,
+		InsecureSkipVerify: true,
+		ClientCertPath:     clientCert,
+		ClientKeyPath:      clientKey,
+	}, testHTTPModel)
+	require.NoError(t, err)
+
+	tokenIDs, _, err := r.Render(context.Background(), fwkrh.PayloadMap{"prompt": "hello"})
+	require.NoError(t, err)
+	assert.Equal(t, [][]uint32{{5, 6}}, tokenIDs)
+}
+
+func TestVLLMHTTPRenderer_TLSBadCACertPath(t *testing.T) {
+	_, err := newVLLMHTTPRenderer(&vllmConfig{
+		URL:        "https://localhost:9999",
+		CACertPath: "/nonexistent/ca.pem",
+	}, testHTTPModel)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading render CA cert")
+}
+
+func TestVLLMHTTPRenderer_TLSBadClientCert(t *testing.T) {
+	_, err := newVLLMHTTPRenderer(&vllmConfig{
+		URL:            "https://localhost:9999",
+		ClientCertPath: "/nonexistent/client.pem",
+		ClientKeyPath:  "/nonexistent/client.key",
+	}, testHTTPModel)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "loading render client cert")
+}
+
+// encodeCertPEM encodes an x509 certificate as PEM.
+func encodeCertPEM(cert *x509.Certificate) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+}
+
+// generateTestCert creates a self-signed cert/key pair for mTLS testing.
+func generateTestCert(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPath = filepath.Join(dir, "client.pem")
+	require.NoError(t, os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0o600))
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPath = filepath.Join(dir, "client.key")
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600))
+	return certPath, keyPath
 }
 
 // TestBuildChatRenderRequest_MessageFields asserts the wire shape of rebuilt


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allows the `token-producer` plugin to connect to render endpoints over HTTPS using a custom CA bundle or mTLS client certificates for clusters with private PKI.


related to https://github.com/llm-d/llm-d-router/issues/2677 but not exatly for sidecar

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The token-producer plugin now supports HTTPS for the vLLM render endpoint. Configure `vllm.caCertPath` for custom CA verification, `vllm.clientCertPath`/`vllm.clientKeyPath` for mTLS, or `vllm.insecureSkipVerify` to skip server certificate verification.
```
