### PR TITLE
fix(kvevents): wait for old subscriber to exit on endpoint change

### DIFF
--- a/pkg/kvevents/subscriber_manager.go
+++ b/pkg/kvevents/subscriber_manager.go
@@ -83,7 +83,16 @@ func (sm *SubscriberManager) EnsureSubscriber(
 			"oldReplayEndpoint", entry.replayEndpoint,
 			"newReplayEndpoint", replayEndpoint)
 		entry.cancel()
+		select {
+		case <-entry.done:
+		case <-ctx.Done():
+		}
 		delete(sm.subscribers, podIdentifier)
+		if err := ctx.Err(); err != nil {
+			metrics.SubscriberActive.Set(float64(len(sm.subscribers)))
+			cleanupSubscriberMetrics(podIdentifier, entry.done)
+			return err
+		}
 		// The replacement subscriber below reuses podIdentifier, so its series
 		// are kept rather than cleaned up.
 	}

--- a/pkg/kvevents/subscriber_manager_test.go
+++ b/pkg/kvevents/subscriber_manager_test.go
@@ -280,3 +280,151 @@ func TestSubscriberManager_Shutdown_HonorsContextCancellation(t *testing.T) {
 	identifiers, _ := sm.GetActiveSubscribers()
 	assert.Empty(t, identifiers)
 }
