### PR TITLE
fix(kvevents): reject conflicting HMA group block sizes

### DIFF
--- a/pkg/kvevents/pool.go
+++ b/pkg/kvevents/pool.go
@@ -571,6 +571,19 @@ func (p *Pool) processEventBatch(ctx context.Context, batch *EventBatch, podIden
 						ev.KVCacheSpecKind = KVCacheSpecKind(meta.Kind)
 					}
 				} else {
+					if meta, found := p.groupCatalog.Get(podIdentifier, g); found &&
+						meta.Kind == string(ev.KVCacheSpecKind) && meta.BlockSize != ev.BlockSize {
+						metrics.KVEventStoresSkipped.WithLabelValues(
+							cacheKindLabel(ev.KVCacheSpecKind), "conflicting_block_size").Inc()
+						log.FromContext(ctx).V(logging.TRACE).Info("Skipping KV cache store event",
+							"podIdentifier", podIdentifier,
+							"groupIdx", ev.GroupIdx,
+							"cacheKind", ev.KVCacheSpecKind,
+							"reason", "conflicting_block_size",
+							"blockSize", ev.BlockSize,
+							"knownBlockSize", meta.BlockSize)
+						continue
+					}
 					p.groupCatalog.Learn(podIdentifier, g, kvblock.GroupMetadata{
 						Kind:              string(ev.KVCacheSpecKind),
 						BlockSize:         ev.BlockSize,

--- a/pkg/kvevents/pool_test.go
+++ b/pkg/kvevents/pool_test.go
@@ -874,6 +874,40 @@ func TestHMAGroupFilterRejectsSparseFullAttentionBeforeParentLookup(t *testing.T
 	assert.Error(t, err)
 }
 
+func TestHMAGroupFilterRejectsConflictingBlockSizeBeforeParentLookup(t *testing.T) {
+	ctx := logging.NewTestLoggerIntoContext(context.Background())
+	pool, idx, _ := newTestPool(t, 16)
+	recording := &recordingIndex{Index: idx}
+	pool.index = recording
+	groupIdx := 0
+
+	pool.processEventBatch(ctx, &EventBatch{Events: []GenericEvent{
+		&BlockStoredEvent{
+			BlockHashes:     makeEngineKeys(1, 960),
+			Tokens:          makeTokens(16),
+			GroupIdx:        &groupIdx,
+			KVCacheSpecKind: KVCacheSpecKindMlaAttention,
+			BlockSize:       16,
+		},
+	}}, "pod-hma", "test-model")
+
+	pool.processEventBatch(ctx, &EventBatch{Events: []GenericEvent{
+		&BlockStoredEvent{
+			BlockHashes:     makeEngineKeys(1, 961),
+			Tokens:          makeTokens(4),
+			ParentHash:      999,
+			GroupIdx:        &groupIdx,
+			KVCacheSpecKind: KVCacheSpecKindMlaAttention,
+			BlockSize:       4,
+		},
+	}}, "pod-hma", "test-model")
+
+	assert.Zero(t, recording.getRequestKeyCalls)
+	meta, ok := pool.GroupCatalog().Get("pod-hma", kvblock.GroupID(groupIdx))
+	require.True(t, ok)
+	assert.Equal(t, 16, meta.BlockSize)
+}
+
 func TestHMAGroupFilterIgnoresRejectedGroupRemoval(t *testing.T) {
 	ctx := logging.NewTestLoggerIntoContext(context.Background())
 	pool, idx, _ := newTestPool(t, 16)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Auxiliary cache events can report the same HMA group and cache kind as the dense cache stream while using a different block size. Accepting both streams overwrites the group metadata and attempts parent lookup against an incompatible lineage, producing repeated parent-key errors.

This change skips conflicting store events before catalog updates and parent lookup, recording the skip as `conflicting_block_size`. Events whose block size matches `tokenProcessor.BlockSize()` can replace conflicting learned metadata. If a 4-token auxiliary event arrives first after an EPP restart, a subsequent canonical 256-token event corrects the group metadata and can be indexed. Later conflicting auxiliary events are skipped.

**Which issue(s) this PR fixes**:

Fixes #2679

**Validation**:

- [x] Regression coverage for rejecting conflicting auxiliary events before parent lookup while preserving the learned canonical geometry.
- [x] Regression coverage for auxiliary-first arrival: correcting learned geometry, indexing a canonical parent and child, and rejecting a later auxiliary event before parent lookup. Confirmed this test fails without the canonical-size preference.
- [x] `go test ./pkg/kvevents -count=1`
- [x] Race tests for both conflicting-block-size regression cases.
- [x] `go vet ./pkg/kvevents`
- [x] `golangci-lint` on `pkg/kvevents` changes: 0 issues.
- [x] Commit signature and DCO checks.

Tests and vet ran with Go 1.27.1. Lint ran with golangci-lint 2.10.1 and Go 1.26.6. Full `make presubmit` was attempted but could not run because the local environment has neither Docker nor Podman.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Reject conflicting HMA KV-cache store events while allowing canonical events to correct group metadata learned from auxiliary events.
```
