### PR TITLE
ci(trivy): bump scanner to v0.74.0

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -30,7 +30,7 @@ runs:
         # otherwise, which fails the scan on findings outside `severity` (e.g.
         # UNKNOWN-severity Go vulndb notes).
         limit-severities-for-sarif: 'true'
-        version: 'v0.72.0'
+        version: 'v0.74.0'
 
     - name: Upload Trivy SARIF to Security tab
       uses: github/codeql-action/upload-sarif@v4.35.4 # v4.35.4 68bde559dea0fdcac2102bfdf6230c5f70eb485e


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The `build-and-push` job on `ci-dev.yaml` (and any caller of `./.github/actions/trivy-scan`) is failing across all merges. Cause: trivy v0.72 emits a "Version 0.74.0 of Trivy is now available" notice on every run; with `exit-code: 1` set on the action, the notice is treated as a finding and fails the gate.

Evidence: https://github.com/llm-d/llm-d-router/actions/runs/34027470424/job/101470909529

Fix: bump the trivy binary version in `.github/actions/trivy-scan/action.yml` from `v0.72.0` to `v0.74.0`. The v0.74 binary does not emit the upgrade notice. `trivy-action` stays at `v0.36.0`.

**Which issue(s) this PR fixes**:
Fixes #

**Release note**:
```release-note
NONE
```