### PR TITLE
docs: drop links to deleted IGW guide pages (#1863)

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,8 +1,7 @@
 # Ignore transient failures on gnu.org (it sometimes refuses connections)
 exclude = [
   "^https://www.gnu.org/software/make/?$",
-  "^https://www.envoyproxy.io/",
-  "^https://gateway-api-inference-extension.sigs.k8s.io/guides/serving-multiple-inference-pools-latest/"
+  "^https://www.envoyproxy.io/"
 ]
 
 # Per-request timeout in seconds. Sized for slow upstream docs sites

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -690,8 +690,8 @@ helm upgrade -i --namespace kgateway-system --version $KGTW_VERSION \
   --set inferenceExtension.enabled=true
 ```
 
-For more details, see the Gateway API Inference Extension
-[getting started guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/).
+For more details, see the
+[Gateway API Inference Extension documentation](https://gateway-api-inference-extension.sigs.k8s.io/).
 
 ### RBAC and Permissions
 
@@ -870,8 +870,8 @@ helm uninstall kgateway -n kgateway-system
 helm uninstall kgateway-crds -n kgateway-system
 ```
 
-For more details, see the Gateway API Inference Extension
-[getting started guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/).
+For more details, see the
+[Gateway API Inference Extension documentation](https://gateway-api-inference-extension.sigs.k8s.io/).
 
 ## Logging
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/kind cleanup

**What this PR does / why we need it**:

IGW's `ebbb148c` cleanup deleted `site-src/guides/index.md`, so `https://gateway-api-inference-extension.sigs.k8s.io/guides/` now 404s. `DEVELOPMENT.md:694` and `:874` still linked to it (both right after a kgateway helm block); both now point at the documentation root instead, since `site-src/guides/` no longer has anything that fits an operator audience (`implementers.md` is scoped to Gateway API controller implementers, not to someone running `helm install`).

The same cleanup deleted the `serving-multiple-inference-pools-latest` guide. #1834 already dropped the only link to it from `docs/architecture.md`, so the `.lychee.toml` exclude added by #1864 was guarding a URL nothing in the repo references anymore. Removed.

**Why CI didn't catch the `DEVELOPMENT.md` links**: `md-link-check.yml` passes `**/*.md`, but lychee-action v2.9.0 evals that unquoted under bash with `globstar` off, so it degrades to `*.md` and only checks the 13 files under `docs/` — root-level `DEVELOPMENT.md` has never been linted. Fixing that glob is a separate change (quoting it today also breaks on the Slack links in `README.md`), so it's not part of this PR.

**Testing**: Ran lychee by hand with the glob quoted, over `DEVELOPMENT.md` and `docs/*.md`: 2 errors (both the dead `/guides/` link) before this change, 0 after. `typos` passes; the diff has no Go files so `golangci-lint` has nothing new to check.

Not done: the issue also suggested re-pointing the `serving-multiple-inference-pools` link at its new home from llm-d/llm-d#1884. There's nothing left to re-point — #1834 deleted that link outright, and no file in this repo mentions `multi-model-routing` anymore.

**Which issue(s) this PR fixes**:

Fixes #1863

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
