### PR TITLE
Add discovery-backed vLLM render balancing

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -30,7 +30,8 @@ Backend selection:
   scheme (`https://`). For in-cluster endpoints using self-signed or private CA
   certificates, configure `vllm.caCertPath` to trust the CA, and optionally
   `vllm.clientCertPath`/`vllm.clientKeyPath` for mTLS. Future protocol fields
-  (e.g. `grpc`) can be added alongside `url` under the same `vllm` block.
+  (e.g. `grpc`) can be added under the same `vllm` block. The HTTP renderer uses
+  either one configured URL or endpoints supplied by data-layer discovery.
 
 > [!WARNING]
 > The `estimate` backend approximates token boundaries (≈4 bytes/token); its
@@ -44,7 +45,9 @@ Backend selection:
 | Parameter                  | Default                 | Description                                                                  |
 | -------------------------- | ----------------------- | ---------------------------------------------------------------------------- |
 | `modelName`                | – (required for `vllm`) | Model whose tokenizer should be loaded / sent in render requests.            |
-| `vllm.url`                 | `http://localhost:8000` | Base URL of the vLLM render endpoint (no trailing slash).                    |
+| `vllm.url`                 | `http://localhost:8000` | Base URL of one vLLM render endpoint. Mutually exclusive with `endpointDiscovery`. |
+| `vllm.endpointDiscovery`   | unset                   | Use the address and port of each endpoint published by data-layer discovery. |
+| `vllm.endpointDiscovery.loadBalancer.type` | `round-robin` | Load-balancing algorithm for discovered endpoints.                 |
 | `vllm.timeout`             | `5s`                    | Per-request timeout for text-only requests.                                  |
 | `vllm.mmTimeout`           | `30s`                   | Per-request timeout for multimodal requests.                                 |
 | `vllm.caCertPath`          | system CA pool          | PEM CA bundle for verifying the render endpoint when using `https://`.       |
@@ -209,6 +212,23 @@ containers:
         name: vllm-api-key
         key: api-key
 ```
+
+Plugin config - discovered engine endpoints:
+
+```yaml
+- type: token-producer
+  parameters:
+    modelName: "${MODEL_NAME}"
+    vllm:
+      endpointDiscovery:
+        loadBalancer:
+          type: round-robin
+```
+
+The Kubernetes discovery path supplies Ready `InferencePool` endpoints and
+their target ports. Other discovery plugins feed the same renderer path; for
+example, `file-discovery` can supply explicit render addresses and ports.
+Discovered endpoints use HTTP.
 
 A complete sample config that pairs this with `precise-prefix-cache-producer` and `prefix-cache-scorer` is at [`deploy/config/sim-epp-tokenizer-vllm-http-config.yaml`](../../../../../../../deploy/config/sim-epp-tokenizer-vllm-http-config.yaml).
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -50,6 +50,10 @@ Backend selection:
 | `vllm.endpointDiscovery.portRules` | empty             | Optional render port mappings; see [Endpoint discovery](#endpoint-discovery). |
 | `vllm.endpointDiscovery.loadBalancer.type` | `round-robin` | Selection algorithm; `round-robin` is the only built-in algorithm. |
 | `vllm.endpointDiscovery.attemptTimeout` | unset         | Optional positive duration limiting each render attempt, e.g. `1s`. |
+| `vllm.endpointDiscovery.discoverModelLimits` | `false` | Probe model context capacity; see [Context limits](#context-limits). |
+| `vllm.endpointDiscovery.minModelLen` | `0` | Minimum eligible renderer context capacity. |
+| `vllm.endpointDiscovery.contextLimitLabel` | unset | Label supplying a positive context capacity, optionally bounded by probes. |
+| `vllm.prefillOnly` | `false` | Use a one-token output budget only for rendering; see [Render-only output budget](#render-only-output-budget). |
 | `vllm.timeout`             | `5s`                    | Per-request timeout for text-only requests.                                  |
 | `vllm.mmTimeout`           | `30s`                   | Per-request timeout for multimodal requests.                                 |
 | `vllm.caCertPath`          | system CA pool          | PEM CA bundle for verifying the render endpoint when using `https://`.       |
@@ -279,10 +283,52 @@ also has at most one second. Choose an attempt timeout that accommodates normal
 render latency, including multimodal processing. Without an attempt timeout,
 a slow endpoint can consume the request budget and leave no time for a retry.
 
