### PR TITLE
fix(epp): rotate only equal top-scoring endpoints in maxscore picker

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/picker/common.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/common.go
@@ -23,6 +23,7 @@ limitations under the License.
 package picker
 
 import (
+	"math"
 	"math/rand/v2"
 	"sync"
 	"time"
@@ -44,7 +45,7 @@ type PickerParameters struct {
 type lockedRand struct {
 	mu      sync.Mutex
 	rand    *rand.Rand
-	counter int // round-robin counter for deterministic tie-breaking, reset when it reaches endpoint count
+	counter int // round-robin counter for deterministic tie-breaking
 }
 
 func newLockedRand() *lockedRand {
@@ -69,6 +70,17 @@ func (r *lockedRand) Shuffle(n int, swap func(i, j int)) {
 	r.rand.Shuffle(n, swap)
 }
 
+// NextCounter returns a monotonically increasing counter for deterministic
+// round-robin tie-breaking across requests.
+func (r *lockedRand) NextCounter() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	c := r.counter
+	r.counter = (r.counter + 1) % math.MaxInt
+	return c
+}
+
 // PickerRand is a thread-safe random number generator shared by all pickers to avoid seeding
 // overhead and ensure controlled randomization.
 var PickerRand = newLockedRand()
@@ -84,23 +96,19 @@ func ShuffleScoredEndpoints(scoredEndpoints []*fwksched.ScoredEndpoint) {
 // equal-score endpoints. Under concurrent load with prefix cache affinity,
 // multiple requests can see identical scores simultaneously. Pure random
 // shuffling causes them to converge on the same winner, creating severe
-// routing imbalance. The round-robin counter ensures each call rotates
-// through the endpoints evenly.
-func RotateScoredEndpoints(scoredEndpoints []*fwksched.ScoredEndpoint) {
+// routing imbalance. The caller supplies a counter drawn once per request,
+// ensuring independent rotation across multiple tie groups.
+func RotateScoredEndpoints(scoredEndpoints []*fwksched.ScoredEndpoint, counter int) {
 	n := len(scoredEndpoints)
 	if n <= 1 {
 		return
 	}
 
-	PickerRand.mu.Lock()
-	defer PickerRand.mu.Unlock()
-
-	PickerRand.counter = (PickerRand.counter + 1) % n
-
-	if PickerRand.counter > 0 {
+	shift := counter % n
+	if shift > 0 {
 		rotated := make([]*fwksched.ScoredEndpoint, n)
-		copy(rotated, scoredEndpoints[PickerRand.counter:])
-		copy(rotated[n-PickerRand.counter:], scoredEndpoints[:PickerRand.counter])
+		copy(rotated, scoredEndpoints[shift:])
+		copy(rotated[n-shift:], scoredEndpoints[:shift])
 		copy(scoredEndpoints, rotated)
 	}
 }

--- a/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go
@@ -88,10 +88,6 @@ func (p *MaxScorePicker) Pick(ctx context.Context, scoredEndpoints []*fwksched.S
 	log.FromContext(ctx).V(logutil.DEBUG).Info("Selecting endpoints from candidates sorted by max score", "max-num-of-endpoints", p.maxNumOfEndpoints,
 		"num-of-candidates", len(scoredEndpoints), "scored-endpoints", scoredEndpoints)
 
-	// RotateScoredEndpoints provides deterministic round-robin
-	// tie-breaking instead of random shuffle (see picker/common.go)
-	picker.RotateScoredEndpoints(scoredEndpoints)
-
 	slices.SortStableFunc(scoredEndpoints, func(i, j *fwksched.ScoredEndpoint) int { // highest score first
 		if i.Score > j.Score {
 			return -1
@@ -101,6 +97,21 @@ func (p *MaxScorePicker) Pick(ctx context.Context, scoredEndpoints []*fwksched.S
 		}
 		return 0
 	})
+
+	// RotateScoredEndpoints provides deterministic round-robin tie-breaking
+	// for equal-score candidates. Rotating within each equal-score tier ensures
+	// traffic is distributed evenly without distortion from lower-scoring endpoints.
+	counter := picker.PickerRand.NextCounter()
+	for start := 0; start < len(scoredEndpoints) && start < p.maxNumOfEndpoints; {
+		end := start + 1
+		for end < len(scoredEndpoints) && scoredEndpoints[end].Score == scoredEndpoints[start].Score {
+			end++
+		}
+		if end-start > 1 {
+			picker.RotateScoredEndpoints(scoredEndpoints[start:end], counter)
+		}
+		start = end
+	}
 
 	// if we have enough endpoints to return keep only the "maxNumOfEndpoints" highest scored endpoints
 	if p.maxNumOfEndpoints < len(scoredEndpoints) {

--- a/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker_test.go
+++ b/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker_test.go
@@ -69,6 +69,143 @@ func TestEqualScoreDistribution(t *testing.T) {
 	}
 }
 
+func TestEqualScoreDistribution_WithLowerScoredCandidates(t *testing.T) {
+	numPods := 8
+	endpoints := make([]fwksched.Endpoint, numPods)
+	for i := 0; i < numPods; i++ {
+		endpoints[i] = fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
+			ID: k8stypes.NamespacedName{Name: fmt.Sprintf("pod%d", i)},
+		}, nil, nil)
+	}
+
+	picker := NewMaxScorePicker(1)
+	picks := make(map[string]int)
+
+	// Simulate 80 requests: pod0 and pod1 both have top score 50 (e.g. prefix cache hit).
+	// pod2 through pod7 have score 0 (cache miss).
+	for i := 0; i < 80; i++ {
+		scored := make([]*fwksched.ScoredEndpoint, numPods)
+		scored[0] = &fwksched.ScoredEndpoint{Endpoint: endpoints[0], Score: 50}
+		scored[1] = &fwksched.ScoredEndpoint{Endpoint: endpoints[1], Score: 50}
+		for j := 2; j < numPods; j++ {
+			scored[j] = &fwksched.ScoredEndpoint{Endpoint: endpoints[j], Score: 0}
+		}
+		result := picker.Pick(context.Background(), scored)
+		winner := result.TargetEndpoints[0].GetMetadata().ID.Name
+		picks[winner]++
+	}
+
+	// Both pod0 and pod1 have identical top scores; they must receive equal traffic (40 each).
+	if picks["pod0"] != 40 || picks["pod1"] != 40 {
+		t.Errorf("Routing imbalance between equal top-scoring endpoints: got pod0=%d, pod1=%d, want 40 each",
+			picks["pod0"], picks["pod1"])
+	}
+}
+
+func TestEqualScoreDistribution_MultiEndpointsTieStraddlingCutoff(t *testing.T) {
+	// Verifies that when maxNumOfEndpoints > 1 and a tie group straddles the cutoff boundary,
+	// the tied candidates are rotated evenly across requests to fill the remaining slots.
+	numPods := 5
+	endpoints := make([]fwksched.Endpoint, numPods)
+	for i := range numPods {
+		endpoints[i] = fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
+			ID: k8stypes.NamespacedName{Name: fmt.Sprintf("pod%d", i)},
+		}, nil, nil)
+	}
+
+	picker := NewMaxScorePicker(2)
+	picks := make(map[string]int)
+
+	// pod0 has top score 50 (always selected).
+	// pod1, pod2, pod3 tie with score 30, straddling the cutoff boundary for maxNumOfEndpoints=2.
+	// pod4 has score 10 (never selected).
+	const numRequests = 90
+	for range numRequests {
+		scored := make([]*fwksched.ScoredEndpoint, numPods)
+		scored[0] = &fwksched.ScoredEndpoint{Endpoint: endpoints[0], Score: 50}
+		scored[1] = &fwksched.ScoredEndpoint{Endpoint: endpoints[1], Score: 30}
+		scored[2] = &fwksched.ScoredEndpoint{Endpoint: endpoints[2], Score: 30}
+		scored[3] = &fwksched.ScoredEndpoint{Endpoint: endpoints[3], Score: 30}
+		scored[4] = &fwksched.ScoredEndpoint{Endpoint: endpoints[4], Score: 10}
+
+		result := picker.Pick(context.Background(), scored)
+		if len(result.TargetEndpoints) != 2 {
+			t.Fatalf("Expected 2 endpoints, got %d", len(result.TargetEndpoints))
+		}
+		for _, ep := range result.TargetEndpoints {
+			picks[ep.GetMetadata().ID.Name]++
+		}
+	}
+
+	// pod0 must be chosen on every request
+	if picks["pod0"] != numRequests {
+		t.Errorf("pod0 got %d requests, expected %d", picks["pod0"], numRequests)
+	}
+
+	// pod1, pod2, pod3 straddle the cutoff and must evenly share the second slot (30 each)
+	expectedTiedPicks := numRequests / 3
+	for _, podName := range []string{"pod1", "pod2", "pod3"} {
+		if picks[podName] != expectedTiedPicks {
+			t.Errorf("%s got %d requests, expected %d", podName, picks[podName], expectedTiedPicks)
+		}
+	}
+
+	// pod4 has lower score and must not be chosen
+	if picks["pod4"] != 0 {
+		t.Errorf("pod4 got %d requests, expected 0", picks["pod4"])
+	}
+}
+
+func TestEqualScoreDistribution_MultipleTieTiers(t *testing.T) {
+	// Verifies that when a single pick call contains multiple tie groups of size > 1,
+	// each group rotates independently across requests without locking the shared counter.
+	numPods := 5
+	endpoints := make([]fwksched.Endpoint, numPods)
+	for i := range numPods {
+		endpoints[i] = fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
+			ID: k8stypes.NamespacedName{Name: fmt.Sprintf("pod%d", i)},
+		}, nil, nil)
+	}
+
+	picker := NewMaxScorePicker(3)
+	picks := make(map[string]int)
+
+	// pod0, pod1 tie with top score 50 (tier 1, size 2; fills 2 slots).
+	// pod2, pod3, pod4 tie with score 30 (tier 2, size 3; straddles cutoff to fill remaining 1 slot).
+	const numRequests = 60
+	for range numRequests {
+		scored := make([]*fwksched.ScoredEndpoint, numPods)
+		scored[0] = &fwksched.ScoredEndpoint{Endpoint: endpoints[0], Score: 50}
+		scored[1] = &fwksched.ScoredEndpoint{Endpoint: endpoints[1], Score: 50}
+		scored[2] = &fwksched.ScoredEndpoint{Endpoint: endpoints[2], Score: 30}
+		scored[3] = &fwksched.ScoredEndpoint{Endpoint: endpoints[3], Score: 30}
+		scored[4] = &fwksched.ScoredEndpoint{Endpoint: endpoints[4], Score: 30}
+
+		result := picker.Pick(context.Background(), scored)
+		if len(result.TargetEndpoints) != 3 {
+			t.Fatalf("Expected 3 endpoints, got %d", len(result.TargetEndpoints))
+		}
+		for _, ep := range result.TargetEndpoints {
+			picks[ep.GetMetadata().ID.Name]++
+		}
+	}
+
+	// pod0 and pod1 must be chosen on every request
+	for _, podName := range []string{"pod0", "pod1"} {
+		if picks[podName] != numRequests {
+			t.Errorf("%s got %d requests, expected %d", podName, picks[podName], numRequests)
+		}
+	}
+
+	// pod2, pod3, pod4 must evenly share the remaining third slot (20 each)
+	expectedTier2Picks := numRequests / 3
+	for _, podName := range []string{"pod2", "pod3", "pod4"} {
+		if picks[podName] != expectedTier2Picks {
+			t.Errorf("%s got %d requests, expected %d", podName, picks[podName], expectedTier2Picks)
+		}
+	}
+}
+
 func TestPickMaxScorePicker(t *testing.T) {
 	endpoint1 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod1"}}, nil, nil)
 	endpoint2 := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{ID: k8stypes.NamespacedName{Name: "pod2"}}, nil, nil)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a routing imbalance in `MaxScorePicker` when equal top-scoring endpoints are accompanied by lower-scoring candidates.
Previously, `RotateScoredEndpoints` rotated the entire slice of `n` candidate endpoints before `slices.SortStableFunc`. Because stable sorting preserves the relative order of equal-scoring elements from the rotated slice, only 1 out of `n` rotation shifts separated the equal top-scoring endpoints; in all other `n - 1` shifts, the first candidate in the original list remained ahead of the second.

#### Example:
Given candidate endpoints `[pod0(50), pod1(50), pod2(0), pod3(0), pod4(0), pod5(0), pod6(0), pod7(0)]`:
- When rotation shift = 1: `[pod1(50), pod2(0), ..., pod0(50)]` $\rightarrow$ `pod1` is ahead $\rightarrow$ `pod1` wins (1 of 8 shifts).
- When rotation shift = 2, 3, 4, 5, 6, 7, or 0: the cut point falls among the score-0 pods, leaving `pod0` ahead of `pod1` in the rotated slice. `SortStableFunc` preserves this order $\rightarrow$ `pod0` wins (7 of 8 shifts).

This change:
1. Sorts candidate endpoints by score first.
2. Draws a monotonically increasing counter once per Pick() call via PickerRand.NextCounter().
3. Rotates candidates only within equal-score tiers up to maxNumOfEndpoints using `counter % groupSize`, ensuring:
   - Balanced round-robin distribution among equal top-scoring endpoints regardless of lower-scoring candidates.
   - Correct tie-breaking when a tie group spans the cutoff boundary (maxNumOfEndpoints > 1).
   - Independent rotation across multiple tie groups in the same request without groups interfering with each other's counter state.

**Which issue(s) this PR fixes**:
<!-- Fixes # or leave blank if submitting as a direct bug fix -->
**Test plan**:
- [x] Verified equal distribution (40 requests each out of 80) across equal top-scoring candidates in the presence of lower-scoring candidates.
- [x] Equal round-robin rotation (30 requests each out of 90) across tied candidates straddling the cutoff boundary when maxNumOfEndpoints > 1 (maxNumOfEndpoints=2).
- [x] Independent rotation across multiple tie groups of different sizes in a single request without shared counter lockup (maxNumOfEndpoints=3).
- [x] All existing picker unit tests pass.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Fixed routing imbalance in MaxScorePicker where equal top-scoring endpoints received skewed traffic when lower-scoring candidates were present.