### PR TITLE
fix(kvblock): early-stop lookup on missing key or empty filtered pods

### DIFF
--- a/pkg/kvcache/indexer_trace_test.go
+++ b/pkg/kvcache/indexer_trace_test.go
@@ -141,3 +141,31 @@ func TestScoreTokensBlockHitTelemetryIgnoresEmptyEntries(t *testing.T) {
 	assert.False(t, matchAttrs["llm_d.kv_cache.prefix_match.walked"].AsBool())
 	assert.Equal(t, int64(1), matchAttrs["llm_d.kv_cache.prefix_match.longest_chain"].AsInt64())
 }
+
+// Early termination in Index.Lookup stops traversing at the first missing
+// key, so blocks after a miss are not looked up and do not count towards
+// blocks_found or block_hit_ratio for a [hit, miss, hit] sequence.
+func TestScoreTokensBlockHitTelemetryEarlyTermination(t *testing.T) {
+	recorder := setupSpanRecorder(t)
+	ctx := logging.NewTestLoggerIntoContext(t.Context())
+
+	tp := &mockTokenProcessor{blockKeys: u64ToBlockKeys([]uint64{10, 20, 30})}
+	indexer := newTestIndexer(t, tp)
+	populateIndex(t, indexer.KVBlockIndex(), map[kvblock.BlockHash][]kvblock.PodEntry{
+		10: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
+		// 20 is missing (cache miss)
+		30: {{PodIdentifier: testPodA, DeviceTier: "gpu"}},
+	})
+
+	scores, err := indexer.ScoreTokens(ctx, []uint32{1, 2, 3}, testModel, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]float64{testPodA: 1.0}, scores)
+
+	scoreAttrs := spanAttributes(t, recorder, "score_tokens")
+	assert.Equal(t, int64(1), scoreAttrs["llm_d.kv_cache.blocks_found"].AsInt64())
+	assert.InDelta(t, 1.0/3.0, scoreAttrs["llm_d.kv_cache.block_hit_ratio"].AsFloat64(), 0.0001)
+
+	matchAttrs := spanAttributes(t, recorder, "match_block_keys")
+	assert.Equal(t, int64(1), matchAttrs["llm_d.kv_cache.prefix_match.longest_chain"].AsInt64())
+	assert.Equal(t, int64(1), matchAttrs["llm_d.kv_cache.prefix_match.pods_matched"].AsInt64())
+}