-With no discovered endpoints, rendering returns an error. Failed URLs remain
-eligible for subsequent requests until discovery removes them; there is no
-circuit breaker or separate render health probe. Retry exclusions preserve
-round-robin cursor progression across the full endpoint list.
+With no eligible discovered endpoints, rendering returns an error. Render
+failures do not remove URLs from subsequent requests; there is no render
+circuit breaker. Retry exclusions preserve round-robin cursor progression
+across the eligible endpoint list.
+
+#### Context limits
+
+Set `vllm.endpointDiscovery.discoverModelLimits: true` to verify each target's
+configured model and `max_model_len` through `GET /v1/models`. Unknown targets,
+failed probes, and observations older than 90 seconds are excluded. Probes run
+every 30 seconds with at most four concurrent requests and a two-second timeout
+per target. New endpoints can wait until the next probe cycle. Probes use
+`VLLM_API_KEY` when set; they do not use an incoming request's credentials.
+The models endpoint verifies model metadata, not render-route availability.
+
+`vllm.endpointDiscovery.minModelLen` sets a nonnegative minimum context capacity
+for the renderer pool. It requires model-limit discovery or
+`vllm.endpointDiscovery.contextLimitLabel`, which names a metadata label holding
+a positive integer capacity. With both sources configured, the smaller limit
+applies. Missing or invalid labels exclude the endpoint.
+
+```yaml
+vllm:
+  endpointDiscovery:
+    discoverModelLimits: true
+    minModelLen: 265088
+    contextLimitLabel: llm-d.ai/render-context-limit
+```
+
+These options are unset by default. They select a renderer pool with a known
+minimum capacity; they do not route by each request's token count, truncate
+prompts, or validate the inference endpoint's capacity. Rendering errors retain
+the existing token-producer error behavior.
+
+#### Render-only output budget
+
+Set `vllm.prefillOnly: true` when the renderer should validate the full prompt
+without reserving the client's generation budget. The render copy uses
+`max_tokens: 1`, caps `max_completion_tokens` at one when present, and sets
+`min_tokens` to zero when present. The inference payload, prompt, and requested
+generation budget are unchanged. This option is false by default and also
+works with `vllm.url`.
+
+This avoids rejecting a prompt solely because its requested output would
+exceed the renderer's context capacity. The prompt itself must still fit;
+this option does not enable partial matching or extend inference context limits.
 
 Each named token producer maintains its own endpoint set and balancing state.
 Its HTTP/1.1 transport retains up to 16 idle connections per endpoint, with no

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -49,6 +49,7 @@ Backend selection:
 | `vllm.endpointDiscovery`   | unset                   | Use endpoints published by data-layer discovery.                              |
 | `vllm.endpointDiscovery.portRules` | empty             | Optional render port mappings; see [Endpoint discovery](#endpoint-discovery). |
 | `vllm.endpointDiscovery.loadBalancer.type` | `round-robin` | Selection algorithm; `round-robin` is the only built-in algorithm. |
+| `vllm.endpointDiscovery.attemptTimeout` | unset         | Optional positive duration limiting each render attempt, e.g. `1s`. |
 | `vllm.timeout`             | `5s`                    | Per-request timeout for text-only requests.                                  |
 | `vllm.mmTimeout`           | `30s`                   | Per-request timeout for multimodal requests.                                 |
 | `vllm.caCertPath`          | system CA pool          | PEM CA bundle for verifying the render endpoint when using `https://`.       |
@@ -268,11 +269,18 @@ reject plugin configuration at startup.
 Transport failures, attempt timeouts, HTTP 408, HTTP 429, and HTTP 5xx permit
 one retry on a different discovered URL. Other HTTP errors return immediately.
 Both attempts share `vllm.timeout` or `vllm.mmTimeout`, capped by the caller's
-deadline. When an alternate URL is available, the first attempt gets half the
-remaining budget and the retry gets the remainder. A single endpoint uses the
-full budget. With no discovered endpoints, rendering returns an error. Failed
-URLs remain eligible for subsequent requests until discovery removes them;
-there is no circuit breaker or separate render health probe.
+deadline. By default, each attempt can use the full remaining request budget.
+Set `vllm.endpointDiscovery.attemptTimeout` to opt into a shorter deadline on
+each attempt, including retries. For example, `attemptTimeout: 1s` with
+`timeout: 5s` permits retrying a slow endpoint after one second; the alternate
+also has at most one second. Choose an attempt timeout that accommodates normal
+render latency, including multimodal processing. Without an attempt timeout,
+a slow endpoint can consume the request budget and leave no time for a retry.
+
+With no discovered endpoints, rendering returns an error. Failed URLs remain
+eligible for subsequent requests until discovery removes them; there is no
+circuit breaker or separate render health probe. Retry exclusions preserve
+round-robin cursor progression across the full endpoint list.
 
 Each named token producer maintains its own endpoint set and balancing state.
 Its HTTP/1.1 transport retains up to 16 idle connections per endpoint, with no
@@ -280,7 +288,7 @@ global idle-connection cap; idle connections expire after 90 seconds.
 Alternative algorithms can be implemented in the tokenizer package through
 `endpointLoadBalancer` and registered in `endpointLoadBalancerFactories`.
 The picker supplies an independent snapshot without holding its endpoint lock;
-algorithms must support concurrent calls to `Pick`.
+algorithms must support concurrent calls to `Pick` and skip excluded URLs.
 
 A complete sample config that pairs this with `precise-prefix-cache-producer` and `prefix-cache-scorer` is at [`deploy/config/sim-epp-tokenizer-vllm-http-config.yaml`](../../../../../../../deploy/config/sim-epp-tokenizer-vllm-http-config.yaml).
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -257,7 +257,9 @@ map these endpoints; they do not discover extra pods or ranks. Other discovery
 plugins feed the same renderer path; `file-discovery`, for example, can supply
 explicit render addresses and ports. All selected endpoints must serve the
 configured model and expose the render routes. Discovered URLs use HTTP;
-use `vllm.url` for an HTTPS endpoint.
+nonempty `caCertPath`, `clientCertPath`, or `clientKeyPath`, or
+`insecureSkipVerify: true`, are rejected with `endpointDiscovery` at startup.
+Use `vllm.url` for an HTTPS endpoint.
 
 Each rule's `basePort` is required and must be between 1 and 65535. An empty or
 omitted `selector` matches all endpoints, so a final catch-all rule can provide

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -47,8 +47,8 @@ Backend selection:
 | `modelName`                | – (required for `vllm`) | Model whose tokenizer should be loaded / sent in render requests.            |
 | `vllm.url`                 | `http://localhost:8000` | Base URL of one vLLM render endpoint. Mutually exclusive with `endpointDiscovery`. |
 | `vllm.endpointDiscovery`   | unset                   | Use endpoints published by data-layer discovery.                              |
-| `vllm.endpointDiscovery.portRules` | empty             | Ordered label-selector rules that resolve render ports as `basePort + RankIndex`; an empty list uses each endpoint's inference port. |
-| `vllm.endpointDiscovery.loadBalancer.type` | `round-robin` | Load-balancing algorithm for discovered endpoints.                 |
+| `vllm.endpointDiscovery.portRules` | empty             | Optional render port mappings; see [Endpoint discovery](#endpoint-discovery). |
+| `vllm.endpointDiscovery.loadBalancer.type` | `round-robin` | Selection algorithm; `round-robin` is the only built-in algorithm. |
 | `vllm.timeout`             | `5s`                    | Per-request timeout for text-only requests.                                  |
 | `vllm.mmTimeout`           | `30s`                   | Per-request timeout for multimodal requests.                                 |
 | `vllm.caCertPath`          | system CA pool          | PEM CA bundle for verifying the render endpoint when using `https://`.       |
@@ -214,7 +214,22 @@ containers:
         key: api-key
 ```
 
-Plugin config - discovered engine endpoints:
+### Endpoint discovery
+
+Set `vllm.endpointDiscovery: {}` to use discovered inference addresses and
+ports with round-robin balancing. Omitted or empty `portRules` keeps each
+endpoint's inference port. Use this when `/v1/*/render` is served on the same
+listener as inference.
+
+When render uses a different listener, configure ordered `portRules`. The
+first matching Kubernetes label selector resolves the port as
+`basePort + RankIndex`. `RankIndex` is the endpoint's zero-based position in
+the `InferencePool`'s `targetPorts`, not a port-number difference. For example,
+a decode endpoint at index 3 uses render port `8203` with `basePort: 8200`,
+even when its inference port is `8003`.
+
+This configuration maps prefill and decode endpoints to separate render port
+ranges:
 
 ```yaml
 - type: token-producer
@@ -236,12 +251,36 @@ Plugin config - discovered engine endpoints:
 ```
 
 The Kubernetes discovery path supplies Ready `InferencePool` endpoints and
-their target ports. Other discovery plugins feed the same renderer path; for
-example, `file-discovery` can supply explicit render addresses and ports.
-With no `portRules`, the renderer uses those inference ports. When rules are
-configured, the first matching Kubernetes label selector chooses the render
-base port and each endpoint's `RankIndex` supplies the port offset. Every
-discovered endpoint must match a rule. Discovered endpoints use HTTP.
+removes endpoints when their pods become unready or leave the pool. Port rules
+map these endpoints; they do not discover extra pods or ranks. Other discovery
+plugins feed the same renderer path; `file-discovery`, for example, can supply
+explicit render addresses and ports. All selected endpoints must serve the
+configured model and expose the render routes. Discovered URLs use HTTP;
+use `vllm.url` for an HTTPS endpoint.
+
+Each rule's `basePort` is required and must be between 1 and 65535. An empty or
+omitted `selector` matches all endpoints, so a final catch-all rule can provide
+a default base port. Nonempty rule lists have no inference-port fallback:
+unmatched endpoints and endpoints whose resolved ports are out of range are
+excluded, and the data layer logs the error. Invalid selectors and base ports
+reject plugin configuration at startup.
+
+Transport failures, attempt timeouts, HTTP 408, HTTP 429, and HTTP 5xx permit
+one retry on a different discovered URL. Other HTTP errors return immediately.
+Both attempts share `vllm.timeout` or `vllm.mmTimeout`, capped by the caller's
+deadline. When an alternate URL is available, the first attempt gets half the
+remaining budget and the retry gets the remainder. A single endpoint uses the
+full budget. With no discovered endpoints, rendering returns an error. Failed
+URLs remain eligible for subsequent requests until discovery removes them;
+there is no circuit breaker or separate render health probe.
+
+Each named token producer maintains its own endpoint set and balancing state.
+Its HTTP/1.1 transport retains up to 16 idle connections per endpoint, with no
+global idle-connection cap; idle connections expire after 90 seconds.
+Alternative algorithms can be implemented in the tokenizer package through
+`endpointLoadBalancer` and registered in `endpointLoadBalancerFactories`.
+The picker supplies an independent snapshot without holding its endpoint lock;
+algorithms must support concurrent calls to `Pick`.
 
 A complete sample config that pairs this with `precise-prefix-cache-producer` and `prefix-cache-scorer` is at [`deploy/config/sim-epp-tokenizer-vllm-http-config.yaml`](../../../../../../../deploy/config/sim-epp-tokenizer-vllm-http-config.yaml).
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/README.md
@@ -46,7 +46,8 @@ Backend selection:
 | -------------------------- | ----------------------- | ---------------------------------------------------------------------------- |
 | `modelName`                | – (required for `vllm`) | Model whose tokenizer should be loaded / sent in render requests.            |
 | `vllm.url`                 | `http://localhost:8000` | Base URL of one vLLM render endpoint. Mutually exclusive with `endpointDiscovery`. |
-| `vllm.endpointDiscovery`   | unset                   | Use the address and port of each endpoint published by data-layer discovery. |
+| `vllm.endpointDiscovery`   | unset                   | Use endpoints published by data-layer discovery.                              |
+| `vllm.endpointDiscovery.portRules` | empty             | Ordered label-selector rules that resolve render ports as `basePort + RankIndex`; an empty list uses each endpoint's inference port. |
 | `vllm.endpointDiscovery.loadBalancer.type` | `round-robin` | Load-balancing algorithm for discovered endpoints.                 |
 | `vllm.timeout`             | `5s`                    | Per-request timeout for text-only requests.                                  |
 | `vllm.mmTimeout`           | `30s`                   | Per-request timeout for multimodal requests.                                 |
@@ -221,6 +222,15 @@ Plugin config - discovered engine endpoints:
     modelName: "${MODEL_NAME}"
     vllm:
       endpointDiscovery:
+        portRules:
+          - selector:
+              matchLabels:
+                llm-d.ai/role: prefill
+            basePort: 8000
+          - selector:
+              matchLabels:
+                llm-d.ai/role: decode
+            basePort: 8200
         loadBalancer:
           type: round-robin
 ```
@@ -228,7 +238,10 @@ Plugin config - discovered engine endpoints:
 The Kubernetes discovery path supplies Ready `InferencePool` endpoints and
 their target ports. Other discovery plugins feed the same renderer path; for
 example, `file-discovery` can supply explicit render addresses and ports.
-Discovered endpoints use HTTP.
+With no `portRules`, the renderer uses those inference ports. When rules are
+configured, the first matching Kubernetes label selector chooses the render
+base port and each endpoint's `RankIndex` supplies the port offset. Every
+discovered endpoint must match a rule. Discovered endpoints use HTTP.
 
 A complete sample config that pairs this with `precise-prefix-cache-producer` and `prefix-cache-scorer` is at [`deploy/config/sim-epp-tokenizer-vllm-http-config.yaml`](../../../../../../../deploy/config/sim-epp-tokenizer-vllm-http-config.yaml).
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery.go
@@ -37,6 +37,7 @@ type endpointDiscoveryConfig struct {
 	LoadBalancer *loadBalancerConfig `json:"loadBalancer,omitempty"`
 }
 
+// loadBalancerType returns the configured algorithm or the default round-robin algorithm.
 func (c *endpointDiscoveryConfig) loadBalancerType() string {
 	if c == nil || c.LoadBalancer == nil || c.LoadBalancer.Type == "" {
 		return roundRobinLoadBalancerType
@@ -44,26 +45,32 @@ func (c *endpointDiscoveryConfig) loadBalancerType() string {
 	return c.LoadBalancer.Type
 }
 
+// renderEndpointPicker resolves the base URL for one render request.
 type renderEndpointPicker interface {
 	Pick() (string, error)
 }
 
+// fixedEndpointPicker always returns the statically configured render URL.
 type fixedEndpointPicker string
 
+// Pick returns the static render URL.
 func (p fixedEndpointPicker) Pick() (string, error) {
 	return string(p), nil
 }
 
+// endpointLoadBalancer selects from the current discovered endpoint snapshot.
 type endpointLoadBalancer interface {
 	Pick(endpoints []string) (string, error)
 }
 
 type endpointLoadBalancerFactory func() endpointLoadBalancer
 
+// endpointLoadBalancerFactories maps configuration names to algorithm constructors.
 var endpointLoadBalancerFactories = map[string]endpointLoadBalancerFactory{
 	roundRobinLoadBalancerType: func() endpointLoadBalancer { return &roundRobinLoadBalancer{} },
 }
 
+// newEndpointLoadBalancer constructs the configured selection algorithm.
 func newEndpointLoadBalancer(loadBalancerType string) (endpointLoadBalancer, error) {
 	factory, ok := endpointLoadBalancerFactories[loadBalancerType]
 	if !ok {
@@ -72,11 +79,13 @@ func newEndpointLoadBalancer(loadBalancerType string) (endpointLoadBalancer, err
 	return factory(), nil
 }
 
+// roundRobinLoadBalancer rotates requests through the endpoint snapshot.
 type roundRobinLoadBalancer struct {
 	mu   sync.Mutex
 	next int
 }
 
+// Pick returns the next endpoint and advances the concurrency-safe cursor.
 func (b *roundRobinLoadBalancer) Pick(endpoints []string) (string, error) {
 	if len(endpoints) == 0 {
 		return "", errors.New("no vLLM render endpoints discovered")
@@ -92,6 +101,7 @@ func (b *roundRobinLoadBalancer) Pick(endpoints []string) (string, error) {
 	return endpoint, nil
 }
 
+// discoveredEndpointPicker maintains render URLs keyed by endpoint identity.
 type discoveredEndpointPicker struct {
 	mu           sync.RWMutex
 	endpoints    map[string]string
@@ -99,6 +109,7 @@ type discoveredEndpointPicker struct {
 	loadBalancer endpointLoadBalancer
 }
 
+// newDiscoveredEndpointPicker constructs a picker with the configured algorithm.
 func newDiscoveredEndpointPicker(loadBalancerType string) (*discoveredEndpointPicker, error) {
 	loadBalancer, err := newEndpointLoadBalancer(loadBalancerType)
 	if err != nil {
@@ -110,12 +121,14 @@ func newDiscoveredEndpointPicker(loadBalancerType string) (*discoveredEndpointPi
 	}, nil
 }
 
+// Pick selects a render URL from a stable endpoint snapshot.
 func (p *discoveredEndpointPicker) Pick() (string, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.loadBalancer.Pick(p.ordered)
 }
 
+// Upsert validates endpoint metadata and stores its HTTP render URL by identity.
 func (p *discoveredEndpointPicker) Upsert(meta *fwkdl.EndpointMetadata) error {
 	if meta == nil {
 		return errors.New("discovered endpoint metadata is nil")
@@ -138,6 +151,7 @@ func (p *discoveredEndpointPicker) Upsert(meta *fwkdl.EndpointMetadata) error {
 	return nil
 }
 
+// Delete removes an endpoint from render selection by identity.
 func (p *discoveredEndpointPicker) Delete(meta *fwkdl.EndpointMetadata) {
 	if meta == nil || meta.ID.Name == "" {
 		return
@@ -149,6 +163,7 @@ func (p *discoveredEndpointPicker) Delete(meta *fwkdl.EndpointMetadata) {
 	p.rebuildOrdered()
 }
 
+// rebuildOrdered sorts by endpoint identity so event arrival order does not affect selection.
 func (p *discoveredEndpointPicker) rebuildOrdered() {
 	ids := make([]string, 0, len(p.endpoints))
 	for id := range p.endpoints {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenizer
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sort"
+	"strconv"
+	"sync"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+)
+
+const roundRobinLoadBalancerType = "round-robin"
+
+type loadBalancerConfig struct {
+	Type string `json:"type,omitempty"`
+}
+
+type endpointDiscoveryConfig struct {
+	LoadBalancer *loadBalancerConfig `json:"loadBalancer,omitempty"`
+}
+
+func (c *endpointDiscoveryConfig) loadBalancerType() string {
+	if c == nil || c.LoadBalancer == nil || c.LoadBalancer.Type == "" {
+		return roundRobinLoadBalancerType
+	}
+	return c.LoadBalancer.Type
+}
+
+type renderEndpointPicker interface {
+	Pick() (string, error)
+}
+
+type fixedEndpointPicker string
+
+func (p fixedEndpointPicker) Pick() (string, error) {
+	return string(p), nil
+}
+
+type endpointLoadBalancer interface {
+	Pick(endpoints []string) (string, error)
+}
+
+type endpointLoadBalancerFactory func() endpointLoadBalancer
+
+var endpointLoadBalancerFactories = map[string]endpointLoadBalancerFactory{
+	roundRobinLoadBalancerType: func() endpointLoadBalancer { return &roundRobinLoadBalancer{} },
+}
+
+func newEndpointLoadBalancer(loadBalancerType string) (endpointLoadBalancer, error) {
+	factory, ok := endpointLoadBalancerFactories[loadBalancerType]
+	if !ok {
+		return nil, fmt.Errorf("unsupported load balancer %q", loadBalancerType)
+	}
+	return factory(), nil
+}
+
+type roundRobinLoadBalancer struct {
+	mu   sync.Mutex
+	next int
+}
+
+func (b *roundRobinLoadBalancer) Pick(endpoints []string) (string, error) {
+	if len(endpoints) == 0 {
+		return "", errors.New("no vLLM render endpoints discovered")
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.next >= len(endpoints) {
+		b.next = 0
+	}
+	endpoint := endpoints[b.next]
+	b.next = (b.next + 1) % len(endpoints)
+	return endpoint, nil
+}
+
+type discoveredEndpointPicker struct {
+	mu           sync.RWMutex
+	endpoints    map[string]string
+	ordered      []string
+	loadBalancer endpointLoadBalancer
+}
+
+func newDiscoveredEndpointPicker(loadBalancerType string) (*discoveredEndpointPicker, error) {
+	loadBalancer, err := newEndpointLoadBalancer(loadBalancerType)
+	if err != nil {
+		return nil, err
+	}
+	return &discoveredEndpointPicker{
+		endpoints:    map[string]string{},
+		loadBalancer: loadBalancer,
+	}, nil
+}
+
+func (p *discoveredEndpointPicker) Pick() (string, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.loadBalancer.Pick(p.ordered)
+}
+
+func (p *discoveredEndpointPicker) Upsert(meta *fwkdl.EndpointMetadata) error {
+	if meta == nil {
+		return errors.New("discovered endpoint metadata is nil")
+	}
+	if meta.ID.Name == "" {
+		return errors.New("discovered endpoint ID is empty")
+	}
+	if meta.Address == "" {
+		return fmt.Errorf("discovered endpoint %s has an empty address", meta.ID)
+	}
+	port, err := strconv.Atoi(meta.Port)
+	if err != nil || port < 1 || port > 65535 {
+		return fmt.Errorf("discovered endpoint %s has invalid port %q", meta.ID, meta.Port)
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.endpoints[meta.ID.String()] = "http://" + net.JoinHostPort(meta.Address, meta.Port)
+	p.rebuildOrdered()
+	return nil
+}
+
+func (p *discoveredEndpointPicker) Delete(meta *fwkdl.EndpointMetadata) {
+	if meta == nil || meta.ID.Name == "" {
+		return
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.endpoints, meta.ID.String())
+	p.rebuildOrdered()
+}
+
+func (p *discoveredEndpointPicker) rebuildOrdered() {
+	ids := make([]string, 0, len(p.endpoints))
+	for id := range p.endpoints {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	ordered := make([]string, 0, len(ids))
+	for _, id := range ids {
+		ordered = append(ordered, p.endpoints[id])
+	}
+	p.ordered = ordered
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery.go
@@ -71,6 +71,7 @@ type renderEndpointPicker interface {
 type retryingRenderEndpointPicker interface {
 	renderEndpointPicker
 	PickExcluding(excluded map[string]struct{}) (string, error)
+	HasAlternative(endpoint string) bool
 }
 
 // fixedEndpointPicker always returns the statically configured render URL.
@@ -108,12 +109,6 @@ type roundRobinLoadBalancer struct {
 	next int
 }
 
-// compiledEndpointPortRule holds a validated selector and base port.
-type compiledEndpointPortRule struct {
-	selector labels.Selector
-	basePort int
-}
-
 // Pick returns the next endpoint and advances the concurrency-safe cursor.
 func (b *roundRobinLoadBalancer) Pick(endpoints []string) (string, error) {
 	if len(endpoints) == 0 {
@@ -128,6 +123,12 @@ func (b *roundRobinLoadBalancer) Pick(endpoints []string) (string, error) {
 	endpoint := endpoints[b.next]
 	b.next = (b.next + 1) % len(endpoints)
 	return endpoint, nil
+}
+
+// compiledEndpointPortRule holds a validated selector and base port.
+type compiledEndpointPortRule struct {
+	selector labels.Selector
+	basePort int
 }
 
 // discoveredEndpointPicker maintains render URLs keyed by endpoint identity.
@@ -176,7 +177,22 @@ func (p *discoveredEndpointPicker) PickExcluding(excluded map[string]struct{}) (
 		}
 		endpoints = available
 	}
+	if len(endpoints) == 0 {
+		return "", errNoRenderEndpoints
+	}
 	return p.loadBalancer.Pick(endpoints)
+}
+
+// HasAlternative reports whether reserving time for a retry can reach another URL.
+func (p *discoveredEndpointPicker) HasAlternative(endpoint string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for _, candidate := range p.ordered {
+		if candidate != endpoint {
+			return true
+		}
+	}
+	return false
 }
 
 // Upsert validates endpoint metadata and stores its HTTP render URL by identity.
@@ -278,7 +294,8 @@ func (p *discoveredEndpointPicker) resolveRenderPort(meta *fwkdl.EndpointMetadat
 type endpointDiscoveryHandler struct {
 	typedName           plugin.TypedName
 	picker              *discoveredEndpointPicker
-	registeredEndpoints sync.Map
+	mu                  sync.Mutex
+	registeredEndpoints map[string]fwkdl.Endpoint
 }
 
 var _ fwkdl.EndpointExtractor = &endpointDiscoveryHandler{}
@@ -290,7 +307,8 @@ func newEndpointDiscoveryHandler(owner plugin.TypedName, picker *discoveredEndpo
 			Type: PluginType + "-endpoint-discovery-" + owner.Name,
 			Name: owner.Name,
 		},
-		picker: picker,
+		picker:              picker,
+		registeredEndpoints: make(map[string]fwkdl.Endpoint),
 	}
 }
 
@@ -305,19 +323,24 @@ func (h *endpointDiscoveryHandler) Extract(_ context.Context, event fwkdl.Endpoi
 		return nil
 	}
 
+	// Keep generation checks and picker updates atomic across lifecycle callbacks.
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	meta := event.Endpoint.GetMetadata()
 	id := meta.ID.String()
 	switch event.Type {
 	case fwkdl.EventAddOrUpdate:
+		h.registeredEndpoints[id] = event.Endpoint
 		if err := h.picker.Upsert(meta); err != nil {
+			h.picker.Delete(meta)
 			return err
 		}
-		h.registeredEndpoints.Store(id, event.Endpoint)
 	case fwkdl.EventDelete:
-		if registered, ok := h.registeredEndpoints.Load(id); ok && registered != event.Endpoint {
+		// Delete events carry the Endpoint object used by the corresponding add.
+		if registered, ok := h.registeredEndpoints[id]; ok && registered != event.Endpoint {
 			return nil
 		}
-		h.registeredEndpoints.Delete(id)
+		delete(h.registeredEndpoints, id)
 		h.picker.Delete(meta)
 	}
 	return nil

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tokenizer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -24,17 +25,33 @@ import (
 	"strconv"
 	"sync"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 )
 
 const roundRobinLoadBalancerType = "round-robin"
+
+// errNoRenderEndpoints indicates that discovery has no selectable render URL.
+var errNoRenderEndpoints = errors.New("no vLLM render endpoints discovered")
 
 type loadBalancerConfig struct {
 	Type string `json:"type,omitempty"`
 }
 
+// endpointPortRule maps matching inference endpoints to a render port range.
+type endpointPortRule struct {
+	Selector metav1.LabelSelector `json:"selector,omitempty"`
+	BasePort int                  `json:"basePort"`
+}
+
 type endpointDiscoveryConfig struct {
 	LoadBalancer *loadBalancerConfig `json:"loadBalancer,omitempty"`
+	// PortRules resolve render ports as BasePort + RankIndex. An empty list uses
+	// the inference port published by discovery.
+	PortRules []endpointPortRule `json:"portRules,omitempty"`
 }
 
 // loadBalancerType returns the configured algorithm or the default round-robin algorithm.
@@ -48,6 +65,12 @@ func (c *endpointDiscoveryConfig) loadBalancerType() string {
 // renderEndpointPicker resolves the base URL for one render request.
 type renderEndpointPicker interface {
 	Pick() (string, error)
+}
+
+// retryingRenderEndpointPicker can avoid endpoints already attempted by a request.
+type retryingRenderEndpointPicker interface {
+	renderEndpointPicker
+	PickExcluding(excluded map[string]struct{}) (string, error)
 }
 
 // fixedEndpointPicker always returns the statically configured render URL.
@@ -85,10 +108,16 @@ type roundRobinLoadBalancer struct {
 	next int
 }
 
+// compiledEndpointPortRule holds a validated selector and base port.
+type compiledEndpointPortRule struct {
+	selector labels.Selector
+	basePort int
+}
+
 // Pick returns the next endpoint and advances the concurrency-safe cursor.
 func (b *roundRobinLoadBalancer) Pick(endpoints []string) (string, error) {
 	if len(endpoints) == 0 {
-		return "", errors.New("no vLLM render endpoints discovered")
+		return "", errNoRenderEndpoints
 	}
 
 	b.mu.Lock()
@@ -107,25 +136,47 @@ type discoveredEndpointPicker struct {
 	endpoints    map[string]string
 	ordered      []string
 	loadBalancer endpointLoadBalancer
+	portRules    []compiledEndpointPortRule
 }
 
 // newDiscoveredEndpointPicker constructs a picker with the configured algorithm.
-func newDiscoveredEndpointPicker(loadBalancerType string) (*discoveredEndpointPicker, error) {
-	loadBalancer, err := newEndpointLoadBalancer(loadBalancerType)
+func newDiscoveredEndpointPicker(config *endpointDiscoveryConfig) (*discoveredEndpointPicker, error) {
+	loadBalancer, err := newEndpointLoadBalancer(config.loadBalancerType())
+	if err != nil {
+		return nil, err
+	}
+	portRules, err := compileEndpointPortRules(config)
 	if err != nil {
 		return nil, err
 	}
 	return &discoveredEndpointPicker{
 		endpoints:    map[string]string{},
 		loadBalancer: loadBalancer,
+		portRules:    portRules,
 	}, nil
 }
 
 // Pick selects a render URL from a stable endpoint snapshot.
 func (p *discoveredEndpointPicker) Pick() (string, error) {
+	return p.PickExcluding(nil)
+}
+
+// PickExcluding selects a render URL that has not been attempted by the request.
+func (p *discoveredEndpointPicker) PickExcluding(excluded map[string]struct{}) (string, error) {
 	p.mu.RLock()
-	defer p.mu.RUnlock()
-	return p.loadBalancer.Pick(p.ordered)
+	endpoints := append([]string(nil), p.ordered...)
+	p.mu.RUnlock()
+
+	if len(excluded) > 0 {
+		available := endpoints[:0]
+		for _, endpoint := range endpoints {
+			if _, found := excluded[endpoint]; !found {
+				available = append(available, endpoint)
+			}
+		}
+		endpoints = available
+	}
+	return p.loadBalancer.Pick(endpoints)
 }
 
 // Upsert validates endpoint metadata and stores its HTTP render URL by identity.
@@ -139,14 +190,14 @@ func (p *discoveredEndpointPicker) Upsert(meta *fwkdl.EndpointMetadata) error {
 	if meta.Address == "" {
 		return fmt.Errorf("discovered endpoint %s has an empty address", meta.ID)
 	}
-	port, err := strconv.Atoi(meta.Port)
-	if err != nil || port < 1 || port > 65535 {
-		return fmt.Errorf("discovered endpoint %s has invalid port %q", meta.ID, meta.Port)
+	port, err := p.resolveRenderPort(meta)
+	if err != nil {
+		return err
 	}
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.endpoints[meta.ID.String()] = "http://" + net.JoinHostPort(meta.Address, meta.Port)
+	p.endpoints[meta.ID.String()] = "http://" + net.JoinHostPort(meta.Address, port)
 	p.rebuildOrdered()
 	return nil
 }
@@ -176,4 +227,98 @@ func (p *discoveredEndpointPicker) rebuildOrdered() {
 		ordered = append(ordered, p.endpoints[id])
 	}
 	p.ordered = ordered
+}
+
+// compileEndpointPortRules validates configured selectors and render port ranges.
+func compileEndpointPortRules(config *endpointDiscoveryConfig) ([]compiledEndpointPortRule, error) {
+	if config == nil || len(config.PortRules) == 0 {
+		return nil, nil
+	}
+
+	rules := make([]compiledEndpointPortRule, 0, len(config.PortRules))
+	for i, rule := range config.PortRules {
+		if rule.BasePort < 1 || rule.BasePort > 65535 {
+			return nil, fmt.Errorf("port rule %d has invalid base port %d", i, rule.BasePort)
+		}
+		selector, err := metav1.LabelSelectorAsSelector(&rule.Selector)
+		if err != nil {
+			return nil, fmt.Errorf("port rule %d has invalid selector: %w", i, err)
+		}
+		rules = append(rules, compiledEndpointPortRule{selector: selector, basePort: rule.BasePort})
+	}
+	return rules, nil
+}
+
+// resolveRenderPort returns the configured render port for an endpoint.
+func (p *discoveredEndpointPicker) resolveRenderPort(meta *fwkdl.EndpointMetadata) (string, error) {
+	if len(p.portRules) == 0 {
+		port, err := strconv.Atoi(meta.Port)
+		if err != nil || port < 1 || port > 65535 {
+			return "", fmt.Errorf("discovered endpoint %s has invalid port %q", meta.ID, meta.Port)
+		}
+		return meta.Port, nil
+	}
+
+	for _, rule := range p.portRules {
+		if !rule.selector.Matches(labels.Set(meta.Labels)) {
+			continue
+		}
+		if meta.RankIndex < 0 {
+			return "", fmt.Errorf("discovered endpoint %s has invalid rank index %d", meta.ID, meta.RankIndex)
+		}
+		if meta.RankIndex > 65535-rule.basePort {
+			return "", fmt.Errorf("discovered endpoint %s resolved render port outside 1-65535", meta.ID)
+		}
+		return strconv.Itoa(rule.basePort + meta.RankIndex), nil
+	}
+	return "", fmt.Errorf("discovered endpoint %s does not match any port rule", meta.ID)
+}
+
+// endpointDiscoveryHandler gives each token producer an independent extractor identity.
+type endpointDiscoveryHandler struct {
+	typedName           plugin.TypedName
+	picker              *discoveredEndpointPicker
+	registeredEndpoints sync.Map
+}
+
+var _ fwkdl.EndpointExtractor = &endpointDiscoveryHandler{}
+
+// newEndpointDiscoveryHandler binds endpoint events to one token producer's picker.
+func newEndpointDiscoveryHandler(owner plugin.TypedName, picker *discoveredEndpointPicker) *endpointDiscoveryHandler {
+	return &endpointDiscoveryHandler{
+		typedName: plugin.TypedName{
+			Type: PluginType + "-endpoint-discovery-" + owner.Name,
+			Name: owner.Name,
+		},
+		picker: picker,
+	}
+}
+
+// TypedName returns the per-instance extractor identity used by the data layer.
+func (h *endpointDiscoveryHandler) TypedName() plugin.TypedName {
+	return h.typedName
+}
+
+// Extract keeps the picker synchronized with endpoint lifecycle events.
+func (h *endpointDiscoveryHandler) Extract(_ context.Context, event fwkdl.EndpointEvent) error {
+	if event.Endpoint == nil || event.Endpoint.GetMetadata() == nil {
+		return nil
+	}
+
+	meta := event.Endpoint.GetMetadata()
+	id := meta.ID.String()
+	switch event.Type {
+	case fwkdl.EventAddOrUpdate:
+		if err := h.picker.Upsert(meta); err != nil {
+			return err
+		}
+		h.registeredEndpoints.Store(id, event.Endpoint)
+	case fwkdl.EventDelete:
+		if registered, ok := h.registeredEndpoints.Load(id); ok && registered != event.Endpoint {
+			return nil
+		}
+		h.registeredEndpoints.Delete(id)
+		h.picker.Delete(meta)
+	}
+	return nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery.go
@@ -49,6 +49,8 @@ type endpointPortRule struct {
 
 type endpointDiscoveryConfig struct {
 	LoadBalancer *loadBalancerConfig `json:"loadBalancer,omitempty"`
+	// AttemptTimeout optionally caps each HTTP attempt within the request timeout.
+	AttemptTimeout string `json:"attemptTimeout,omitempty"`
 	// PortRules resolve render ports as BasePort + RankIndex. An empty list uses
 	// the inference port published by discovery.
 	PortRules []endpointPortRule `json:"portRules,omitempty"`
@@ -71,7 +73,6 @@ type renderEndpointPicker interface {
 type retryingRenderEndpointPicker interface {
 	renderEndpointPicker
 	PickExcluding(excluded map[string]struct{}) (string, error)
-	HasAlternative(endpoint string) bool
 }
 
 // fixedEndpointPicker always returns the statically configured render URL.
@@ -82,9 +83,9 @@ func (p fixedEndpointPicker) Pick() (string, error) {
 	return string(p), nil
 }
 
-// endpointLoadBalancer selects from the current discovered endpoint snapshot.
+// endpointLoadBalancer selects a non-excluded URL from the full endpoint snapshot.
 type endpointLoadBalancer interface {
-	Pick(endpoints []string) (string, error)
+	Pick(endpoints []string, excluded map[string]struct{}) (string, error)
 }
 
 type endpointLoadBalancerFactory func() endpointLoadBalancer
@@ -110,7 +111,7 @@ type roundRobinLoadBalancer struct {
 }
 
 // Pick returns the next endpoint and advances the concurrency-safe cursor.
-func (b *roundRobinLoadBalancer) Pick(endpoints []string) (string, error) {
+func (b *roundRobinLoadBalancer) Pick(endpoints []string, excluded map[string]struct{}) (string, error) {
 	if len(endpoints) == 0 {
 		return "", errNoRenderEndpoints
 	}
@@ -120,9 +121,15 @@ func (b *roundRobinLoadBalancer) Pick(endpoints []string) (string, error) {
 	if b.next >= len(endpoints) {
 		b.next = 0
 	}
-	endpoint := endpoints[b.next]
-	b.next = (b.next + 1) % len(endpoints)
-	return endpoint, nil
+	// Advance across the full snapshot so retry exclusions cannot shift the cursor.
+	for range endpoints {
+		endpoint := endpoints[b.next]
+		b.next = (b.next + 1) % len(endpoints)
+		if _, skip := excluded[endpoint]; !skip {
+			return endpoint, nil
+		}
+	}
+	return "", errNoRenderEndpoints
 }
 
 // compiledEndpointPortRule holds a validated selector and base port.
@@ -168,31 +175,10 @@ func (p *discoveredEndpointPicker) PickExcluding(excluded map[string]struct{}) (
 	endpoints := append([]string(nil), p.ordered...)
 	p.mu.RUnlock()
 
-	if len(excluded) > 0 {
-		available := endpoints[:0]
-		for _, endpoint := range endpoints {
-			if _, found := excluded[endpoint]; !found {
-				available = append(available, endpoint)
-			}
-		}
-		endpoints = available
-	}
 	if len(endpoints) == 0 {
 		return "", errNoRenderEndpoints
 	}
-	return p.loadBalancer.Pick(endpoints)
-}
-
-// HasAlternative reports whether reserving time for a retry can reach another URL.
-func (p *discoveredEndpointPicker) HasAlternative(endpoint string) bool {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	for _, candidate := range p.ordered {
-		if candidate != endpoint {
-			return true
-		}
-	}
-	return false
+	return p.loadBalancer.Pick(endpoints, excluded)
 }
 
 // Upsert validates endpoint metadata and stores its HTTP render URL by identity.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -48,7 +49,10 @@ type endpointPortRule struct {
 }
 
 type endpointDiscoveryConfig struct {
-	LoadBalancer *loadBalancerConfig `json:"loadBalancer,omitempty"`
+	DiscoverModelLimits bool                `json:"discoverModelLimits,omitempty"`
+	MinModelLen         int                 `json:"minModelLen,omitempty"`
+	ContextLimitLabel   string              `json:"contextLimitLabel,omitempty"`
+	LoadBalancer        *loadBalancerConfig `json:"loadBalancer,omitempty"`
 	// AttemptTimeout optionally caps each HTTP attempt within the request timeout.
 	AttemptTimeout string `json:"attemptTimeout,omitempty"`
 	// PortRules resolve render ports as BasePort + RankIndex. An empty list uses
@@ -140,6 +144,8 @@ type compiledEndpointPortRule struct {
 
 // discoveredEndpointPicker maintains render URLs keyed by endpoint identity.
 type discoveredEndpointPicker struct {
+	config       endpointDiscoveryConfig
+	capabilities map[string]*renderCapability
 	mu           sync.RWMutex
 	endpoints    map[string]string
 	ordered      []string
@@ -149,6 +155,15 @@ type discoveredEndpointPicker struct {
 
 // newDiscoveredEndpointPicker constructs a picker with the configured algorithm.
 func newDiscoveredEndpointPicker(config *endpointDiscoveryConfig) (*discoveredEndpointPicker, error) {
+	if config == nil {
+		config = &endpointDiscoveryConfig{}
+	}
+	if config.MinModelLen < 0 {
+		return nil, errors.New("minModelLen must not be negative")
+	}
+	if config.MinModelLen > 0 && !config.DiscoverModelLimits && config.ContextLimitLabel == "" {
+		return nil, errors.New("minModelLen requires discoverModelLimits or contextLimitLabel")
+	}
 	loadBalancer, err := newEndpointLoadBalancer(config.loadBalancerType())
 	if err != nil {
 		return nil, err
@@ -158,6 +173,8 @@ func newDiscoveredEndpointPicker(config *endpointDiscoveryConfig) (*discoveredEn
 		return nil, err
 	}
 	return &discoveredEndpointPicker{
+		config:       *config,
+		capabilities: map[string]*renderCapability{},
 		endpoints:    map[string]string{},
 		loadBalancer: loadBalancer,
 		portRules:    portRules,
@@ -172,7 +189,19 @@ func (p *discoveredEndpointPicker) Pick() (string, error) {
 // PickExcluding selects a render URL that has not been attempted by the request.
 func (p *discoveredEndpointPicker) PickExcluding(excluded map[string]struct{}) (string, error) {
 	p.mu.RLock()
-	endpoints := append([]string(nil), p.ordered...)
+	eligible := make(map[string]bool, len(p.capabilities))
+	now := time.Now()
+	for _, c := range p.capabilities {
+		if p.eligible(c, now) {
+			eligible[c.url] = true
+		}
+	}
+	endpoints := make([]string, 0, len(p.ordered))
+	for _, url := range p.ordered {
+		if eligible[url] {
+			endpoints = append(endpoints, url)
+		}
+	}
 	p.mu.RUnlock()
 
 	if len(endpoints) == 0 {
@@ -196,10 +225,22 @@ func (p *discoveredEndpointPicker) Upsert(meta *fwkdl.EndpointMetadata) error {
 	if err != nil {
 		return err
 	}
+	declared := 0
+	if key := p.config.ContextLimitLabel; key != "" {
+		declared, err = strconv.Atoi(meta.Labels[key])
+		if err != nil || declared <= 0 {
+			return fmt.Errorf("discovered endpoint %s has invalid context limit label %q", meta.ID, key)
+		}
+	}
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.endpoints[meta.ID.String()] = "http://" + net.JoinHostPort(meta.Address, port)
+	id := meta.ID.String()
+	url := "http://" + net.JoinHostPort(meta.Address, port)
+	if old := p.capabilities[id]; old == nil || old.url != url || old.declared != declared {
+		p.capabilities[id] = &renderCapability{url: url, declared: declared}
+	}
+	p.endpoints[id] = url
 	p.rebuildOrdered()
 	return nil
 }
@@ -213,6 +254,7 @@ func (p *discoveredEndpointPicker) Delete(meta *fwkdl.EndpointMetadata) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	delete(p.endpoints, meta.ID.String())
+	delete(p.capabilities, meta.ID.String())
 	p.rebuildOrdered()
 }
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery_test.go
@@ -19,14 +19,20 @@ package tokenizer
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
@@ -37,16 +43,22 @@ import (
 )
 
 func discoveredEndpoint(name, address, port string) fwkdl.Endpoint {
+	return discoveredEndpointWithRank(name, address, port, 0, nil)
+}
+
+func discoveredEndpointWithRank(name, address, port string, rank int, labels map[string]string) fwkdl.Endpoint {
 	return fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
-		ID:      types.NamespacedName{Namespace: "default", Name: name},
-		Name:    name,
-		Address: address,
-		Port:    port,
+		ID:        types.NamespacedName{Namespace: "default", Name: name},
+		Name:      name,
+		Address:   address,
+		Port:      port,
+		Labels:    labels,
+		RankIndex: rank,
 	}, nil)
 }
 
-func TestDiscoveredEndpointPicker_RoundRobin(t *testing.T) {
-	picker, err := newDiscoveredEndpointPicker(roundRobinLoadBalancerType)
+func TestDiscoveredEndpointPicker_RoundRobinUsesInferencePortsByDefault(t *testing.T) {
+	picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{})
 	require.NoError(t, err)
 
 	require.NoError(t, picker.Upsert(discoveredEndpoint("rank-b", "10.0.0.2", "8001").GetMetadata()))
@@ -65,7 +77,7 @@ func TestDiscoveredEndpointPicker_RoundRobin(t *testing.T) {
 }
 
 func TestDiscoveredEndpointPicker_TracksUpdatesAndDeletes(t *testing.T) {
-	picker, err := newDiscoveredEndpointPicker(roundRobinLoadBalancerType)
+	picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{})
 	require.NoError(t, err)
 
 	meta := discoveredEndpoint("rank-a", "10.0.0.1", "8000").GetMetadata()
@@ -91,6 +103,12 @@ func (firstEndpointLoadBalancer) Pick(endpoints []string) (string, error) {
 	return endpoints[0], nil
 }
 
+type endpointLoadBalancerFunc func(endpoints []string) (string, error)
+
+func (f endpointLoadBalancerFunc) Pick(endpoints []string) (string, error) {
+	return f(endpoints)
+}
+
 func TestDiscoveredEndpointPicker_LoadBalancerIsPluggable(t *testing.T) {
 	const loadBalancerType = "test-first"
 	endpointLoadBalancerFactories[loadBalancerType] = func() endpointLoadBalancer {
@@ -98,7 +116,9 @@ func TestDiscoveredEndpointPicker_LoadBalancerIsPluggable(t *testing.T) {
 	}
 	t.Cleanup(func() { delete(endpointLoadBalancerFactories, loadBalancerType) })
 
-	picker, err := newDiscoveredEndpointPicker(loadBalancerType)
+	picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{
+		LoadBalancer: &loadBalancerConfig{Type: loadBalancerType},
+	})
 	require.NoError(t, err)
 	require.NoError(t, picker.Upsert(discoveredEndpoint("rank-a", "10.0.0.1", "8000").GetMetadata()))
 
@@ -108,7 +128,7 @@ func TestDiscoveredEndpointPicker_LoadBalancerIsPluggable(t *testing.T) {
 }
 
 func TestDiscoveredEndpointPicker_RejectsInvalidEndpoint(t *testing.T) {
-	picker, err := newDiscoveredEndpointPicker(roundRobinLoadBalancerType)
+	picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{})
 	require.NoError(t, err)
 
 	for _, meta := range []*fwkdl.EndpointMetadata{
@@ -119,6 +139,104 @@ func TestDiscoveredEndpointPicker_RejectsInvalidEndpoint(t *testing.T) {
 	} {
 		require.Error(t, picker.Upsert(meta))
 	}
+}
+
+func TestDiscoveredEndpointPicker_PortRules(t *testing.T) {
+	picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{
+		PortRules: []endpointPortRule{
+			{
+				Selector: metav1.LabelSelector{MatchLabels: map[string]string{"llm-d.ai/role": "prefill"}},
+				BasePort: 8000,
+			},
+			{
+				Selector: metav1.LabelSelector{MatchLabels: map[string]string{"llm-d.ai/role": "decode"}},
+				BasePort: 8200,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, picker.Upsert(discoveredEndpointWithRank(
+		"prefill-rank", "10.0.0.1", "9002", 2, map[string]string{"llm-d.ai/role": "prefill"},
+	).GetMetadata()))
+	require.NoError(t, picker.Upsert(discoveredEndpointWithRank(
+		"decode-rank", "10.0.0.2", "8003", 3, map[string]string{"llm-d.ai/role": "decode"},
+	).GetMetadata()))
+
+	for _, want := range []string{"http://10.0.0.2:8203", "http://10.0.0.1:8002"} {
+		got, pickErr := picker.Pick()
+		require.NoError(t, pickErr)
+		assert.Equal(t, want, got)
+	}
+}
+
+func TestDiscoveredEndpointPicker_PortRulesRejectInvalidConfiguration(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *endpointDiscoveryConfig
+		wantErr string
+	}{
+		{
+			name: "invalid selector",
+			config: &endpointDiscoveryConfig{PortRules: []endpointPortRule{{
+				Selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key: "role", Operator: "not-an-operator",
+				}}},
+				BasePort: 8200,
+			}}},
+			wantErr: "invalid selector",
+		},
+		{
+			name:    "invalid base port",
+			config:  &endpointDiscoveryConfig{PortRules: []endpointPortRule{{BasePort: 0}}},
+			wantErr: "invalid base port",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newDiscoveredEndpointPicker(tt.config)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestDiscoveredEndpointPicker_PortRulesRejectUnmatchedAndInvalidRank(t *testing.T) {
+	picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{
+		PortRules: []endpointPortRule{{
+			Selector: metav1.LabelSelector{MatchLabels: map[string]string{"llm-d.ai/role": "decode"}},
+			BasePort: 65535,
+		}},
+	})
+	require.NoError(t, err)
+
+	require.ErrorContains(t, picker.Upsert(discoveredEndpointWithRank(
+		"prefill", "10.0.0.1", "8000", 0, map[string]string{"llm-d.ai/role": "prefill"},
+	).GetMetadata()), "does not match any port rule")
+	require.ErrorContains(t, picker.Upsert(discoveredEndpointWithRank(
+		"negative", "10.0.0.1", "8000", -1, map[string]string{"llm-d.ai/role": "decode"},
+	).GetMetadata()), "invalid rank index")
+	require.ErrorContains(t, picker.Upsert(discoveredEndpointWithRank(
+		"overflow", "10.0.0.1", "8000", 1, map[string]string{"llm-d.ai/role": "decode"},
+	).GetMetadata()), "resolved render port")
+}
+
+func TestDiscoveredEndpointPicker_ReleasesLockBeforeLoadBalancing(t *testing.T) {
+	picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{})
+	require.NoError(t, err)
+	require.NoError(t, picker.Upsert(discoveredEndpoint("rank-a", "10.0.0.1", "8000").GetMetadata()))
+
+	picker.loadBalancer = endpointLoadBalancerFunc(func(endpoints []string) (string, error) {
+		locked := picker.mu.TryLock()
+		if locked {
+			picker.mu.Unlock()
+		}
+		assert.True(t, locked, "picker lock must not cover the pluggable load balancer")
+		return endpoints[0], nil
+	})
+
+	_, err = picker.Pick()
+	require.NoError(t, err)
 }
 
 func TestVLLMHTTPRenderer_DiscoveryRoundRobin(t *testing.T) {
@@ -147,6 +265,131 @@ func TestVLLMHTTPRenderer_DiscoveryRoundRobin(t *testing.T) {
 	}
 }
 
+func TestVLLMHTTPRenderer_DiscoveryRetriesDifferentEndpoint(t *testing.T) {
+	var failedCalls atomic.Int32
+	failedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		failedCalls.Add(1)
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(failedServer.Close)
+
+	var successfulCalls atomic.Int32
+	successfulServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		successfulCalls.Add(1)
+		_ = json.NewEncoder(w).Encode([]renderResponse{{TokenIDs: []uint32{42}}})
+	}))
+	t.Cleanup(successfulServer.Close)
+
+	renderer, err := newVLLMHTTPRenderer(&vllmConfig{EndpointDiscovery: &endpointDiscoveryConfig{}}, testHTTPModel)
+	require.NoError(t, err)
+	picker := renderer.endpointPicker.(*discoveredEndpointPicker)
+	for name, server := range map[string]*httptest.Server{"rank-a": failedServer, "rank-b": successfulServer} {
+		address := server.Listener.Addr().(*net.TCPAddr)
+		require.NoError(t, picker.Upsert(discoveredEndpoint(name, address.IP.String(), strconv.Itoa(address.Port)).GetMetadata()))
+	}
+
+	tokens, _, err := renderer.Render(context.Background(), fwkrh.PayloadMap{"prompt": "hello"})
+	require.NoError(t, err)
+	assert.Equal(t, [][]uint32{{42}}, tokens)
+	assert.Equal(t, int32(1), failedCalls.Load())
+	assert.Equal(t, int32(1), successfulCalls.Load())
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestVLLMHTTPRenderer_DiscoveryRetriesTransportFailureWithinRequestTimeout(t *testing.T) {
+	picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{})
+	require.NoError(t, err)
+	require.NoError(t, picker.Upsert(discoveredEndpoint("rank-a", "10.0.0.1", "8000").GetMetadata()))
+	require.NoError(t, picker.Upsert(discoveredEndpoint("rank-b", "10.0.0.2", "8000").GetMetadata()))
+
+	var deadlines []time.Time
+	renderer := &vllmHTTPRenderer{
+		client: &http.Client{Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+			deadline, ok := request.Context().Deadline()
+			require.True(t, ok)
+			deadlines = append(deadlines, deadline)
+			if request.URL.Host == "10.0.0.1:8000" {
+				return nil, errors.New("connection refused")
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`[{"token_ids":[7]}]`)),
+				Request:    request,
+			}, nil
+		})},
+		endpointPicker: picker,
+		modelName:      testHTTPModel,
+		timeout:        time.Second,
+	}
+
+	tokens, _, err := renderer.Render(context.Background(), fwkrh.PayloadMap{"prompt": "hello"})
+	require.NoError(t, err)
+	assert.Equal(t, [][]uint32{{7}}, tokens)
+	require.Len(t, deadlines, 2)
+	assert.Equal(t, deadlines[0], deadlines[1])
+}
+
+func TestVLLMHTTPRenderer_DiscoveryDoesNotRetryDeterministicClientError(t *testing.T) {
+	var clientErrorCalls atomic.Int32
+	clientErrorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		clientErrorCalls.Add(1)
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	t.Cleanup(clientErrorServer.Close)
+
+	var alternateCalls atomic.Int32
+	alternateServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		alternateCalls.Add(1)
+		_ = json.NewEncoder(w).Encode([]renderResponse{{TokenIDs: []uint32{42}}})
+	}))
+	t.Cleanup(alternateServer.Close)
+
+	renderer, err := newVLLMHTTPRenderer(&vllmConfig{EndpointDiscovery: &endpointDiscoveryConfig{}}, testHTTPModel)
+	require.NoError(t, err)
+	picker := renderer.endpointPicker.(*discoveredEndpointPicker)
+	for name, server := range map[string]*httptest.Server{"rank-a": clientErrorServer, "rank-b": alternateServer} {
+		address := server.Listener.Addr().(*net.TCPAddr)
+		require.NoError(t, picker.Upsert(discoveredEndpoint(name, address.IP.String(), strconv.Itoa(address.Port)).GetMetadata()))
+	}
+
+	_, _, err = renderer.Render(context.Background(), fwkrh.PayloadMap{"prompt": "hello"})
+	require.ErrorContains(t, err, "status 400")
+	assert.Equal(t, int32(1), clientErrorCalls.Load())
+	assert.Zero(t, alternateCalls.Load())
+}
+
+func TestVLLMHTTPRenderer_RetryableStatus(t *testing.T) {
+	for _, status := range []int{http.StatusRequestTimeout, http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusServiceUnavailable} {
+		assert.True(t, isRetryableRenderStatus(status), "status %d", status)
+	}
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, 600} {
+		assert.False(t, isRetryableRenderStatus(status), "status %d", status)
+	}
+}
+
+type errorEndpointPicker struct {
+	err error
+}
+
+func (p errorEndpointPicker) Pick() (string, error) {
+	return "", p.err
+}
+
+func TestVLLMHTTPRenderer_EndpointPickErrorHasContext(t *testing.T) {
+	pickErr := errors.New("picker failed")
+	renderer := &vllmHTTPRenderer{endpointPicker: errorEndpointPicker{err: pickErr}}
+
+	err := renderer.postJSON(context.Background(), completionsRenderPath, map[string]any{}, time.Second, &renderResponse{})
+	require.ErrorContains(t, err, "pick render endpoint")
+	assert.ErrorIs(t, err, pickErr)
+}
+
 type recordingRegistrar struct {
 	registrations []fwkdl.PendingRegistration
 }
@@ -166,7 +409,6 @@ func TestPlugin_DiscoveryRegistersAndTracksEndpointNotifications(t *testing.T) {
 	require.NoError(t, err)
 
 	var _ fwkdl.Registrant = p
-	var _ fwkdl.EndpointExtractor = p
 
 	registrar := &recordingRegistrar{}
 	require.NoError(t, p.RegisterDependencies(registrar))
@@ -174,25 +416,66 @@ func TestPlugin_DiscoveryRegistersAndTracksEndpointNotifications(t *testing.T) {
 	registration := registrar.registrations[0]
 	assert.Equal(t, p.TypedName(), registration.Owner)
 	assert.Equal(t, sourcenotifications.EndpointNotificationSourceType, registration.SourceType)
-	assert.Same(t, p, registration.Extractor)
 	require.NotNil(t, registration.DefaultSource)
+	handler, ok := registration.Extractor.(*endpointDiscoveryHandler)
+	require.True(t, ok)
 
 	ep := discoveredEndpoint("rank-a", "10.0.0.1", "8000")
-	require.NoError(t, p.Extract(context.Background(), fwkdl.EndpointEvent{
+	require.NoError(t, handler.Extract(context.Background(), fwkdl.EndpointEvent{
 		Type:     fwkdl.EventAddOrUpdate,
 		Endpoint: ep,
 	}))
 
-	got, err := p.endpointDiscovery.Pick()
+	got, err := handler.picker.Pick()
 	require.NoError(t, err)
 	assert.Equal(t, "http://10.0.0.1:8000", got)
 
-	require.NoError(t, p.Extract(context.Background(), fwkdl.EndpointEvent{
+	require.NoError(t, handler.Extract(context.Background(), fwkdl.EndpointEvent{
 		Type:     fwkdl.EventDelete,
 		Endpoint: ep,
 	}))
-	_, err = p.endpointDiscovery.Pick()
+	_, err = handler.picker.Pick()
 	require.Error(t, err)
+}
+
+func TestEndpointDiscoveryHandler_IgnoresStaleDelete(t *testing.T) {
+	picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{})
+	require.NoError(t, err)
+	handler := newEndpointDiscoveryHandler(plugin.TypedName{Type: PluginType, Name: "test"}, picker)
+	oldEndpoint := discoveredEndpoint("rank-a", "10.0.0.1", "8000")
+	replacement := discoveredEndpoint("rank-a", "10.0.0.2", "8000")
+
+	require.NoError(t, handler.Extract(context.Background(), fwkdl.EndpointEvent{Type: fwkdl.EventAddOrUpdate, Endpoint: oldEndpoint}))
+	require.NoError(t, handler.Extract(context.Background(), fwkdl.EndpointEvent{Type: fwkdl.EventAddOrUpdate, Endpoint: replacement}))
+	require.NoError(t, handler.Extract(context.Background(), fwkdl.EndpointEvent{Type: fwkdl.EventDelete, Endpoint: oldEndpoint}))
+
+	got, err := picker.Pick()
+	require.NoError(t, err)
+	assert.Equal(t, "http://10.0.0.2:8000", got)
+
+	require.NoError(t, handler.Extract(context.Background(), fwkdl.EndpointEvent{Type: fwkdl.EventDelete, Endpoint: replacement}))
+	_, err = picker.Pick()
+	require.ErrorContains(t, err, "no vLLM render endpoints discovered")
+}
+
+func TestPlugin_DiscoveryHandlersHavePerInstanceTypes(t *testing.T) {
+	registrations := make([]fwkdl.PendingRegistration, 0, 2)
+	for _, name := range []string{"first", "second"} {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		p, err := NewPlugin(ctx, name, &tokenizerPluginConfig{
+			ModelName: "model",
+			VLLM:      &vllmConfig{EndpointDiscovery: &endpointDiscoveryConfig{}},
+		})
+		require.NoError(t, err)
+
+		registrar := &recordingRegistrar{}
+		require.NoError(t, p.RegisterDependencies(registrar))
+		require.Len(t, registrar.registrations, 1)
+		registrations = append(registrations, registrar.registrations[0])
+	}
+
+	assert.NotEqual(t, registrations[0].Extractor.TypedName().Type, registrations[1].Extractor.TypedName().Type)
 }
 
 func TestPlugin_StaticURLDoesNotRegisterForEndpointNotifications(t *testing.T) {
@@ -217,7 +500,10 @@ func TestPluginFactory_EndpointDiscoveryValidation(t *testing.T) {
 			name: "accepts endpoint discovery",
 			parameters: `{
 				"modelName": "m",
-				"vllm": {"endpointDiscovery": {"loadBalancer": {"type": "round-robin"}}}
+				"vllm": {"endpointDiscovery": {
+					"portRules": [{"selector": {"matchLabels": {"llm-d.ai/role": "decode"}}, "basePort": 8200}],
+					"loadBalancer": {"type": "round-robin"}
+				}}
 			}`,
 		},
 		{

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery_test.go
@@ -28,13 +28,16 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	dlruntime "github.com/llm-d/llm-d-router/pkg/epp/datalayer"
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
@@ -152,6 +155,7 @@ func TestDiscoveredEndpointPicker_PortRules(t *testing.T) {
 				Selector: metav1.LabelSelector{MatchLabels: map[string]string{"llm-d.ai/role": "decode"}},
 				BasePort: 8200,
 			},
+			{BasePort: 9000},
 		},
 	})
 	require.NoError(t, err)
@@ -162,8 +166,9 @@ func TestDiscoveredEndpointPicker_PortRules(t *testing.T) {
 	require.NoError(t, picker.Upsert(discoveredEndpointWithRank(
 		"decode-rank", "10.0.0.2", "8003", 3, map[string]string{"llm-d.ai/role": "decode"},
 	).GetMetadata()))
+	require.NoError(t, picker.Upsert(discoveredEndpointWithRank("other-rank", "::1", "8001", 1, nil).GetMetadata()))
 
-	for _, want := range []string{"http://10.0.0.2:8203", "http://10.0.0.1:8002"} {
+	for _, want := range []string{"http://10.0.0.2:8203", "http://[::1]:9001", "http://10.0.0.1:8002"} {
 		got, pickErr := picker.Pick()
 		require.NoError(t, pickErr)
 		assert.Equal(t, want, got)
@@ -332,7 +337,88 @@ func TestVLLMHTTPRenderer_DiscoveryRetriesTransportFailureWithinRequestTimeout(t
 	require.NoError(t, err)
 	assert.Equal(t, [][]uint32{{7}}, tokens)
 	require.Len(t, deadlines, 2)
-	assert.Equal(t, deadlines[0], deadlines[1])
+	assert.True(t, deadlines[0].Before(deadlines[1]), "first attempt reserves time for retry")
+}
+
+func TestVLLMHTTPRenderer_DiscoveryRetriesSlowEndpoint(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{})
+		require.NoError(t, err)
+		require.NoError(t, picker.Upsert(discoveredEndpoint("rank-a", "10.0.0.1", "8000").GetMetadata()))
+		require.NoError(t, picker.Upsert(discoveredEndpoint("rank-b", "10.0.0.2", "8000").GetMetadata()))
+		var hosts []string
+		start := time.Now()
+		renderer := &vllmHTTPRenderer{
+			endpointPicker: picker,
+			timeout:        time.Second,
+			client: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				hosts = append(hosts, req.URL.Host)
+				if req.URL.Host == "10.0.0.1:8000" {
+					<-req.Context().Done()
+					return nil, req.Context().Err()
+				}
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`[{"token_ids":[7]}]`))}, nil
+			})},
+		}
+		tokens, _, err := renderer.Render(context.Background(), fwkrh.PayloadMap{"prompt": "hello"})
+		require.NoError(t, err)
+		assert.Equal(t, [][]uint32{{7}}, tokens)
+		assert.Equal(t, []string{"10.0.0.1:8000", "10.0.0.2:8000"}, hosts)
+		assert.Less(t, time.Since(start), time.Second)
+	})
+}
+
+func TestVLLMHTTPRenderer_DiscoveryAttemptsAreBounded(t *testing.T) {
+	picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{})
+	require.NoError(t, err)
+	for _, name := range []string{"a", "b", "c"} {
+		require.NoError(t, picker.Upsert(discoveredEndpoint(name, name, "8000").GetMetadata()))
+	}
+	var hosts []string
+	renderer := &vllmHTTPRenderer{
+		endpointPicker: picker,
+		timeout:        time.Second,
+		client: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			hosts = append(hosts, req.URL.Host)
+			return nil, errors.New("connection refused")
+		})},
+	}
+	_, _, err = renderer.Render(context.Background(), fwkrh.PayloadMap{"prompt": "hello"})
+	require.ErrorContains(t, err, "connection refused")
+	require.Len(t, hosts, 2)
+	assert.NotEqual(t, hosts[0], hosts[1])
+}
+
+func TestVLLMHTTPRenderer_DiscoveryHonorsCallerDeadline(t *testing.T) {
+	for _, endpointCount := range []int{1, 2} {
+		t.Run(strconv.Itoa(endpointCount), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{})
+				require.NoError(t, err)
+				for i := range endpointCount {
+					name := strconv.Itoa(i)
+					require.NoError(t, picker.Upsert(discoveredEndpoint(name, name, "8000").GetMetadata()))
+				}
+				calls := 0
+				renderer := &vllmHTTPRenderer{
+					endpointPicker: picker,
+					timeout:        time.Second,
+					client: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+						calls++
+						<-req.Context().Done()
+						return nil, req.Context().Err()
+					})},
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+				defer cancel()
+				start := time.Now()
+				_, _, err = renderer.Render(ctx, fwkrh.PayloadMap{"prompt": "hello"})
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+				assert.Equal(t, endpointCount, calls)
+				assert.Equal(t, 200*time.Millisecond, time.Since(start))
+			})
+		})
+	}
 }
 
 func TestVLLMHTTPRenderer_DiscoveryDoesNotRetryDeterministicClientError(t *testing.T) {
@@ -458,7 +544,22 @@ func TestEndpointDiscoveryHandler_IgnoresStaleDelete(t *testing.T) {
 	require.ErrorContains(t, err, "no vLLM render endpoints discovered")
 }
 
+func TestEndpointDiscoveryHandler_RemovesInvalidUpdate(t *testing.T) {
+	picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{PortRules: []endpointPortRule{{
+		Selector: metav1.LabelSelector{MatchLabels: map[string]string{"role": "decode"}}, BasePort: 8200,
+	}}})
+	require.NoError(t, err)
+	handler := newEndpointDiscoveryHandler(plugin.TypedName{Type: PluginType, Name: "test"}, picker)
+	ep := discoveredEndpointWithRank("a", "10.0.0.1", "8000", 0, map[string]string{"role": "decode"})
+	require.NoError(t, handler.Extract(context.Background(), fwkdl.EndpointEvent{Endpoint: ep}))
+	ep.UpdateMetadata(discoveredEndpoint("a", "10.0.0.1", "8000").GetMetadata())
+	require.ErrorContains(t, handler.Extract(context.Background(), fwkdl.EndpointEvent{Endpoint: ep}), "does not match any port rule")
+	_, err = picker.Pick()
+	require.ErrorIs(t, err, errNoRenderEndpoints)
+}
+
 func TestPlugin_DiscoveryHandlersHavePerInstanceTypes(t *testing.T) {
+	runtime := dlruntime.NewRuntime(0)
 	registrations := make([]fwkdl.PendingRegistration, 0, 2)
 	for _, name := range []string{"first", "second"} {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -473,9 +574,25 @@ func TestPlugin_DiscoveryHandlersHavePerInstanceTypes(t *testing.T) {
 		require.NoError(t, p.RegisterDependencies(registrar))
 		require.Len(t, registrar.registrations, 1)
 		registrations = append(registrations, registrar.registrations[0])
+		require.NoError(t, p.RegisterDependencies(runtime))
 	}
 
 	assert.NotEqual(t, registrations[0].Extractor.TypedName().Type, registrations[1].Extractor.TypedName().Type)
+	ctx := utils.NewTestContext(t)
+	require.NoError(t, runtime.Configure(nil, log.FromContext(ctx)))
+	ep := runtime.NewEndpoint(ctx, discoveredEndpoint("a", "10.0.0.1", "8000").GetMetadata())
+	require.NotNil(t, ep)
+	for _, registration := range registrations {
+		picker := registration.Extractor.(*endpointDiscoveryHandler).picker
+		url, err := picker.Pick()
+		require.NoError(t, err)
+		assert.Equal(t, "http://10.0.0.1:8000", url)
+	}
+	runtime.ReleaseEndpoint(ep)
+	for _, registration := range registrations {
+		_, err := registration.Extractor.(*endpointDiscoveryHandler).picker.Pick()
+		require.ErrorIs(t, err, errNoRenderEndpoints)
+	}
 }
 
 func TestPlugin_StaticURLDoesNotRegisterForEndpointNotifications(t *testing.T) {

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenizer
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+	sourcenotifications "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
+	"github.com/llm-d/llm-d-router/test/utils"
+)
+
+func discoveredEndpoint(name, address, port string) fwkdl.Endpoint {
+	return fwkdl.NewEndpoint(&fwkdl.EndpointMetadata{
+		ID:      types.NamespacedName{Namespace: "default", Name: name},
+		Name:    name,
+		Address: address,
+		Port:    port,
+	}, nil)
+}
+
+func TestDiscoveredEndpointPicker_RoundRobin(t *testing.T) {
+	picker, err := newDiscoveredEndpointPicker(roundRobinLoadBalancerType)
+	require.NoError(t, err)
+
+	require.NoError(t, picker.Upsert(discoveredEndpoint("rank-b", "10.0.0.2", "8001").GetMetadata()))
+	require.NoError(t, picker.Upsert(discoveredEndpoint("rank-a", "10.0.0.1", "8000").GetMetadata()))
+
+	for _, want := range []string{
+		"http://10.0.0.1:8000",
+		"http://10.0.0.2:8001",
+		"http://10.0.0.1:8000",
+		"http://10.0.0.2:8001",
+	} {
+		got, pickErr := picker.Pick()
+		require.NoError(t, pickErr)
+		assert.Equal(t, want, got)
+	}
+}
+
+func TestDiscoveredEndpointPicker_TracksUpdatesAndDeletes(t *testing.T) {
+	picker, err := newDiscoveredEndpointPicker(roundRobinLoadBalancerType)
+	require.NoError(t, err)
+
+	meta := discoveredEndpoint("rank-a", "10.0.0.1", "8000").GetMetadata()
+	require.NoError(t, picker.Upsert(meta))
+
+	meta = meta.Clone()
+	meta.Address = "10.0.0.9"
+	meta.Port = "8200"
+	require.NoError(t, picker.Upsert(meta))
+
+	got, err := picker.Pick()
+	require.NoError(t, err)
+	assert.Equal(t, "http://10.0.0.9:8200", got)
+
+	picker.Delete(meta)
+	_, err = picker.Pick()
+	require.ErrorContains(t, err, "no vLLM render endpoints discovered")
+}
+
+type firstEndpointLoadBalancer struct{}
+
+func (firstEndpointLoadBalancer) Pick(endpoints []string) (string, error) {
+	return endpoints[0], nil
+}
+
+func TestDiscoveredEndpointPicker_LoadBalancerIsPluggable(t *testing.T) {
+	const loadBalancerType = "test-first"
+	endpointLoadBalancerFactories[loadBalancerType] = func() endpointLoadBalancer {
+		return firstEndpointLoadBalancer{}
+	}
+	t.Cleanup(func() { delete(endpointLoadBalancerFactories, loadBalancerType) })
+
+	picker, err := newDiscoveredEndpointPicker(loadBalancerType)
+	require.NoError(t, err)
+	require.NoError(t, picker.Upsert(discoveredEndpoint("rank-a", "10.0.0.1", "8000").GetMetadata()))
+
+	got, err := picker.Pick()
+	require.NoError(t, err)
+	assert.Equal(t, "http://10.0.0.1:8000", got)
+}
+
+func TestDiscoveredEndpointPicker_RejectsInvalidEndpoint(t *testing.T) {
+	picker, err := newDiscoveredEndpointPicker(roundRobinLoadBalancerType)
+	require.NoError(t, err)
+
+	for _, meta := range []*fwkdl.EndpointMetadata{
+		nil,
+		{Address: "10.0.0.1", Port: "8000"},
+		discoveredEndpoint("rank-a", "", "8000").GetMetadata(),
+		discoveredEndpoint("rank-a", "10.0.0.1", "bad").GetMetadata(),
+	} {
+		require.Error(t, picker.Upsert(meta))
+	}
+}
+
+func TestVLLMHTTPRenderer_DiscoveryRoundRobin(t *testing.T) {
+	newRenderServer := func(tokenID uint32) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode([]renderResponse{{TokenIDs: []uint32{tokenID}}})
+		}))
+	}
+	serverA := newRenderServer(1)
+	t.Cleanup(serverA.Close)
+	serverB := newRenderServer(2)
+	t.Cleanup(serverB.Close)
+
+	renderer, err := newVLLMHTTPRenderer(&vllmConfig{EndpointDiscovery: &endpointDiscoveryConfig{}}, testHTTPModel)
+	require.NoError(t, err)
+	picker := renderer.endpointPicker.(*discoveredEndpointPicker)
+	for name, server := range map[string]*httptest.Server{"rank-a": serverA, "rank-b": serverB} {
+		address := server.Listener.Addr().(*net.TCPAddr)
+		require.NoError(t, picker.Upsert(discoveredEndpoint(name, address.IP.String(), strconv.Itoa(address.Port)).GetMetadata()))
+	}
+
+	for _, want := range []uint32{1, 2, 1, 2} {
+		tokens, _, renderErr := renderer.Render(context.Background(), fwkrh.PayloadMap{"prompt": "hello"})
+		require.NoError(t, renderErr)
+		require.Equal(t, [][]uint32{{want}}, tokens)
+	}
+}
+
+type recordingRegistrar struct {
+	registrations []fwkdl.PendingRegistration
+}
+
+func (r *recordingRegistrar) Register(registration fwkdl.PendingRegistration) error {
+	r.registrations = append(r.registrations, registration)
+	return nil
+}
+
+func TestPlugin_DiscoveryRegistersAndTracksEndpointNotifications(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	p, err := NewPlugin(ctx, "discovered-tokenizer", &tokenizerPluginConfig{
+		ModelName: "model",
+		VLLM:      &vllmConfig{EndpointDiscovery: &endpointDiscoveryConfig{}},
+	})
+	require.NoError(t, err)
+
+	var _ fwkdl.Registrant = p
+	var _ fwkdl.EndpointExtractor = p
+
+	registrar := &recordingRegistrar{}
+	require.NoError(t, p.RegisterDependencies(registrar))
+	require.Len(t, registrar.registrations, 1)
+	registration := registrar.registrations[0]
+	assert.Equal(t, p.TypedName(), registration.Owner)
+	assert.Equal(t, sourcenotifications.EndpointNotificationSourceType, registration.SourceType)
+	assert.Same(t, p, registration.Extractor)
+	require.NotNil(t, registration.DefaultSource)
+
+	ep := discoveredEndpoint("rank-a", "10.0.0.1", "8000")
+	require.NoError(t, p.Extract(context.Background(), fwkdl.EndpointEvent{
+		Type:     fwkdl.EventAddOrUpdate,
+		Endpoint: ep,
+	}))
+
+	got, err := p.endpointDiscovery.Pick()
+	require.NoError(t, err)
+	assert.Equal(t, "http://10.0.0.1:8000", got)
+
+	require.NoError(t, p.Extract(context.Background(), fwkdl.EndpointEvent{
+		Type:     fwkdl.EventDelete,
+		Endpoint: ep,
+	}))
+	_, err = p.endpointDiscovery.Pick()
+	require.Error(t, err)
+}
+
+func TestPlugin_StaticURLDoesNotRegisterForEndpointNotifications(t *testing.T) {
+	p, err := NewPlugin(utils.NewTestContext(t), "static-tokenizer", &tokenizerPluginConfig{
+		ModelName: "model",
+		VLLM:      &vllmConfig{URL: "http://localhost:8000"},
+	})
+	require.NoError(t, err)
+
+	registrar := &recordingRegistrar{}
+	require.NoError(t, p.RegisterDependencies(registrar))
+	assert.Empty(t, registrar.registrations)
+}
+
+func TestPluginFactory_EndpointDiscoveryValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters string
+		wantErr    string
+	}{
+		{
+			name: "accepts endpoint discovery",
+			parameters: `{
+				"modelName": "m",
+				"vllm": {"endpointDiscovery": {"loadBalancer": {"type": "round-robin"}}}
+			}`,
+		},
+		{
+			name: "rejects URL with endpoint discovery",
+			parameters: `{
+				"modelName": "m",
+				"vllm": {"url": "http://localhost:8000", "endpointDiscovery": {}}
+			}`,
+			wantErr: "only one of 'url' or 'endpointDiscovery'",
+		},
+		{
+			name: "rejects unknown load balancer",
+			parameters: `{
+				"modelName": "m",
+				"vllm": {"endpointDiscovery": {"loadBalancer": {"type": "random"}}}
+			}`,
+			wantErr: "unsupported load balancer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			handle := plugin.NewEppHandle(ctx, nil)
+			p, err := PluginFactory("test", plugin.StrictDecoder([]byte(tt.parameters)), handle)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				assert.NotNil(t, p)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+			assert.Nil(t, p)
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery_test.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -100,16 +101,40 @@ func TestDiscoveredEndpointPicker_TracksUpdatesAndDeletes(t *testing.T) {
 	require.ErrorContains(t, err, "no vLLM render endpoints discovered")
 }
 
-type firstEndpointLoadBalancer struct{}
-
-func (firstEndpointLoadBalancer) Pick(endpoints []string) (string, error) {
-	return endpoints[0], nil
+func TestDiscoveredEndpointPicker_ExclusionsPreserveCursor(t *testing.T) {
+	picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{})
+	require.NoError(t, err)
+	for _, name := range []string{"a", "b", "c"} {
+		require.NoError(t, picker.Upsert(discoveredEndpoint(name, name, "8000").GetMetadata()))
+	}
+	first, err := picker.Pick()
+	require.NoError(t, err)
+	assert.Equal(t, "http://a:8000", first)
+	second, err := picker.PickExcluding(map[string]struct{}{"http://a:8000": {}, "http://b:8000": {}})
+	require.NoError(t, err)
+	assert.Equal(t, "http://c:8000", second)
+	_, err = picker.PickExcluding(map[string]struct{}{"http://a:8000": {}, "http://b:8000": {}, "http://c:8000": {}})
+	require.ErrorIs(t, err, errNoRenderEndpoints)
+	third, err := picker.Pick()
+	require.NoError(t, err)
+	assert.Equal(t, "http://a:8000", third)
 }
 
-type endpointLoadBalancerFunc func(endpoints []string) (string, error)
+type firstEndpointLoadBalancer struct{}
 
-func (f endpointLoadBalancerFunc) Pick(endpoints []string) (string, error) {
-	return f(endpoints)
+func (firstEndpointLoadBalancer) Pick(endpoints []string, excluded map[string]struct{}) (string, error) {
+	for _, endpoint := range endpoints {
+		if _, skip := excluded[endpoint]; !skip {
+			return endpoint, nil
+		}
+	}
+	return "", errNoRenderEndpoints
+}
+
+type endpointLoadBalancerFunc func(endpoints []string, excluded map[string]struct{}) (string, error)
+
+func (f endpointLoadBalancerFunc) Pick(endpoints []string, excluded map[string]struct{}) (string, error) {
+	return f(endpoints, excluded)
 }
 
 func TestDiscoveredEndpointPicker_LoadBalancerIsPluggable(t *testing.T) {
@@ -231,7 +256,7 @@ func TestDiscoveredEndpointPicker_ReleasesLockBeforeLoadBalancing(t *testing.T) 
 	require.NoError(t, err)
 	require.NoError(t, picker.Upsert(discoveredEndpoint("rank-a", "10.0.0.1", "8000").GetMetadata()))
 
-	picker.loadBalancer = endpointLoadBalancerFunc(func(endpoints []string) (string, error) {
+	picker.loadBalancer = endpointLoadBalancerFunc(func(endpoints []string, _ map[string]struct{}) (string, error) {
 		locked := picker.mu.TryLock()
 		if locked {
 			picker.mu.Unlock()
@@ -337,10 +362,10 @@ func TestVLLMHTTPRenderer_DiscoveryRetriesTransportFailureWithinRequestTimeout(t
 	require.NoError(t, err)
 	assert.Equal(t, [][]uint32{{7}}, tokens)
 	require.Len(t, deadlines, 2)
-	assert.True(t, deadlines[0].Before(deadlines[1]), "first attempt reserves time for retry")
+	assert.Equal(t, deadlines[0], deadlines[1], "retry must retain the original request deadline")
 }
 
-func TestVLLMHTTPRenderer_DiscoveryRetriesSlowEndpoint(t *testing.T) {
+func TestVLLMHTTPRenderer_DiscoveryRetriesSlowEndpointWithAttemptTimeout(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{})
 		require.NoError(t, err)
@@ -351,6 +376,7 @@ func TestVLLMHTTPRenderer_DiscoveryRetriesSlowEndpoint(t *testing.T) {
 		renderer := &vllmHTTPRenderer{
 			endpointPicker: picker,
 			timeout:        time.Second,
+			attemptTimeout: 100 * time.Millisecond,
 			client: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				hosts = append(hosts, req.URL.Host)
 				if req.URL.Host == "10.0.0.1:8000" {
@@ -389,6 +415,112 @@ func TestVLLMHTTPRenderer_DiscoveryAttemptsAreBounded(t *testing.T) {
 	assert.NotEqual(t, hosts[0], hosts[1])
 }
 
+func TestVLLMHTTPRenderer_DiscoveryRetriesDoNotStarveHealthyEndpoints(t *testing.T) {
+	picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{})
+	require.NoError(t, err)
+	for _, name := range []string{"a", "b", "c"} {
+		require.NoError(t, picker.Upsert(discoveredEndpoint(name, name, "8000").GetMetadata()))
+	}
+	calls := map[string]int{}
+	renderer := &vllmHTTPRenderer{
+		endpointPicker: picker,
+		timeout:        time.Second,
+		client: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			calls[req.URL.Hostname()]++
+			if req.URL.Hostname() == "a" {
+				return &http.Response{StatusCode: http.StatusServiceUnavailable, Body: io.NopCloser(strings.NewReader("unavailable"))}, nil
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`[{"token_ids":[7]}]`))}, nil
+		})},
+	}
+	for range 12 {
+		_, _, err := renderer.Render(context.Background(), fwkrh.PayloadMap{"prompt": "hello"})
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 6, calls["b"])
+	assert.Equal(t, 6, calls["c"])
+}
+
+type failingRenderBody struct {
+	err error
+}
+
+func (b failingRenderBody) Read([]byte) (int, error) { return 0, b.err }
+func (b failingRenderBody) Close() error             { return nil }
+
+func TestVLLMHTTPRenderer_DiscoveryRetriesResponseBodyNetworkError(t *testing.T) {
+	picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{})
+	require.NoError(t, err)
+	for _, name := range []string{"a", "b"} {
+		require.NoError(t, picker.Upsert(discoveredEndpoint(name, name, "8000").GetMetadata()))
+	}
+	var hosts []string
+	renderer := &vllmHTTPRenderer{
+		endpointPicker: picker,
+		timeout:        time.Second,
+		client: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			hosts = append(hosts, req.URL.Hostname())
+			body := io.NopCloser(strings.NewReader(`[{"token_ids":[7]}]`))
+			if req.URL.Hostname() == "a" {
+				body = failingRenderBody{err: &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}}
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+		})},
+	}
+	tokens, _, err := renderer.Render(context.Background(), fwkrh.PayloadMap{"prompt": "hello"})
+	require.NoError(t, err)
+	assert.Equal(t, [][]uint32{{7}}, tokens)
+	assert.Equal(t, []string{"a", "b"}, hosts)
+}
+
+func TestVLLMHTTPRenderer_DiscoveryPreservesFullTimeoutByDefault(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		picker, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{})
+		require.NoError(t, err)
+		for _, name := range []string{"a", "b"} {
+			require.NoError(t, picker.Upsert(discoveredEndpoint(name, name, "8000").GetMetadata()))
+		}
+		calls := 0
+		renderer := &vllmHTTPRenderer{
+			endpointPicker: picker,
+			timeout:        5 * time.Second,
+			client: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				select {
+				case <-time.After(3 * time.Second):
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`[{"token_ids":[7]}]`))}, nil
+				case <-req.Context().Done():
+					return nil, req.Context().Err()
+				}
+			})},
+		}
+		tokens, _, err := renderer.Render(context.Background(), fwkrh.PayloadMap{"prompt": "hello"})
+		require.NoError(t, err)
+		assert.Equal(t, [][]uint32{{7}}, tokens)
+		assert.Equal(t, 1, calls)
+	})
+}
+
+func TestVLLMHTTPRenderer_DiscoveryAttemptTimeoutConfiguration(t *testing.T) {
+	for _, value := range []string{"", "100ms", "0s", "-1s", "invalid"} {
+		t.Run(value, func(t *testing.T) {
+			renderer, err := newVLLMHTTPRenderer(&vllmConfig{
+				EndpointDiscovery: &endpointDiscoveryConfig{AttemptTimeout: value},
+			}, testHTTPModel)
+			switch value {
+			case "":
+				require.NoError(t, err)
+				assert.Zero(t, renderer.attemptTimeout)
+			case "100ms":
+				require.NoError(t, err)
+				assert.Equal(t, 100*time.Millisecond, renderer.attemptTimeout)
+			default:
+				require.ErrorContains(t, err, "invalid 'endpointDiscovery.attemptTimeout'")
+			}
+		})
+	}
+}
+
 func TestVLLMHTTPRenderer_DiscoveryHonorsCallerDeadline(t *testing.T) {
 	for _, endpointCount := range []int{1, 2} {
 		t.Run(strconv.Itoa(endpointCount), func(t *testing.T) {
@@ -414,7 +546,7 @@ func TestVLLMHTTPRenderer_DiscoveryHonorsCallerDeadline(t *testing.T) {
 				start := time.Now()
 				_, _, err = renderer.Render(ctx, fwkrh.PayloadMap{"prompt": "hello"})
 				require.ErrorIs(t, err, context.DeadlineExceeded)
-				assert.Equal(t, endpointCount, calls)
+				assert.Equal(t, 1, calls, "caller deadline must stop retries")
 				assert.Equal(t, 200*time.Millisecond, time.Since(start))
 			})
 		})
@@ -618,6 +750,7 @@ func TestPluginFactory_EndpointDiscoveryValidation(t *testing.T) {
 			parameters: `{
 				"modelName": "m",
 				"vllm": {"endpointDiscovery": {
+					"attemptTimeout": "1s",
 					"portRules": [{"selector": {"matchLabels": {"llm-d.ai/role": "decode"}}, "basePort": 8200}],
 					"loadBalancer": {"type": "round-robin"}
 				}}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/endpoint_discovery_test.go
@@ -757,6 +757,45 @@ func TestPluginFactory_EndpointDiscoveryValidation(t *testing.T) {
 			}`,
 		},
 		{
+			name: "accepts endpoint discovery with default TLS settings",
+			parameters: `{
+				"modelName": "m",
+				"vllm": {"endpointDiscovery": {}, "caCertPath": "", "clientCertPath": "", "clientKeyPath": "", "insecureSkipVerify": false}
+			}`,
+		},
+		{
+			name: "rejects CA certificate with endpoint discovery",
+			parameters: `{
+				"modelName": "m",
+				"vllm": {"endpointDiscovery": {}, "caCertPath": "/nonexistent/ca.pem"}
+			}`,
+			wantErr: "endpointDiscovery uses HTTP and cannot be combined with TLS settings",
+		},
+		{
+			name: "rejects client certificate with endpoint discovery",
+			parameters: `{
+				"modelName": "m",
+				"vllm": {"endpointDiscovery": {}, "clientCertPath": "/nonexistent/client.pem"}
+			}`,
+			wantErr: "endpointDiscovery uses HTTP and cannot be combined with TLS settings",
+		},
+		{
+			name: "rejects client key with endpoint discovery",
+			parameters: `{
+				"modelName": "m",
+				"vllm": {"endpointDiscovery": {}, "clientKeyPath": "/nonexistent/client.key"}
+			}`,
+			wantErr: "endpointDiscovery uses HTTP and cannot be combined with TLS settings",
+		},
+		{
+			name: "rejects insecure skip verify with endpoint discovery",
+			parameters: `{
+				"modelName": "m",
+				"vllm": {"endpointDiscovery": {}, "insecureSkipVerify": true}
+			}`,
+			wantErr: "endpointDiscovery uses HTTP and cannot be combined with TLS settings",
+		},
+		{
 			name: "rejects URL with endpoint discovery",
 			parameters: `{
 				"modelName": "m",

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/model_limits.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/model_limits.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenizer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+)
+
+const modelLimitFreshness = 90 * time.Second
+
+type renderCapability struct {
+	url       string
+	declared  int
+	observed  int
+	refreshed time.Time
+}
+
+// eligible is called with the picker read lock held.
+func (p *discoveredEndpointPicker) eligible(c *renderCapability, now time.Time) bool {
+	limit := c.declared
+	if p.config.DiscoverModelLimits {
+		if c.observed <= 0 || now.Sub(c.refreshed) > modelLimitFreshness {
+			return false
+		}
+		if limit == 0 || c.observed < limit {
+			limit = c.observed
+		}
+	}
+	return limit >= p.config.MinModelLen
+}
+
+// watchModelLimits keeps network I/O outside endpoint notification callbacks.
+func (p *discoveredEndpointPicker) watchModelLimits(ctx context.Context, client *http.Client, model string) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		p.refreshModelLimits(ctx, client, model)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// refreshModelLimits probes a bounded snapshot. Replaced endpoints cannot inherit
+// results from probes of their predecessors.
+func (p *discoveredEndpointPicker) refreshModelLimits(ctx context.Context, client *http.Client, model string) {
+	p.mu.RLock()
+	snapshot := make(map[string]*renderCapability, len(p.capabilities))
+	for id, c := range p.capabilities {
+		snapshot[id] = c
+	}
+	p.mu.RUnlock()
+	semaphore := make(chan struct{}, 4)
+	var wg sync.WaitGroup
+	for id, c := range snapshot {
+		select {
+		case semaphore <- struct{}{}:
+		case <-ctx.Done():
+			wg.Wait()
+			return
+		}
+		wg.Add(1)
+		go func(id string, c *renderCapability) {
+			defer wg.Done()
+			defer func() { <-semaphore }()
+			probeCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			defer cancel()
+			limit, err := readModelLimit(probeCtx, client, c.url, model)
+			p.mu.Lock()
+			changed := false
+			if p.capabilities[id] == c {
+				changed = c.observed != limit
+				c.observed = limit
+				c.refreshed = time.Now()
+			}
+			p.mu.Unlock()
+			if err != nil {
+				log.FromContext(ctx).Error(err, "renderer model discovery failed", "endpoint", id)
+			}
+			if changed && err == nil {
+				log.FromContext(ctx).V(logging.DEBUG).Info("renderer model limit discovered", "endpoint", id, "maxModelLen", limit)
+			}
+		}(id, c)
+	}
+	wg.Wait()
+}
+
+func readModelLimit(ctx context.Context, client *http.Client, url, model string) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url+"/v1/models", nil)
+	if err != nil {
+		return 0, err
+	}
+	if auth := vllmWarmupAuthHeader(); auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("models endpoint returned HTTP %d", resp.StatusCode)
+	}
+	var body struct {
+		Data []struct {
+			ID          string `json:"id"`
+			MaxModelLen int    `json:"max_model_len"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&body); err != nil {
+		return 0, err
+	}
+	for _, m := range body.Data {
+		if m.ID == model && m.MaxModelLen > 0 {
+			return m.MaxModelLen, nil
+		}
+	}
+	return 0, fmt.Errorf("models endpoint has no positive max_model_len for %q", model)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/model_limits_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/model_limits_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenizer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
+)
+
+func TestDiscoveredModelLimits(t *testing.T) {
+	var limit atomic.Int64
+	limit.Store(265088)
+	var bad atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/models", r.URL.Path)
+		if bad.Load() {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []any{map[string]any{"id": "glm", "max_model_len": limit.Load()}}})
+	}))
+	defer server.Close()
+	host, port, _ := net.SplitHostPort(server.Listener.Addr().String())
+	p, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{DiscoverModelLimits: true, MinModelLen: 250000, ContextLimitLabel: "render-limit"})
+	require.NoError(t, err)
+	ep := discoveredEndpointWithRank("a", host, port, 0, map[string]string{"render-limit": "265088"})
+	require.NoError(t, p.Upsert(ep.GetMetadata()))
+	_, err = p.Pick()
+	require.Error(t, err, "unknown capacity must not be selectable")
+	p.refreshModelLimits(context.Background(), server.Client(), "glm")
+	_, err = p.Pick()
+	require.NoError(t, err)
+	limit.Store(240000)
+	p.refreshModelLimits(context.Background(), server.Client(), "glm")
+	_, err = p.Pick()
+	require.Error(t, err, "shrunk capacity must be excluded")
+	limit.Store(300000)
+	p.refreshModelLimits(context.Background(), server.Client(), "glm")
+	_, err = p.Pick()
+	require.NoError(t, err)
+	bad.Store(true)
+	p.refreshModelLimits(context.Background(), server.Client(), "glm")
+	_, err = p.Pick()
+	require.Error(t, err, "failed metadata refresh must not retain an unverified target")
+	p.Delete(ep.GetMetadata())
+	require.Empty(t, p.capabilities)
+}
+
+func TestModelLimitLabelValidation(t *testing.T) {
+	for _, v := range []string{"", "0", "-1", "not-a-number"} {
+		p, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{ContextLimitLabel: "limit", MinModelLen: 200000})
+		require.NoError(t, err)
+		ep := discoveredEndpointWithRank("a", "127.0.0.1", "8000", 0, map[string]string{"limit": v})
+		require.Error(t, p.Upsert(ep.GetMetadata()))
+	}
+	p, err := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{ContextLimitLabel: "limit", MinModelLen: 300000})
+	require.NoError(t, err)
+	ep := discoveredEndpointWithRank("a", "127.0.0.1", "8000", 0, map[string]string{"limit": "265088"})
+	require.NoError(t, p.Upsert(ep.GetMetadata()))
+	_, err = p.Pick()
+	require.Error(t, err)
+}
+
+func TestRenderOnlyBudgetPreservesPayload(t *testing.T) {
+	for _, completions := range []bool{false, true} {
+		for _, enabled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("completions=%t/prefillOnly=%t", completions, enabled), func(t *testing.T) {
+				payload := fwkrh.PayloadMap{"max_tokens": 32000, "max_completion_tokens": 32000, "min_tokens": 5}
+				path := chatRenderPath
+				if completions {
+					payload["prompt"] = "unchanged"
+					path = completionsRenderPath
+				} else {
+					payload["messages"] = []any{map[string]any{"role": "user", "content": "unchanged"}}
+				}
+				before, err := json.Marshal(payload)
+				require.NoError(t, err)
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					var body map[string]any
+					if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+						return
+					}
+					assert.Equal(t, path, r.URL.Path)
+					wantMax, wantMin := float64(32000), float64(5)
+					if enabled {
+						wantMax, wantMin = 1, 0
+					}
+					assert.Equal(t, wantMax, body["max_tokens"])
+					assert.Equal(t, wantMax, body["max_completion_tokens"])
+					assert.Equal(t, wantMin, body["min_tokens"])
+					if completions {
+						assert.Equal(t, "unchanged", body["prompt"])
+					} else {
+						assert.Equal(t, payload["messages"], body["messages"])
+					}
+					w.Header().Set("Content-Type", "application/json")
+					if completions {
+						_, _ = w.Write([]byte(`[{"token_ids":[1,2,3]}]`))
+					} else {
+						_, _ = w.Write([]byte(`{"token_ids":[1,2,3]}`))
+					}
+				}))
+				defer server.Close()
+				r, err := newVLLMHTTPRenderer(&vllmConfig{URL: server.URL, PrefillOnly: enabled}, "glm")
+				require.NoError(t, err)
+				if completions {
+					_, _, err = r.Render(context.Background(), payload)
+				} else {
+					_, _, err = r.RenderChat(context.Background(), payload)
+				}
+				require.NoError(t, err)
+				after, err := json.Marshal(payload)
+				require.NoError(t, err)
+				require.Equal(t, before, after)
+			})
+		}
+	}
+}
+
+func TestModelLimitProbeDeadline(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { <-r.Context().Done() }))
+	defer server.Close()
+	host, port, _ := net.SplitHostPort(server.Listener.Addr().String())
+	p, _ := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{DiscoverModelLimits: true})
+	require.NoError(t, p.Upsert(discoveredEndpoint("a", host, port).GetMetadata()))
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	p.refreshModelLimits(ctx, server.Client(), "glm")
+	_, err := p.Pick()
+	require.Error(t, err)
+}
+
+func TestRenderRejectsEmptyTokenIDs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == completionsRenderPath {
+			_, _ = w.Write([]byte(`[{"token_ids":[]}]`))
+		} else {
+			_, _ = w.Write([]byte(`{"token_ids":[]}`))
+		}
+	}))
+	defer server.Close()
+	renderer, err := newVLLMHTTPRenderer(&vllmConfig{URL: server.URL}, "glm")
+	require.NoError(t, err)
+	_, _, err = renderer.RenderChat(context.Background(), fwkrh.PayloadMap{"messages": []any{}})
+	require.Error(t, err)
+	_, _, err = renderer.Render(context.Background(), fwkrh.PayloadMap{"prompt": "test"})
+	require.Error(t, err)
+}
+
+func TestModelLimitStaleProbeCannotResurrectDeletedEndpoint(t *testing.T) {
+	started, release := make(chan struct{}), make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release
+		_, _ = w.Write([]byte(`{"data":[{"id":"glm","max_model_len":300000}]}`))
+	}))
+	defer server.Close()
+	host, port, _ := net.SplitHostPort(server.Listener.Addr().String())
+	p, _ := newDiscoveredEndpointPicker(&endpointDiscoveryConfig{DiscoverModelLimits: true})
+	ep := discoveredEndpoint("a", host, port)
+	require.NoError(t, p.Upsert(ep.GetMetadata()))
+	done := make(chan struct{})
+	go func() { p.refreshModelLimits(context.Background(), server.Client(), "glm"); close(done) }()
+	<-started
+	p.Delete(ep.GetMetadata())
+	require.NoError(t, p.Upsert(ep.GetMetadata()))
+	close(release)
+	<-done
+	_, err := p.Pick()
+	require.Error(t, err)
+}
+
+func TestReadModelLimitRejectsWrongModelAndInvalidMetadata(t *testing.T) {
+	for _, body := range []string{`{"data":[{"id":"other","max_model_len":300000}]}`, `{"data":[{"id":"glm","max_model_len":0}]}`, `{"data":[{"id":"glm","max_model_len":"300000"}]}`, "invalid"} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(body)) }))
+		_, err := readModelLimit(context.Background(), server.Client(), server.URL, "glm")
+		require.Error(t, err)
+		server.Close()
+	}
+}
+
+func TestModelLimitEligibility(t *testing.T) {
+	now := time.Now()
+	for _, tc := range []struct {
+		name       string
+		config     endpointDiscoveryConfig
+		capability renderCapability
+		want       bool
+	}{
+		{"defaults", endpointDiscoveryConfig{}, renderCapability{}, true},
+		{"unknown", endpointDiscoveryConfig{DiscoverModelLimits: true}, renderCapability{}, false},
+		{"fresh", endpointDiscoveryConfig{DiscoverModelLimits: true, MinModelLen: 100}, renderCapability{observed: 100, refreshed: now}, true},
+		{"stale", endpointDiscoveryConfig{DiscoverModelLimits: true}, renderCapability{observed: 100, refreshed: now.Add(-modelLimitFreshness - time.Second)}, false},
+		{"label bounds observed", endpointDiscoveryConfig{DiscoverModelLimits: true, MinModelLen: 100}, renderCapability{declared: 99, observed: 200, refreshed: now}, false},
+		{"observed bounds label", endpointDiscoveryConfig{DiscoverModelLimits: true, MinModelLen: 100}, renderCapability{declared: 200, observed: 99, refreshed: now}, false},
+		{"label only", endpointDiscoveryConfig{MinModelLen: 100, ContextLimitLabel: "limit"}, renderCapability{declared: 100}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := newDiscoveredEndpointPicker(&tc.config)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, p.eligible(&tc.capability, now))
+		})
+	}
+	for _, cfg := range []endpointDiscoveryConfig{{MinModelLen: -1}, {MinModelLen: 100}} {
+		_, err := newDiscoveredEndpointPicker(&cfg)
+		require.Error(t, err)
+	}
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -298,7 +298,7 @@ func LegacyPluginFactory(name string, rawParameters *json.Decoder, handle plugin
 func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) (*Plugin, error) {
 	var backend tokenInputProducer
 	var backendName string
-	var endpointDiscovery *discoveredEndpointPicker
+	var endpointPicker *discoveredEndpointPicker
 	switch {
 	case config.VLLM != nil || config.ModelName != "":
 		cfg := config.VLLM
@@ -311,18 +311,21 @@ func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) 
 		}
 		backend = renderBackend{tk: renderer, warmupAuth: vllmWarmupAuthHeader()}
 		backendName = backendVLLM
-		endpointDiscovery, _ = renderer.endpointPicker.(*discoveredEndpointPicker)
+		endpointPicker, _ = renderer.endpointPicker.(*discoveredEndpointPicker)
 	default:
 		backend = estimateBackend{img: newImageEstimator(config.Estimate), vid: newVideoEstimator(config.Estimate)}
 		backendName = backendEstimate
 	}
 
+	typedName := plugin.TypedName{Type: PluginType, Name: name}
 	p := &Plugin{
-		typedName:         plugin.TypedName{Type: PluginType, Name: name},
-		backend:           backend,
-		backendName:       backendName,
-		dk:                TokenizedPromptDataKey.WithNonEmptyProducerName(name),
-		endpointDiscovery: endpointDiscovery,
+		typedName:   typedName,
+		backend:     backend,
+		backendName: backendName,
+		dk:          TokenizedPromptDataKey.WithNonEmptyProducerName(name),
+	}
+	if endpointPicker != nil {
+		p.endpointDiscovery = newEndpointDiscoveryHandler(typedName, endpointPicker)
 	}
 	if w, ok := backend.(warmer); ok {
 		go w.warmup(ctx)
@@ -338,7 +341,7 @@ type Plugin struct {
 	// backendName identifies the configured backend on the tokenize span.
 	backendName       string
 	dk                plugin.DataKey
-	endpointDiscovery *discoveredEndpointPicker
+	endpointDiscovery *endpointDiscoveryHandler
 }
 
 // compile-time assertions.
@@ -346,7 +349,6 @@ var (
 	_ requestcontrol.DataProducer         = &Plugin{}
 	_ requestcontrol.TimeoutAwareProducer = &Plugin{}
 	_ datalayer.Registrant                = &Plugin{}
-	_ datalayer.EndpointExtractor         = &Plugin{}
 )
 
 // TypedName returns the typed name of the plugin.
@@ -367,24 +369,9 @@ func (p *Plugin) RegisterDependencies(r datalayer.Registrar) error {
 	return r.Register(datalayer.PendingRegistration{
 		Owner:         p.TypedName(),
 		SourceType:    sourcenotifications.EndpointNotificationSourceType,
-		Extractor:     p,
+		Extractor:     p.endpointDiscovery,
 		DefaultSource: sourcenotifications.NewEndpointDataSource(sourcenotifications.EndpointNotificationSourceType, sourcenotifications.EndpointNotificationSourceType),
 	})
-}
-
-// Extract updates the render endpoint set from data-layer lifecycle events.
-func (p *Plugin) Extract(_ context.Context, event datalayer.EndpointEvent) error {
-	if p.endpointDiscovery == nil || event.Endpoint == nil || event.Endpoint.GetMetadata() == nil {
-		return nil
-	}
-	meta := event.Endpoint.GetMetadata()
-	switch event.Type {
-	case datalayer.EventAddOrUpdate:
-		return p.endpointDiscovery.Upsert(meta)
-	case datalayer.EventDelete:
-		p.endpointDiscovery.Delete(meta)
-	}
-	return nil
 }
 
 // ProduceTimeout surfaces the backend's render timeout when it manages one, so

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -312,6 +312,9 @@ func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) 
 		backend = renderBackend{tk: renderer, warmupAuth: vllmWarmupAuthHeader()}
 		backendName = backendVLLM
 		endpointPicker, _ = renderer.endpointPicker.(*discoveredEndpointPicker)
+		if endpointPicker != nil && endpointPicker.config.DiscoverModelLimits {
+			go endpointPicker.watchModelLimits(ctx, renderer.client, config.ModelName)
+		}
 	default:
 		backend = estimateBackend{img: newImageEstimator(config.Estimate), vid: newVideoEstimator(config.Estimate)}
 		backendName = backendEstimate

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/tokenizer.go
@@ -39,11 +39,13 @@ import (
 
 	"github.com/llm-d/llm-d-router/pkg/common/observability/semconv"
 	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	mmobs "github.com/llm-d/llm-d-router/pkg/epp/framework/observability/multimodal"
+	sourcenotifications "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/notifications"
 	rcplugins "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
@@ -296,6 +298,7 @@ func LegacyPluginFactory(name string, rawParameters *json.Decoder, handle plugin
 func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) (*Plugin, error) {
 	var backend tokenInputProducer
 	var backendName string
+	var endpointDiscovery *discoveredEndpointPicker
 	switch {
 	case config.VLLM != nil || config.ModelName != "":
 		cfg := config.VLLM
@@ -308,16 +311,18 @@ func NewPlugin(ctx context.Context, name string, config *tokenizerPluginConfig) 
 		}
 		backend = renderBackend{tk: renderer, warmupAuth: vllmWarmupAuthHeader()}
 		backendName = backendVLLM
+		endpointDiscovery, _ = renderer.endpointPicker.(*discoveredEndpointPicker)
 	default:
 		backend = estimateBackend{img: newImageEstimator(config.Estimate), vid: newVideoEstimator(config.Estimate)}
 		backendName = backendEstimate
 	}
 
 	p := &Plugin{
-		typedName:   plugin.TypedName{Type: PluginType, Name: name},
-		backend:     backend,
-		backendName: backendName,
-		dk:          TokenizedPromptDataKey.WithNonEmptyProducerName(name),
+		typedName:         plugin.TypedName{Type: PluginType, Name: name},
+		backend:           backend,
+		backendName:       backendName,
+		dk:                TokenizedPromptDataKey.WithNonEmptyProducerName(name),
+		endpointDiscovery: endpointDiscovery,
 	}
 	if w, ok := backend.(warmer); ok {
 		go w.warmup(ctx)
@@ -331,14 +336,17 @@ type Plugin struct {
 	typedName plugin.TypedName
 	backend   tokenInputProducer
 	// backendName identifies the configured backend on the tokenize span.
-	backendName string
-	dk          plugin.DataKey
+	backendName       string
+	dk                plugin.DataKey
+	endpointDiscovery *discoveredEndpointPicker
 }
 
 // compile-time assertions.
 var (
 	_ requestcontrol.DataProducer         = &Plugin{}
 	_ requestcontrol.TimeoutAwareProducer = &Plugin{}
+	_ datalayer.Registrant                = &Plugin{}
+	_ datalayer.EndpointExtractor         = &Plugin{}
 )
 
 // TypedName returns the typed name of the plugin.
@@ -349,6 +357,34 @@ func (p *Plugin) TypedName() plugin.TypedName {
 // Produces returns the data keys this plugin produces.
 func (p *Plugin) Produces() map[plugin.DataKey]any {
 	return map[plugin.DataKey]any{p.dk: fwkrh.TokenizedRequest{}}
+}
+
+// RegisterDependencies wires discovery-backed renderers to endpoint lifecycle events.
+func (p *Plugin) RegisterDependencies(r datalayer.Registrar) error {
+	if p.endpointDiscovery == nil {
+		return nil
+	}
+	return r.Register(datalayer.PendingRegistration{
+		Owner:         p.TypedName(),
+		SourceType:    sourcenotifications.EndpointNotificationSourceType,
+		Extractor:     p,
+		DefaultSource: sourcenotifications.NewEndpointDataSource(sourcenotifications.EndpointNotificationSourceType, sourcenotifications.EndpointNotificationSourceType),
+	})
+}
+
+// Extract updates the render endpoint set from data-layer lifecycle events.
+func (p *Plugin) Extract(_ context.Context, event datalayer.EndpointEvent) error {
+	if p.endpointDiscovery == nil || event.Endpoint == nil || event.Endpoint.GetMetadata() == nil {
+		return nil
+	}
+	meta := event.Endpoint.GetMetadata()
+	switch event.Type {
+	case datalayer.EventAddOrUpdate:
+		return p.endpointDiscovery.Upsert(meta)
+	case datalayer.EventDelete:
+		p.endpointDiscovery.Delete(meta)
+	}
+	return nil
 }
 
 // ProduceTimeout surfaces the backend's render timeout when it manages one, so

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -104,12 +104,15 @@ func isRenderAuthError(err error) bool {
 }
 
 // vllmConfig configures the vLLM /render backend. Future protocol fields
-// (e.g., grpc) can be added alongside url.
+// (e.g., grpc) can be added under the same vllm block.
 type vllmConfig struct {
 	// URL is the base URL of the vLLM render endpoint (no trailing slash).
 	// Can be a loopback sidecar or a dedicated Service.
 	// Defaults to http://localhost:8000.
 	URL string `json:"url,omitempty"`
+	// EndpointDiscovery sends render requests directly to endpoints published
+	// by the configured data-layer discovery provider. Mutually exclusive with URL.
+	EndpointDiscovery *endpointDiscoveryConfig `json:"endpointDiscovery,omitempty"`
 	// Timeout is the per-request timeout for text-only requests
 	// (Go duration string, e.g. "5s"). Defaults to 5s.
 	Timeout string `json:"timeout,omitempty"`
@@ -133,17 +136,31 @@ type vllmConfig struct {
 // vllmHTTPRenderer implements the tokenizer interface by calling vLLM's
 // /v1/completions/render and /v1/chat/completions/render endpoints.
 type vllmHTTPRenderer struct {
-	client    *http.Client
-	baseURL   string
-	modelName string
-	timeout   time.Duration
-	mmTimeout time.Duration
+	client         *http.Client
+	endpointPicker renderEndpointPicker
+	modelName      string
+	timeout        time.Duration
+	mmTimeout      time.Duration
 }
 
 func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, error) {
-	url := strings.TrimRight(cfg.URL, "/")
-	if url == "" {
-		url = defaultHTTPRenderURL
+	if cfg.URL != "" && cfg.EndpointDiscovery != nil {
+		return nil, errors.New("only one of 'url' or 'endpointDiscovery' may be set")
+	}
+
+	var endpointPicker renderEndpointPicker
+	if cfg.EndpointDiscovery != nil {
+		discovered, err := newDiscoveredEndpointPicker(cfg.EndpointDiscovery.loadBalancerType())
+		if err != nil {
+			return nil, err
+		}
+		endpointPicker = discovered
+	} else {
+		url := strings.TrimRight(cfg.URL, "/")
+		if url == "" {
+			url = defaultHTTPRenderURL
+		}
+		endpointPicker = fixedEndpointPicker(url)
 	}
 	timeout, err := parseHTTPDuration(cfg.Timeout, defaultHTTPRenderTimeout)
 	if err != nil {
@@ -163,10 +180,10 @@ func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, 
 			// transport's default "HTTP POST" so traces identify render calls.
 			func(_ string, r *http.Request) string { return "tokenize_render " + r.URL.Path },
 		))},
-		baseURL:   url,
-		modelName: modelName,
-		timeout:   timeout,
-		mmTimeout: mmTimeout,
+		endpointPicker: endpointPicker,
+		modelName:      modelName,
+		timeout:        timeout,
+		mmTimeout:      mmTimeout,
 	}, nil
 }
 
@@ -451,11 +468,15 @@ func (r *vllmHTTPRenderer) postJSON(ctx context.Context, path string, body any, 
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)
 	}
+	baseURL, err := r.endpointPicker.Pick()
+	if err != nil {
+		return err
+	}
 
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, r.baseURL+path, bytes.NewReader(payload))
+	httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, baseURL+path, bytes.NewReader(payload))
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -111,6 +111,8 @@ type vllmConfig struct {
 	// Can be a loopback sidecar or a dedicated Service.
 	// Defaults to http://localhost:8000.
 	URL string `json:"url,omitempty"`
+	// PrefillOnly reserves one output token on the render copy, without changing inference.
+	PrefillOnly bool `json:"prefillOnly,omitempty"`
 	// EndpointDiscovery sends render requests directly to endpoints published
 	// by the configured data-layer discovery provider. Mutually exclusive with URL.
 	EndpointDiscovery *endpointDiscoveryConfig `json:"endpointDiscovery,omitempty"`
@@ -143,6 +145,7 @@ type vllmHTTPRenderer struct {
 	timeout        time.Duration
 	mmTimeout      time.Duration
 	attemptTimeout time.Duration
+	prefillOnly    bool
 }
 
 func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, error) {
@@ -197,6 +200,7 @@ func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, 
 		timeout:        timeout,
 		mmTimeout:      mmTimeout,
 		attemptTimeout: attemptTimeout,
+		prefillOnly:    cfg.PrefillOnly,
 	}, nil
 }
 
@@ -286,6 +290,9 @@ func (r *vllmHTTPRenderer) postCompletionsRender(ctx context.Context, body any) 
 	}
 	allTokenIDs := make([][]uint32, len(resp))
 	for i, r := range resp {
+		if len(r.TokenIDs) == 0 {
+			return nil, nil, errors.New("vLLM render returned no token IDs")
+		}
 		allTokenIDs[i] = r.TokenIDs
 	}
 	return allTokenIDs, nil, nil
@@ -308,6 +315,9 @@ func (r *vllmHTTPRenderer) postChatRender(ctx context.Context, body any, timeout
 	var resp renderResponse
 	if err := r.postJSON(ctx, chatRenderPath, body, timeout, &resp); err != nil {
 		return nil, nil, err
+	}
+	if len(resp.TokenIDs) == 0 {
+		return nil, nil, errors.New("vLLM render returned no token IDs")
 	}
 	return resp.TokenIDs, toKVCacheMM(resp.Features), nil
 }
@@ -478,6 +488,19 @@ func toKVCacheMM(f *renderMMFeatures) *tokenization.MultiModalFeatures {
 
 // postJSON permits one retry on a different endpoint within the request budget.
 func (r *vllmHTTPRenderer) postJSON(ctx context.Context, path string, body any, timeout time.Duration, out any) error {
+	if r.prefillOnly {
+		if typed, ok := body.(fwkrh.PayloadMap); ok {
+			cloned := maps.Clone(typed)
+			cloned["max_tokens"] = 1
+			if _, ok := cloned["max_completion_tokens"]; ok {
+				cloned["max_completion_tokens"] = 1
+			}
+			if _, ok := cloned["min_tokens"]; ok {
+				cloned["min_tokens"] = 0
+			}
+			body = cloned
+		}
+	}
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -153,6 +153,9 @@ func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, 
 	var endpointPicker renderEndpointPicker
 	var attemptTimeout time.Duration
 	if cfg.EndpointDiscovery != nil {
+		if cfg.hasTLS() {
+			return nil, errors.New("endpointDiscovery uses HTTP and cannot be combined with TLS settings; use 'url' for HTTPS")
+		}
 		discovered, err := newDiscoveredEndpointPicker(cfg.EndpointDiscovery)
 		if err != nil {
 			return nil, err

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -141,6 +142,7 @@ type vllmHTTPRenderer struct {
 	modelName      string
 	timeout        time.Duration
 	mmTimeout      time.Duration
+	attemptTimeout time.Duration
 }
 
 func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, error) {
@@ -149,12 +151,19 @@ func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, 
 	}
 
 	var endpointPicker renderEndpointPicker
+	var attemptTimeout time.Duration
 	if cfg.EndpointDiscovery != nil {
 		discovered, err := newDiscoveredEndpointPicker(cfg.EndpointDiscovery)
 		if err != nil {
 			return nil, err
 		}
 		endpointPicker = discovered
+		if value := cfg.EndpointDiscovery.AttemptTimeout; value != "" {
+			attemptTimeout, err = time.ParseDuration(value)
+			if err != nil || attemptTimeout <= 0 {
+				return nil, fmt.Errorf("invalid 'endpointDiscovery.attemptTimeout' %q: must be a positive duration", value)
+			}
+		}
 	} else {
 		url := strings.TrimRight(cfg.URL, "/")
 		if url == "" {
@@ -184,6 +193,7 @@ func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, 
 		modelName:      modelName,
 		timeout:        timeout,
 		mmTimeout:      mmTimeout,
+		attemptTimeout: attemptTimeout,
 	}, nil
 }
 
@@ -478,15 +488,7 @@ func (r *vllmHTTPRenderer) postJSON(ctx context.Context, path string, body any, 
 		return fmt.Errorf("pick render endpoint: %w", err)
 	}
 	picker, canRetry := r.endpointPicker.(retryingRenderEndpointPicker)
-	attemptCtx := reqCtx
-	cancelAttempt := func() {}
-	if canRetry && picker.HasAlternative(baseURL) {
-		// Reserve half the remaining budget so a slow endpoint cannot consume it all.
-		deadline, _ := reqCtx.Deadline()
-		attemptCtx, cancelAttempt = context.WithTimeout(reqCtx, time.Until(deadline)/2)
-	}
-	retryable, attemptErr := r.postJSONAttempt(attemptCtx, baseURL, path, payload, out)
-	cancelAttempt()
+	retryable, attemptErr := r.postJSONAttempt(reqCtx, baseURL, path, payload, out)
 	if attemptErr == nil || !retryable || !canRetry || reqCtx.Err() != nil {
 		return attemptErr
 	}
@@ -503,6 +505,11 @@ func (r *vllmHTTPRenderer) postJSON(ctx context.Context, path string, body any, 
 
 // postJSONAttempt sends one render request and reports whether another endpoint may succeed.
 func (r *vllmHTTPRenderer) postJSONAttempt(reqCtx context.Context, baseURL, path string, payload []byte, out any) (bool, error) {
+	if r.attemptTimeout > 0 {
+		var cancel context.CancelFunc
+		reqCtx, cancel = context.WithTimeout(reqCtx, r.attemptTimeout)
+		defer cancel()
+	}
 	httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, baseURL+path, bytes.NewReader(payload))
 	if err != nil {
 		return false, fmt.Errorf("build request: %w", err)
@@ -525,7 +532,10 @@ func (r *vllmHTTPRenderer) postJSONAttempt(reqCtx context.Context, baseURL, path
 		return isRetryableRenderStatus(httpResp.StatusCode), &renderStatusError{StatusCode: httpResp.StatusCode, Body: string(snippet)}
 	}
 	if err := json.NewDecoder(httpResp.Body).Decode(out); err != nil {
-		return reqCtx.Err() != nil || errors.Is(err, io.ErrUnexpectedEOF), fmt.Errorf("unmarshal response: %w", err)
+		// Connection failures can surface after successful response headers.
+		var networkErr net.Error
+		retryable := reqCtx.Err() != nil || errors.As(err, &networkErr) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
+		return retryable, fmt.Errorf("unmarshal response: %w", err)
 	}
 	return false, nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -150,7 +150,7 @@ func newVLLMHTTPRenderer(cfg *vllmConfig, modelName string) (*vllmHTTPRenderer, 
 
 	var endpointPicker renderEndpointPicker
 	if cfg.EndpointDiscovery != nil {
-		discovered, err := newDiscoveredEndpointPicker(cfg.EndpointDiscovery.loadBalancerType())
+		discovered, err := newDiscoveredEndpointPicker(cfg.EndpointDiscovery)
 		if err != nil {
 			return nil, err
 		}
@@ -468,37 +468,75 @@ func (r *vllmHTTPRenderer) postJSON(ctx context.Context, path string, body any, 
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)
 	}
-	baseURL, err := r.endpointPicker.Pick()
-	if err != nil {
-		return err
-	}
 
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	excluded := map[string]struct{}{}
+	var lastErr error
+	for {
+		var baseURL string
+		if len(excluded) == 0 {
+			baseURL, err = r.endpointPicker.Pick()
+		} else {
+			picker, ok := r.endpointPicker.(retryingRenderEndpointPicker)
+			if !ok {
+				return lastErr
+			}
+			baseURL, err = picker.PickExcluding(excluded)
+		}
+		if err != nil {
+			if lastErr != nil {
+				if errors.Is(err, errNoRenderEndpoints) {
+					return lastErr
+				}
+				return fmt.Errorf("pick alternate render endpoint: %w", err)
+			}
+			return fmt.Errorf("pick render endpoint: %w", err)
+		}
+
+		retryable, attemptErr := r.postJSONAttempt(reqCtx, ctx, baseURL, path, payload, out)
+		if attemptErr == nil {
+			return nil
+		}
+		if !retryable {
+			return attemptErr
+		}
+		lastErr = attemptErr
+		excluded[baseURL] = struct{}{}
+	}
+}
+
+// postJSONAttempt sends one render request and reports whether another endpoint may succeed.
+func (r *vllmHTTPRenderer) postJSONAttempt(reqCtx, authCtx context.Context, baseURL, path string, payload []byte, out any) (bool, error) {
 	httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, baseURL+path, bytes.NewReader(payload))
 	if err != nil {
-		return fmt.Errorf("build request: %w", err)
+		return false, fmt.Errorf("build request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	// The render endpoint may require the same credential as inference;
 	// forward the inbound Authorization when present.
-	if auth := authHeaderFromContext(ctx); auth != "" {
+	if auth := authHeaderFromContext(authCtx); auth != "" {
 		httpReq.Header.Set("Authorization", auth)
 	}
 
 	httpResp, err := r.client.Do(httpReq)
 	if err != nil {
-		return fmt.Errorf("post %s: %w", path, err)
+		return reqCtx.Err() == nil, fmt.Errorf("post %s: %w", path, err)
 	}
 	defer httpResp.Body.Close()
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		snippet, _ := io.ReadAll(io.LimitReader(httpResp.Body, maxErrorBodySnippetBytes))
-		return &renderStatusError{StatusCode: httpResp.StatusCode, Body: string(snippet)}
+		return isRetryableRenderStatus(httpResp.StatusCode), &renderStatusError{StatusCode: httpResp.StatusCode, Body: string(snippet)}
 	}
 	if err := json.NewDecoder(httpResp.Body).Decode(out); err != nil {
-		return fmt.Errorf("unmarshal response: %w", err)
+		return false, fmt.Errorf("unmarshal response: %w", err)
 	}
-	return nil
+	return false, nil
+}
+
+// isRetryableRenderStatus reports whether a different endpoint may succeed.
+func isRetryableRenderStatus(status int) bool {
+	return status == http.StatusRequestTimeout || status == http.StatusTooManyRequests || status >= 500 && status <= 599
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/vllm_http.go
@@ -463,6 +463,7 @@ func toKVCacheMM(f *renderMMFeatures) *tokenization.MultiModalFeatures {
 	return out
 }
 
+// postJSON permits one retry on a different endpoint within the request budget.
 func (r *vllmHTTPRenderer) postJSON(ctx context.Context, path string, body any, timeout time.Duration, out any) error {
 	payload, err := json.Marshal(body)
 	if err != nil {
@@ -472,43 +473,36 @@ func (r *vllmHTTPRenderer) postJSON(ctx context.Context, path string, body any, 
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	excluded := map[string]struct{}{}
-	var lastErr error
-	for {
-		var baseURL string
-		if len(excluded) == 0 {
-			baseURL, err = r.endpointPicker.Pick()
-		} else {
-			picker, ok := r.endpointPicker.(retryingRenderEndpointPicker)
-			if !ok {
-				return lastErr
-			}
-			baseURL, err = picker.PickExcluding(excluded)
-		}
-		if err != nil {
-			if lastErr != nil {
-				if errors.Is(err, errNoRenderEndpoints) {
-					return lastErr
-				}
-				return fmt.Errorf("pick alternate render endpoint: %w", err)
-			}
-			return fmt.Errorf("pick render endpoint: %w", err)
-		}
-
-		retryable, attemptErr := r.postJSONAttempt(reqCtx, ctx, baseURL, path, payload, out)
-		if attemptErr == nil {
-			return nil
-		}
-		if !retryable {
-			return attemptErr
-		}
-		lastErr = attemptErr
-		excluded[baseURL] = struct{}{}
+	baseURL, err := r.endpointPicker.Pick()
+	if err != nil {
+		return fmt.Errorf("pick render endpoint: %w", err)
 	}
+	picker, canRetry := r.endpointPicker.(retryingRenderEndpointPicker)
+	attemptCtx := reqCtx
+	cancelAttempt := func() {}
+	if canRetry && picker.HasAlternative(baseURL) {
+		// Reserve half the remaining budget so a slow endpoint cannot consume it all.
+		deadline, _ := reqCtx.Deadline()
+		attemptCtx, cancelAttempt = context.WithTimeout(reqCtx, time.Until(deadline)/2)
+	}
+	retryable, attemptErr := r.postJSONAttempt(attemptCtx, baseURL, path, payload, out)
+	cancelAttempt()
+	if attemptErr == nil || !retryable || !canRetry || reqCtx.Err() != nil {
+		return attemptErr
+	}
+	baseURL, err = picker.PickExcluding(map[string]struct{}{baseURL: {}})
+	if errors.Is(err, errNoRenderEndpoints) {
+		return attemptErr
+	}
+	if err != nil {
+		return fmt.Errorf("pick alternate render endpoint: %w", err)
+	}
+	_, err = r.postJSONAttempt(reqCtx, baseURL, path, payload, out)
+	return err
 }
 
 // postJSONAttempt sends one render request and reports whether another endpoint may succeed.
-func (r *vllmHTTPRenderer) postJSONAttempt(reqCtx, authCtx context.Context, baseURL, path string, payload []byte, out any) (bool, error) {
+func (r *vllmHTTPRenderer) postJSONAttempt(reqCtx context.Context, baseURL, path string, payload []byte, out any) (bool, error) {
 	httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, baseURL+path, bytes.NewReader(payload))
 	if err != nil {
 		return false, fmt.Errorf("build request: %w", err)
@@ -516,13 +510,13 @@ func (r *vllmHTTPRenderer) postJSONAttempt(reqCtx, authCtx context.Context, base
 	httpReq.Header.Set("Content-Type", "application/json")
 	// The render endpoint may require the same credential as inference;
 	// forward the inbound Authorization when present.
-	if auth := authHeaderFromContext(authCtx); auth != "" {
+	if auth := authHeaderFromContext(reqCtx); auth != "" {
 		httpReq.Header.Set("Authorization", auth)
 	}
 
 	httpResp, err := r.client.Do(httpReq)
 	if err != nil {
-		return reqCtx.Err() == nil, fmt.Errorf("post %s: %w", path, err)
+		return true, fmt.Errorf("post %s: %w", path, err)
 	}
 	defer httpResp.Body.Close()
 
@@ -531,7 +525,7 @@ func (r *vllmHTTPRenderer) postJSONAttempt(reqCtx, authCtx context.Context, base
 		return isRetryableRenderStatus(httpResp.StatusCode), &renderStatusError{StatusCode: httpResp.StatusCode, Body: string(snippet)}
 	}
 	if err := json.NewDecoder(httpResp.Body).Decode(out); err != nil {
-		return false, fmt.Errorf("unmarshal response: %w", err)
+		return reqCtx.Err() != nil || errors.Is(err, io.ErrUnexpectedEOF), fmt.Errorf("unmarshal response: %w", err)
 	}
 	return false, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

`token-producer` can select vLLM render targets from endpoints published by data-layer discovery instead of sending every render request through one configured URL.

- Adds `vllm.endpointDiscovery`, mutually exclusive with `vllm.url`.
- Tracks endpoint additions, updates, and deletions through the data-layer endpoint notification source.
- Selects render targets through a pluggable load-balancer interface. `round-robin` is the default and currently supported algorithm.
- Keeps the existing `vllm.url` mode available for sidecars and dedicated render Services.
- Supports optional model-limit discovery and label-based minimum renderer capacity filtering.
- Supports `vllm.prefillOnly` to reduce the render-only output budget without changing the inference payload. Requests with explicit prompt truncation retain their original budget.

Kubernetes discovery supplies Ready `InferencePool` endpoints and their target ports. Other discovery plugins can supply explicit render addresses and ports.

**Which issue(s) this PR fixes**:

Fixes #2696

**Release note** _(write `NONE` if no user-facing change)_:

```release-note
Set `vllm.endpointDiscovery: {}` on `token-producer` to render against discovered endpoints with round-robin balancing. This option is mutually exclusive with `vllm.url` and uses inference ports by default. Under `vllm.endpointDiscovery`, optional `portRules` map pod labels to render ports; nonempty rule lists exclude unmatched endpoints. Optional `attemptTimeout` limits each render attempt. Transient failures permit one retry on another endpoint within the request deadline. Discovered render URLs use HTTP; use `vllm.url` for HTTPS.

Optional `discoverModelLimits`, `minModelLen`, and `contextLimitLabel` settings under `vllm.endpointDiscovery` filter render targets by context capacity. Set `vllm.prefillOnly: true` to use a one-token render-only output budget without changing the inference payload. Requests with explicit prompt truncation retain their original output budget. These settings are opt-in. Producer failures are logged and routing continues; inference validation remains with vLLM.
```

