### PR TITLE
feat(coordinator): prefer mm_metadata on prefill with EC

### DIFF
--- a/docs/communication.md
+++ b/docs/communication.md
@@ -825,10 +825,12 @@ Prefill only needs the metadata sibling plus `ec_transfer_params` to load those
 embeddings. For large images the pixel tensors dominate payload size, so dropping
 `kwargs_data` on prefill cuts coordinator-to-prefill traffic.
 
+The multimodal data each stage sends:
+
 ```text
-Encode  = kwargs_data
-Prefill = mm_metadata + ec_transfer_params
-no EC / old renderers = kwargs_data unchanged
+Encode              = kwargs_data
+Prefill (optimized) = mm_metadata + ec_transfer_params
+Prefill (fallback)  = kwargs_data
 ```
 
 **Coordinator behavior:**

--- a/docs/communication.md
+++ b/docs/communication.md
@@ -814,37 +814,48 @@ No `features` or `ec_transfer_params` (no images); `prompt` contains the token a
 
 ### Optimization: avoid sending pixel data to prefill
 
-Currently the full `kwargs_data` blobs (containing both `pixel_values` and `image_grid_thw`) are forwarded to the prefill worker. The prefill worker only needs `image_grid_thw` for mRoPE -- the `pixel_values` are redundant since the encoder already consumed them. For large images, the pixel tensors dominate the payload size, so stripping them would significantly reduce the data sent to prefill.
+With a renderer that emits `features.mm_metadata` (see vLLM
+[#54659](https://github.com/vllm-project/vllm/pull/54659)), the coordinator can
+omit `kwargs_data` on the prefill request when `ec_transfer_params` is present.
 
-**Required changes:**
+`kwargs_data` mixes encoder tensors (`pixel_values`) with lightweight fields
+(`image_grid_thw` and other `keep_on_cpu` / placeholder-metadata fields). Encode
+already consumes the tensors and publishes embeddings through the EC connector.
+Prefill only needs the metadata sibling plus `ec_transfer_params` to load those
+embeddings. For large images the pixel tensors dominate payload size, so dropping
+`kwargs_data` on prefill cuts coordinator-to-prefill traffic.
 
-1. **vLLM render endpoint** (`vllm/entrypoints/openai/render/serving.py`): return `image_grid_thw` as a separate top-level field in the render response, alongside `kwargs_data`. The render step already computes it during image preprocessing (`get_image_grid_thw()` in the vision processor). Example response:
-   ```json
-   {
-     "token_ids": [1, 32000, 32000, 32000, ...],
-     "features": {
-       "mm_hashes": {"image": ["abc123hash", "def456hash"]},
-       "mm_placeholders": {"image": [{"offset": 1, "length": 3}, {"offset": 4, "length": 3}]},
-       "kwargs_data": {"image": ["<full-msgpack-blob-1>", "<full-msgpack-blob-2>"]},
-       "image_grid_thw": {"image": [[1, 24, 24], [1, 16, 16]]}
-     }
-   }
-   ```
+```text
+Encode  = kwargs_data
+Prefill = mm_metadata + ec_transfer_params
+no EC / old renderers = kwargs_data unchanged
+```
 
-2. **vLLM prefill worker**: accept `image_grid_thw` directly in the features dict (as plain JSON arrays) instead of extracting it from the msgpack `kwargs_data` blob.
+**Coordinator behavior:**
 
-3. **Coordinator render step** (`pkg/steps/render.go`): parse `image_grid_thw` from the render response and store it per `MultimodalEntry`.
+1. **Render step** (`pkg/coordinator/steps/render.go`): parse optional
+   `features.mm_metadata` from the render response (same per-modality item order
+   as `mm_hashes` / `kwargs_data`) and store it on each `MultimodalEntry`.
+2. **Encode step** (`pkg/coordinator/steps/encode.go`): unchanged; encode still
+   sends full `kwargs_data`.
+3. **Prefill step** (`pkg/coordinator/steps/prefill.go`): when
+   `ec_transfer_params` is non-empty and every multimodal entry has
+   `MMMetadata`, emit `mm_metadata` and omit `kwargs_data`. Otherwise keep
+   sending `kwargs_data` so older renderers and non-EC paths (for example
+   generate-path encode skip) stay compatible.
 
-4. **Coordinator prefill step** (`pkg/steps/prefill.go`): send `image_grid_thw` instead of `kwargs_data` in the prefill request features:
-   ```json
-   "features": {
-     "mm_hashes": {"image": ["abc123hash", "def456hash"]},
-     "mm_placeholders": {"image": [{"offset": 1, "length": 3}, {"offset": 4, "length": 3}]},
-     "image_grid_thw": {"image": [[1, 24, 24], [1, 16, 16]]}
-   }
-   ```
+Example prefill features when the metadata path is active:
 
-5. **Coordinator encode step** (`pkg/steps/encode.go`): no change -- encode continues to send the full `kwargs_data` (pixel values needed for ViT).
+```json
+"features": {
+  "mm_hashes": {"image": ["abc123hash", "def456hash"]},
+  "mm_placeholders": {"image": [{"offset": 1, "length": 3}, {"offset": 4, "length": 3}]},
+  "mm_metadata": {"image": ["<base64-metadata-only-msgpack-1>", "<base64-metadata-only-msgpack-2>"]}
+}
+```
+
+vLLM rejects metadata-only `features` without `ec_transfer_params`, so the
+coordinator never takes this path when the EC connector emits no transfer map.
 
 ### Output (mutates RequestContext)
 

--- a/pkg/coordinator/pipeline/context.go
+++ b/pkg/coordinator/pipeline/context.go
@@ -94,14 +94,21 @@ type RequestContext struct {
 // MultimodalEntry describes one downloaded multimodal item (e.g. an image) and
 // where it sits in the tokenized prompt. Index is its position in the request's
 // multimodal list. Base64Data and ContentType come from the media download;
-// Hash and KwargsData are filled in by the render step; Placeholder marks the
-// span of placeholder tokens the encode step replaces.
+// Hash, KwargsData, and MMMetadata are filled in by the render step; Placeholder
+// marks the span of placeholder tokens the encode step replaces.
+//
+// KwargsData is the full MultiModalKwargsItem blob (encoder tensors plus
+// metadata). MMMetadata is the sibling metadata-only blob from render
+// (placeholder_metadata_fields and keep_on_cpu fields such as image_grid_thw),
+// without encoder inputs like pixel_values. Prefill may send MMMetadata with
+// ec_transfer_params instead of KwargsData.
 type MultimodalEntry struct {
 	Index       int
 	Hash        string
 	Base64Data  string
 	ContentType string
 	KwargsData  string
+	MMMetadata  string
 	Placeholder PlaceholderRange
 }
 

--- a/pkg/coordinator/steps/prefill.go
+++ b/pkg/coordinator/steps/prefill.go
@@ -82,10 +82,8 @@ func (s *PrefillStep) Name() string { return PrefillStepName }
 func (s *PrefillStep) Execute(ctx context.Context, reqCtx *pipeline.RequestContext) error {
 	logger := log.FromContext(ctx).WithName(PrefillStepName)
 
-	features := buildMMFeatures(reqCtx.MultimodalEntries, true)
-
 	format := resolveFormat(s.useOpenAIFormat, reqCtx.OriginalPath)
-	body, err := s.buildPrefillBody(ctx, reqCtx, features, format)
+	body, err := s.buildPrefillBody(ctx, reqCtx, format)
 	if err != nil {
 		return fmt.Errorf("prefill: %w", err)
 	}
@@ -130,12 +128,16 @@ func (s *PrefillStep) Execute(ctx context.Context, reqCtx *pipeline.RequestConte
 	return nil
 }
 
-func (s *PrefillStep) buildPrefillBody(ctx context.Context, reqCtx *pipeline.RequestContext, features map[string]any, format gateway.RequestFormat) (map[string]any, error) {
+func (s *PrefillStep) buildPrefillBody(ctx context.Context, reqCtx *pipeline.RequestContext, format gateway.RequestFormat) (map[string]any, error) {
 	ecParams, err := s.ec.PreparePrefillECParams(ctx, reqCtx)
 	if err != nil {
 		return nil, err
 	}
 	kvParams := s.kv.PreparePrefillKVParams(ctx, reqCtx)
+
+	// Prefer mm_metadata over kwargs_data only when EC transfer params are
+	// present. vLLM rejects metadata-only features without ec_transfer_params.
+	features := buildPrefillMMFeatures(reqCtx.MultimodalEntries, len(ecParams) > 0)
 
 	switch format {
 	case gateway.FormatChatCompletions:
@@ -148,6 +150,12 @@ func (s *PrefillStep) buildPrefillBody(ctx context.Context, reqCtx *pipeline.Req
 			tokensFeatures := map[string]any{
 				"mm_hashes":       features["mm_hashes"],
 				"mm_placeholders": features["mm_placeholders"],
+			}
+			// Chat tokens.features never carried kwargs_data. When the metadata
+			// path is active, forward mm_metadata so prefill can compute mRoPE
+			// without re-processing encoder tensors.
+			if md, ok := features["mm_metadata"]; ok {
+				tokensFeatures["mm_metadata"] = md
 			}
 			tokens["features"] = tokensFeatures
 		}

--- a/pkg/coordinator/steps/prefill_test.go
+++ b/pkg/coordinator/steps/prefill_test.go
@@ -70,8 +70,8 @@ func TestPrefillStep_SendsCorrectGenerateRequest(t *testing.T) {
 		Model:     "llama-3",
 		TokenIDs:  []int{1, 32000, 32000, 32000, 32000, 32000, 32000, 2345},
 		MultimodalEntries: []pipeline.MultimodalEntry{
-			{Index: 0, Hash: "hash-a", KwargsData: "dGVuc29yLWE=", Placeholder: pipeline.PlaceholderRange{Offset: 1, Length: 3}},
-			{Index: 1, Hash: "hash-b", KwargsData: "dGVuc29yLWI=", Placeholder: pipeline.PlaceholderRange{Offset: 4, Length: 3}},
+			{Index: 0, Hash: "hash-a", KwargsData: testKwargsA, Placeholder: pipeline.PlaceholderRange{Offset: 1, Length: 3}},
+			{Index: 1, Hash: "hash-b", KwargsData: testKwargsB, Placeholder: pipeline.PlaceholderRange{Offset: 4, Length: 3}},
 		},
 		ECTransferParams: []map[string]any{
 			{"hash-a": map[string]any{"peer_port": 5501, "size_bytes": 1228800, "nixl_agent_metadata_b64": "bml4..."}},
@@ -121,8 +121,8 @@ func TestPrefillStep_SendsCorrectGenerateRequest(t *testing.T) {
 		t.Fatalf("expected kwargs_data map in prefill, got %T", features["kwargs_data"])
 	}
 	imageKwargs, _ := kwargsData[ModalityImage].([]any)
-	if len(imageKwargs) != 2 || imageKwargs[0] != "dGVuc29yLWE=" || imageKwargs[1] != "dGVuc29yLWI=" {
-		t.Fatalf("expected kwargs_data.image=[dGVuc29yLWE=,dGVuc29yLWI=], got %v", imageKwargs)
+	if len(imageKwargs) != 2 || imageKwargs[0] != testKwargsA || imageKwargs[1] != testKwargsB {
+		t.Fatalf("expected kwargs_data.image=[%s,%s], got %v", testKwargsA, testKwargsB, imageKwargs)
 	}
 
 	// Verify sampling_params with extra_args workaround
@@ -174,6 +174,127 @@ func TestPrefillStep_SendsCorrectGenerateRequest(t *testing.T) {
 	// Verify response populated KVTransferParams
 	if reqCtx.KVTransferParams["block_id"] != "block-xyz" {
 		t.Fatalf("expected block_id=block-xyz, got %v", reqCtx.KVTransferParams["block_id"])
+	}
+}
+
+func TestPrefillStep_GenerateUsesMMMetadataWhenECPresent(t *testing.T) {
+	var prefillBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &prefillBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"kv_transfer_params": map[string]any{"block_id": "block-xyz"},
+		})
+	}))
+	defer server.Close()
+
+	gwClient := gateway.New(config.GatewayConfig{Address: server.URL})
+	step, err := NewPrefillStep(gwClient, map[string]any{
+		"use_openai_format": false,
+		ParamECConnector:    ec.NIXL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reqCtx := &pipeline.RequestContext{
+		RequestID: "req-meta",
+		Model:     "llama-3",
+		TokenIDs:  []int{1, 32000, 32000, 2345},
+		MultimodalEntries: []pipeline.MultimodalEntry{
+			{Index: 0, Hash: "hash-a", KwargsData: testKwargsA, MMMetadata: testMetadataA, Placeholder: pipeline.PlaceholderRange{Offset: 1, Length: 2}},
+		},
+		ECTransferParams: []map[string]any{
+			{"hash-a": map[string]any{"peer_port": 5501, "size_bytes": 1228800, "nixl_agent_metadata_b64": "bml4..."}},
+		},
+		KVTransferParams: make(map[string]any),
+	}
+
+	if err := step.Execute(context.Background(), reqCtx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	features, ok := prefillBody["features"].(map[string]any)
+	if !ok {
+		t.Fatal("expected features in prefill request")
+	}
+	if _, ok := features["kwargs_data"]; ok {
+		t.Fatalf("expected kwargs_data omitted when mm_metadata is used, got %v", features["kwargs_data"])
+	}
+	md, ok := features["mm_metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected mm_metadata map, got %T", features["mm_metadata"])
+	}
+	items, _ := md[ModalityImage].([]any)
+	if len(items) != 1 || items[0] != testMetadataA {
+		t.Fatalf("unexpected mm_metadata: %#v", items)
+	}
+}
+
+func TestPrefillStep_ChatForwardsMMMetadataInTokensFeatures(t *testing.T) {
+	var prefillBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &prefillBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"kv_transfer_params": map[string]any{"block_id": "block-xyz"},
+		})
+	}))
+	defer server.Close()
+
+	gwClient := gateway.New(config.GatewayConfig{Address: server.URL})
+	step, err := NewPrefillStep(gwClient, map[string]any{
+		"use_openai_format": true,
+		ParamECConnector:    ec.NIXL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reqCtx := &pipeline.RequestContext{
+		RequestID:    "req-chat-meta",
+		OriginalPath: gateway.PathChatCompletions,
+		Model:        "llama-3",
+		Body: map[string]any{
+			"model": "llama-3",
+			"messages": []any{
+				map[string]any{"role": "user", "content": "hi"},
+			},
+		},
+		TokenIDs: []int{1, 32000, 2345},
+		MultimodalEntries: []pipeline.MultimodalEntry{
+			{Index: 0, Hash: "hash-a", KwargsData: testKwargsA, MMMetadata: testMetadataA, Placeholder: pipeline.PlaceholderRange{Offset: 1, Length: 1}},
+		},
+		ECTransferParams: []map[string]any{
+			{"hash-a": map[string]any{"peer_port": 5501}},
+		},
+		KVTransferParams: make(map[string]any),
+	}
+
+	if err := step.Execute(context.Background(), reqCtx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tokens, ok := prefillBody["tokens"].(map[string]any)
+	if !ok {
+		t.Fatal("expected tokens in chat prefill body")
+	}
+	features, ok := tokens["features"].(map[string]any)
+	if !ok {
+		t.Fatal("expected tokens.features")
+	}
+	if _, ok := features["kwargs_data"]; ok {
+		t.Fatal("tokens.features must not include kwargs_data")
+	}
+	md, ok := features["mm_metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected tokens.features.mm_metadata, got %v", features)
+	}
+	items, _ := md[ModalityImage].([]any)
+	if len(items) != 1 || items[0] != testMetadataA {
+		t.Fatalf("unexpected mm_metadata: %#v", items)
 	}
 }
 

--- a/pkg/coordinator/steps/render.go
+++ b/pkg/coordinator/steps/render.go
@@ -273,6 +273,7 @@ func (s *RenderStep) executeChatCompletions(ctx context.Context, reqCtx *pipelin
 	imageHashes := renderResp.Features.MMHashes[ModalityImage]
 	imagePlaceholders := renderResp.Features.MMPlaceholders[ModalityImage]
 	imageKwargs := renderResp.Features.KwargsData[ModalityImage]
+	imageMetadata := renderResp.Features.MMMetadata[ModalityImage]
 
 	expected := len(reqCtx.MultimodalEntries)
 	if len(imageHashes) != expected {
@@ -284,18 +285,26 @@ func (s *RenderStep) executeChatCompletions(ctx context.Context, reqCtx *pipelin
 	if len(imageKwargs) != expected {
 		return fmt.Errorf("render returned %d kwargs_data but expected %d", len(imageKwargs), expected)
 	}
+	// mm_metadata is optional for backward compatibility with older renderers.
+	// When present it must be parallel to mm_hashes.
+	if len(imageMetadata) > 0 && len(imageMetadata) != expected {
+		return fmt.Errorf("render returned %d mm_metadata but expected %d", len(imageMetadata), expected)
+	}
 
 	for i := range reqCtx.MultimodalEntries {
 		reqCtx.MultimodalEntries[i].Hash = imageHashes[i]
 		reqCtx.MultimodalEntries[i].KwargsData = imageKwargs[i]
 		reqCtx.MultimodalEntries[i].Placeholder = imagePlaceholders[i]
+		if i < len(imageMetadata) {
+			reqCtx.MultimodalEntries[i].MMMetadata = imageMetadata[i]
+		}
 	}
 
 	if err := s.checkPlaceholderLimit(reqCtx.MultimodalEntries); err != nil {
 		return err
 	}
 
-	logger.V(logutil.DEBUG).Info("response", "mm_hashes", imageHashes, "mm_placeholders", imagePlaceholders, "kwargs_data_len", len(imageKwargs))
+	logger.V(logutil.DEBUG).Info("response", "mm_hashes", imageHashes, "mm_placeholders", imagePlaceholders, "kwargs_data_len", len(imageKwargs), "mm_metadata_len", len(imageMetadata))
 	logger.V(logutil.DEFAULT).Info("complete", "token_ids_len", len(renderResp.TokenIDs), "images", len(imageHashes))
 	return nil
 }
@@ -354,6 +363,7 @@ type renderFeatures struct {
 	MMHashes       map[string][]string                    `json:"mm_hashes"`
 	MMPlaceholders map[string][]pipeline.PlaceholderRange `json:"mm_placeholders"`
 	KwargsData     map[string][]string                    `json:"kwargs_data"`
+	MMMetadata     map[string][]string                    `json:"mm_metadata"`
 }
 
 // completionsRenderResponse is a minimal view of the per-prompt object returned

--- a/pkg/coordinator/steps/render_test.go
+++ b/pkg/coordinator/steps/render_test.go
@@ -52,7 +52,8 @@ func TestRenderStep_ParsesFullResponse(t *testing.T) {
 			"features": map[string]any{
 				"mm_hashes":       map[string][]string{ModalityImage: {"vllm-hash-a", "vllm-hash-b"}},
 				"mm_placeholders": map[string][]any{ModalityImage: {map[string]any{"offset": 1, "length": 3}, map[string]any{"offset": 4, "length": 3}}},
-				"kwargs_data":     map[string][]string{ModalityImage: {"dGVuc29yLWE=", "dGVuc29yLWI="}},
+				"kwargs_data":     map[string][]string{ModalityImage: {testKwargsA, testKwargsB}},
+				"mm_metadata":     map[string][]string{ModalityImage: {testMetadataA, testMetadataB}},
 			},
 		})
 	}))
@@ -96,11 +97,14 @@ func TestRenderStep_ParsesFullResponse(t *testing.T) {
 	}
 
 	// Verify kwargs_data
-	if reqCtx.MultimodalEntries[0].KwargsData != "dGVuc29yLWE=" {
+	if reqCtx.MultimodalEntries[0].KwargsData != testKwargsA {
 		t.Fatalf("expected kwargs_data for entry 0, got %s", reqCtx.MultimodalEntries[0].KwargsData)
 	}
-	if reqCtx.MultimodalEntries[1].KwargsData != "dGVuc29yLWI=" {
+	if reqCtx.MultimodalEntries[1].KwargsData != testKwargsB {
 		t.Fatalf("expected kwargs_data for entry 1, got %s", reqCtx.MultimodalEntries[1].KwargsData)
+	}
+	if reqCtx.MultimodalEntries[0].MMMetadata != testMetadataA || reqCtx.MultimodalEntries[1].MMMetadata != testMetadataB {
+		t.Fatalf("unexpected mm_metadata: %q / %q", reqCtx.MultimodalEntries[0].MMMetadata, reqCtx.MultimodalEntries[1].MMMetadata)
 	}
 
 	// Verify placeholders

--- a/pkg/coordinator/steps/utils.go
+++ b/pkg/coordinator/steps/utils.go
@@ -112,12 +112,41 @@ func capSingleTokenOutput(body map[string]any, format gateway.RequestFormat) {
 // and optionally kwargs_data) from the request's multimodal entries. It returns
 // nil when there are no entries.
 func buildMMFeatures(entries []pipeline.MultimodalEntry, includeKwargs bool) map[string]any {
+	return buildMMFeaturesOpts(entries, includeKwargs, false)
+}
+
+// buildPrefillMMFeatures builds features for the prefill request.
+//
+// When preferMetadata is true and every entry carries non-empty MMMetadata,
+// the result includes mm_metadata and omits kwargs_data. That path is only
+// valid together with ec_transfer_params (vLLM rejects metadata-only features
+// without EC params). Otherwise kwargs_data is included for backward
+// compatibility with renders that do not emit mm_metadata.
+func buildPrefillMMFeatures(entries []pipeline.MultimodalEntry, preferMetadata bool) map[string]any {
+	useMetadata := preferMetadata && allEntriesHaveMMMetadata(entries)
+	return buildMMFeaturesOpts(entries, !useMetadata, useMetadata)
+}
+
+func allEntriesHaveMMMetadata(entries []pipeline.MultimodalEntry) bool {
+	if len(entries) == 0 {
+		return false
+	}
+	for _, e := range entries {
+		if e.MMMetadata == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func buildMMFeaturesOpts(entries []pipeline.MultimodalEntry, includeKwargs, includeMetadata bool) map[string]any {
 	if len(entries) == 0 {
 		return nil
 	}
 	hashes := make([]string, len(entries))
 	placeholders := make([]any, len(entries))
 	kwargs := make([]string, len(entries))
+	metadata := make([]string, len(entries))
 	for i, entry := range entries {
 		hashes[i] = entry.Hash
 		placeholders[i] = map[string]any{
@@ -125,31 +154,41 @@ func buildMMFeatures(entries []pipeline.MultimodalEntry, includeKwargs bool) map
 			"length": entry.Placeholder.Length,
 		}
 		kwargs[i] = entry.KwargsData
+		metadata[i] = entry.MMMetadata
 	}
 	features := map[string]any{
 		"mm_hashes":       map[string][]string{ModalityImage: hashes},
 		"mm_placeholders": map[string][]any{ModalityImage: placeholders},
 	}
 	if includeKwargs {
-		features["kwargs_data"] = mmKwargsField(kwargs)
+		features["kwargs_data"] = mmBase64Field(kwargs)
+	}
+	if includeMetadata {
+		features["mm_metadata"] = mmBase64Field(metadata)
 	}
 	return features
 }
 
-// mmKwargsField builds the kwargs_data feature value from per-entry KwargsData
-// strings. The empty string is our internal "resolve from cache" sentinel and
-// MUST serialize as JSON null, not "": vLLM treats null (or an absent field) as
-// a cache-hit item to fetch from the encoder cache by hash, whereas "" is decoded
-// as an inline tensor and fails with "Input data was truncated". Non-empty entries
-// are the base64 tensor blobs and are forwarded verbatim.
-func mmKwargsField(kwargs []string) map[string][]any {
-	items := make([]any, len(kwargs))
-	for i, k := range kwargs {
-		if k != "" {
-			items[i] = k
+// mmBase64Field builds a modality-keyed feature value from per-entry base64
+// strings (kwargs_data or mm_metadata). The empty string is our internal
+// "resolve from cache" / absent sentinel and MUST serialize as JSON null, not
+// "": vLLM treats null (or an absent field) as a cache-hit item to fetch from
+// the encoder cache by hash, whereas "" is decoded as an inline blob and fails
+// with "Input data was truncated". Non-empty entries are forwarded verbatim.
+func mmBase64Field(values []string) map[string][]any {
+	items := make([]any, len(values))
+	for i, v := range values {
+		if v != "" {
+			items[i] = v
 		}
 	}
 	return map[string][]any{ModalityImage: items}
+}
+
+// mmKwargsField is kept as a thin alias for tests and call sites that name the
+// kwargs_data wire field explicitly.
+func mmKwargsField(kwargs []string) map[string][]any {
+	return mmBase64Field(kwargs)
 }
 
 // setGenerateTransferParams nests the kv/ec transfer params under
@@ -284,6 +323,8 @@ func mmImageArray(features map[string]any, field string) (arr []any, present boo
 // encoder cache by hash (a cache-hit request), so each entry's KwargsData is "".
 // When present, kwargs_data must be parallel to mm_hashes, but an individual
 // item may be null (a cache hit within a mixed batch), which maps to "".
+// mm_metadata is optional and follows the same parallel/null rules as
+// kwargs_data when present.
 //
 // Returns ErrBadRequest when a present field has the wrong type, required slices
 // have different lengths, or any element has an unexpected type.
@@ -315,6 +356,11 @@ func extractMultimodalEntries(features map[string]any) ([]pipeline.MultimodalEnt
 		return nil, err
 	}
 
+	rawMetadata, hasMetadata, err := mmImageArray(features, "mm_metadata")
+	if err != nil {
+		return nil, err
+	}
+
 	n := len(rawHashes)
 	if len(rawPlaceholders) != n {
 		return nil, fmt.Errorf("features length mismatch: mm_hashes has %d, mm_placeholders has %d: %w",
@@ -326,6 +372,10 @@ func extractMultimodalEntries(features map[string]any) ([]pipeline.MultimodalEnt
 	if hasKwargs && len(rawKwargs) != n {
 		return nil, fmt.Errorf("features length mismatch: mm_hashes has %d, kwargs_data has %d: %w",
 			n, len(rawKwargs), pipeline.ErrBadRequest)
+	}
+	if hasMetadata && len(rawMetadata) != n {
+		return nil, fmt.Errorf("features length mismatch: mm_hashes has %d, mm_metadata has %d: %w",
+			n, len(rawMetadata), pipeline.ErrBadRequest)
 	}
 
 	entries := make([]pipeline.MultimodalEntry, n)
@@ -367,10 +417,22 @@ func extractMultimodalEntries(features map[string]any) ([]pipeline.MultimodalEnt
 			}
 		}
 
+		var metadata string
+		if hasMetadata {
+			switch m := rawMetadata[i].(type) {
+			case string:
+				metadata = m
+			case nil:
+			default:
+				return nil, fmt.Errorf("mm_metadata[%d] must be a string or null: %w", i, pipeline.ErrBadRequest)
+			}
+		}
+
 		entries[i] = pipeline.MultimodalEntry{
 			Index:      i,
 			Hash:       hash,
 			KwargsData: kwarg,
+			MMMetadata: metadata,
 			Placeholder: pipeline.PlaceholderRange{
 				Offset: offset,
 				Length: length,

--- a/pkg/coordinator/steps/utils_test.go
+++ b/pkg/coordinator/steps/utils_test.go
@@ -33,6 +33,14 @@ const testHash = "abc123"
 // kwargs_data entry.
 const testKwargs = "dGVuc29y"
 
+// Per-image stand-ins used across prefill/render feature tests.
+const (
+	testKwargsA   = "dGVuc29yLWE="
+	testKwargsB   = "dGVuc29yLWI="
+	testMetadataA = "bWV0YS1h"
+	testMetadataB = "bWV0YS1i"
+)
+
 func TestReadErrorBody_CapsOversizedBody(t *testing.T) {
 	body := readErrorBody(strings.NewReader(strings.Repeat("a", maxErrorBodySize*4)))
 	if len(body) != maxErrorBodySize {
@@ -296,6 +304,46 @@ func TestExtractMultimodalEntries(t *testing.T) {
 		_, err := extractMultimodalEntries(features)
 		if err == nil {
 			t.Fatal("expected error for mismatched kwargs count")
+		}
+		if !errors.Is(err, pipeline.ErrBadRequest) {
+			t.Errorf("expected ErrBadRequest, got %v", err)
+		}
+	})
+
+	t.Run("mm_metadata_parallel_to_hashes", func(t *testing.T) {
+		features := map[string]any{
+			"mm_hashes": map[string]any{"image": []any{"hash1", "hash2"}},
+			"mm_placeholders": map[string]any{"image": []any{
+				map[string]any{"offset": float64(1), "length": float64(3)},
+				map[string]any{"offset": float64(5), "length": float64(2)},
+			}},
+			"kwargs_data": map[string]any{"image": []any{"d1", "d2"}},
+			"mm_metadata": map[string]any{"image": []any{"m1", nil}},
+		}
+		entries, err := extractMultimodalEntries(features)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if entries[0].MMMetadata != "m1" {
+			t.Fatalf("entry 0 metadata: got %q", entries[0].MMMetadata)
+		}
+		if entries[1].MMMetadata != "" {
+			t.Fatalf("entry 1 metadata: expected empty for null, got %q", entries[1].MMMetadata)
+		}
+	})
+
+	t.Run("length_mismatch_mm_metadata", func(t *testing.T) {
+		features := map[string]any{
+			"mm_hashes": map[string]any{"image": []any{"hash1", "hash2"}},
+			"mm_placeholders": map[string]any{"image": []any{
+				map[string]any{"offset": float64(1), "length": float64(3)},
+				map[string]any{"offset": float64(4), "length": float64(3)},
+			}},
+			"mm_metadata": map[string]any{"image": []any{"m1"}},
+		}
+		_, err := extractMultimodalEntries(features)
+		if err == nil {
+			t.Fatal("expected error for mismatched mm_metadata count")
 		}
 		if !errors.Is(err, pipeline.ErrBadRequest) {
 			t.Errorf("expected ErrBadRequest, got %v", err)
@@ -612,6 +660,62 @@ func TestBuildMMFeatures_CacheHitSentinelSerializesAsNull(t *testing.T) {
 		features := buildMMFeatures([]pipeline.MultimodalEntry{entry("")}, false)
 		if _, ok := features["kwargs_data"]; ok {
 			t.Errorf("expected kwargs_data absent when includeKwargs is false")
+		}
+	})
+}
+
+func TestBuildPrefillMMFeatures_PreferMetadata(t *testing.T) {
+	entry := func(kwargs, metadata string) pipeline.MultimodalEntry {
+		return pipeline.MultimodalEntry{
+			Hash:        testHash,
+			KwargsData:  kwargs,
+			MMMetadata:  metadata,
+			Placeholder: pipeline.PlaceholderRange{Offset: 1, Length: 3},
+		}
+	}
+
+	t.Run("with EC prefers mm_metadata and omits kwargs_data", func(t *testing.T) {
+		features := buildPrefillMMFeatures([]pipeline.MultimodalEntry{
+			entry(testKwargsA, testMetadataA),
+			entry(testKwargsB, testMetadataB),
+		}, true)
+		if _, ok := features["kwargs_data"]; ok {
+			t.Fatalf("expected kwargs_data omitted, got %v", features["kwargs_data"])
+		}
+		md, ok := features["mm_metadata"].(map[string][]any)
+		if !ok {
+			t.Fatalf("expected mm_metadata map, got %T", features["mm_metadata"])
+		}
+		items := md[ModalityImage]
+		if len(items) != 2 || items[0] != testMetadataA || items[1] != testMetadataB {
+			t.Fatalf("unexpected mm_metadata: %#v", items)
+		}
+	})
+
+	t.Run("without EC keeps kwargs_data even when metadata is present", func(t *testing.T) {
+		features := buildPrefillMMFeatures([]pipeline.MultimodalEntry{
+			entry(testKwargsA, testMetadataA),
+		}, false)
+		if _, ok := features["mm_metadata"]; ok {
+			t.Fatalf("expected mm_metadata omitted without EC, got %v", features["mm_metadata"])
+		}
+		kwargs := mmImageKwargs(t, features)
+		if len(kwargs) != 1 || kwargs[0] != testKwargsA {
+			t.Fatalf("expected kwargs_data fallback, got %#v", kwargs)
+		}
+	})
+
+	t.Run("partial metadata falls back to kwargs_data", func(t *testing.T) {
+		features := buildPrefillMMFeatures([]pipeline.MultimodalEntry{
+			entry(testKwargsA, testMetadataA),
+			entry(testKwargsB, ""),
+		}, true)
+		if _, ok := features["mm_metadata"]; ok {
+			t.Fatalf("expected mm_metadata omitted on partial metadata, got %v", features["mm_metadata"])
+		}
+		kwargs := mmImageKwargs(t, features)
+		if len(kwargs) != 2 || kwargs[0] != testKwargsA || kwargs[1] != testKwargsB {
+			t.Fatalf("expected kwargs_data fallback, got %#v", kwargs)
 		}
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
vLLM [#54659](https://github.com/vllm-project/vllm/pull/54659) adds render `features.mm_metadata` so prefill can drop full `kwargs_data` when embeddings arrive via `ec_transfer_params`. This wires that path in the coordinator: parse `mm_metadata` from render, keep encode on `kwargs_data`, and on prefill emit `mm_metadata` (omit `kwargs_data`) when EC params are present and every entry has metadata. Older renderers and non-EC paths keep sending `kwargs_data`.

**Which issue(s) this PR fixes**:
Fixes #2722

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Coordinator prefill for native /inference/v1/generate endpoints sends multimodal mm_metadata instead of full kwargs_data when EC transfer params are available.
```

## Test plan
- [x] Unit tests for prefer-metadata prefill (generate + chat tokens.features)
- [x] Unit tests for kwargs_data fallback without EC / partial metadata
- [x] Render parses optional mm_metadata; extractMultimodalEntries parallel/null rules
- [x] `go test ./pkg/coordinator/steps/ ./pkg/coordinator/pipeline/`