--- a/pkg/kvcache/kvblock/cost_aware_memory.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory.go
@@ -297,36 +297,40 @@ func (m *CostAwareMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHa
 
 	for idx, key := range requestKeys {
 		keyStr := key.String()
-		if pods, found := m.data.Get(keyStr); found { //nolint:nestif // TODO: can this be optimized?
-			if pods == nil || pods.Len() == 0 {
-				traceLogger.Info("no pods found for key, cutting search", "key", key)
-				return podsPerKey, nil // early stop since prefix-chain breaks here
-			}
-
-			highestHitIdx = idx
-
-			if podIdentifierSet.Len() == 0 {
-				// If no pod identifiers are provided, return all pods
-				pods.cache.Range(func(k, value interface{}) bool {
-					if pod, ok := k.(PodEntry); ok {
-						podsPerKey[key] = append(podsPerKey[key], pod)
-					}
-					return true
-				})
-			} else {
-				// Filter pods based on the provided pod identifiers
-				pods.cache.Range(func(k, value interface{}) bool {
-					if pod, ok := k.(PodEntry); ok {
-						if podIdentifierSet.Has(pod.PodIdentifier) {
-							podsPerKey[key] = append(podsPerKey[key], pod)
-						}
-					}
-					return true
-				})
-			}
-		} else {
-			traceLogger.Info("key not found in index", "key", key)
+		pods, found := m.data.Get(keyStr)
+		if !found || pods == nil || pods.Len() == 0 {
+			traceLogger.Info("no pods found for key, cutting search", "key", key)
+			return podsPerKey, nil // early stop since prefix-chain breaks here
 		}
+
+		var filteredPods []PodEntry
+		if podIdentifierSet.Len() == 0 {
+			// If no pod identifiers are provided, return all pods
+			pods.cache.Range(func(k, value interface{}) bool {
+				if pod, ok := k.(PodEntry); ok {
+					filteredPods = append(filteredPods, pod)
+				}
+				return true
+			})
+		} else {
+			// Filter pods based on the provided pod identifiers
+			pods.cache.Range(func(k, value interface{}) bool {
+				if pod, ok := k.(PodEntry); ok {
+					if podIdentifierSet.Has(pod.PodIdentifier) {
+						filteredPods = append(filteredPods, pod)
+					}
+				}
+				return true
+			})
+		}
+
+		if len(filteredPods) == 0 {
+			traceLogger.Info("no pods found for key, cutting search", "key", key)
+			return podsPerKey, nil // early stop since prefix-chain breaks here
+		}
+
+		podsPerKey[key] = filteredPods
+		highestHitIdx = idx
 	}
 
 	traceLogger.Info("lookup completed", "highest-hit-index", highestHitIdx,

--- a/pkg/kvcache/kvblock/cost_aware_memory_test.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory_test.go
@@ -73,29 +73,23 @@ func TestCostAwareIndexSize(t *testing.T) {
 	err = index.Add(ctx, []BlockHash{engineKey2}, []BlockHash{requestKey2}, []PodEntry{{PodIdentifier: "pod2", DeviceTier: "gpu"}})
 	require.NoError(t, err)
 
-	// Add third key - should evict the first one due to LRU
+	// Add third key to exceed configured size
 	engineKey3 := BlockHash(96187092)
 	requestKey3 := BlockHash(56789012)
 	err = index.Add(ctx, []BlockHash{engineKey3}, []BlockHash{requestKey3}, []PodEntry{{PodIdentifier: "pod3", DeviceTier: "cpu"}})
 	require.NoError(t, err)
 
-	// Verify requestKey1 and requestKey2 were evicted
-	evicted1, err := index.Lookup(ctx, []BlockHash{requestKey1}, nil)
-	require.NoError(t, err)
-	assert.Empty(t, evicted1)
-
-	evicted2, err := index.Lookup(ctx, []BlockHash{requestKey2}, nil)
-	require.NoError(t, err)
-	assert.Empty(t, evicted2)
-
-	// Lookup should return requestKey3
-	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey3}, nil)
-	require.NoError(t, err)
-
-	assert.Len(t, podsPerKey, 1) // Only requestKey3 should be present
-	assert.Len(t, podsPerKey[requestKey3], 1)
-
-	assert.Contains(t, podsPerKey[requestKey3], PodEntry{PodIdentifier: "pod3", DeviceTier: "cpu"})
+	// cfg.Size bounds the index to one key. Ristretto eviction or rejection
+	// bounds the live set to exactly one key.
+	var retainedKeys []BlockHash
+	for _, key := range []BlockHash{requestKey1, requestKey2, requestKey3} {
+		res, err := index.Lookup(ctx, []BlockHash{key}, nil)
+		require.NoError(t, err)
+		if len(res[key]) > 0 {
+			retainedKeys = append(retainedKeys, key)
+		}
+	}
+	assert.Len(t, retainedKeys, 1)
 }
 
 func TestSizeHumanize(t *testing.T) {

--- a/pkg/kvcache/kvblock/cost_aware_memory_test.go
+++ b/pkg/kvcache/kvblock/cost_aware_memory_test.go
@@ -79,8 +79,17 @@ func TestCostAwareIndexSize(t *testing.T) {
 	err = index.Add(ctx, []BlockHash{engineKey3}, []BlockHash{requestKey3}, []PodEntry{{PodIdentifier: "pod3", DeviceTier: "cpu"}})
 	require.NoError(t, err)
 
-	// Lookup should only return the last two keys
-	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey1, requestKey2, requestKey3}, nil)
+	// Verify requestKey1 and requestKey2 were evicted
+	evicted1, err := index.Lookup(ctx, []BlockHash{requestKey1}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, evicted1)
+
+	evicted2, err := index.Lookup(ctx, []BlockHash{requestKey2}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, evicted2)
+
+	// Lookup should return requestKey3
+	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey3}, nil)
 	require.NoError(t, err)
 
 	assert.Len(t, podsPerKey, 1) // Only requestKey3 should be present

