### PR TITLE
docs: add a repository contributing guide covering issue claiming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to llm-d-router
+
+Project-wide guidelines, code of conduct, contribution process, and commit and
+pull request style live in the
+[llm-d organization contributing guide](https://github.com/llm-d/llm-d/blob/main/CONTRIBUTING.md).
+Please start there — this page covers only what is specific to this repository.
+
+See [DEVELOPMENT.md](DEVELOPMENT.md) for how to build, run, and test the codebase.
+
+## Claiming an issue
+
+Comment on the issue to say you would like to work on it. That comment is what
+marks the issue as taken, so check for an existing claim before you start work.
+A maintainer will acknowledge in a reply and assign the issue to you where
+possible.
+
+Some llm-d repositories still run Prow and accept `/assign` as a self-assignment
+command. `llm-d-router` does not: Prow was removed in
+[#2114](https://github.com/llm-d/llm-d-router/pull/2114), and GitHub's API only
+permits assigning users who have triage access or prior involvement on the
+issue. Commenting is therefore the only way to claim an issue here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,7 @@
 # Contributing to llm-d-router
 
-Project-wide guidelines, code of conduct, contribution process, and commit and
-pull request style live in the
-[llm-d organization contributing guide](https://github.com/llm-d/llm-d/blob/main/CONTRIBUTING.md).
-Please start there — this page covers only what is specific to this repository.
+Please access the
+[llm-d organization contributing guide](https://github.com/llm-d/llm-d/blob/main/CONTRIBUTING.md) for overall contributing guidelines. This document covers only what is different or specific to this repository.
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for how to build, run, and test the codebase.
 
@@ -14,8 +12,5 @@ marks the issue as taken, so check for an existing claim before you start work.
 A maintainer will acknowledge in a reply and assign the issue to you where
 possible.
 
-Some llm-d repositories still run Prow and accept `/assign` as a self-assignment
-command. `llm-d-router` does not: Prow was removed in
-[#2114](https://github.com/llm-d/llm-d-router/pull/2114), and GitHub's API only
-permits assigning users who have triage access or prior involvement on the
-issue. Commenting is therefore the only way to claim an issue here.
+> [!NOTE]
+> Some llm-d repositories may still run Prow and accept `/assign` as a self-assignment command.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To ensure clarity across the project, we use the following standard terminology:
 
 ## Contributing
 
-Start with the [llm-d organization contributing guide][org-contributing] for project-wide guidelines, code of conduct, and community resources.
+Start with the [llm-d organization contributing guide][org-contributing] for project-wide guidelines, code of conduct, and community resources, then see [CONTRIBUTING.md](CONTRIBUTING.md) for what is specific to this repository, including how to claim an issue.
 
 Our community meeting is bi-weekly at Wednesday 10AM PDT ([Google Meet], [Meeting Notes]).
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Since Prow was removed in #2114, `/assign` no longer works in this repository, and GitHub's API only permits assigning users who have triage access or prior involvement on an issue. That leaves a non-member contributor with no documented way to claim an issue, which is the gap #2212 describes.

Adds a short `CONTRIBUTING.md` that defers to the [organization contributing guide](https://github.com/llm-d/llm-d/blob/main/CONTRIBUTING.md) for project-wide process and documents only what differs here: that commenting is what marks an issue as taken, and that sibling repositories still running Prow behave differently. The README contributing section now links to it.

Per @hickeyma's steer in the issue, this lands as a repo-local guide rather than a section in the community guide, so GitHub surfaces it automatically from this repository's issue and PR creation flows — which is where a first-time contributor is standing when they need it. It is deliberately small and does not duplicate the community guide. Worth noting that `llm-d-router` was the only llm-d component repository without a `CONTRIBUTING.md`; `llm-d-inference-sim`, `llm-d-kv-cache`, `llm-d-infra`, and `llm-d-benchmark` all have one.

The wording follows the workaround agreed in #956 and reviewed in the issue thread.

**Which issue(s) this PR fixes**:

Fixes #2212

**Release note**:
```release-note
NONE
```

---

Two things noticed while writing this, both out of scope here — happy to open issues or fold either in if you would prefer:

1. The organization contributing guide documents DCO sign-off but not the cryptographic commit signing that `ci-signed-commits.yaml` enforces via the shared `llm-d-infra` workflow. As a first-time contributor I passed DCO and failed `signed-commits`, which is easy to do because the two checks have similar names and only one is documented. That looks like it belongs in the community guide rather than here, since the workflow is shared across repositories.

2. I kept this guide to issue claiming only, as requested. If you would rather it also carry a short "before you open a pull request" section covering the checks this repository runs, say the word and I will add it.