+
+func TestSubscriberManager_EndpointChange_WaitsForOldSubscriberExit(t *testing.T) {
+	ctx := context.Background()
+
+	indexConfig := kvblock.DefaultIndexConfig()
+	index, err := kvblock.NewIndex(ctx, indexConfig)
+	require.NoError(t, err)
+
+	poolConfig := kvevents.DefaultConfig()
+	tokenProcessor, err := kvblock.NewChunkedTokenDatabase(kvblock.DefaultTokenProcessorConfig())
+	require.NoError(t, err)
+	pool := kvevents.NewPool(poolConfig, index, tokenProcessor, engineadapter.NewVLLMAdapter())
+
+	sm := kvevents.NewSubscriberManager(pool)
+
+	l1, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr1 := l1.Addr().String()
+	require.NoError(t, l1.Close())
+
+	l2, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr2 := l2.Addr().String()
+	require.NoError(t, l2.Close())
+
+	endpoint1 := fmt.Sprintf("tcp://%s", addr1)
+	endpoint2 := fmt.Sprintf("tcp://%s", addr2)
+
+	podID := "default/test-pod-0"
+	err = sm.EnsureSubscriber(ctx, podID, "", endpoint1, "", "kv@", false)
+	require.NoError(t, err)
+
+	// Wait for subscriber to bind to addr1.
+	require.Eventually(t, func() bool {
+		conn, err := net.Dial("tcp", addr1)
+		if err == nil {
+			_ = conn.Close()
+			return true
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Replace subscriber with endpoint2. EnsureSubscriber must wait until the old
+	// subscriber has exited and closed its socket before returning.
+	err = sm.EnsureSubscriber(ctx, podID, "", endpoint2, "", "kv@", false)
+	require.NoError(t, err)
+
+	// addr1 should now be released and available to bind immediately.
+	newL, err := net.Listen("tcp", addr1)
+	require.NoError(t, err)
+	require.NoError(t, newL.Close())
+
+	sm.Shutdown(ctx)
+}
+
+func TestSubscriberManager_EndpointChange_HonorsContextCancellation(t *testing.T) {
+	ctx := context.Background()
+
+	indexConfig := kvblock.DefaultIndexConfig()
+	index, err := kvblock.NewIndex(ctx, indexConfig)
+	require.NoError(t, err)
+
+	poolConfig := kvevents.DefaultConfig()
+	tokenProcessor, err := kvblock.NewChunkedTokenDatabase(kvblock.DefaultTokenProcessorConfig())
+	require.NoError(t, err)
+	pool := kvevents.NewPool(poolConfig, index, tokenProcessor, engineadapter.NewVLLMAdapter())
+
+	sm := kvevents.NewSubscriberManager(pool)
+
+	podID := "default/test-pod-0"
+	endpoint1 := "tcp://10.0.0.1:5557"
+	endpoint2 := "tcp://10.0.0.2:5557"
+
+	err = sm.EnsureSubscriber(ctx, podID, "", endpoint1, "", "kv@", true)
+	require.NoError(t, err)
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	err = sm.EnsureSubscriber(canceledCtx, podID, "", endpoint2, "", "kv@", true)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	identifiers, _ := sm.GetActiveSubscribers()
+	assert.Empty(t, identifiers)
+}
+
+func TestSubscriberManager_EndpointChange_BothChannelsReady_HonorsContextCancellation(t *testing.T) {
+	ctx := context.Background()
+
+	indexConfig := kvblock.DefaultIndexConfig()
+	index, err := kvblock.NewIndex(ctx, indexConfig)
+	require.NoError(t, err)
+
+	poolConfig := kvevents.DefaultConfig()
+	tokenProcessor, err := kvblock.NewChunkedTokenDatabase(kvblock.DefaultTokenProcessorConfig())
+	require.NoError(t, err)
+	pool := kvevents.NewPool(poolConfig, index, tokenProcessor, engineadapter.NewVLLMAdapter())
+
+	sm := kvevents.NewSubscriberManager(pool)
+
+	l1, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr1 := l1.Addr().String()
+	require.NoError(t, l1.Close())
+
+	endpoint1 := fmt.Sprintf("tcp://%s", addr1)
+	endpoint2 := "tcp://127.0.0.1:5557"
+	podID := "default/test-pod-0"
+
+	subCtx, subCancel := context.WithCancel(ctx)
+	err = sm.EnsureSubscriber(subCtx, podID, "", endpoint1, "", "kv@", false)
+	require.NoError(t, err)
+
+	// Wait for subscriber to bind to addr1.
+	require.Eventually(t, func() bool {
+		conn, err := net.Dial("tcp", addr1)
+		if err == nil {
+			_ = conn.Close()
+			return true
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Cancel the subscriber and wait until its socket is released, guaranteeing
+	// that its goroutine has returned and entry.done is closed.
+	subCancel()
+	require.Eventually(t, func() bool {
+		l, err := net.Listen("tcp", addr1)
+		if err == nil {
+			_ = l.Close()
+			return true
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Create an already-canceled context so ctx.Done() is also ready.
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	// Both entry.done and canceledCtx.Done() are ready. EnsureSubscriber must
+	// honor the context cancellation, clean up, and return context.Canceled
+	// rather than creating a replacement subscriber and returning nil.
+	err = sm.EnsureSubscriber(canceledCtx, podID, "", endpoint2, "", "kv@", false)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	identifiers, _ := sm.GetActiveSubscribers()
+	assert.Empty(t, identifiers)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This fix is similar to https://github.com/llm-d/llm-d-router/pull/2717.

When `SubscriberManager.EnsureSubscriber` replaces an existing subscriber due to an endpoint change, it cancels the old subscriber's context but does not wait for its goroutine to terminate before spawning the replacement subscriber. This allows the old and new subscribers for the same pod to run concurrently, potentially interleaving events out-of-order into the worker pool.

This change waits on `entry.done` before creating and starting the replacement subscriber, and honors context cancellation during the wait.

**Which issue(s) this PR fixes**:
Fixes #

**Test plan**:
- [x] Verified `TestSubscriberManager_EndpointChange_WaitsForOldSubscriberExit` confirms the old listening socket is closed before `EnsureSubscriber` returns.
- [x] Verified `TestSubscriberManager_EndpointChange_HonorsContextCancellation` cleans up state when the context is cancelled.
- [x] Verified all tests in `pkg/kvevents/...` pass with race detector enabled (`go test -v -race ./pkg/kvevents/...`).

**Release note**:
```release-note
Fix a race condition where replacing a subscriber on endpoint change could run two subscriber goroutines concurrently for the same pod.