--- a/pkg/kvcache/kvblock/in_memory.go
+++ b/pkg/kvcache/kvblock/in_memory.go
@@ -288,17 +288,16 @@ func (m *InMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 		pods, found := m.data.Peek(requestKey)
 		if !found {
 			if traceLogger.Enabled() {
-				traceLogger.Info("key not found in index", "key", requestKey)
+				traceLogger.Info("no pods found for key, cutting search", "key", requestKey)
 			}
-			continue
+			return podsPerKey, nil // early stop since prefix-chain breaks here
 		}
 		var filtered []PodEntry
-		total := 0
 		if pods != nil {
-			filtered, total = pods.filteredEntries(podIdentifierSet)
+			filtered, _ = pods.filteredEntries(podIdentifierSet)
 		}
 		visited = idx + 1
-		if total == 0 {
+		if len(filtered) == 0 {
 			if traceLogger.Enabled() {
 				traceLogger.Info("no pods found for key, cutting search", "key", requestKey)
 			}
@@ -309,10 +308,7 @@ func (m *InMemoryIndex) Lookup(ctx context.Context, requestKeys []BlockHash,
 		}
 
 		highestHitIdx = idx
-
-		if len(filtered) > 0 {
-			podsPerKey[requestKey] = filtered
-		}
+		podsPerKey[requestKey] = filtered
 	}
 
 	if err := ctx.Err(); err != nil {

--- a/pkg/kvcache/kvblock/in_memory_test.go
+++ b/pkg/kvcache/kvblock/in_memory_test.go
@@ -74,8 +74,13 @@ func TestInMemoryIndexSize(t *testing.T) {
 	err = index.Add(ctx, []BlockHash{engineKey3}, []BlockHash{requestKey3}, []PodEntry{{PodIdentifier: "pod3", DeviceTier: "cpu"}})
 	require.NoError(t, err)
 
-	// Lookup should only return the last two keys
-	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey1, requestKey2, requestKey3}, nil)
+	// Verify requestKey1 was evicted
+	evicted, err := index.Lookup(ctx, []BlockHash{requestKey1}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, evicted)
+
+	// Lookup should return the remaining keys
+	podsPerKey, err := index.Lookup(ctx, []BlockHash{requestKey2, requestKey3}, nil)
 	require.NoError(t, err)
 
 	assert.Len(t, podsPerKey, 2) // Only key2 and key3 should be present

--- a/pkg/kvcache/kvblock/index_test.go
+++ b/pkg/kvcache/kvblock/index_test.go
@@ -54,6 +54,16 @@ func testCommonIndexBehavior(t *testing.T, indexFactory func(t *testing.T) Index
 		testFilteredLookup(t, ctx, index)
 	})
 
+	t.Run("EarlyStopOnMiss", func(t *testing.T) {
+		index := indexFactory(t)
+		testEarlyStopOnMiss(t, ctx, index)
+	})
+
+	t.Run("EarlyStopOnFilteredEmpty", func(t *testing.T) {
+		index := indexFactory(t)
+		testEarlyStopOnFilteredEmpty(t, ctx, index)
+	})
+
 	t.Run("EvictBasic", func(t *testing.T) {
 		index := indexFactory(t)
 		testEvictBasic(t, ctx, index)
@@ -343,6 +353,58 @@ func testFilteredLookup(t *testing.T, ctx context.Context, index Index) {
 	podsPerKey, err = index.Lookup(ctx, []BlockHash{requestKey}, filterSet)
 	require.NoError(t, err)
 	assert.Len(t, podsPerKey, 0) // No matching pods found
+}
+
+// testEarlyStopOnMiss verifies that Lookup stops traversing keys at the first miss
+// in requestKeys and does not return subsequent matching keys.
+func testEarlyStopOnMiss(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	k0 := BlockHash(8001)
+	k1 := BlockHash(8002)
+	k2 := BlockHash(8003)
+	pod := []PodEntry{{PodIdentifier: "pod-early-stop", DeviceTier: "gpu"}}
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{k0, k2}, pod))
+
+	// k1 is missing; lookup along [k0, k1, k2] must stop at k1 and not return k2.
+	result, err := index.Lookup(ctx, []BlockHash{k0, k1, k2}, nil)
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Contains(t, result, k0)
+	assert.NotContains(t, result, k2)
+
+	// First key is missing; lookup must return empty map.
+	result, err = index.Lookup(ctx, []BlockHash{k1, k0}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+// testEarlyStopOnFilteredEmpty verifies that Lookup stops traversing keys when
+// a key has no pods matching the podIdentifierSet filter, even if subsequent
+// keys have matches.
+func testEarlyStopOnFilteredEmpty(t *testing.T, ctx context.Context, index Index) {
+	t.Helper()
+	k0 := BlockHash(8101)
+	k1 := BlockHash(8102)
+	k2 := BlockHash(8103)
+	podA := []PodEntry{{PodIdentifier: "pod-A", DeviceTier: "gpu"}}
+	podB := []PodEntry{{PodIdentifier: "pod-B", DeviceTier: "gpu"}}
+
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{k0, k2}, podA))
+	require.NoError(t, index.Add(ctx, nil, []BlockHash{k1}, podB))
+
+	// Filter for pod-A only: k0 matches, k1 has only pod-B (0 matches), so lookup stops.
+	filter := sets.New("pod-A")
+	result, err := index.Lookup(ctx, []BlockHash{k0, k1, k2}, filter)
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Contains(t, result, k0)
+	assert.NotContains(t, result, k2)
+
+	// First key has no matching pods for filter; lookup must return empty map.
+	result, err = index.Lookup(ctx, []BlockHash{k1, k0}, filter)
+	require.NoError(t, err)
+	assert.Empty(t, result)
 }
 
 // testEvictBasic tests basic eviction functionality.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In-memory and cost-aware memory index implementations (`InMemoryIndex` and `CostAwareMemoryIndex`) did not early-stop when a key in `requestKeys` was not found (`!found`) or when filtering against `podIdentifierSet` resulted in an empty pod list. Instead, they logged a message and continued traversing remaining keys. This is inconsistent with the behavior in `RedisIndex`.

Because `Index.Lookup` represents a contiguous prefix-cache lookup (longest prefix match), breaking the prefix chain at any key invalidates subsequent keys and must terminate traversal immediately, matching the behavior of `RedisIndex`.

This PR:
- Adds early return (`return podsPerKey, nil`) on missing keys and empty filtered pod slices in `InMemoryIndex.Lookup` and `CostAwareMemoryIndex.Lookup`.
- Adds `EarlyStopOnMiss` and `EarlyStopOnFilteredEmpty` test cases to `testCommonIndexBehavior` in `index_test.go` to enforce prefix-break early-stop semantics across all `Index` backends.
- Updates `TestInMemoryIndexSize` and `TestCostAwareIndexSize` to query evicted keys and remaining cached keys independently, respecting prefix lookup semantics.

**Which issue(s) this PR fixes**:
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
`NONE`
