### PR TITLE
metrics: remove core legacy metric families

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -562,9 +562,7 @@ the current names in new dashboards and alerts. The aliases do not cover every c
 |---|---|---|
 | `llm_d_inference_scheduler_disagg_decision_total` | `llm_d_epp_disagg_decision_total` | Dual emission. |
 | `llm_d_inference_scheduler_datalayer_poll_errors_total`, `llm_d_inference_scheduler_datalayer_extract_errors_total` | `llm_d_epp_datalayer_poll_errors_total`, `llm_d_epp_datalayer_extract_errors_total` | Dual emission. |
-| `inference_objective_*` request, latency, predicted-latency, and SLO series | Corresponding `llm_d_epp_*` series | Dual emission. Some predicted-latency labels differ between legacy and current series. |
-| `inference_pool_average_*`, `inference_pool_ready_pods` | Corresponding `llm_d_epp_*` series | Dual emission. Current standard-deviation series have no legacy twin. |
-| `inference_pool_per_pod_queue_size` | `llm_d_epp_per_endpoint_queue_size` | Dual emission with different metric names and labels. |
+| `inference_objective_*` predicted-latency series | Corresponding `llm_d_epp_*` series | Dual emission. Some predicted-latency labels differ between legacy and current series. |
 | `inference_extension_scheduler_e2e_duration_seconds` | `llm_d_epp_scheduler_e2e_duration_seconds` | Dual emission. |
 | `inference_extension_scheduler_attempts_total` | `llm_d_epp_scheduler_attempts_total` | Dual emission. |
 | `inference_extension_plugin_duration_seconds` | `llm_d_epp_plugin_duration_seconds` | Dual emission. |

--- a/pkg/epp/datalayer/logger/logger_test.go
+++ b/pkg/epp/datalayer/logger/logger_test.go
@@ -181,8 +181,8 @@ func TestRefreshPrometheusMetricsAvgValues(t *testing.T) {
 		return 0
 	}
 
-	avgRunning := findGauge("inference_pool_average_running_requests")
-	avgQueue := findGauge("inference_pool_average_queue_size")
+	avgRunning := findGauge("llm_d_epp_average_running_requests")
+	avgQueue := findGauge("llm_d_epp_average_queue_size")
 
 	assert.InDelta(t, 0.5, avgRunning, 0.001, "average running requests should be 0.5, not truncated to 0")
 	assert.InDelta(t, 1.5, avgQueue, 0.001, "average queue size should be 1.5, not truncated to 1")

