### PR TITLE
refactor(epp): add NewExtProcServerRunner and route every caller through it (#1370)

### DIFF
--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -476,28 +476,8 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 		director.SetRequestEvictor(requestEvictor)
 	}
 
-	serverRunner := &runserver.ExtProcServerRunner{
-		GrpcPort:                         opts.GRPCPort,
-		GKNN:                             *gknn,
-		Datastore:                        ds,
-		ControllerCfg:                    controllerCfg,
-		SecureServing:                    opts.SecureServing,
-		HealthChecking:                   opts.HealthChecking,
-		CertPath:                         opts.CertPath,
-		EnableCertReload:                 opts.EnableCertReload,
-		TLSMinVersion:                    opts.TLSMinVersionValue(),
-		TLSCipherSuites:                  opts.TLSCipherSuiteValues(),
-		RefreshPrometheusMetricsInterval: opts.RefreshPrometheusMetricsInterval,
-		MetricsStalenessThreshold:        opts.MetricsStalenessThreshold,
-		Director:                         director,
-		ParserRegistry:                   r.parserRegistry,
-		SaturationDetector:               eppConfig.SaturationDetector,
-		PriorityBandControlPlane:         priorityBandControlPlane,
-		GRPCMaxRecvMsgSize:               opts.GRPCMaxRecvMsgSize,
-		GRPCMaxSendMsgSize:               opts.GRPCMaxSendMsgSize,
-		EnableGRPCStreamMetrics:          opts.EnableGRPCStreamMetrics,
-		EmitEndpointScores:               opts.EmitEndpointScores,
-	}
+	serverRunner := runserver.NewExtProcServerRunner(opts, *gknn, controllerCfg, ds, director,
+		r.parserRegistry, eppConfig.SaturationDetector, priorityBandControlPlane)
 	if requestEvictor != nil {
 		serverRunner.EvictChannelLookup = requestEvictor.EvictionRegistry()
 	}
