### PR TITLE
docs: use blockSizeTokens in tokenProcessorConfig samples (#641)

### DIFF
--- a/deploy/config/epp-mm-embeddings-cache-config.yaml
+++ b/deploy/config/epp-mm-embeddings-cache-config.yaml
@@ -17,7 +17,7 @@ plugins:
   - type: precise-prefix-cache-producer
     parameters:
       tokenProcessorConfig:
-        blockSize: 64
+        blockSizeTokens: 64
       indexerConfig:
         kvBlockIndexConfig:
           enableMetrics: true

--- a/deploy/config/epp-precise-prefix-cache-config.yaml
+++ b/deploy/config/epp-precise-prefix-cache-config.yaml
@@ -16,7 +16,7 @@ plugins:
   - type: precise-prefix-cache-producer
     parameters:
       tokenProcessorConfig:
-        blockSize: 64
+        blockSizeTokens: 64
       indexerConfig:
         kvBlockIndexConfig:
           enableMetrics: true       # enable kv-block index metrics (prometheus)

--- a/deploy/config/sim-epp-kvcache-config.yaml
+++ b/deploy/config/sim-epp-kvcache-config.yaml
@@ -11,7 +11,7 @@ plugins:
 - type: precise-prefix-cache-producer
   parameters:
     tokenProcessorConfig:
-      blockSize: 16
+      blockSizeTokens: 16
     kvEventsConfig:
       zmqEndpoint: tcp://0.0.0.0:5557
     indexerConfig:

--- a/deploy/config/sim-epp-tokenizer-vllm-http-config.yaml
+++ b/deploy/config/sim-epp-tokenizer-vllm-http-config.yaml
@@ -15,7 +15,7 @@ plugins:
 - type: precise-prefix-cache-producer
   parameters:
     tokenProcessorConfig:
-      blockSize: 16
+      blockSizeTokens: 16
       hashSeed: "42"
     kvEventsConfig:
       zmqEndpoint: tcp://0.0.0.0:5557

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/p2psource/README.md
@@ -19,7 +19,7 @@ plugins:
   - type: precise-prefix-cache-producer
     parameters:
       tokenProcessorConfig:
-        blockSize: 64
+        blockSizeTokens: 64
       kvEventsConfig:
         topicFilter: "kv@"
   - type: p2p-source-producer

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md
@@ -55,7 +55,7 @@ Block keys are recomputed by the EPP from `TokenizedPrompt` (tokens, model,
 multimodal features, cache salt) on both the lookup path and the KV-event
 ingestion path, using this plugin's `tokenProcessorConfig`. The engine's own
 block hashes serve only as opaque keys for the engine-to-request mapping, so
-`blockSize`/`hashSeed` need not match the engine.
+`blockSizeTokens`/`hashSeed` need not match the engine.
 
 The cross-engine requirement is that the engine emits, in its KV-events, the
 hash-affecting inputs the EPP hashes: `token_ids`, and `extra_keys` carrying

--- a/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/README.md
+++ b/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache/README.md
@@ -28,7 +28,7 @@ end up active.
 ```yaml
 - type: precise-prefix-cache-scorer
   parameters:
-    tokenProcessorConfig: { blockSize: 64 }
+    tokenProcessorConfig: { blockSizeTokens: 64 }
     kvEventsConfig: { discoverPods: true, podDiscoveryConfig: { socketPort: 5557 } }
 ```
 
@@ -37,7 +37,7 @@ becomes
 ```yaml
 - type: precise-prefix-cache-producer
   parameters:
-    tokenProcessorConfig: { blockSize: 64 }
+    tokenProcessorConfig: { blockSizeTokens: 64 }
     kvEventsConfig: { discoverPods: true, podDiscoveryConfig: { socketPort: 5557 } }
 - type: prefix-cache-scorer
   parameters:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Four sample EPP configs and three plugin READMEs still show the deprecated
`blockSize` key inside `tokenProcessorConfig`. `TokenProcessorConfig` resolves
`blockSizeTokens` first and only falls back to `blockSize`
(`pkg/kvcache/kvblock/token_processor.go`), so every sample a user copies
teaches the deprecated spelling. Nothing in Go parses `deploy/config/*.yaml`,
so these files had no test or compile-time guard, which is how they were
missed when the rest of the repo was renamed (#2072).

Renames the key in place, values unchanged (`64`, `64`, `16`, `16`). The
deprecation fallback itself is untouched, so existing configs still using
`blockSize` keep working.

Verified: every file under `deploy/config/` still parses through
`loader.LoadRawConfig`, and the four renamed samples decode to
`"tokenProcessorConfig":{"blockSizeTokens":N}` with `N` unchanged; `typos`
passes.

**Which issue(s) this PR fixes**:

Fixes #641
Fixes #747

(#747's first checkbox landed in #748; this closes the second and last one —
the `llm-d-kv-cache` dependency it named was dropped in #2512.)

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