--- a/pkg/epp/metrics/cardinality_test.go
+++ b/pkg/epp/metrics/cardinality_test.go
@@ -39,10 +39,10 @@ func TestPreAdmitModelLabelsSurvivesFlood(t *testing.T) {
 	const testCap = 5
 	old := modelLabelLimiter
 	modelLabelLimiter = metricsutil.NewBoundedLabel(testCap)
-	requestCounter.Reset()
+	llmdRequestCounter.Reset()
 	t.Cleanup(func() {
 		modelLabelLimiter = old
-		requestCounter.Reset()
+		llmdRequestCounter.Reset()
 	})
 
 	PreAdmitModelLabels("llama-70b", "llama-70b-canary")
@@ -51,7 +51,7 @@ func TestPreAdmitModelLabelsSurvivesFlood(t *testing.T) {
 	}
 	RecordRequestCounter("llama-70b", "llama-70b-canary", "fairness", 0)
 
-	series := promtestutil.CollectAndCount(requestCounter)
+	series := promtestutil.CollectAndCount(llmdRequestCounter)
 	require.LessOrEqualf(t, series, testCap+2, "cardinality must stay bounded, got %d series", series)
 	require.Equal(t, "llama-70b", boundModel("llama-70b"),
 		"configured model emits its real label after the flood")
@@ -65,17 +65,17 @@ func TestRecordRequestCounterBoundsModelCardinality(t *testing.T) {
 	const testCap = 5
 	old := modelLabelLimiter
 	modelLabelLimiter = metricsutil.NewBoundedLabel(testCap)
-	requestCounter.Reset()
+	llmdRequestCounter.Reset()
 	t.Cleanup(func() {
 		modelLabelLimiter = old
-		requestCounter.Reset()
+		llmdRequestCounter.Reset()
 	})
 
 	for i := 0; i < 1000; i++ {
 		RecordRequestCounter(fmt.Sprintf("model-%d", i), "target", "fairness", 0)
 	}
 
-	count := promtestutil.CollectAndCount(requestCounter)
+	count := promtestutil.CollectAndCount(llmdRequestCounter)
 	require.LessOrEqualf(t, count, testCap+1,
 		"model_name cardinality must stay bounded by the cap, got %d series", count)
 }
@@ -140,11 +140,9 @@ func TestFairnessLabelBoundOnRequestMetrics(t *testing.T) {
 	metricsutil.SetFairnessIDLabelLimit(testCap)
 	oldModels := modelLabelLimiter
 	modelLabelLimiter = metricsutil.NewBoundedLabel(10)
-	requestCounter.Reset()
 	llmdRequestCounter.Reset()
 	t.Cleanup(func() {
 		modelLabelLimiter = oldModels
-		requestCounter.Reset()
 		llmdRequestCounter.Reset()
 	})
 
@@ -154,8 +152,6 @@ func TestFairnessLabelBoundOnRequestMetrics(t *testing.T) {
 
 	require.Equal(t, testCap+1, promtestutil.CollectAndCount(llmdRequestCounter),
 		"100 distinct fairness IDs must collapse to cap+overflow series on the request family")
-	require.Equal(t, 1, promtestutil.CollectAndCount(requestCounter),
-		"the deprecated family has no fairness_id label and must stay a single series")
 }
 
 // RecordFlowControlRequestQueueDuration takes request-body model names; they must flow through the

--- a/pkg/epp/metrics/collectors/inference_pool.go
+++ b/pkg/epp/metrics/collectors/inference_pool.go
@@ -23,8 +23,6 @@ import (
 	eppmetrics "github.com/llm-d/llm-d-router/pkg/epp/metrics"
 )
 
-var ()
-
 type inferencePoolMetricsCollector struct {
 	ds datastore.Datastore
 }

--- a/pkg/epp/metrics/collectors/inference_pool.go
+++ b/pkg/epp/metrics/collectors/inference_pool.go
@@ -18,23 +18,12 @@ package collectors
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	compbasemetrics "k8s.io/component-base/metrics"
 
-	metricsutil "github.com/llm-d/llm-d-router/pkg/common/observability/metrics"
 	"github.com/llm-d/llm-d-router/pkg/epp/datastore"
 	eppmetrics "github.com/llm-d/llm-d-router/pkg/epp/metrics"
 )
 
-var (
-	descInferencePoolPerPodQueueSize = prometheus.NewDesc(
-		"inference_pool_per_pod_queue_size",
-		metricsutil.HelpMsgWithStability("The total number of requests pending in the model server queue for each underlying pod.", compbasemetrics.ALPHA),
-		[]string{
-			"name",
-			"model_server_pod",
-		}, nil,
-	)
-)
+var ()
 
 type inferencePoolMetricsCollector struct {
 	ds datastore.Datastore
@@ -53,7 +42,6 @@ func NewInferencePoolMetricsCollector(ds datastore.Datastore) prometheus.Collect
 
 // DescribeWithStability implements the prometheus.Collector interface.
 func (c *inferencePoolMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- descInferencePoolPerPodQueueSize
 	ch <- eppmetrics.DescInferencePoolPerEndpointQueueSize
 }
 
@@ -70,13 +58,6 @@ func (c *inferencePoolMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	for _, pod := range podMetrics {
-		ch <- prometheus.MustNewConstMetric(
-			descInferencePoolPerPodQueueSize,
-			prometheus.GaugeValue,
-			float64(pod.GetMetrics().WaitingQueueSize),
-			pool.Name,
-			pod.GetMetadata().ID.Name,
-		)
 		ch <- prometheus.MustNewConstMetric(
 			eppmetrics.DescInferencePoolPerEndpointQueueSize,
 			prometheus.GaugeValue,

--- a/pkg/epp/metrics/collectors/inference_pool_test.go
+++ b/pkg/epp/metrics/collectors/inference_pool_test.go
@@ -108,22 +108,13 @@ func TestMetricsCollected(t *testing.T) {
 		collector := &inferencePoolMetricsCollector{
 			ds: ds,
 		}
-		err := testutil.CollectAndCompare(collector, strings.NewReader(`
-		# HELP inference_pool_per_pod_queue_size [ALPHA] The total number of requests pending in the model server queue for each underlying pod.
-		# TYPE inference_pool_per_pod_queue_size gauge
-		inference_pool_per_pod_queue_size{model_server_pod="pod1-rank-0",name="test-pool"} 100
-`), "inference_pool_per_pod_queue_size")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		errNew := promtestutil.CollectAndCompare(collector, strings.NewReader(`
+		err := promtestutil.CollectAndCompare(collector, strings.NewReader(`
 		# HELP llm_d_epp_per_endpoint_queue_size [ALPHA] The total number of requests pending in the model server queue for each underlying endpoint.
 		# TYPE llm_d_epp_per_endpoint_queue_size gauge
 		llm_d_epp_per_endpoint_queue_size{model_server_endpoint="pod1-rank-0",name="test-pool"} 100
 `), "llm_d_epp_per_endpoint_queue_size")
-		if errNew != nil {
-			t.Fatal(errNew)
+		if err != nil {
+			t.Fatal(err)
 		}
 	}
 }

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -34,12 +34,11 @@ import (
 
 const (
 	// --- Subsystems ---
-	inferenceObjectiveComponent = "inference_objective"
-	inferencePoolComponent      = "inference_pool"
-	inferenceExtension          = "inference_extension"
+	inferenceExtension = "inference_extension"
 
-	// InferenceObjectiveSubsystem is the legacy subsystem for inference objective metrics.
-	InferenceObjectiveSubsystem = inferenceObjectiveComponent
+	// InferenceObjectiveSubsystem is retained for predicted-latency metrics.
+	InferenceObjectiveSubsystem = "inference_objective"
+
 	// InferenceExtensionSubsystem is the legacy subsystem for inference extension metrics.
 	InferenceExtensionSubsystem = inferenceExtension
 
@@ -49,185 +48,9 @@ const (
 
 var (
 	// --- Common Label Sets ---
-	modelLabels             = []string{"model_name", "target_model_name"}
-	modelWithPriorityLabels = []string{"model_name", "target_model_name", "priority"}
-	poolLabels              = []string{"name"}
-	endpointLabels          = []string{"pod_name", "namespace", "port"}
-)
-
-// --- Inference Objective Metrics ---
-var (
-	// Deprecated: Use llm_d_epp_request_total instead.
-	// Tracked in: https://github.com/llm-d/llm-d-inference-scheduler/issues/1070
-	requestCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: inferenceObjectiveComponent,
-			Name:      "request_total",
-			Help:      metricsutil.HelpMsgWithStability("[Deprecated: Use llm_d_epp_request_total] Counter of inference objective requests broken out for each model and target model.", compbasemetrics.ALPHA),
-		},
-		modelWithPriorityLabels,
-	)
-
-	// Deprecated: Use llm_d_epp_request_error_total instead.
-	// Tracked in: https://github.com/llm-d/llm-d-inference-scheduler/issues/1070
-	requestErrCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: inferenceObjectiveComponent,
-			Name:      "request_error_total",
-			Help:      metricsutil.HelpMsgWithStability("[Deprecated: Use llm_d_epp_request_error_total] Counter of inference objective requests errors broken out for each model and target model.", compbasemetrics.ALPHA),
-		},
-		append(modelLabels, "error_code"),
-	)
-
-	// Deprecated: Use llm_d_epp_request_duration_seconds instead.
-	// Tracked in: https://github.com/llm-d/llm-d-inference-scheduler/issues/1070
-	requestLatencies = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Subsystem: inferenceObjectiveComponent,
-			Name:      "request_duration_seconds",
-			Help:      metricsutil.HelpMsgWithStability("[Deprecated: Use llm_d_epp_request_duration_seconds] Inference objective response latency distribution in seconds for each model and target model.", compbasemetrics.ALPHA),
-			Buckets:   metricsutil.GeneralLatencyBuckets,
-		},
-		modelLabels,
-	)
-
-	// Deprecated: Use llm_d_epp_request_size_bytes instead.
-	// Tracked in: https://github.com/llm-d/llm-d-inference-scheduler/issues/1070
-	requestSizes = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Subsystem: inferenceObjectiveComponent,
-			Name:      "request_sizes",
-			Help:      metricsutil.HelpMsgWithStability("[Deprecated: Use llm_d_epp_request_size_bytes] Inference objective requests size distribution in bytes for each model and target model.", compbasemetrics.ALPHA),
-			Buckets:   metricsutil.RequestSizeBuckets,
-		},
-		modelLabels,
-	)
-
-	// Deprecated: Use llm_d_epp_response_size_bytes instead.
-	// Tracked in: https://github.com/llm-d/llm-d-inference-scheduler/issues/1070
-	responseSizes = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Subsystem: inferenceObjectiveComponent,
-			Name:      "response_sizes",
-			Help:      metricsutil.HelpMsgWithStability("[Deprecated: Use llm_d_epp_response_size_bytes] Inference objective responses size distribution in bytes for each model and target model.", compbasemetrics.ALPHA),
-			// Most models have a response token < 8192 tokens. Each token, in average, has 4 characters.
-			// 8192 * 4 = 32768.
-			Buckets: []float64{1, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
-		},
-		modelLabels,
-	)
-
-	// Deprecated: Use llm_d_epp_request_input_tokens instead.
-	// Tracked in: https://github.com/llm-d/llm-d-inference-scheduler/issues/1070
-	inputTokens = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Subsystem: inferenceObjectiveComponent,
-			Name:      "input_tokens",
-			Help:      metricsutil.HelpMsgWithStability("[Deprecated: Use llm_d_epp_request_input_tokens] Inference objective input token count distribution for requests in each model.", compbasemetrics.ALPHA),
-			// Most models have a input context window less than 1 million tokens.
-			Buckets: metricsutil.TokenCountBuckets,
-		},
-		modelLabels,
-	)
-
-	// Deprecated: Use llm_d_epp_request_output_tokens instead.
-	// Tracked in: https://github.com/llm-d/llm-d-inference-scheduler/issues/1070
-	outputTokens = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Subsystem: inferenceObjectiveComponent,
-			Name:      "output_tokens",
-			Help:      metricsutil.HelpMsgWithStability("[Deprecated: Use llm_d_epp_request_output_tokens] Inference objective output token count distribution for requests in each model.", compbasemetrics.ALPHA),
-			// Most models generates output less than 8192 tokens.
-			Buckets: []float64{1, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192},
-		},
-		modelLabels,
-	)
-
-	// Deprecated: Use llm_d_epp_request_cached_tokens instead.
-	// Tracked in: https://github.com/llm-d/llm-d-inference-scheduler/issues/1070
-	promptCachedTokens = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Subsystem: inferenceObjectiveComponent,
-			Name:      "prompt_cached_tokens",
-			Help:      metricsutil.HelpMsgWithStability("[Deprecated: Use llm_d_epp_request_cached_tokens] Inference objective prompt cached token count distribution for requests in each model.", compbasemetrics.ALPHA),
-			// Most models have a input context window less than 1 million tokens.
-			Buckets: metricsutil.TokenCountBuckets,
-		},
-		modelLabels,
-	)
-
-	// Deprecated: Use llm_d_epp_request_running instead.
-	// Tracked in: https://github.com/llm-d/llm-d-inference-scheduler/issues/1070
-	runningRequests = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: inferenceObjectiveComponent,
-			Name:      "running_requests",
-			Help:      metricsutil.HelpMsgWithStability("[Deprecated: Use llm_d_epp_request_running] Inference objective number of running requests in each model.", compbasemetrics.ALPHA),
-		},
-		[]string{"model_name"},
-	)
-
-	// Deprecated: Use llm_d_epp_request_ntpot_seconds instead.
-	// Tracked in: https://github.com/llm-d/llm-d-inference-scheduler/issues/1070
-	normalizedTimePerOutputToken = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Subsystem: inferenceObjectiveComponent,
-			Name:      "normalized_time_per_output_token_seconds",
-			Help:      metricsutil.HelpMsgWithStability("[Deprecated: Use llm_d_epp_request_ntpot_seconds] Inference objective latency divided by number of output tokens in seconds for each model and target model.", compbasemetrics.ALPHA),
-			// From few milliseconds per token to multiple seconds per token
-			Buckets: []float64{
-				0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0,
-			},
-		},
-		modelLabels,
-	)
-)
-
-// --- Inference Pool Metrics ---
-var (
-	// Deprecated: Use llm_d_epp_average_kv_cache_utilization instead.
-	// Tracked in: https://github.com/llm-d/llm-d-inference-scheduler/issues/1070
-	inferencePoolAvgKVCache = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: inferencePoolComponent,
-			Name:      "average_kv_cache_utilization",
-			Help:      metricsutil.HelpMsgWithStability("[Deprecated: Use llm_d_epp_average_kv_cache_utilization] The average kv cache utilization for an inference server pool.", compbasemetrics.ALPHA),
-		},
-		poolLabels,
-	)
-
-	// Deprecated: Use llm_d_epp_average_queue_size instead.
-	// Tracked in: https://github.com/llm-d/llm-d-inference-scheduler/issues/1070
-	inferencePoolAvgQueueSize = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: inferencePoolComponent,
-			Name:      "average_queue_size",
-			Help:      metricsutil.HelpMsgWithStability("[Deprecated: Use llm_d_epp_average_queue_size] The average number of requests pending in the model server queue.", compbasemetrics.ALPHA),
-		},
-		poolLabels,
-	)
-
-	// Deprecated: Use llm_d_epp_average_running_requests instead.
-	// Tracked in: https://github.com/llm-d/llm-d-inference-scheduler/issues/1070
-	inferencePoolAvgRunningRequests = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: inferencePoolComponent,
-			Name:      "average_running_requests",
-			Help:      metricsutil.HelpMsgWithStability("[Deprecated: Use llm_d_epp_average_running_requests] The average number of running requests across model servers in the pool.", compbasemetrics.ALPHA),
-		},
-		poolLabels,
-	)
-
-	// Deprecated: Use llm_d_epp_ready_endpoints instead.
-	// Tracked in: https://github.com/llm-d/llm-d-inference-scheduler/issues/1070
-	inferencePoolReadyPods = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: inferencePoolComponent,
-			Name:      "ready_pods",
-			Help:      metricsutil.HelpMsgWithStability("[Deprecated: Use llm_d_epp_ready_endpoints] The number of ready pods in the inference server pool.", compbasemetrics.ALPHA),
-		},
-		poolLabels,
-	)
+	modelLabels    = []string{"model_name", "target_model_name"}
+	poolLabels     = []string{"name"}
+	endpointLabels = []string{"pod_name", "namespace", "port"}
 )
 
 // --- Scheduling Metrics ---
@@ -412,39 +235,25 @@ var registerMetrics sync.Once
 func Register(customCollectors ...prometheus.Collector) {
 	registerMetrics.Do(func() {
 		// Register other metrics
-		metrics.Registry.MustRegister(requestCounter)
 		metrics.Registry.MustRegister(llmdRequestCounter)
-		metrics.Registry.MustRegister(requestErrCounter)
 		metrics.Registry.MustRegister(llmdRequestErrCounter)
-		metrics.Registry.MustRegister(requestLatencies)
 		metrics.Registry.MustRegister(llmdRequestLatencies)
-		metrics.Registry.MustRegister(requestSizes)
 		metrics.Registry.MustRegister(llmdRequestSizes)
-		metrics.Registry.MustRegister(responseSizes)
 		metrics.Registry.MustRegister(llmdResponseSizes)
-		metrics.Registry.MustRegister(inputTokens)
 		metrics.Registry.MustRegister(llmdInputTokens)
-		metrics.Registry.MustRegister(outputTokens)
 		metrics.Registry.MustRegister(llmdOutputTokens)
-		metrics.Registry.MustRegister(promptCachedTokens)
 		metrics.Registry.MustRegister(llmdPromptCachedTokens)
-		metrics.Registry.MustRegister(runningRequests)
 		metrics.Registry.MustRegister(llmdRunningRequests)
-		metrics.Registry.MustRegister(normalizedTimePerOutputToken)
 		metrics.Registry.MustRegister(llmdNormalizedTimePerOutputToken)
 		metrics.Registry.MustRegister(llmdRequestTTFT)
 		metrics.Registry.MustRegister(llmdRequestTPOT)
 		metrics.Registry.MustRegister(llmdInterTokenLatency)
-		metrics.Registry.MustRegister(inferencePoolAvgKVCache)
 		metrics.Registry.MustRegister(llmdInferencePoolAvgKVCache)
 		metrics.Registry.MustRegister(llmdInferencePoolStdDevKVCache)
-		metrics.Registry.MustRegister(inferencePoolAvgQueueSize)
 		metrics.Registry.MustRegister(llmdInferencePoolAvgQueueSize)
 		metrics.Registry.MustRegister(llmdInferencePoolStdDevQueueSize)
-		metrics.Registry.MustRegister(inferencePoolAvgRunningRequests)
 		metrics.Registry.MustRegister(llmdInferencePoolAvgRunningRequests)
 		metrics.Registry.MustRegister(llmdInferencePoolStdDevRunningRequests)
-		metrics.Registry.MustRegister(inferencePoolReadyPods)
 		metrics.Registry.MustRegister(llmdInferencePoolReadyEndpoints)
 		metrics.Registry.MustRegister(schedulerE2ELatency)
 		metrics.Registry.MustRegister(llmdSchedulerE2ELatency)
@@ -497,39 +306,25 @@ func Register(customCollectors ...prometheus.Collector) {
 // Just for integration test
 func Reset() {
 	// Reset other metrics
-	requestCounter.Reset()
 	llmdRequestCounter.Reset()
-	requestErrCounter.Reset()
 	llmdRequestErrCounter.Reset()
-	requestLatencies.Reset()
 	llmdRequestLatencies.Reset()
-	requestSizes.Reset()
 	llmdRequestSizes.Reset()
-	responseSizes.Reset()
 	llmdResponseSizes.Reset()
-	inputTokens.Reset()
 	llmdInputTokens.Reset()
-	outputTokens.Reset()
 	llmdOutputTokens.Reset()
-	promptCachedTokens.Reset()
 	llmdPromptCachedTokens.Reset()
-	runningRequests.Reset()
 	llmdRunningRequests.Reset()
-	normalizedTimePerOutputToken.Reset()
 	llmdNormalizedTimePerOutputToken.Reset()
 	llmdRequestTTFT.Reset()
 	llmdRequestTPOT.Reset()
 	llmdInterTokenLatency.Reset()
-	inferencePoolAvgKVCache.Reset()
 	llmdInferencePoolAvgKVCache.Reset()
 	llmdInferencePoolStdDevKVCache.Reset()
-	inferencePoolAvgQueueSize.Reset()
 	llmdInferencePoolAvgQueueSize.Reset()
 	llmdInferencePoolStdDevQueueSize.Reset()
-	inferencePoolAvgRunningRequests.Reset()
 	llmdInferencePoolAvgRunningRequests.Reset()
 	llmdInferencePoolStdDevRunningRequests.Reset()
-	inferencePoolReadyPods.Reset()
 	llmdInferencePoolReadyEndpoints.Reset()
 	schedulerE2ELatency.Reset()
 	llmdSchedulerE2ELatency.Reset()
@@ -578,7 +373,6 @@ func RecordRequestCounter(modelName, targetModelName, fairnessID string, priorit
 	modelName, targetModelName = boundModels(modelName, targetModelName)
 	fairnessID = boundFairnessID(fairnessID)
 	prioStr := strconv.Itoa(priority)
-	requestCounter.WithLabelValues(modelName, targetModelName, prioStr).Inc()
 	llmdRequestCounter.WithLabelValues(modelName, targetModelName, fairnessID, prioStr).Inc()
 }
 
@@ -587,7 +381,6 @@ func RecordRequestErrCounter(modelName, targetModelName, fairnessID, priority st
 	modelName, targetModelName = boundModels(modelName, targetModelName)
 	fairnessID = boundFairnessID(fairnessID)
 	if code != "" {
-		requestErrCounter.WithLabelValues(modelName, targetModelName, code).Inc()
 		llmdRequestErrCounter.WithLabelValues(modelName, targetModelName, fairnessID, priority, code).Inc()
 	}
 }
@@ -596,7 +389,6 @@ func RecordRequestErrCounter(modelName, targetModelName, fairnessID, priority st
 func RecordRequestSizes(modelName, targetModelName, fairnessID, priority string, reqSize int) {
 	modelName, targetModelName = boundModels(modelName, targetModelName)
 	fairnessID = boundFairnessID(fairnessID)
-	requestSizes.WithLabelValues(modelName, targetModelName).Observe(float64(reqSize))
 	llmdRequestSizes.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(float64(reqSize))
 }
 
@@ -610,7 +402,6 @@ func RecordRequestLatencies(ctx context.Context, modelName, targetModelName, fai
 		return false
 	}
 	elapsedSeconds := complete.Sub(received).Seconds()
-	requestLatencies.WithLabelValues(modelName, targetModelName).Observe(elapsedSeconds)
 	llmdRequestLatencies.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(elapsedSeconds)
 	return true
 }
@@ -619,7 +410,6 @@ func RecordRequestLatencies(ctx context.Context, modelName, targetModelName, fai
 func RecordResponseSizes(modelName, targetModelName, fairnessID, priority string, size int) {
 	modelName, targetModelName = boundModels(modelName, targetModelName)
 	fairnessID = boundFairnessID(fairnessID)
-	responseSizes.WithLabelValues(modelName, targetModelName).Observe(float64(size))
 	llmdResponseSizes.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(float64(size))
 }
 
@@ -628,7 +418,6 @@ func RecordInputTokens(modelName, targetModelName, fairnessID, priority string, 
 	modelName, targetModelName = boundModels(modelName, targetModelName)
 	fairnessID = boundFairnessID(fairnessID)
 	if size > 0 {
-		inputTokens.WithLabelValues(modelName, targetModelName).Observe(float64(size))
 		llmdInputTokens.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(float64(size))
 	}
 }
@@ -638,7 +427,6 @@ func RecordOutputTokens(modelName, targetModelName, fairnessID, priority string,
 	modelName, targetModelName = boundModels(modelName, targetModelName)
 	fairnessID = boundFairnessID(fairnessID)
 	if size > 0 {
-		outputTokens.WithLabelValues(modelName, targetModelName).Observe(float64(size))
 		llmdOutputTokens.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(float64(size))
 	}
 }
@@ -647,7 +435,6 @@ func RecordOutputTokens(modelName, targetModelName, fairnessID, priority string,
 func RecordPromptCachedTokens(modelName, targetModelName, fairnessID, priority string, size int) {
 	modelName, targetModelName = boundModels(modelName, targetModelName)
 	fairnessID = boundFairnessID(fairnessID)
-	promptCachedTokens.WithLabelValues(modelName, targetModelName).Observe(float64(size))
 	llmdPromptCachedTokens.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(float64(size))
 }
 
@@ -668,7 +455,6 @@ func RecordNormalizedTimePerOutputToken(ctx context.Context, modelName, targetMo
 	elapsedSeconds := complete.Sub(received).Seconds()
 	secondsPerToken := elapsedSeconds / float64(outputTokenCount)
 
-	normalizedTimePerOutputToken.WithLabelValues(modelName, targetModelName).Observe(secondsPerToken)
 	llmdNormalizedTimePerOutputToken.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(secondsPerToken)
 	return true
 }
@@ -742,7 +528,6 @@ func IncRunningRequests(modelName, targetModelName, fairnessID, priority string)
 	modelName, targetModelName = boundModels(modelName, targetModelName)
 	fairnessID = boundFairnessID(fairnessID)
 	if modelName != "" {
-		runningRequests.WithLabelValues(modelName).Inc()
 		llmdRunningRequests.WithLabelValues(modelName, targetModelName, fairnessID, priority).Inc()
 	}
 }
@@ -752,23 +537,19 @@ func DecRunningRequests(modelName, targetModelName, fairnessID, priority string)
 	modelName, targetModelName = boundModels(modelName, targetModelName)
 	fairnessID = boundFairnessID(fairnessID)
 	if modelName != "" {
-		runningRequests.WithLabelValues(modelName).Dec()
 		llmdRunningRequests.WithLabelValues(modelName, targetModelName, fairnessID, priority).Dec()
 	}
 }
 
 func RecordInferencePoolAvgKVCache(name string, utilization float64) {
-	inferencePoolAvgKVCache.WithLabelValues(name).Set(utilization)
 	llmdInferencePoolAvgKVCache.WithLabelValues(name).Set(utilization)
 }
 
 func RecordInferencePoolAvgQueueSize(name string, queueSize float64) {
-	inferencePoolAvgQueueSize.WithLabelValues(name).Set(queueSize)
 	llmdInferencePoolAvgQueueSize.WithLabelValues(name).Set(queueSize)
 }
 
 func RecordInferencePoolAvgRunningRequests(name string, runningRequests float64) {
-	inferencePoolAvgRunningRequests.WithLabelValues(name).Set(runningRequests)
 	llmdInferencePoolAvgRunningRequests.WithLabelValues(name).Set(runningRequests)
 }
 
@@ -785,7 +566,6 @@ func RecordInferencePoolStdDevRunningRequests(name string, runningRequests float
 }
 
 func RecordInferencePoolReadyPods(name string, runningPods float64) {
-	inferencePoolReadyPods.WithLabelValues(name).Set(runningPods)
 	llmdInferencePoolReadyEndpoints.WithLabelValues(name).Set(runningPods)
 }
 

--- a/pkg/epp/metrics/metrics_test.go
+++ b/pkg/epp/metrics/metrics_test.go
@@ -37,25 +37,35 @@ import (
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 )
 
-const (
-	requestTotalMetric                 = inferenceObjectiveComponent + "_request_total"
-	requestErrorTotalMetric            = inferenceObjectiveComponent + "_request_error_total"
-	requestLatenciesMetric             = inferenceObjectiveComponent + "_request_duration_seconds"
-	requestSizesMetric                 = inferenceObjectiveComponent + "_request_sizes"
-	responseSizesMetric                = inferenceObjectiveComponent + "_response_sizes"
-	inputTokensMetric                  = inferenceObjectiveComponent + "_input_tokens"
-	outputTokensMetric                 = inferenceObjectiveComponent + "_output_tokens"
-	normalizedTimePerOutputTokenMetric = inferenceObjectiveComponent + "_normalized_time_per_output_token_seconds"
-	runningRequestsMetric              = inferenceObjectiveComponent + "_running_requests"
-	kvCacheAvgUsageMetric              = inferencePoolComponent + "_average_kv_cache_utilization"
-	queueAvgSizeMetric                 = inferencePoolComponent + "_average_queue_size"
-	runningRequestsAvgMetric           = inferencePoolComponent + "_average_running_requests"
-)
-
 func TestMain(m *testing.M) {
 	// Register all metrics once for the entire test suite.
 	Register()
 	os.Exit(m.Run())
+}
+
+func TestCoreLegacyMetricFamiliesAreNotRegistered(t *testing.T) {
+	families, err := metrics.Registry.Gather()
+	require.NoError(t, err)
+
+	legacy := map[string]struct{}{
+		"inference_objective_request_total":            {},
+		"inference_objective_request_error_total":      {},
+		"inference_objective_request_duration_seconds": {},
+		"inference_objective_request_sizes":            {},
+		"inference_objective_response_sizes":           {},
+		"inference_objective_input_tokens":             {},
+		"inference_objective_output_tokens":            {},
+		"inference_objective_prompt_cached_tokens":     {},
+		"inference_objective_running_requests":         {},
+		"inference_pool_average_kv_cache_utilization":  {},
+		"inference_pool_average_queue_size":            {},
+		"inference_pool_average_running_requests":      {},
+		"inference_pool_ready_pods":                    {},
+	}
+	for _, family := range families {
+		_, found := legacy[family.GetName()]
+		require.Falsef(t, found, "legacy metric family %q must not be registered", family.GetName())
+	}
 }
 
 func TestRecordRequestCounterandSizes(t *testing.T) {
@@ -105,26 +115,7 @@ func TestRecordRequestCounterandSizes(t *testing.T) {
 				RecordRequestSizes(req.modelName, req.targetModelName, req.fairnessID, "0", req.reqSize)
 			}
 
-			// Verify deprecated metrics
-			wantRequestTotal, err := os.Open("testdata/request_total_metric")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer wantRequestTotal.Close()
-			if err := testutil.GatherAndCompare(metrics.Registry, wantRequestTotal, requestTotalMetric); err != nil {
-				t.Error(err)
-			}
-
-			wantRequestSizes, err := os.Open("testdata/request_sizes_metric")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer wantRequestSizes.Close()
-			if err := testutil.GatherAndCompare(metrics.Registry, wantRequestSizes, requestSizesMetric); err != nil {
-				t.Error(err)
-			}
-
-			// Verify llm_d_epp metrics
+			// Verify llm_d_epp metrics.
 			wantRequestTotalNew, err := os.Open("testdata/llm_d_request_total_metric")
 			if err != nil {
 				t.Fatal(err)
@@ -190,17 +181,7 @@ func TestRecordRequestErrorCounter(t *testing.T) {
 				RecordRequestErrCounter(req.modelName, req.targetModelName, "", "0", req.error)
 			}
 
-			// Verify deprecated metric
-			wantRequestErrorCounter, err := os.Open("testdata/request_error_total_metric")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer wantRequestErrorCounter.Close()
-			if err := testutil.GatherAndCompare(metrics.Registry, wantRequestErrorCounter, requestErrorTotalMetric); err != nil {
-				t.Error(err)
-			}
-
-			// Verify llm_d_epp metric
+			// Verify llm_d_epp metric.
 			wantRequestErrorCounterNew, err := os.Open("testdata/llm_d_request_error_total_metric")
 			if err != nil {
 				t.Fatal(err)
@@ -279,17 +260,7 @@ func TestRecordRequestLatencies(t *testing.T) {
 				}
 			}
 
-			// Verify deprecated metric
-			wantRequestLatencies, err := os.Open("testdata/request_duration_seconds_metric")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer wantRequestLatencies.Close()
-			if err := testutil.GatherAndCompare(metrics.Registry, wantRequestLatencies, requestLatenciesMetric); err != nil {
-				t.Error(err)
-			}
-
-			// Verify llm_d_epp metric
+			// Verify llm_d_epp metric.
 			wantRequestLatenciesNew, err := os.Open("testdata/llm_d_request_duration_seconds_metric")
 			if err != nil {
 				t.Fatal(err)
@@ -387,17 +358,7 @@ func TestRecordNormalizedTimePerOutputToken(t *testing.T) {
 				}
 			}
 
-			// Verify deprecated metric
-			wantLatencyPerToken, err := os.Open("testdata/normalized_time_per_output_token_seconds_metric")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer wantLatencyPerToken.Close()
-			if err := testutil.GatherAndCompare(metrics.Registry, wantLatencyPerToken, normalizedTimePerOutputTokenMetric); err != nil {
-				t.Error(err)
-			}
-
-			// Verify llm_d_epp metric
+			// Verify llm_d_epp metric.
 			wantLatencyPerTokenNew, err := os.Open("testdata/llm_d_normalized_time_per_output_token_seconds_metric")
 			if err != nil {
 				t.Fatal(err)
@@ -477,35 +438,7 @@ func TestRecordResponseMetrics(t *testing.T) {
 				RecordPromptCachedTokens(resp.modelName, resp.targetModelName, "", "0", resp.cachedToken)
 			}
 
-			// Verify deprecated metrics
-			wantResponseSize, err := os.Open("testdata/response_sizes_metric")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer wantResponseSize.Close()
-			if err := testutil.GatherAndCompare(metrics.Registry, wantResponseSize, responseSizesMetric); err != nil {
-				t.Error(err)
-			}
-
-			wantInputToken, err := os.Open("testdata/input_tokens_metric")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer wantInputToken.Close()
-			if err := testutil.GatherAndCompare(metrics.Registry, wantInputToken, inputTokensMetric); err != nil {
-				t.Error(err)
-			}
-
-			wantOutputToken, err := os.Open("testdata/output_tokens_metric")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer wantOutputToken.Close()
-			if err := testutil.GatherAndCompare(metrics.Registry, wantOutputToken, outputTokensMetric); err != nil {
-				t.Error(err)
-			}
-
-			// Verify llm_d_epp metrics
+			// Verify llm_d_epp metrics.
 			wantResponseSizeNew, err := os.Open("testdata/llm_d_response_size_bytes_metric")
 			if err != nil {
 				t.Fatal(err)
@@ -595,17 +528,7 @@ func TestRunningRequestsMetrics(t *testing.T) {
 				}
 			}
 
-			// Verify deprecated metric
-			wantRunningRequests, err := os.Open("testdata/running_requests_metrics")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer wantRunningRequests.Close()
-			if err := testutil.GatherAndCompare(metrics.Registry, wantRunningRequests, runningRequestsMetric); err != nil {
-				t.Error(err)
-			}
-
-			// Verify llm_d_epp metric
+			// Verify llm_d_epp metric.
 			wantRunningRequestsNew, err := os.Open("testdata/llm_d_running_requests_metrics")
 			if err != nil {
 				t.Fatal(err)
@@ -650,35 +573,7 @@ func TestInferencePoolMetrics(t *testing.T) {
 			RecordInferencePoolStdDevQueueSize(scenario.poolName, scenario.queueSizeStdDev)
 			RecordInferencePoolStdDevRunningRequests(scenario.poolName, scenario.runningRequestsStdDev)
 
-			// Verify deprecated metrics
-			wantKVCache, err := os.Open("testdata/kv_cache_avg_metrics")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer wantKVCache.Close()
-			if err := testutil.GatherAndCompare(metrics.Registry, wantKVCache, kvCacheAvgUsageMetric); err != nil {
-				t.Error(err)
-			}
-
-			wantQueueSize, err := os.Open("testdata/queue_avg_size_metrics")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer wantQueueSize.Close()
-			if err := testutil.GatherAndCompare(metrics.Registry, wantQueueSize, queueAvgSizeMetric); err != nil {
-				t.Error(err)
-			}
-
-			wantRunningRequests, err := os.Open("testdata/running_requests_avg_metrics")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer wantRunningRequests.Close()
-			if err := testutil.GatherAndCompare(metrics.Registry, wantRunningRequests, runningRequestsAvgMetric); err != nil {
-				t.Error(err)
-			}
-
-			// Verify llm_d_epp metrics
+			// Verify llm_d_epp metrics.
 			wantKVCacheNew, err := os.Open("testdata/llm_d_kv_cache_avg_metrics")
 			if err != nil {
 				t.Fatal(err)

--- a/test/e2e/requests_test.go
+++ b/test/e2e/requests_test.go
@@ -400,19 +400,6 @@ func verifyMetrics(infPoolName string, numTargetPorts int) {
 
 	// Define the metrics we expect to see
 	preset := []string{ //nolint:prealloc
-		"inference_objective_request_total",
-		"inference_objective_request_error_total",
-		"inference_objective_request_duration_seconds",
-		"inference_objective_normalized_time_per_output_token_seconds",
-		"inference_objective_request_sizes",
-		"inference_objective_response_sizes",
-		"inference_objective_input_tokens",
-		"inference_objective_output_tokens",
-		"inference_pool_average_kv_cache_utilization",
-		"inference_pool_average_queue_size",
-		"inference_pool_per_pod_queue_size",
-		"inference_objective_running_requests",
-		"inference_pool_ready_pods",
 		"inference_extension_info",
 
 		// llm_d metrics
@@ -438,13 +425,6 @@ func verifyMetrics(infPoolName string, numTargetPorts int) {
 
 	for _, modelServerPodName := range decodePods {
 		for rank := range numTargetPorts {
-			metricQueueSize := fmt.Sprintf(
-				"inference_pool_per_pod_queue_size{model_server_pod=\"%s-rank-%d\",name=\"%s\"}",
-				modelServerPodName,
-				rank,
-				infPoolName)
-			expectedMetrics = append(expectedMetrics, metricQueueSize)
-
 			metricQueueSizeNew := fmt.Sprintf(
 				"llm_d_epp_per_endpoint_queue_size{model_server_endpoint=\"%s-rank-%d\",name=\"%s\"}",
 				modelServerPodName,

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -117,7 +117,7 @@ func getPodNames(labels map[string]string, nsName string) []string {
 	return names
 }
 
-// waitForEPPToDiscoverPods blocks until the EPP's inference_pool_ready_pods
+// waitForEPPToDiscoverPods blocks until the EPP's llm_d_epp_ready_endpoints
 // gauge for poolName reports at least one pod, indicating the InferencePool
 // controller has finished its initial pod discovery. The EPP reports gRPC
 // health as SERVING as soon as the pool is set, even if pod discovery found
@@ -131,7 +131,7 @@ func waitForEPPToDiscoverPods(poolName string) {
 	startEPPMetricsPortForward()
 	labelMatch := fmt.Sprintf(`name="%s"`, poolName)
 	gomega.Eventually(func() int {
-		return getCounterMetric(metricsURL, "inference_pool_ready_pods", labelMatch)
+		return getCounterMetric(metricsURL, "llm_d_epp_ready_endpoints", labelMatch)
 	}, readyTimeout, time.Second).Should(gomega.BeNumerically(">", 0), "EPP should discover pool members within the ready timeout")
 }
 

--- a/test/integration/epp/common_tests.go
+++ b/test/integration/epp/common_tests.go
@@ -314,8 +314,8 @@ func commonTestCases(prio func(int) int) []testCase {
 			},
 			wantResponses: ExpectRouteTo("192.168.1.2:8000", modelMyModelTarget, "test1"),
 			wantMetrics: map[string]string{
-				"inference_objective_request_total": cleanMetric(metricReqTotal(modelMyModel, modelMyModelTarget, prio(2))),
-				"inference_pool_ready_pods":         cleanMetric(metricReadyPods(3)),
+				"llm_d_epp_request_total":   cleanMetric(metricReqTotal(modelMyModel, modelMyModelTarget, prio(2))),
+				"llm_d_epp_ready_endpoints": cleanMetric(metricReadyPods(3)),
 			},
 			wantSpans: []string{"request", "request_orchestration"},
 		},
@@ -329,7 +329,7 @@ func commonTestCases(prio func(int) int) []testCase {
 			},
 			wantResponses: ExpectRouteTo("192.168.1.2:8000", modelSQLLoraTarget, "test2"),
 			wantMetrics: map[string]string{
-				"inference_objective_request_total": cleanMetric(metricReqTotal(modelSQLLora, modelSQLLoraTarget, prio(2))),
+				"llm_d_epp_request_total": cleanMetric(metricReqTotal(modelSQLLora, modelSQLLoraTarget, prio(2))),
 			},
 		},
 		{
@@ -378,17 +378,17 @@ func labelsToString(labels []label) string {
 
 func metricReqTotal(model, target string, priority int) string {
 	return fmt.Sprintf(`
-    # HELP inference_objective_request_total [ALPHA] [Deprecated: Use llm_d_epp_request_total] Counter of inference objective requests broken out for each model and target model.
-    # TYPE inference_objective_request_total counter
-    inference_objective_request_total{%s} 1
-    `, labelsToString([]label{{"model_name", model}, {"priority", strconv.Itoa(priority)}, {"target_model_name", target}}))
+    # HELP llm_d_epp_request_total [ALPHA] Total number of processed requests.
+    # TYPE llm_d_epp_request_total counter
+    llm_d_epp_request_total{%s} 1
+    `, labelsToString([]label{{"fairness_id", ""}, {"model_name", model}, {"priority", strconv.Itoa(priority)}, {"target_model_name", target}}))
 }
 
 func metricReadyPods(count int) string {
 	return fmt.Sprintf(`
-    # HELP inference_pool_ready_pods [ALPHA] [Deprecated: Use llm_d_epp_ready_endpoints] The number of ready pods in the inference server pool.
-    # TYPE inference_pool_ready_pods gauge
-    inference_pool_ready_pods{%s} %d
+	# HELP llm_d_epp_ready_endpoints [ALPHA] The number of ready endpoints in the inference server pool.
+	# TYPE llm_d_epp_ready_endpoints gauge
+	llm_d_epp_ready_endpoints{%s} %d
     `, labelsToString([]label{{"name", testPoolName}}), count)
 }
 

--- a/test/integration/epp/common_tests.go
+++ b/test/integration/epp/common_tests.go
@@ -28,6 +28,7 @@ import (
 
 	errcommon "github.com/llm-d/llm-d-router/pkg/common/error"
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 	"github.com/llm-d/llm-d-router/test/integration"
 )
 
@@ -381,7 +382,7 @@ func metricReqTotal(model, target string, priority int) string {
     # HELP llm_d_epp_request_total [ALPHA] Total number of processed requests.
     # TYPE llm_d_epp_request_total counter
     llm_d_epp_request_total{%s} 1
-    `, labelsToString([]label{{"fairness_id", ""}, {"model_name", model}, {"priority", strconv.Itoa(priority)}, {"target_model_name", target}}))
+    `, labelsToString([]label{{"fairness_id", metadata.DefaultFairnessID}, {"model_name", model}, {"priority", strconv.Itoa(priority)}, {"target_model_name", target}}))
 }
 
 func metricReadyPods(count int) string {

--- a/test/integration/epp/grpc_test.go
+++ b/test/integration/epp/grpc_test.go
@@ -82,8 +82,8 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 			},
 			wantResponses: ExpectGRPCRouteTo("192.168.1.2:8000", "test1", integration.GenerateGRPCMethodName),
 			wantMetrics: map[string]string{
-				"inference_objective_request_total": cleanMetric(metricReqTotal("", "", 4)),
-				"inference_pool_ready_pods":         cleanMetric(metricReadyPods(3)),
+				"llm_d_epp_request_total":   cleanMetric(metricReqTotal("", "", 4)),
+				"llm_d_epp_ready_endpoints": cleanMetric(metricReadyPods(3)),
 			},
 		},
 		{
@@ -96,8 +96,8 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 			},
 			wantResponses: ExpectGRPCRouteTo("192.168.1.2:8000", "test1", integration.EmbedGRPCMethodName),
 			wantMetrics: map[string]string{
-				"inference_objective_request_total": cleanMetric(metricReqTotal("", "", 4)),
-				"inference_pool_ready_pods":         cleanMetric(metricReadyPods(3)),
+				"llm_d_epp_request_total":   cleanMetric(metricReqTotal("", "", 4)),
+				"llm_d_epp_ready_endpoints": cleanMetric(metricReadyPods(3)),
 			},
 		},
 		{
@@ -110,8 +110,8 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 			},
 			wantResponses: ExpectGRPCRouteToWithStream("192.168.1.2:8000", "test-stream", integration.GenerateGRPCMethodName),
 			wantMetrics: map[string]string{
-				"inference_objective_request_total": cleanMetric(metricReqTotal("", "", 4)),
-				"inference_pool_ready_pods":         cleanMetric(metricReadyPods(3)),
+				"llm_d_epp_request_total":   cleanMetric(metricReqTotal("", "", 4)),
+				"llm_d_epp_ready_endpoints": cleanMetric(metricReadyPods(3)),
 			},
 		},
 		{
@@ -124,7 +124,7 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 			},
 			wantResponses: ExpectGRPCRouteTo("192.168.1.1:8000", "test2", integration.GenerateGRPCMethodName),
 			wantMetrics: map[string]string{
-				"inference_objective_request_total": cleanMetric(metricReqTotal("", "", 0)),
+				"llm_d_epp_request_total": cleanMetric(metricReqTotal("", "", 0)),
 			},
 		},
 
@@ -164,7 +164,7 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 			},
 			wantResponses: ExpectGRPCRouteTo("192.168.1.1:8000", "test3", integration.GenerateGRPCMethodName),
 			wantMetrics: map[string]string{
-				"inference_objective_request_total": cleanMetric(metricReqTotal("", "", 0)),
+				"llm_d_epp_request_total": cleanMetric(metricReqTotal("", "", 0)),
 			},
 		},
 		{
@@ -285,34 +285,7 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 				return ExpectBufferResp(string(gRPCPayload), "application/grpc")
 			}(),
 			// Labels are empty because we skipped the Request phase.
