### PR TITLE
Validate prefix cache affinity threshold bounds

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin.go
@@ -133,8 +133,8 @@ func Factory(name string, rawParameters *json.Decoder, handle fwkplugin.Handle) 
 }
 
 func (c *Config) validate() error {
-	if c.AffinityThreshold > 1.0 {
-		return fmt.Errorf("affinityThreshold must be <= 1.0, got %f", c.AffinityThreshold)
+	if c.AffinityThreshold < 0 || c.AffinityThreshold > 1.0 {
+		return fmt.Errorf("affinityThreshold must be in [0, 1], got %f", c.AffinityThreshold)
 	}
 	if c.ExplorationProbability < 0 || c.ExplorationProbability > 1.0 {
 		return fmt.Errorf("explorationProbability must be in [0, 1], got %f", c.ExplorationProbability)

--- a/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity/plugin_test.go
@@ -215,9 +215,25 @@ func TestFactory_PartialConfigPreservesDefaults(t *testing.T) {
 }
 
 func TestFactory_InvalidAffinityThreshold(t *testing.T) {
-	_, err := Factory("test", fwkplugin.StrictDecoder([]byte(`{"affinityThreshold": 1.5}`)), nil)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "affinityThreshold must be <= 1.0")
+	for _, tc := range []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "below zero",
+			raw:  `{"affinityThreshold": -0.1}`,
+		},
+		{
+			name: "above one",
+			raw:  `{"affinityThreshold": 1.5}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Factory("test", fwkplugin.StrictDecoder([]byte(tc.raw)), nil)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "affinityThreshold must be in [0, 1]")
+		})
+	}
 }
 
 func TestFactory_InvalidExplorationProbability(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Validates `affinityThreshold` as a bounded ratio in the prefix cache affinity filter. Values below 0 and above 1 are rejected during configuration loading.

**Which issue(s) this PR fixes**:

None

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

**Test plan**:

- [x] Invalid prefix cache affinity thresholds are rejected by package tests.