### PR TITLE
fix(epp): read the KV-cache attribute the scorer declares

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/README.md
@@ -13,7 +13,14 @@ For each candidate endpoint, the plugin computes:
   {score(endpoint)} = 1 - {kvCacheUsagePercent}
 ```
 
-Where `kvCacheUsagePercent` is read from endpoint metrics.
+Where `kvCacheUsagePercent` is read from the `KVCacheUsagePercent` attribute
+the core metrics extractor publishes — the same attribute the plugin declares
+in `Consumes`.
+
+An endpoint without that attribute is left **unscored**, rather than scored as
+if its cache were empty. The two used to be the same reading, so an endpoint
+the extractor had not populated outranked every endpoint whose utilization was
+known.
 
 This means:
 

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization.go
@@ -22,8 +22,14 @@ import (
 
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 )
+
+// kvCacheUsageDataKey is the attribute this scorer declares and reads. Keeping
+// it in one place stops the declaration in Consumes and the read in Score from
+// naming different things, which is how they came apart in the first place.
+var kvCacheUsageDataKey = fwkplugin.NewDataKey(metrics.KVCacheUsagePercentKey, metrics.MetricsExtractorType)
 
 const (
 	KvCacheUtilizationScorerType = "kv-cache-utilization-scorer"
@@ -62,14 +68,14 @@ func (s *KVCacheUtilizationScorer) Category() fwksched.ScorerCategory {
 	return fwksched.Distribution
 }
 
-// Consumes declares that the scorer reads the KV-cache utilization field
-// from the endpoint's Metrics struct. The DataKey names the field the
-// core-metrics-extractor publishes; the registry validates the consumer's
+// Consumes declares the KV-cache utilization attribute the core metrics
+// extractor publishes. Required, so a config with no producer for it fails at
+// init rather than scoring on an absent value; the registry validates the
 // declared type against the producer's declaration.
 func (s *KVCacheUtilizationScorer) Consumes() fwkplugin.DataDependencies {
 	return fwkplugin.DataDependencies{
 		Required: map[fwkplugin.DataKey]any{
-			fwkplugin.NewDataKey(metrics.KVCacheUsagePercentKey, metrics.MetricsExtractorType): float64(0),
+			kvCacheUsageDataKey: attrmetrics.ScalarMetricValue(0),
 		},
 	}
 }
@@ -80,11 +86,24 @@ func (s *KVCacheUtilizationScorer) WithName(name string) *KVCacheUtilizationScor
 	return s
 }
 
-// Score returns the scoring result for the given list of endpoints based on context.
+// Score scores each endpoint as 1 - its KV-cache utilization, read from the
+// attribute Consumes declares.
+//
+// An endpoint without the attribute is left unscored rather than scored. The
+// read went through GetMetrics() before, where an endpoint the extractor has
+// not populated is indistinguishable from one reporting an empty cache: both
+// give 0, so the unknown endpoint scored 1.0 and outranked every endpoint
+// whose utilization was actually known. Reading the attribute makes absence
+// observable, and omitting is what the multi-cluster variant in this package
+// already does.
 func (s *KVCacheUtilizationScorer) Score(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) map[fwksched.Endpoint]float64 {
 	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 	for _, endpoint := range endpoints {
-		scores[endpoint] = 1 - endpoint.GetMetrics().KVCacheUsagePercent
+		util, ok := attrmetrics.ReadScalarMetricValue(endpoint, kvCacheUsageDataKey)
+		if !ok {
+			continue
+		}
+		scores[endpoint] = 1 - float64(util)
 	}
 	return scores
 }

--- a/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization/kvcache_utilization_test.go
@@ -24,7 +24,16 @@ import (
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
 )
+
+// endpointWith builds an endpoint carrying the KV-cache utilization attribute,
+// the way the core metrics extractor publishes it.
+func endpointWith(util float64) fwksched.Endpoint {
+	attr := fwkdl.NewAttributes()
+	attr.Put(kvCacheUsageDataKey, attrmetrics.ScalarMetricValue(util))
+	return fwksched.NewEndpoint(nil, nil, attr)
+}
 
 func TestKvCacheUtilizationScorer(t *testing.T) {
 	tests := []struct {
@@ -33,12 +42,8 @@ func TestKvCacheUtilizationScorer(t *testing.T) {
 		expectedScoresEndpoint map[int]float64 // Map of endpoint index to expected score
 	}{
 		{
-			name: "Different KV cache utilization",
-			endpoints: []fwksched.Endpoint{
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{}, &fwkdl.Metrics{KVCacheUsagePercent: 0.8}, nil),
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{}, &fwkdl.Metrics{KVCacheUsagePercent: 0.5}, nil),
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{}, &fwkdl.Metrics{KVCacheUsagePercent: 0.0}, nil),
-			},
+			name:      "Different KV cache utilization",
+			endpoints: []fwksched.Endpoint{endpointWith(0.8), endpointWith(0.5), endpointWith(0.0)},
 			expectedScoresEndpoint: map[int]float64{
 				0: 0.2, // Highest KV cache usage (0.8) gets lowest score (1-0.8=0.2)
 				1: 0.5, // Medium KV cache usage (0.5) gets medium score (1-0.5=0.5)
@@ -46,33 +51,24 @@ func TestKvCacheUtilizationScorer(t *testing.T) {
 			},
 		},
 		{
-			name: "Same KV cache utilization",
-			endpoints: []fwksched.Endpoint{
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{}, &fwkdl.Metrics{KVCacheUsagePercent: 0.6}, nil),
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{}, &fwkdl.Metrics{KVCacheUsagePercent: 0.6}, nil),
-			},
+			name:      "Same KV cache utilization",
+			endpoints: []fwksched.Endpoint{endpointWith(0.6), endpointWith(0.6)},
 			expectedScoresEndpoint: map[int]float64{
 				0: 0.4, // Both get same score (1-0.6=0.4)
 				1: 0.4,
 			},
 		},
 		{
-			name: "Zero KV cache utilization",
-			endpoints: []fwksched.Endpoint{
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{}, &fwkdl.Metrics{KVCacheUsagePercent: 0.0}, nil),
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{}, &fwkdl.Metrics{KVCacheUsagePercent: 0.0}, nil),
-			},
+			name:      "Zero KV cache utilization",
+			endpoints: []fwksched.Endpoint{endpointWith(0.0), endpointWith(0.0)},
 			expectedScoresEndpoint: map[int]float64{
 				0: 1.0, // No KV cache usage gets highest score
 				1: 1.0,
 			},
 		},
 		{
-			name: "Full KV cache utilization",
-			endpoints: []fwksched.Endpoint{
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{}, &fwkdl.Metrics{KVCacheUsagePercent: 1.0}, nil),
-				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{}, &fwkdl.Metrics{KVCacheUsagePercent: 0.5}, nil),
-			},
+			name:      "Full KV cache utilization",
+			endpoints: []fwksched.Endpoint{endpointWith(1.0), endpointWith(0.5)},
 			expectedScoresEndpoint: map[int]float64{
 				0: 0.0, // Full KV cache (1.0) gets lowest score (1-1=0)
 				1: 0.5, // Half KV cache (0.5) gets medium score (1-0.5=0.5)
@@ -90,4 +86,39 @@ func TestKvCacheUtilizationScorer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// An endpoint the extractor has not populated is left out of the scores rather
+// than scored 1.0. Through GetMetrics() the two were the same reading — an
+// absent value and an empty cache both came back 0 — so an endpoint nothing was
+// known about outranked every endpoint whose utilization was known.
+func TestKvCacheUtilizationScorerSkipsEndpointsWithoutTheAttribute(t *testing.T) {
+	known := endpointWith(0.9)
+	unknown := fwksched.NewEndpoint(nil, nil, nil)
+
+	scores := NewKVCacheUtilizationScorer().Score(
+		context.Background(), &fwksched.InferenceRequest{},
+		[]fwksched.Endpoint{known, unknown})
+
+	assert.Len(t, scores, 1, "only the endpoint carrying the attribute is scored")
+	assert.InDelta(t, 0.1, scores[known], 0.0001)
+
+	_, scored := scores[unknown]
+	assert.False(t, scored, "an endpoint without the attribute must not be scored")
+}
+
+// The scorer reads the key it declares. Consumes and Score naming different
+// keys is what let the declaration and the read drift apart before.
+func TestKvCacheUtilizationScorerReadsTheKeyItDeclares(t *testing.T) {
+	s := NewKVCacheUtilizationScorer()
+
+	_, declared := s.Consumes().Required[kvCacheUsageDataKey]
+	assert.True(t, declared, "the key Score reads must be the one Consumes declares")
+
+	attr := fwkdl.NewAttributes()
+	attr.Put(kvCacheUsageDataKey, attrmetrics.ScalarMetricValue(0.25))
+	ep := fwksched.NewEndpoint(nil, nil, attr)
+
+	scores := s.Score(context.Background(), &fwksched.InferenceRequest{}, []fwksched.Endpoint{ep})
+	assert.InDelta(t, 0.75, scores[ep], 0.0001)
 }

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -32,6 +32,8 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+	extractormetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/metrics"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/picker"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/picker/maxscore"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/profilehandler/single"
@@ -40,6 +42,18 @@ import (
 	schedprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/prefix"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/queuedepth"
 )
+
+// kvAttr carries the KV-cache utilization attribute the core metrics extractor
+// publishes, which the kv-cache-utilization scorer reads. The Metrics struct is
+// still populated alongside it: the queue and lora scorers in this profile read
+// from there.
+func kvAttr(util float64) fwkdl.AttributeMap {
+	attr := fwkdl.NewAttributes()
+	attr.Put(
+		fwkplugin.NewDataKey(extractormetrics.KVCacheUsagePercentKey, extractormetrics.MetricsExtractorType),
+		attrmetrics.ScalarMetricValue(util))
+	return attr
+}
 
 // Tests the default scheduler configuration and expected behavior.
 func TestSchedule(t *testing.T) {
@@ -100,7 +114,7 @@ func TestSchedule(t *testing.T) {
 							"foo": 1,
 							"bar": 1,
 						},
-					}, nil),
+					}, kvAttr(0.2)),
 				fwksched.NewEndpoint(
 					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}},
 					&fwkdl.Metrics{
@@ -111,7 +125,7 @@ func TestSchedule(t *testing.T) {
 							"foo":      1,
 							"critical": 1,
 						},
-					}, nil),
+					}, kvAttr(0.2)),
 				fwksched.NewEndpoint(
 					&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod3"}},
 					&fwkdl.Metrics{
@@ -121,7 +135,7 @@ func TestSchedule(t *testing.T) {
 						ActiveModels: map[string]int{
 							"foo": 1,
 						},
-					}, nil),
+					}, kvAttr(0.8)),
 			},
 			wantRes: &fwksched.SchedulingResult{
 				ProfileResults: map[string]*fwksched.ProfileRunResult{
@@ -138,7 +152,7 @@ func TestSchedule(t *testing.T) {
 											"foo":      1,
 											"critical": 1,
 										},
-									}, nil),
+									}, kvAttr(0.2)),
 								Score: 2.8,
 							},
 						},


### PR DESCRIPTION
KVCacheUtilizationScorer declares a Required dependency on the
KVCacheUsagePercent attribute published by the core metrics extractor, then
scores from endpoint.GetMetrics().KVCacheUsagePercent. The declaration and the
read name different things, and the read is the one that loses information.

Through GetMetrics(), an endpoint the extractor has not populated is
indistinguishable from one reporting an empty cache: both come back 0, so the
unknown endpoint scores 1 - 0 = 1.0 and outranks every endpoint whose
utilization is actually known. An endpoint nothing is known about is the most
attractive one in the pool.

Required does not prevent this. data_graph.go checks that a producer exists
for the key, not that every endpoint carries a value, so an endpoint whose
scrape has not landed yet reaches Score with nothing in it.

Reading the declared attribute makes absence observable, and an endpoint
without it is left unscored rather than scored. That is what
MultiClusterScorer in this same package already does, for the same reason its
comment gives - the stock per-pod field is empty there, so it scores on the
attribute or not at all.

No behaviour changes when the attribute is present: the four existing cases
keep their expected scores unchanged, and TestSchedule's composite Score of
2.8 across four scorers is unchanged once its endpoints carry the attribute
they always had in Metrics.

Scope: this scorer only. queuedepth and runningrequests have the same split
between what they declare and what they read, and can follow in the same shape
if this one is accepted. The Metrics fields stay - latency, loadaware and
loraaffinity read them and are not part of this.

Part of #2059 item 2.