-			wantMetrics: map[string]string{
-				"inference_objective_input_tokens": cleanMetric(`
-					# HELP inference_objective_input_tokens [ALPHA] [Deprecated: Use llm_d_epp_request_input_tokens] Inference objective input token count distribution for requests in each model.
-					# TYPE inference_objective_input_tokens histogram
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="1"} 0
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="8"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="16"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="32"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="64"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="128"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="256"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="512"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="1024"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="2048"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="4096"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="8192"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="16384"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="32768"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="65536"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="131072"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="262144"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="524288"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="1.048576e+06"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="+Inf"} 1
-					inference_objective_input_tokens_sum{model_name="",target_model_name=""} 7
-					inference_objective_input_tokens_count{model_name="",target_model_name=""} 1
-					`),
-			},
+			wantMetrics: map[string]string{},
 		},
 		{
 			name: "response streaming with token usage",
@@ -409,53 +382,7 @@ func TestFullDuplexStreamed_GRPC_KubeInferenceObjectiveRequest(t *testing.T) {
 
 				return append(reqs, respRespHeaders, respChunk1, respChunk2)
 			}(),
-			wantMetrics: map[string]string{
-				"inference_objective_input_tokens": cleanMetric(`
-					# HELP inference_objective_input_tokens [ALPHA] [Deprecated: Use llm_d_epp_request_input_tokens] Inference objective input token count distribution for requests in each model.
-					# TYPE inference_objective_input_tokens histogram
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="1"} 0
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="8"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="16"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="32"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="64"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="128"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="256"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="512"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="1024"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="2048"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="4096"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="8192"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="16384"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="32768"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="65536"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="131072"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="262144"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="524288"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="1.048576e+06"} 1
-					inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="+Inf"} 1
-					inference_objective_input_tokens_sum{model_name="",target_model_name=""} 7
-					inference_objective_input_tokens_count{model_name="",target_model_name=""} 1
-					`),
-				"inference_objective_output_tokens": cleanMetric(`
-					# HELP inference_objective_output_tokens [ALPHA] [Deprecated: Use llm_d_epp_request_output_tokens] Inference objective output token count distribution for requests in each model.
-					# TYPE inference_objective_output_tokens histogram
-					inference_objective_output_tokens_bucket{model_name="",target_model_name="",le="1"} 0
-					inference_objective_output_tokens_bucket{model_name="",target_model_name="",le="8"} 0
-					inference_objective_output_tokens_bucket{model_name="",target_model_name="",le="16"} 1
-					inference_objective_output_tokens_bucket{model_name="",target_model_name="",le="32"} 1
-					inference_objective_output_tokens_bucket{model_name="",target_model_name="",le="64"} 1
-					inference_objective_output_tokens_bucket{model_name="",target_model_name="",le="128"} 1
-					inference_objective_output_tokens_bucket{model_name="",target_model_name="",le="256"} 1
-					inference_objective_output_tokens_bucket{model_name="",target_model_name="",le="512"} 1
-					inference_objective_output_tokens_bucket{model_name="",target_model_name="",le="1024"} 1
-					inference_objective_output_tokens_bucket{model_name="",target_model_name="",le="2048"} 1
-					inference_objective_output_tokens_bucket{model_name="",target_model_name="",le="4096"} 1
-					inference_objective_output_tokens_bucket{model_name="",target_model_name="",le="8192"} 1
-					inference_objective_output_tokens_bucket{model_name="",target_model_name="",le="+Inf"} 1
-					inference_objective_output_tokens_sum{model_name="",target_model_name=""} 10
-					inference_objective_output_tokens_count{model_name="",target_model_name=""} 1
-					`),
-			},
+			wantMetrics: map[string]string{},
 		},
 	}
 

