### PR TITLE
Enforce ordering for configured optional dependencies

### DIFF
--- a/pkg/epp/datalayer/data_graph.go
+++ b/pkg/epp/datalayer/data_graph.go
@@ -222,9 +222,13 @@ func buildDAG(producers map[string]plugin.ProducerPlugin, consumers map[string]p
 				continue
 			}
 			dependencies := consumer.Consumes()
-			if producer.Produces() != nil && dependencies.Required != nil {
+			if producer.Produces() != nil {
 				for producedKey, producedData := range producer.Produces() {
-					if consumedData, ok := dependencies.Required[producedKey]; ok {
+					consumedData, ok := dependencies.Required[producedKey]
+					if !ok {
+						consumedData, ok = dependencies.Optional[producedKey]
+					}
+					if ok {
 						// Check types are same.
 						if reflect.TypeOf(producedData) != reflect.TypeOf(consumedData) {
 							return nil, errors.New("data type mismatch between produced and consumed data for key: " + producedKey.String())

--- a/pkg/epp/datalayer/data_graph_test.go
+++ b/pkg/epp/datalayer/data_graph_test.go
@@ -42,6 +42,7 @@ type mockDataProducerP struct {
 	pluginType string
 	produces   map[fwkplugin.DataKey]any
 	consumes   map[fwkplugin.DataKey]any
+	optional   map[fwkplugin.DataKey]any
 }
 
 type mockProducedDataType struct {
@@ -65,7 +66,61 @@ func (m *mockDataProducerP) Produces() map[fwkplugin.DataKey]any {
 }
 
 func (m *mockDataProducerP) Consumes() fwkplugin.DataDependencies {
-	return fwkplugin.DataDependencies{Required: m.consumes}
+	return fwkplugin.DataDependencies{Required: m.consumes, Optional: m.optional}
+}
+
+func TestOptionalDataDependencyOrder(t *testing.T) {
+	key := fwkplugin.NewDataKey("prefixMatch", "cache")
+	cache := &mockDataProducerP{name: "cache", produces: map[fwkplugin.DataKey]any{key: int(0)}}
+	load := &mockDataProducerP{name: "load", optional: map[fwkplugin.DataKey]any{key: int(0)}}
+
+	t.Run("configured producer precedes optional consumer", func(t *testing.T) {
+		dag, err := buildDAG(
+			map[string]fwkplugin.ProducerPlugin{"cache/mock": cache, "load/mock": load},
+			map[string]fwkplugin.ConsumerPlugin{"load/mock": load})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"cache/mock"}, dag["load/mock"])
+		ordered, err := util.TopologicalSort(dag)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"cache/mock", "load/mock"}, ordered)
+	})
+
+	t.Run("absent optional producer allows fallback", func(t *testing.T) {
+		ordered, err := ValidateAndOrderDataDependencies([]fwkplugin.Plugin{load})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"load/mock"}, ordered)
+
+		handle := fwkplugin.NewEppHandle(context.Background(), func() []k8stypes.NamespacedName { return nil })
+		handle.AddPlugin(load.TypedName().Name, load)
+		factory := fwkplugin.FactoryFunc(func(string, *json.Decoder, fwkplugin.Handle) (fwkplugin.Plugin, error) {
+			t.Error("optional dependency must not instantiate its default producer")
+			return cache, nil
+		})
+		err = CreateMissingDataProducers(context.Background(), map[string]string{key.String(): "cache"},
+			map[string]fwkplugin.FactoryFunc{"cache": factory}, handle)
+		assert.NoError(t, err)
+		assert.Len(t, handle.GetAllPlugins(), 1)
+	})
+
+	t.Run("optional dependency type must match", func(t *testing.T) {
+		wrong := &mockDataProducerP{name: "wrong", optional: map[fwkplugin.DataKey]any{key: string("")}}
+		_, err := ValidateAndOrderDataDependencies([]fwkplugin.Plugin{cache, wrong})
+		assert.ErrorContains(t, err, "data type mismatch")
+	})
+
+	t.Run("optional dependency respects execution layers", func(t *testing.T) {
+		consumer := &MockConsumerFairnessPolicy{optional: map[fwkplugin.DataKey]any{key: int(0)}}
+		_, err := ValidateAndOrderDataDependencies([]fwkplugin.Plugin{cache, consumer})
+		assert.ErrorContains(t, err, "invalid plugin layer execution order")
+	})
+
+	t.Run("optional cycle is rejected", func(t *testing.T) {
+		other := fwkplugin.NewDataKey("load", "load")
+		first := &mockDataProducerP{name: "first", produces: map[fwkplugin.DataKey]any{key: nil}, optional: map[fwkplugin.DataKey]any{other: nil}}
+		second := &mockDataProducerP{name: "second", produces: map[fwkplugin.DataKey]any{other: nil}, consumes: map[fwkplugin.DataKey]any{key: nil}}
+		_, err := ValidateAndOrderDataDependencies([]fwkplugin.Plugin{first, second})
+		assert.ErrorContains(t, err, "cycle detected")
+	})
 }
 
 func (m *mockDataProducerP) Produce(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
@@ -92,10 +147,11 @@ func (m *typedMockPlugin) Produce(ctx context.Context, request *fwksched.Inferen
 type MockConsumerFairnessPolicy struct {
 	fwkfcmocks.MockFairnessPolicy
 	consumes map[fwkplugin.DataKey]any
+	optional map[fwkplugin.DataKey]any
 }
 
 func (m *MockConsumerFairnessPolicy) Consumes() fwkplugin.DataDependencies {
-	return fwkplugin.DataDependencies{Required: m.consumes}
+	return fwkplugin.DataDependencies{Required: m.consumes, Optional: m.optional}
 }
 
 type MockSchedulingPlugin struct {

--- a/pkg/epp/framework/interface/plugin/plugins.go
+++ b/pkg/epp/framework/interface/plugin/plugins.go
@@ -50,6 +50,7 @@ type DataDependencies struct {
 	// Required keys — the framework will error at init time if no producer exists for any of these.
 	Required map[DataKey]any
 	// Optional keys — the framework logs a warning at init time but does NOT error if no producer exists.
+	// Configured producers run before their optional consumers.
 	// The plugin must handle the case where this data is absent at runtime.
 	Optional map[DataKey]any
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -113,6 +113,7 @@ func InFlightLoadProducerFactory(name string, decoder *json.Decoder, handle fwkp
 		addEstimatedOutputTokens: cfg.AddEstimatedOutputTokens,
 		dk:                       attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
 		prefixMatchInfoDK:        attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(cfg.PrefixMatchInfoProducerName),
+		requirePrefixMatchInfo:   cfg.PrefixMatchInfoProducerName != "",
 		uncachedRequestTokensDk:  attrconcurrency.UncachedRequestTokensDataKey.WithNonEmptyProducerName(name),
 		syncCrossReplicaState:    syncCrossReplicaState,
 		PluginState:              fwkplugin.NewPluginState(ctx),
@@ -139,6 +140,7 @@ type InFlightLoadProducer struct {
 	PluginState              *fwkplugin.PluginState
 	dk                       fwkplugin.DataKey
 	prefixMatchInfoDK        fwkplugin.DataKey
+	requirePrefixMatchInfo   bool
 	uncachedRequestTokensDk  fwkplugin.DataKey
 	syncCrossReplicaState    bool
 	registeredEndpoints      sync.Map // key: string (NamespacedName), value: datalayer.Endpoint
@@ -703,11 +705,11 @@ func (p *InFlightLoadProducer) Produces() map[fwkplugin.DataKey]any {
 // Consumes declares TokenizedRequest as required so the data-layer DAG orders a
 // token-producer ahead of this producer and auto-creates one when none is
 // configured; without it the input-token estimate silently reads zero.
-// PrefixCacheMatchInfo is optional -- used to discount the already-cached prompt
-// prefix from the prefix producer selected by prefixMatchInfoProducerName
-// (approximate by default, or a precise-prefix-cache producer).
+// An explicitly configured prefix producer is required so its cache match is
+// available before UncachedRequestTokens is calculated. Without an explicit
+// producer, the default prefix match remains optional for load-only configs.
 func (p *InFlightLoadProducer) Consumes() fwkplugin.DataDependencies {
-	return fwkplugin.DataDependencies{
+	deps := fwkplugin.DataDependencies{
 		Required: map[fwkplugin.DataKey]any{
 			tokenproducer.TokenizedPromptDataKey: fwksched.TokenizedRequest{},
 		},
@@ -715,6 +717,11 @@ func (p *InFlightLoadProducer) Consumes() fwkplugin.DataDependencies {
 			p.prefixMatchInfoDK: attrprefix.PrefixCacheMatchInfo{},
 		},
 	}
+	if p.requirePrefixMatchInfo {
+		deps.Required[p.prefixMatchInfoDK] = attrprefix.PrefixCacheMatchInfo{}
+		delete(deps.Optional, p.prefixMatchInfoDK)
+	}
+	return deps
 }
 
 // DeleteEndpoint removes an endpoint from the concurrency trackers to prevent memory leaks.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer.go
@@ -113,7 +113,6 @@ func InFlightLoadProducerFactory(name string, decoder *json.Decoder, handle fwkp
 		addEstimatedOutputTokens: cfg.AddEstimatedOutputTokens,
 		dk:                       attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(name),
 		prefixMatchInfoDK:        attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(cfg.PrefixMatchInfoProducerName),
-		requirePrefixMatchInfo:   cfg.PrefixMatchInfoProducerName != "",
 		uncachedRequestTokensDk:  attrconcurrency.UncachedRequestTokensDataKey.WithNonEmptyProducerName(name),
 		syncCrossReplicaState:    syncCrossReplicaState,
 		PluginState:              fwkplugin.NewPluginState(ctx),
@@ -140,7 +139,6 @@ type InFlightLoadProducer struct {
 	PluginState              *fwkplugin.PluginState
 	dk                       fwkplugin.DataKey
 	prefixMatchInfoDK        fwkplugin.DataKey
-	requirePrefixMatchInfo   bool
 	uncachedRequestTokensDk  fwkplugin.DataKey
 	syncCrossReplicaState    bool
 	registeredEndpoints      sync.Map // key: string (NamespacedName), value: datalayer.Endpoint
@@ -705,11 +703,11 @@ func (p *InFlightLoadProducer) Produces() map[fwkplugin.DataKey]any {
 // Consumes declares TokenizedRequest as required so the data-layer DAG orders a
 // token-producer ahead of this producer and auto-creates one when none is
 // configured; without it the input-token estimate silently reads zero.
-// An explicitly configured prefix producer is required so its cache match is
-// available before UncachedRequestTokens is calculated. Without an explicit
-// producer, the default prefix match remains optional for load-only configs.
+// PrefixCacheMatchInfo is optional -- used to discount the already-cached prompt
+// prefix from the prefix producer selected by prefixMatchInfoProducerName
+// (approximate by default, or a precise-prefix-cache producer).
 func (p *InFlightLoadProducer) Consumes() fwkplugin.DataDependencies {
-	deps := fwkplugin.DataDependencies{
+	return fwkplugin.DataDependencies{
 		Required: map[fwkplugin.DataKey]any{
 			tokenproducer.TokenizedPromptDataKey: fwksched.TokenizedRequest{},
 		},
@@ -717,11 +715,6 @@ func (p *InFlightLoadProducer) Consumes() fwkplugin.DataDependencies {
 			p.prefixMatchInfoDK: attrprefix.PrefixCacheMatchInfo{},
 		},
 	}
-	if p.requirePrefixMatchInfo {
-		deps.Required[p.prefixMatchInfoDK] = attrprefix.PrefixCacheMatchInfo{}
-		delete(deps.Optional, p.prefixMatchInfoDK)
-	}
-	return deps
 }
 
 // DeleteEndpoint removes an endpoint from the concurrency trackers to prevent memory leaks.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -77,7 +77,7 @@ func TestInFlightLoadProducer_Consumes(t *testing.T) {
 }
 
 // prefixMatchInfoProducerName selects which prefix producer (approximate or
-// precise) feeds the cached-prefix discount, by both the required dependency key
+// precise) feeds the cached-prefix discount, by both the optional dependency key
 // and the runtime read.
 func TestInFlightLoadProducer_PrefixMatchInfoProducerName(t *testing.T) {
 	t.Parallel()
@@ -94,10 +94,9 @@ func TestInFlightLoadProducer_PrefixMatchInfoProducerName(t *testing.T) {
 
 	preciseKey := attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(preciseName)
 
-	// An explicitly selected producer must run before this producer computes
-	// UncachedRequestTokens. Optional dependencies do not establish DAG ordering.
-	require.Contains(t, producer.Consumes().Required, preciseKey)
-	require.NotContains(t, producer.Consumes().Optional, preciseKey)
+	// The dependency remains optional even when a producer is explicitly selected.
+	require.Contains(t, producer.Consumes().Optional, preciseKey)
+	require.NotContains(t, producer.Consumes().Required, preciseKey)
 	require.NotContains(t, producer.Consumes().Optional, attrprefix.PrefixCacheMatchInfoDataKey)
 
 	// The discount reads PrefixCacheMatchInfo from the configured producer's key

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/inflightload/producer_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -34,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	datagraph "github.com/llm-d/llm-d-router/pkg/epp/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requestcontrol"
@@ -75,7 +77,7 @@ func TestInFlightLoadProducer_Consumes(t *testing.T) {
 }
 
 // prefixMatchInfoProducerName selects which prefix producer (approximate or
-// precise) feeds the cached-prefix discount, by both the optional dependency key
+// precise) feeds the cached-prefix discount, by both the required dependency key
 // and the runtime read.
 func TestInFlightLoadProducer_PrefixMatchInfoProducerName(t *testing.T) {
 	t.Parallel()
@@ -92,8 +94,10 @@ func TestInFlightLoadProducer_PrefixMatchInfoProducerName(t *testing.T) {
 
 	preciseKey := attrprefix.PrefixCacheMatchInfoDataKey.WithNonEmptyProducerName(preciseName)
 
-	// The optional dependency points at the configured precise producer, not approx.
-	require.Contains(t, producer.Consumes().Optional, preciseKey)
+	// An explicitly selected producer must run before this producer computes
+	// UncachedRequestTokens. Optional dependencies do not establish DAG ordering.
+	require.Contains(t, producer.Consumes().Required, preciseKey)
+	require.NotContains(t, producer.Consumes().Optional, preciseKey)
 	require.NotContains(t, producer.Consumes().Optional, attrprefix.PrefixCacheMatchInfoDataKey)
 
 	// The discount reads PrefixCacheMatchInfo from the configured producer's key
@@ -106,6 +110,44 @@ func TestInFlightLoadProducer_PrefixMatchInfoProducerName(t *testing.T) {
 	miss := newStubSchedulingEndpoint("ep-miss")
 	miss.Put(attrprefix.PrefixCacheMatchInfoDataKey, attrprefix.NewPrefixCacheMatchInfo(1, 2, 4))
 	require.Equal(t, int64(5), producer.estimateRequestTokens(miss, nil, 5))
+
+	// Exercise the real dependency sorter and current-request projection. The
+	// selected owner has 41,280 of 43,992 input tokens cached; charging the full
+	// prompt would make an idle cold endpoint look cheaper than a busy warm one.
+	cache := &cacheMatchTestProducer{key: preciseKey}
+	ordered, err := datagraph.ValidateAndOrderDataDependencies([]fwkplugin.Plugin{producer, cache})
+	require.NoError(t, err)
+	require.Less(t, slices.Index(ordered, cache.TypedName().String()), slices.Index(ordered, producer.TypedName().String()))
+	endpoints := []fwksched.Endpoint{newStubSchedulingEndpoint("warm"), newStubSchedulingEndpoint("cold")}
+	req := makeTokenRequest("warm-follow-up", 43992)
+	for _, name := range ordered {
+		var next requestcontrol.DataProducer = producer
+		if name == cache.TypedName().String() {
+			next = cache
+		}
+		require.NoError(t, next.Produce(ctx, req, endpoints))
+	}
+	for i, want := range []int64{2712, 43992} {
+		value, ok := endpoints[i].Get(producer.uncachedRequestTokensDk)
+		require.True(t, ok)
+		require.Equal(t, want, value.(*attrconcurrency.UncachedRequestTokens).Tokens)
+	}
+}
+
+type cacheMatchTestProducer struct{ key fwkplugin.DataKey }
+
+func (p *cacheMatchTestProducer) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Type: "precise-prefix-cache-producer", Name: "precise-prefix-cache-producer"}
+}
+
+func (p *cacheMatchTestProducer) Produces() map[fwkplugin.DataKey]any {
+	return map[fwkplugin.DataKey]any{p.key: attrprefix.PrefixCacheMatchInfo{}}
+}
+
+func (p *cacheMatchTestProducer) Produce(_ context.Context, _ *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
+	endpoints[0].Put(p.key, attrprefix.NewPrefixCacheMatchInfo(645, 687, 64))
+	endpoints[1].Put(p.key, attrprefix.NewPrefixCacheMatchInfo(0, 687, 64))
+	return nil
 }
 
 func TestInFlightLoadProducer_Produce(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Include optional dependencies in the plugin execution graph when a matching producer is configured. This orders producers before their consumers, regardless of whether the dependency is required or optional.

Configured optional dependencies also participate in the existing type, execution-layer, and cycle checks. Missing optional producers remain allowed and are not automatically created.

Regression tests cover ordering, absent optional producers, invalid dependencies, and a consumer reading optional data. The EPP unit suite with race detection and `make presubmit` passed.

**Which issue(s) this PR fixes**:

Fixes #<issue-number>

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
EPP runs configured producers before plugins that consume their optional data. Configurations with optional dependency cycles, incompatible data types, or invalid execution-layer ordering fail startup. Missing optional producers remain allowed.
```