### PR TITLE
Fix(helm): Enforce Boolean Types for Priority Routing and Health Checking

### DIFF
--- a/config/charts/routerlib/templates/_helpers.tpl
+++ b/config/charts/routerlib/templates/_helpers.tpl
@@ -464,7 +464,11 @@ Helper to check if priorityRouting is enabled across chart contexts.
 {{- $proxy := index $router "proxy" | default dict -}}
 {{- if empty $proxy }}{{ $proxy = .Values.proxy | default dict }}{{ end -}}
 {{- $pr := index $proxy "priorityRouting" | default dict -}}
-{{- if index $pr "enabled" }}true{{ end -}}
+{{- $enabled := index $pr "enabled" -}}
+{{- if and (not (kindIs "invalid" $enabled)) (not (kindIs "bool" $enabled)) -}}
+{{- fail (printf "priorityRouting.enabled must be a boolean, got %q" (toString $enabled)) -}}
+{{- end -}}
+{{- if and (kindIs "bool" $enabled) $enabled }}true{{ end -}}
 {{- end -}}
 
 {{- define "llm-d-router.priorityRouting.primaryReplicas" -}}
@@ -500,8 +504,14 @@ Helper to check if priorityRouting is enabled across chart contexts.
 {{- fail "priorityRouting is only supported when proxy mode is set to 'service' (router.proxy.mode=service)" -}}
 {{- end -}}
 {{- $eppFlags := .Values.router.epp.flags | default dict -}}
-{{- if and $isPriorityRouting (hasKey $eppFlags "health-checking") (not (index $eppFlags "health-checking")) -}}
+{{- if and $isPriorityRouting (hasKey $eppFlags "health-checking") -}}
+{{- $healthChecking := index $eppFlags "health-checking" -}}
+{{- if not (kindIs "bool" $healthChecking) -}}
+{{- fail (printf ".Values.router.epp.flags.health-checking must be a boolean, got %q" (toString $healthChecking)) -}}
+{{- end -}}
+{{- if not $healthChecking -}}
 {{- fail "priorityRouting requires EPP's gRPC health service on port 9002 (router.epp.flags.health-checking cannot be false when priorityRouting.enabled=true)" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/hack/verify-helm.sh
+++ b/hack/verify-helm.sh
@@ -226,6 +226,20 @@ if eval "${invalid_failopen_command}"; then
   exit 1
 fi
 
+invalid_priority_routing_enabled_command="${HELM} template ${SCRIPT_ROOT}/config/charts/llm-d-router-standalone --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set router.proxy.mode=service --set-string router.proxy.priorityRouting.enabled=false >/dev/null"
+echo "Executing: ${invalid_priority_routing_enabled_command}"
+if eval "${invalid_priority_routing_enabled_command}"; then
+  echo "Helm template unexpectedly succeeded for non-boolean router.proxy.priorityRouting.enabled"
+  exit 1
+fi
+
+invalid_priority_routing_health_checking_command="${HELM} template ${SCRIPT_ROOT}/config/charts/llm-d-router-standalone --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set router.proxy.mode=service --set router.proxy.priorityRouting.enabled=true --set-string router.epp.flags.health-checking=false >/dev/null"
+echo "Executing: ${invalid_priority_routing_health_checking_command}"
+if eval "${invalid_priority_routing_health_checking_command}"; then
+  echo "Helm template unexpectedly succeeded for non-boolean router.epp.flags.health-checking with priority routing"
+  exit 1
+fi
+
 echo "Verifying llm-d-router-standalone extra flags render as --flag=value..."
 flag_render_output="${TEMP_DIR}/llm-d-router-standalone-flag-render.yaml"
 flag_render_command="${HELM} template ${SCRIPT_ROOT}/config/charts/llm-d-router-standalone --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.inferencePool.create=false --set-string router.epp.flags.secure-serving=false > ${flag_render_output}"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`Values.router.proxy.priorityRouting.enabled` is defined as a boolean in `config/charts/llm-d-router-standalone/values.yaml`. However, in `_helpers.tpl`, any non-empty value including the string `"false" or "wrong"`, was treated as truthy and rendered as `true`.

The same missing type validation affected  `.Values.router.epp.flags.health-checking`

So the fix is to implement type validation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Fix(helm): Enforce Boolean Types for Priority Routing and Health Checking
```