--- a/test/integration/epp/harness.go
+++ b/test/integration/epp/harness.go
@@ -397,16 +397,16 @@ func (h *TestHarness) WithPods(pods []PodState) *TestHarness {
 	return h
 }
 
-// WaitForReadyPodsMetric blocks until the prometheus metric 'inference_pool_ready_pods' matches the expected count.
+// WaitForReadyPodsMetric blocks until the prometheus metric 'llm_d_epp_ready_endpoints' matches the expected count.
 func (h *TestHarness) WaitForReadyPodsMetric(expectedCount int) {
 	h.t.Helper()
 
 	expected := cleanMetric(metricReadyPods(expectedCount))
 	require.Eventually(h.t, func() bool {
 		err := metricsutils.GatherAndCompare(crmetrics.Registry, strings.NewReader(expected),
-			"inference_pool_ready_pods")
+			"llm_d_epp_ready_endpoints")
 		return err == nil
-	}, 10*time.Second, 50*time.Millisecond, "Timed out waiting for inference_pool_ready_pods metric to settle")
+	}, 10*time.Second, 50*time.Millisecond, "Timed out waiting for llm_d_epp_ready_endpoints metric to settle")
 }
 
 // WaitForSync blocks until the EPP Datastore has synced the expected number of pods.

--- a/test/integration/epp/harness.go
+++ b/test/integration/epp/harness.go
@@ -27,6 +27,7 @@ import (
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/google/uuid"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
@@ -41,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	metricsutils "k8s.io/component-base/metrics/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -403,7 +403,7 @@ func (h *TestHarness) WaitForReadyPodsMetric(expectedCount int) {
 
 	expected := cleanMetric(metricReadyPods(expectedCount))
 	require.Eventually(h.t, func() bool {
-		err := metricsutils.GatherAndCompare(crmetrics.Registry, strings.NewReader(expected),
+		err := promtestutil.GatherAndCompare(crmetrics.Registry, strings.NewReader(expected),
 			"llm_d_epp_ready_endpoints")
 		return err == nil
 	}, 10*time.Second, 50*time.Millisecond, "Timed out waiting for llm_d_epp_ready_endpoints metric to settle")
@@ -447,7 +447,7 @@ func (h *TestHarness) ExpectMetrics(expected map[string]string) {
 	for name, value := range expected {
 		var err error
 		assert.Eventually(h.t, func() bool {
-			err = metricsutils.GatherAndCompare(crmetrics.Registry, strings.NewReader(value), name)
+			err = promtestutil.GatherAndCompare(crmetrics.Registry, strings.NewReader(value), name)
 			return err == nil
 		}, 2*time.Second, 50*time.Millisecond, "Timed out waiting for metric %s to match: %v", name)
 		if err != nil {

--- a/test/integration/epp/hermetic_test.go
+++ b/test/integration/epp/hermetic_test.go
@@ -154,7 +154,7 @@ func TestFullDuplexStreamed_KubeInferenceObjectiveRequest(t *testing.T) {
 					},
 					wantResponses: ExpectRouteTo("192.168.1.2:8000", modelSQLLoraTarget, "test3"),
 					wantMetrics: map[string]string{
-						"inference_objective_request_total": cleanMetric(metricReqTotal(modelSQLLora, modelSQLLoraTarget, prio(2))),
+						"llm_d_epp_request_total": cleanMetric(metricReqTotal(modelSQLLora, modelSQLLoraTarget, prio(2))),
 					},
 				},
 				{
@@ -194,8 +194,8 @@ dataLayer:
 					},
 					wantResponses: ExpectPassthroughRouteTo("192.168.1.2:8000", []byte("passthrough-parser")),
 					wantMetrics: map[string]string{
-						"inference_objective_request_total": cleanMetric(metricReqTotal("", "", prio(2))),
-						"inference_pool_ready_pods":         cleanMetric(metricReadyPods(3)),
+						"llm_d_epp_request_total":   cleanMetric(metricReqTotal("", "", prio(2))),
+						"llm_d_epp_ready_endpoints": cleanMetric(metricReadyPods(3)),
 					},
 				},
 				{
@@ -208,7 +208,7 @@ dataLayer:
 					},
 					wantResponses: ExpectRouteTo("192.168.1.1:8000", modelSQLLoraTarget, "test4"),
 					wantMetrics: map[string]string{
-						"inference_objective_request_total": cleanMetric(metricReqTotal(modelSQLLora, modelSQLLoraTarget, prio(2))),
+						"llm_d_epp_request_total": cleanMetric(metricReqTotal(modelSQLLora, modelSQLLoraTarget, prio(2))),
 					},
 				},
 
@@ -245,7 +245,7 @@ dataLayer:
 					},
 					wantResponses: ExpectRouteTo("192.168.1.1:8000", modelSheddableTarget, "test6"),
 					wantMetrics: map[string]string{
-						"inference_objective_request_total": cleanMetric(metricReqTotal(modelSheddable, modelSheddableTarget, prio(0))),
+						"llm_d_epp_request_total": cleanMetric(metricReqTotal(modelSheddable, modelSheddableTarget, prio(0))),
 					},
 				},
 				{
@@ -348,7 +348,7 @@ dataLayer:
 					},
 					wantResponses: ExpectRouteTo("192.168.1.1:8000", modelDirect, "test6"),
 					wantMetrics: map[string]string{
-						"inference_objective_request_total": cleanMetric(metricReqTotal(modelDirect, modelDirect, prio(2))),
+						"llm_d_epp_request_total": cleanMetric(metricReqTotal(modelDirect, modelDirect, prio(2))),
 					},
 				},
 				{
@@ -359,7 +359,7 @@ dataLayer:
 					},
 					wantResponses: ExpectRouteTo("192.168.1.1:8000", modelAfterRewrite, "test-rewrite"),
 					wantMetrics: map[string]string{
-						"inference_objective_request_total": cleanMetric(metricReqTotal(modelToBeWritten, modelAfterRewrite, prio(0))),
+						"llm_d_epp_request_total": cleanMetric(metricReqTotal(modelToBeWritten, modelAfterRewrite, prio(0))),
 					},
 					requiresCRDs: true,
 				},
