### PR TITLE
fix(epp): support vLLM render endpoints started with --api-key

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -106,7 +106,10 @@ The plugin calls `POST {http}/v1/completions/render` and
 `vllm serve <model>` and by the GPU-less `vllm launch render <model>`.
 Any reachable HTTP endpoint serving the same model the scheduler tokenizes
 for will work — sidecar in the EPP pod (loopback) or a dedicated Service
-shared by multiple EPP replicas.
+shared by multiple EPP replicas. When the inbound request carries an
+`Authorization` header, it is forwarded verbatim on render requests, so an
+endpoint started with `--api-key` accepts them; the startup warmup probe
+sends no `Authorization` header.
 
 ```yaml
 # EPP pod spec

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -109,7 +109,8 @@ for will work — sidecar in the EPP pod (loopback) or a dedicated Service
 shared by multiple EPP replicas. When the inbound request carries an
 `Authorization` header, it is forwarded verbatim on render requests, so an
 endpoint started with `--api-key` accepts them; the startup warmup probe
-sends no `Authorization` header.
+sends no `Authorization` header, so against such an endpoint it is skipped
+and the first request pays the cold-start cost.
 
 ```yaml
 # EPP pod spec

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/backend.go
@@ -65,14 +65,23 @@ type warmer interface {
 
 // warmup primes the render path so the first request does not pay the cold-start
 // cost. It retries a text render until the backend responds, then issues a
-// best-effort multimodal render. It returns on success, on the attempt cap, or
-// on context cancellation.
+// best-effort multimodal render. It returns on success, on the attempt cap, on
+// an authentication rejection, or on context cancellation.
 func (b renderBackend) warmup(ctx context.Context) {
-	logger := log.FromContext(ctx).V(logutil.DEBUG)
+	logger := log.FromContext(ctx)
 	for i := 0; i < warmupAttempts; i++ {
-		if _, err := b.produce(ctx, warmupChat()); err == nil {
+		_, err := b.produce(ctx, warmupChat())
+		if err == nil {
 			_, _ = b.produce(ctx, warmupChat(warmupImage))
-			logger.Info("token-producer backend warmed up", "attempts", i+1)
+			logger.V(logutil.DEBUG).Info("token-producer backend warmed up", "attempts", i+1)
+			return
+		}
+		// Warmup carries no credentials; an auth rejection will not clear on retry.
+		if isRenderAuthError(err) {
+			logger.V(logutil.DEFAULT).Info(
+				"token-producer backend requires authentication, skipping warmup; "+
+					"the first request pays the cold-start cost",
+				"err", err)
 			return
 		}
 		select {
@@ -81,7 +90,7 @@ func (b renderBackend) warmup(ctx context.Context) {
 			return
 		}
 	}
-	logger.Info("token-producer backend warmup did not complete")
+	logger.V(logutil.DEBUG).Info("token-producer backend warmup did not complete")
 }
 
 // warmupChat builds a single-message chat body carrying the given image URLs.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -45,6 +45,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	mmobs "github.com/llm-d/llm-d-router/pkg/epp/framework/observability/multimodal"
 	rcplugins "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol"
+	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
 
 type tokenizer interface {
@@ -399,6 +400,9 @@ func (p *Plugin) Produce(ctx context.Context, request *scheduling.InferenceReque
 	}
 
 	ctx = withMMMetadata(ctx, parseMMMetadataHeaders(request.Headers))
+	if auth, ok := metadata.GetLowerCaseHeaderValue(request.Headers, "authorization"); ok {
+		ctx = withAuthHeader(ctx, auth)
+	}
 
 	ctx, span := tracing.Tracer(rcplugins.TracerScope).Start(ctx, "tokenize",
 		trace.WithSpanKind(trace.SpanKindInternal),

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -56,6 +56,21 @@ const (
 // pre-marshaled chat message (multimodal parts).
 var arrayContentMarker = []byte(`"content":[`)
 
+// authHeaderCtxKey carries the inbound request's Authorization header from
+// Plugin.Produce to the render call without widening tokenInputProducer.produce.
+type authHeaderCtxKey struct{}
+
+// withAuthHeader returns ctx carrying the Authorization header value verbatim.
+func withAuthHeader(ctx context.Context, value string) context.Context {
+	return context.WithValue(ctx, authHeaderCtxKey{}, value)
+}
+
+// authHeaderFromContext returns the Authorization header value on ctx, or "".
+func authHeaderFromContext(ctx context.Context) string {
+	value, _ := ctx.Value(authHeaderCtxKey{}).(string)
+	return value
+}
+
 // vllmConfig configures the vLLM /render backend. Future protocol fields
 // (e.g., grpc) can be added alongside url.
 type vllmConfig struct {
@@ -358,6 +373,11 @@ func (r *vllmHTTPRenderer) postJSON(ctx context.Context, path string, body any, 
 		return fmt.Errorf("build request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	// The render endpoint may require the same credential as inference;
+	// forward the inbound Authorization when present.
+	if auth := authHeaderFromContext(ctx); auth != "" {
+		httpReq.Header.Set("Authorization", auth)
+	}
 
 	httpResp, err := r.client.Do(httpReq)
 	if err != nil {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -71,6 +71,22 @@ func authHeaderFromContext(ctx context.Context) string {
 	return value
 }
 
+// renderStatusError is a non-2xx response from the render endpoint.
+type renderStatusError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *renderStatusError) Error() string {
+	return fmt.Sprintf("vLLM render returned status %d: %s", e.StatusCode, e.Body)
+}
+
+// isRenderAuthError reports whether err carries a 401 or 403 render response.
+func isRenderAuthError(err error) bool {
+	var se *renderStatusError
+	return errors.As(err, &se) && (se.StatusCode == http.StatusUnauthorized || se.StatusCode == http.StatusForbidden)
+}
+
 // vllmConfig configures the vLLM /render backend. Future protocol fields
 // (e.g., grpc) can be added alongside url.
 type vllmConfig struct {
@@ -387,7 +403,7 @@ func (r *vllmHTTPRenderer) postJSON(ctx context.Context, path string, body any, 
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		snippet, _ := io.ReadAll(io.LimitReader(httpResp.Body, maxErrorBodySnippetBytes))
-		return fmt.Errorf("vLLM render returned status %d: %s", httpResp.StatusCode, string(snippet))
+		return &renderStatusError{StatusCode: httpResp.StatusCode, Body: string(snippet)}
 	}
 	if err := json.NewDecoder(httpResp.Body).Decode(out); err != nil {
 		return fmt.Errorf("unmarshal response: %w", err)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
@@ -367,6 +367,38 @@ func TestProduce_VLLMHTTPForwardsAuthorization(t *testing.T) {
 	assert.Empty(t, cap.chatAuth, "request without Authorization must not send one")
 }
 
+func TestRenderBackend_WarmupStopsOnAuthRejection(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		status     int
+		wantsRetry bool
+	}{
+		{name: "401 gives up", status: http.StatusUnauthorized},
+		{name: "403 gives up", status: http.StatusForbidden},
+		{name: "503 retries", status: http.StatusServiceUnavailable, wantsRetry: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls++
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), warmupRetryInterval/2)
+			defer cancel()
+			renderBackend{tk: newHTTPRenderer(t, srv)}.warmup(ctx)
+
+			assert.Equal(t, 1, calls)
+			if tc.wantsRetry {
+				assert.ErrorIs(t, ctx.Err(), context.DeadlineExceeded, "non-auth failure must keep retrying until ctx ends")
+			} else {
+				assert.NoError(t, ctx.Err(), "auth failure must return before the retry interval")
+			}
+		})
+	}
+}
+
 func TestVLLMHTTPRenderer_RenderMultiPrompt(t *testing.T) {
 	srv, _ := httpFixture(t,
 		[]renderResponse{

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http_test.go
@@ -51,23 +51,29 @@ func newHTTPRenderer(t *testing.T, srv *httptest.Server) *vllmHTTPRenderer {
 	return r
 }
 
-// httpFixture mimics vLLM's /render endpoints and captures request bodies.
+// httpFixture mimics vLLM's /render endpoints and captures request bodies
+// and Authorization headers.
 func httpFixture(t *testing.T, completionsResp []renderResponse, chatResp renderResponse) (*httptest.Server, *httpCaptured) {
 	t.Helper()
 	cap := &httpCaptured{}
 	mux := http.NewServeMux()
 	mux.HandleFunc(completionsRenderPath, func(w http.ResponseWriter, r *http.Request) {
 		cap.completions, _ = io.ReadAll(r.Body)
+		cap.completionsAuth = r.Header.Get("Authorization")
 		_ = json.NewEncoder(w).Encode(completionsResp)
 	})
 	mux.HandleFunc(chatRenderPath, func(w http.ResponseWriter, r *http.Request) {
 		cap.chat, _ = io.ReadAll(r.Body)
+		cap.chatAuth = r.Header.Get("Authorization")
 		_ = json.NewEncoder(w).Encode(chatResp)
 	})
 	return httptest.NewServer(mux), cap
 }
 
-type httpCaptured struct{ completions, chat []byte }
+type httpCaptured struct {
+	completions, chat         []byte
+	completionsAuth, chatAuth string
+}
 
 func TestVLLMHTTPRenderer_Render(t *testing.T) {
 	srv, cap := httpFixture(t,
@@ -320,6 +326,45 @@ func TestProduce_MessagesVLLMHTTPFullAgenticTurn(t *testing.T) {
 	assert.Equal(t, "tool", toolResult["role"])
 	assert.Equal(t, "toolu_01", toolResult["tool_call_id"])
 	assert.Equal(t, "Sunny, 22C", toolResult["content"])
+}
+
+func TestProduce_VLLMHTTPForwardsAuthorization(t *testing.T) {
+	srv, cap := httpFixture(t,
+		[]renderResponse{{TokenIDs: []uint32{1}}}, renderResponse{TokenIDs: []uint32{2}})
+	defer srv.Close()
+
+	p := newTestPlugin(newHTTPRenderer(t, srv))
+
+	authReq := func() *scheduling.InferenceRequest {
+		return &scheduling.InferenceRequest{
+			Headers: map[string]string{"authorization": "Bearer secret-token"},
+			Body: &fwkrh.InferenceRequestBody{
+				ChatCompletions: &fwkrh.ChatCompletionsRequest{
+					Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Raw: "hi"}}},
+				},
+			},
+		}
+	}
+
+	require.NoError(t, p.Produce(context.Background(), authReq(), nil))
+	assert.Equal(t, "Bearer secret-token", cap.chatAuth)
+
+	completions := authReq()
+	completions.Body = &fwkrh.InferenceRequestBody{
+		Completions: &fwkrh.CompletionsRequest{Prompt: fwkrh.Prompt{Raw: "hello"}},
+	}
+	require.NoError(t, p.Produce(context.Background(), completions, nil))
+	assert.Equal(t, "Bearer secret-token", cap.completionsAuth)
+
+	cap.chatAuth = ""
+	require.NoError(t, p.Produce(context.Background(), &scheduling.InferenceRequest{
+		Body: &fwkrh.InferenceRequestBody{
+			ChatCompletions: &fwkrh.ChatCompletionsRequest{
+				Messages: []fwkrh.Message{{Role: "user", Content: fwkrh.Content{Raw: "hi"}}},
+			},
+		},
+	}, nil))
+	assert.Empty(t, cap.chatAuth, "request without Authorization must not send one")
 }
 
 func TestVLLMHTTPRenderer_RenderMultiPrompt(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind bug

**What this PR does / why we need it**:

The token-producer's vLLM HTTP render backend sends `/v1/completions/render` and `/v1/chat/completions/render` requests without an `Authorization` header. A vLLM instance started with `--api-key` rejects them with 401, so tokenization fails and every consumer of token IDs (precise prefix-cache routing among them) silently degrades.

The render backend forwards the inbound request's `Authorization` header verbatim on render requests. The render endpoint serves the same model as the pods the request is routed to, so the credential the client presents for inference is the credential the render endpoint expects. Requests without an `Authorization` header send none. 

The warmup probe runs at plugin load with no inbound request and therefore no credential. Against an endpoint started with `--api-key` it gets 401, treats it the same as "backend not yet reachable", and spends the full retry budget (24 attempts, 5s apart) before logging the generic `warmup did not complete` at DEBUG. An authentication rejection cannot clear on retry, so the probe returns on the first 401/403 and logs at Info that warmup was skipped and the first request pays the cold-start cost. `postJSON` returns a typed `renderStatusError` so the status code is available to the caller; the error text is unchanged.

Warmup is still not possible against an authenticated render endpoint. Supporting that would require a plugin-level credential (for example `vllm.apiKeyEnv`) used only by the warmup probe; that is left for a follow-up.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/llm-d/llm-d-router/issues/2671

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
token-producer forwards the inbound Authorization header on vLLM render requests, so render endpoints started with --api-key are supported. The startup warmup probe skips such endpoints instead of exhausting its retry budget.
```