@@ -1137,27 +1117,9 @@ func (r *Runner) runWithFileDiscovery(ctx context.Context, opts *runserver.Optio
 	gknn := common.GKNN{
 		NamespacedName: types.NamespacedName{Name: poolName, Namespace: namespace},
 	}
-	serverRunner := &runserver.ExtProcServerRunner{
-		GrpcPort:                         opts.GRPCPort,
-		GKNN:                             gknn,
-		Datastore:                        ds,
-		ControllerCfg:                    runserver.NewControllerConfig(false),
-		SecureServing:                    opts.SecureServing,
-		HealthChecking:                   opts.HealthChecking,
-		CertPath:                         opts.CertPath,
-		EnableCertReload:                 opts.EnableCertReload,
-		TLSMinVersion:                    opts.TLSMinVersionValue(),
-		TLSCipherSuites:                  opts.TLSCipherSuiteValues(),
-		RefreshPrometheusMetricsInterval: opts.RefreshPrometheusMetricsInterval,
-		MetricsStalenessThreshold:        opts.MetricsStalenessThreshold,
-		Director:                         director,
-		ParserRegistry:                   r.parserRegistry,
-		SaturationDetector:               eppConfig.SaturationDetector,
-		GRPCMaxRecvMsgSize:               opts.GRPCMaxRecvMsgSize,
-		GRPCMaxSendMsgSize:               opts.GRPCMaxSendMsgSize,
-		EnableGRPCStreamMetrics:          opts.EnableGRPCStreamMetrics,
-		EmitEndpointScores:               opts.EmitEndpointScores,
-	}
+	// nil control plane: file-discovery mode has no InferenceObjective reconciler to drive one.
+	serverRunner := runserver.NewExtProcServerRunner(opts, gknn, runserver.NewControllerConfig(false),
+		ds, director, r.parserRegistry, eppConfig.SaturationDetector, nil)
 	if requestEvictor != nil {
 		serverRunner.EvictChannelLookup = requestEvictor.EvictionRegistry()
 	}

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -81,8 +81,50 @@ type ExtProcServerRunner struct {
 	EvictChannelLookup handlers.EvictChannelLookup
 }
 
+// NewExtProcServerRunner builds a runner from the runtime options plus the dependencies the
+// caller has already constructed. It is the single place that maps *Options onto
+// ExtProcServerRunner: adding an option here reaches every ext_proc server, instead of only
+// whichever call site the author happened to edit.
+//
+// GrpcListener and EvictChannelLookup stay the caller's job -- both are optional and only
+// some call sites have one.
+func NewExtProcServerRunner(
+	opts *Options,
+	gknn common.GKNN,
+	controllerCfg ControllerConfig,
+	ds datastore.Datastore,
+	director *requestcontrol.Director,
+	parserRegistry *handlers.ParserRegistry,
+	saturationDetector fwkfc.SaturationDetector,
+	priorityBandControlPlane contracts.PriorityBandControlPlane,
+) *ExtProcServerRunner {
+	return &ExtProcServerRunner{
+		GrpcPort:                         opts.GRPCPort,
+		GKNN:                             gknn,
+		ControllerCfg:                    controllerCfg,
+		Datastore:                        ds,
+		SecureServing:                    opts.SecureServing,
+		HealthChecking:                   opts.HealthChecking,
+		CertPath:                         opts.CertPath,
+		EnableCertReload:                 opts.EnableCertReload,
+		TLSMinVersion:                    opts.TLSMinVersionValue(),
+		TLSCipherSuites:                  opts.TLSCipherSuiteValues(),
+		RefreshPrometheusMetricsInterval: opts.RefreshPrometheusMetricsInterval,
+		MetricsStalenessThreshold:        opts.MetricsStalenessThreshold,
+		Director:                         director,
+		ParserRegistry:                   parserRegistry,
+		SaturationDetector:               saturationDetector,
+		PriorityBandControlPlane:         priorityBandControlPlane,
+		GRPCMaxRecvMsgSize:               opts.GRPCMaxRecvMsgSize,
+		GRPCMaxSendMsgSize:               opts.GRPCMaxSendMsgSize,
+		EnableGRPCStreamMetrics:          opts.EnableGRPCStreamMetrics,
+		EmitEndpointScores:               opts.EmitEndpointScores,
+	}
+}
+
 // NewDefaultExtProcServerRunner creates a runner with default values.
-// Note: Dependencies like Datastore, Scheduler, SD need to be set separately.
+// Note: Dependencies like Datastore, Scheduler, SD need to be set separately, hence the
+// nil arguments below.
 func NewDefaultExtProcServerRunner() *ExtProcServerRunner {
 	opts := NewOptions()
 	if opts.PoolNamespace == "" {
@@ -96,24 +138,13 @@ func NewDefaultExtProcServerRunner() *ExtProcServerRunner {
 			Kind:  "InferencePool",
 		},
 	}
-	return &ExtProcServerRunner{
-		GrpcPort:           opts.GRPCPort,
-		GRPCMaxRecvMsgSize: opts.GRPCMaxRecvMsgSize,
-		GRPCMaxSendMsgSize: opts.GRPCMaxSendMsgSize,
-		GKNN:               gknn,
-		ControllerCfg: ControllerConfig{
-			startCrdReconcilers:       true,
-			hasInferenceObjective:     true,
-			hasInferenceModelRewrites: true,
-			InferenceObjectiveGV:      inferenceAPIGV,
-			InferenceModelRewriteGV:   inferenceAPIGV,
-		},
-		SecureServing:                    opts.SecureServing,
-		HealthChecking:                   opts.HealthChecking,
-		RefreshPrometheusMetricsInterval: opts.RefreshPrometheusMetricsInterval,
-		MetricsStalenessThreshold:        opts.MetricsStalenessThreshold,
-		// Dependencies can be assigned later.
-	}
+	return NewExtProcServerRunner(opts, gknn, ControllerConfig{
+		startCrdReconcilers:       true,
+		hasInferenceObjective:     true,
+		hasInferenceModelRewrites: true,
+		InferenceObjectiveGV:      inferenceAPIGV,
+		InferenceModelRewriteGV:   inferenceAPIGV,
+	}, nil, nil, nil, nil, nil)
 }
 
 // SetupWithManager sets up the runner with the given manager.

--- a/pkg/epp/server/runserver.go
+++ b/pkg/epp/server/runserver.go
@@ -123,8 +123,8 @@ func NewExtProcServerRunner(
 }
 
 // NewDefaultExtProcServerRunner creates a runner with default values.
-// Note: Dependencies like Datastore, Scheduler, SD need to be set separately, hence the
-// nil arguments below.
+// Note: Dependencies like Datastore, Director, ParserRegistry, SaturationDetector, and
+// PriorityBandControlPlane need to be set separately, hence the nil arguments below.
 func NewDefaultExtProcServerRunner() *ExtProcServerRunner {
 	opts := NewOptions()
 	if opts.PoolNamespace == "" {

--- a/pkg/epp/server/runserver_test.go
+++ b/pkg/epp/server/runserver_test.go
@@ -17,11 +17,23 @@ limitations under the License.
 package server_test
 
 import (
+	"crypto/tls"
+	"reflect"
 	"testing"
+	"time"
 
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/llm-d/llm-d-router/pkg/common"
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/epp/datastore"
+	"github.com/llm-d/llm-d-router/pkg/epp/flowcontrol/contracts"
+	fwkfcmocks "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/flowcontrol/mocks"
+	"github.com/llm-d/llm-d-router/pkg/epp/handlers"
+	"github.com/llm-d/llm-d-router/pkg/epp/requestcontrol"
 	"github.com/llm-d/llm-d-router/pkg/epp/server"
 )
 
@@ -35,4 +47,55 @@ func TestRunnable(t *testing.T) {
 	if r.NeedLeaderElection() {
 		t.Error("runner returned NeedLeaderElection = true, expected false")
 	}
+}
+
+// stubDatastore and stubBands are non-nil placeholders: the factory only stores these
+// dependencies, so an embedded nil interface is enough to make the field observably set.
+type stubDatastore struct{ datastore.Datastore }
+type stubBands struct {
+	contracts.PriorityBandControlPlane
+}
+
+// TestNewExtProcServerRunnerPopulatesEveryField fails the day a field is added to
+// ExtProcServerRunner without being wired through the constructor -- the drift that let
+// a new Options flag reach only one of the two hand-written composite literals.
+func TestNewExtProcServerRunnerPopulatesEveryField(t *testing.T) {
+	// Fields the caller sets after construction, not the factory.
+	callerSet := map[string]bool{"GrpcListener": true, "EvictChannelLookup": true}
+
+	opts := server.NewOptions()
+	// AddFlags registers the logging flag set that Complete() dereferences.
+	opts.AddFlags(pflag.NewFlagSet("t", pflag.ContinueOnError))
+	opts.GRPCPort, opts.CertPath = 19002, "/tmp/certs"
+	opts.SecureServing, opts.HealthChecking, opts.EnableCertReload = true, true, true
+	opts.EnableGRPCStreamMetrics, opts.EmitEndpointScores = true, true
+	opts.TLSMinVersion, opts.TLSCipherSuites = "VersionTLS13", []string{"TLS_AES_128_GCM_SHA256"}
+	opts.RefreshPrometheusMetricsInterval, opts.MetricsStalenessThreshold = 7*time.Second, 11*time.Second
+	require.NoError(t, opts.Complete()) // parses the TLS strings into the unexported fields
+	// Set after Complete(): the *Str flags are empty, so Complete() leaves these alone.
+	opts.GRPCMaxRecvMsgSize, opts.GRPCMaxSendMsgSize = 4<<20, 5<<20
+
+	ds, sd := &stubDatastore{}, &fwkfcmocks.MockSaturationDetector{}
+	r := server.NewExtProcServerRunner(opts,
+		common.GKNN{NamespacedName: types.NamespacedName{Name: "pool", Namespace: "ns"}},
+		server.NewControllerConfig(true), ds, &requestcontrol.Director{},
+		&handlers.ParserRegistry{}, sd, &stubBands{})
+
+	v := reflect.ValueOf(*r)
+	fields := reflect.VisibleFields(reflect.TypeOf(*r))
+	require.NotEmpty(t, fields) // never vacuous
+	for _, f := range fields {
+		// FieldByIndex, not Field(i): VisibleFields flattens promoted fields.
+		if !callerSet[f.Name] && v.FieldByIndex(f.Index).IsZero() {
+			t.Errorf("%s left zero by NewExtProcServerRunner", f.Name)
+		}
+	}
+
+	// IsZero cannot see two fields wired to each other's source, so pin the pairs.
+	require.Equal(t, 4<<20, r.GRPCMaxRecvMsgSize)
+	require.Equal(t, 5<<20, r.GRPCMaxSendMsgSize)
+	require.Equal(t, 19002, r.GrpcPort)
+	require.Equal(t, uint16(tls.VersionTLS13), r.TLSMinVersion)
+	require.Same(t, ds, r.Datastore)
+	require.Same(t, sd, r.SaturationDetector)
 }

--- a/pkg/epp/server/runserver_test.go
+++ b/pkg/epp/server/runserver_test.go
@@ -76,10 +76,10 @@ func TestNewExtProcServerRunnerPopulatesEveryField(t *testing.T) {
 	opts.GRPCMaxRecvMsgSize, opts.GRPCMaxSendMsgSize = 4<<20, 5<<20
 
 	ds, sd := &stubDatastore{}, &fwkfcmocks.MockSaturationDetector{}
+	director, registry, bands := &requestcontrol.Director{}, &handlers.ParserRegistry{}, &stubBands{}
 	r := server.NewExtProcServerRunner(opts,
 		common.GKNN{NamespacedName: types.NamespacedName{Name: "pool", Namespace: "ns"}},
-		server.NewControllerConfig(true), ds, &requestcontrol.Director{},
-		&handlers.ParserRegistry{}, sd, &stubBands{})
+		server.NewControllerConfig(true), ds, director, registry, sd, bands)
 
 	v := reflect.ValueOf(*r)
 	fields := reflect.VisibleFields(reflect.TypeOf(*r))
@@ -91,11 +91,65 @@ func TestNewExtProcServerRunnerPopulatesEveryField(t *testing.T) {
 		}
 	}
 
-	// IsZero cannot see two fields wired to each other's source, so pin the pairs.
+	// IsZero cannot see two fields wired to each other's source, so pin every field that
+	// shares its type with another one: the three ints, the two durations, and each
+	// dependency. The bools cannot be told apart by value and are covered by
+	// TestNewExtProcServerRunnerMapsEachBoolOption below.
 	require.Equal(t, 4<<20, r.GRPCMaxRecvMsgSize)
 	require.Equal(t, 5<<20, r.GRPCMaxSendMsgSize)
 	require.Equal(t, 19002, r.GrpcPort)
 	require.Equal(t, uint16(tls.VersionTLS13), r.TLSMinVersion)
+	require.Equal(t, 7*time.Second, r.RefreshPrometheusMetricsInterval)
+	require.Equal(t, 11*time.Second, r.MetricsStalenessThreshold)
 	require.Same(t, ds, r.Datastore)
+	require.Same(t, director, r.Director)
+	require.Same(t, registry, r.ParserRegistry)
 	require.Same(t, sd, r.SaturationDetector)
+	require.Same(t, bands, r.PriorityBandControlPlane)
+}
+
+// boolOptions pairs each boolean Options field the factory reads with the runner field it
+// must land in.
+var boolOptions = []struct {
+	name string
+	set  func(*server.Options, bool)
+	get  func(*server.ExtProcServerRunner) bool
+}{
+	{"SecureServing",
+		func(o *server.Options, v bool) { o.SecureServing = v },
+		func(r *server.ExtProcServerRunner) bool { return r.SecureServing }},
+	{"HealthChecking",
+		func(o *server.Options, v bool) { o.HealthChecking = v },
+		func(r *server.ExtProcServerRunner) bool { return r.HealthChecking }},
+	{"EnableCertReload",
+		func(o *server.Options, v bool) { o.EnableCertReload = v },
+		func(r *server.ExtProcServerRunner) bool { return r.EnableCertReload }},
+	{"EnableGRPCStreamMetrics",
+		func(o *server.Options, v bool) { o.EnableGRPCStreamMetrics = v },
+		func(r *server.ExtProcServerRunner) bool { return r.EnableGRPCStreamMetrics }},
+	{"EmitEndpointScores",
+		func(o *server.Options, v bool) { o.EmitEndpointScores = v },
+		func(r *server.ExtProcServerRunner) bool { return r.EmitEndpointScores }},
+}
+
+// TestNewExtProcServerRunnerMapsEachBoolOption sets one boolean option at a time and
+// asserts exactly one runner field follows. Every bool holding the same value cannot
+// distinguish a swapped pair, which is the wiring mistake the all-true sweep above misses.
+func TestNewExtProcServerRunnerMapsEachBoolOption(t *testing.T) {
+	for _, tc := range boolOptions {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := server.NewOptions()
+			for _, o := range boolOptions {
+				o.set(opts, false) // NewOptions defaults SecureServing to true
+			}
+			tc.set(opts, true)
+
+			r := server.NewExtProcServerRunner(opts, common.GKNN{},
+				server.NewControllerConfig(true), nil, nil, nil, nil, nil)
+
+			for _, o := range boolOptions {
+				require.Equal(t, o.name == tc.name, o.get(r), "runner field %s", o.name)
+			}
+		})
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

`ExtProcServerRunner` is built by hand at three places: `(*Runner).setup`
(`cmd/epp/runner/runner.go:479`), `(*Runner).runWithFileDiscovery` (`:1140`, ~660 lines away),
and `NewDefaultExtProcServerRunner` (`pkg/epp/server/runserver.go:86`). The struct has 22 fields,
and a composite literal zero-fills whatever it omits, so adding an `Options` field and wiring it
at one site still compiles — the other ext_proc servers just run with the zero value and nothing
points that out. That's how #1362's two gRPC message size fields reached one server and not the
other. The three literals agree today, so this is preventive rather than a live bug.

`runserver.NewExtProcServerRunner` becomes the one place `*Options` is mapped onto the runner. It
takes the options plus the seven dependencies the caller already built, and all three sites now
call it.

- `GrpcListener` and `EvictChannelLookup` stay caller-assigned — both are optional and only some
  call sites have one.
- `PriorityBandControlPlane` is a constructor parameter rather than a post-construction
  assignment, so a silent omission fails to compile instead of staying invisible to every
  cluster-free test.
- `NewDefaultExtProcServerRunner` collapses onto the factory and passes five `nil` dependencies —
  what its doc comment already promised ("set separately"). Behaviour-preserving: every field the
  factory sets beyond the nine it used to set is zero under `NewOptions()`.

`TestNewExtProcServerRunnerPopulatesEveryField` walks `reflect.VisibleFields` over the returned
runner and fails on any field left zero except the two the caller owns; same-typed fields wired
to each other's source (the two durations, the five bools) are pinned directly since `IsZero`
alone can't tell a swap from a correct assignment.

Before:
```
$ go test ./pkg/epp/server/... -run 'TestNewExtProcServerRunnerPopulatesEveryField'
pkg/epp/server/runserver_test.go:77:14: undefined: server.NewExtProcServerRunner
FAIL	github.com/llm-d/llm-d-router/pkg/epp/server [build failed]
```

After:
```
$ go test ./pkg/epp/server/... ./cmd/epp/runner/...
ok  	github.com/llm-d/llm-d-router/pkg/epp/server	22.811s
ok  	github.com/llm-d/llm-d-router/cmd/epp/runner	2.609s
```

`bands` (`PriorityBandControlPlane`) stays `nil` in file-discovery mode, same as before this
change — there's no reconciler driving it on that path.

**Which issue(s) this PR fixes**:
Fixes #1370

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