@@ -425,34 +425,7 @@ dataLayer:
 						"",
 					),
 					// Labels are empty because we skipped the Request phase.
-					wantMetrics: map[string]string{
-						"inference_objective_input_tokens": cleanMetric(`
-              # HELP inference_objective_input_tokens [ALPHA] [Deprecated: Use llm_d_epp_request_input_tokens] Inference objective input token count distribution for requests in each model.
-              # TYPE inference_objective_input_tokens histogram
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="1"} 0
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="8"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="16"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="32"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="64"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="128"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="256"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="512"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="1024"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="2048"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="4096"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="8192"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="16384"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="32768"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="65536"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="131072"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="262144"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="524288"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="1.048576e+06"} 1
-              inference_objective_input_tokens_bucket{model_name="",target_model_name="",le="+Inf"} 1
-              inference_objective_input_tokens_sum{model_name="",target_model_name=""} 7
-              inference_objective_input_tokens_count{model_name="",target_model_name=""} 1
-              `),
-					},
+					wantMetrics: map[string]string{},
 				},
 			}
 			tests := append(commonTestCases(prio), hermeticTests...)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind deprecation

**What this PR does / why we need it**:

This is PR 1 of the incremental removal tracked by #1070. It stops dual-emitting the core request and inference-pool legacy metric families and retains their canonical `llm_d_epp_*` replacements. It also removes the legacy per-pod queue collector in favor of `llm_d_epp_per_endpoint_queue_size`, updates metric assertions, and adds coverage that the removed families are not registered.

The work is intentionally split by legacy metric family so each PR is reviewable and so downstream compatibility can be managed where it matters. PR 1 is the most valuable safe slice to advance now: WVA #1202 does not consume the core request or inference-pool families removed here. Therefore, WVA should not block #1070 as a whole; it should block only later PRs that remove the legacy scheduler and flow-control metric families WVA still consumes. Follow-up PRs (P2, P3, and later) will address those remaining families independently.

The predicted-latency plugin still emits its separate `inference_objective_*` families and is deliberately out of scope for this PR; it will be handled in a dedicated follow-up.

**Which issue(s) this PR fixes**:

Part of #1070

**Release note**:
```release-note
Remove deprecated core request and inference-pool Prometheus metrics. Use the corresponding llm_d_epp_* metric families.
```

**Testing**:

- `go test ./pkg/epp/metrics ./pkg/epp/metrics/collectors`
- Integration test execution is blocked locally because the Kubebuilder `etcd` binary is not installed at `/usr/local/kubebuilder/bin/etcd`.