### PR TITLE
[ci]: Run required checks on merge_group events

### DIFF
--- a/.github/workflows/check-typos.yaml
+++ b/.github/workflows/check-typos.yaml
@@ -3,6 +3,8 @@ name: Check Typos
 on:
   pull_request:
   push:
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -12,6 +12,8 @@ on:
     branches:
       - main
     types: [ opened, synchronize, reopened ]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -59,7 +59,7 @@ jobs:
 
   verify-helm-charts:
     needs: check-changes
-    if: ${{ needs.check-changes.outputs.helm == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
+    if: ${{ needs.check-changes.outputs.helm == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -102,7 +102,7 @@ jobs:
       # Missing cache is not an error; compare-coverage.sh reports all
       # components as new and exits 0.
       - name: Restore main branch coverage baseline
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         uses: actions/cache/restore@v6
         with:
           path: coverage/baseline
@@ -134,13 +134,13 @@ jobs:
 
       - name: Compare coverage against main baseline
         id: coverage-gate
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         continue-on-error: true
         shell: bash
         run: make coverage-compare BASELINE_DIR=coverage/baseline
 
       - name: Find latest release branch
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         id: find-releases
         shell: bash
         run: |
@@ -154,7 +154,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Download and compare release coverage baselines
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         shell: bash
         run: |
           if [[ ! -s /tmp/release_branches.txt ]]; then
@@ -216,7 +216,7 @@ jobs:
           overwrite: true
 
       - name: Enforce coverage gate
-        if: github.event_name == 'pull_request' && steps.coverage-gate.outcome == 'failure'
+        if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && steps.coverage-gate.outcome == 'failure'
         run: |
           echo "::error::Coverage regression detected -- see the coverage report in the job summary above."
           exit 1

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -11,6 +11,8 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -9,6 +9,8 @@ on:
     branches: [ main ]
     types: [ opened, synchronize, reopened ]
   workflow_dispatch:
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
A merge queue needs every required check to trigger on the `merge_group` event GitHub creates for a queued merge. A workflow that doesn't subscribe to it never reports on that ref, so the queue waits on it indefinitely. Add `merge_group` to typos, lint, test, and markdown-link-check.

**Which issue(s) this PR fixes**:
Partial #2257

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
