### PR TITLE
Preserve SGLang prompt JSON when adding bootstrap fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,8 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	github.com/tidwall/gjson v1.18.0
+	github.com/tidwall/sjson v1.2.5
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/otel v1.44.0
@@ -115,10 +117,8 @@ require (
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect

--- a/pkg/sidecar/proxy/connector_sglang.go
+++ b/pkg/sidecar/proxy/connector_sglang.go
@@ -167,11 +167,13 @@ func (s *Server) handleSGLangConcurrentRequests(w http.ResponseWriter, r *http.R
 	}
 }
 
+// prepareSGLangRequest returns the request body with SGLang bootstrap fields set.
 func (s *Server) prepareSGLangRequest(r *http.Request, prefillHostPort string, roomID int64) ([]byte, error) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read request body: %w", err)
 	}
+	// Preserve the original request body encoding while adding SGLang bootstrap fields.
 	if !gjson.ValidBytes(body) {
 		return nil, fmt.Errorf("failed to parse request body: %w", errInvalidJSON)
 	}

--- a/pkg/sidecar/proxy/connector_sglang.go
+++ b/pkg/sidecar/proxy/connector_sglang.go
@@ -18,7 +18,6 @@ package proxy
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -30,6 +29,9 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
@@ -54,22 +56,9 @@ func init() {
 func (s *Server) handleSGLang(w http.ResponseWriter, r *http.Request, prefillPodHostPort string) {
 	s.logger.V(logging.DEBUG).Info("running SGLang protocol", "url", prefillPodHostPort)
 
-	// Make Request
-	requestData, err := s.parseSGLangRequest(r)
-
-	if err != nil {
-		if err := errorJSONInvalid(err, w); err != nil {
-			s.logger.Error(err, "failed to send error response to client")
-		}
-		return
-	}
-
 	roomID := s.generateSGLangRoomID()
 
-	// Inject bootstrap info for both prefill and decode
-	bootstrapInfo := s.addSGLangBootstrapInfo(requestData, prefillPodHostPort, roomID)
-
-	body, err := json.Marshal(bootstrapInfo)
+	body, err := s.prepareSGLangRequest(r, prefillPodHostPort, roomID)
 	if err != nil {
 		if err := errorJSONInvalid(err, w); err != nil {
 			s.logger.Error(err, "failed to send error response to client")
@@ -177,40 +166,62 @@ func (s *Server) handleSGLangConcurrentRequests(w http.ResponseWriter, r *http.R
 	}
 }
 
-func (s *Server) addSGLangBootstrapInfo(requestData map[string]interface{}, prefillHostPort string, roomID int64) map[string]interface{} {
-	modifiedRequest := make(map[string]interface{})
-	for k, v := range requestData {
-		modifiedRequest[k] = v
+func (s *Server) prepareSGLangRequest(r *http.Request, prefillHostPort string, roomID int64) ([]byte, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read request body: %w", err)
+	}
+	if !gjson.ValidBytes(body) {
+		return nil, fmt.Errorf("failed to parse request body: %w", errInvalidJSON)
+	}
+	parsed := gjson.ParseBytes(body)
+	if !parsed.IsObject() {
+		return nil, fmt.Errorf("failed to parse request body: SGLang request body is not a JSON object")
+	}
+	if err := validateSGLangBootstrapFields(parsed); err != nil {
+		return nil, err
 	}
 
-	// Generate bootstrap host from prefill host
 	bootstrapHost := extractHost(prefillHostPort)
-
-	// Add bootstrap information
-	modifiedRequest[requestFieldBootstrapHost] = bootstrapHost
-	modifiedRequest[requestFieldBootstrapPort] = sglangBootstrapPort
-	modifiedRequest[requestFieldBootstrapRoom] = roomID
+	body, err = sjson.SetBytes(body, requestFieldBootstrapHost, bootstrapHost)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add bootstrap host: %w", err)
+	}
+	body, err = sjson.SetBytes(body, requestFieldBootstrapPort, sglangBootstrapPort)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add bootstrap port: %w", err)
+	}
+	body, err = sjson.SetBytes(body, requestFieldBootstrapRoom, roomID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add bootstrap room: %w", err)
+	}
 
 	s.logger.V(logging.TRACE).Info("bootstrap info added",
 		"bootstrap_host", bootstrapHost,
 		"bootstrap_port", sglangBootstrapPort,
 		"bootstrap_room", roomID)
 
-	return modifiedRequest
+	return body, nil
 }
 
-func (s *Server) parseSGLangRequest(r *http.Request) (map[string]interface{}, error) {
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read request body: %w", err)
+func validateSGLangBootstrapFields(request gjson.Result) error {
+	counts := map[string]int{
+		requestFieldBootstrapHost: 0,
+		requestFieldBootstrapPort: 0,
+		requestFieldBootstrapRoom: 0,
 	}
-
-	var requestData map[string]interface{}
-	if err := json.Unmarshal(body, &requestData); err != nil {
-		return nil, fmt.Errorf("failed to parse request body: %w", err)
+	request.ForEach(func(key, _ gjson.Result) bool {
+		if _, ok := counts[key.String()]; ok {
+			counts[key.String()]++
+		}
+		return true
+	})
+	for field, count := range counts {
+		if count > 1 {
+			return fmt.Errorf("duplicate top-level SGLang field %q", field)
+		}
 	}
-
-	return requestData, nil
+	return nil
 }
 
 func (s *Server) generateSGLangRoomID() int64 {

--- a/pkg/sidecar/proxy/connector_sglang.go
+++ b/pkg/sidecar/proxy/connector_sglang.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -176,7 +177,7 @@ func (s *Server) prepareSGLangRequest(r *http.Request, prefillHostPort string, r
 	}
 	parsed := gjson.ParseBytes(body)
 	if !parsed.IsObject() {
-		return nil, fmt.Errorf("failed to parse request body: SGLang request body is not a JSON object")
+		return nil, errors.New("failed to parse request body: SGLang request body is not a JSON object")
 	}
 	if err := validateSGLangBootstrapFields(parsed); err != nil {
 		return nil, err

--- a/pkg/sidecar/proxy/connector_sglang_test.go
+++ b/pkg/sidecar/proxy/connector_sglang_test.go
@@ -40,6 +40,65 @@ var _ = Describe("SGLang Connector", func() {
 		testInfo = sidecarConnectionTestSetup(KVConnectorSGLang)
 	})
 
+	It("should preserve prompt-bearing nested JSON when forwarding requests", func() {
+		testInfo.decodeBackend.Close()
+		testInfo.prefillBackend.Close()
+
+		prefillBodies := make(chan []byte, 1)
+		decodeBodies := make(chan []byte, 1)
+		recordBody := func(ch chan<- []byte) http.HandlerFunc {
+			return func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				Expect(err).ToNot(HaveOccurred())
+				ch <- body
+				w.WriteHeader(http.StatusOK)
+				_, err = w.Write([]byte(`{"id":"ok"}`))
+				Expect(err).ToNot(HaveOccurred())
+			}
+		}
+
+		testInfo.prefillBackend = httptest.NewServer(recordBody(prefillBodies))
+		testInfo.decodeBackend = httptest.NewServer(recordBody(decodeBodies))
+		testInfo.decodeURL, _ = url.Parse(testInfo.decodeBackend.URL)
+		testInfo.proxy = NewProxy(Config{
+			Port:        "0",
+			DecoderURL:  testInfo.decodeURL,
+			KVConnector: KVConnectorSGLang,
+		})
+
+		proxyBaseAddr := testInfo.startProxy()
+		body := `{"model":"Qwen","tools":[{"type":"function","function":{"parameters":{"type":"object","properties":{"query":{"description":"Lookup query","type":"string"}},"required":["query"]},"description":"Lookup a value","name":"lookup"}}],"messages":[{"content":"Call the lookup tool","role":"user"}]}`
+		originalTools := `"tools":[{"type":"function","function":{"parameters":{"type":"object","properties":{"query":{"description":"Lookup query","type":"string"}},"required":["query"]},"description":"Lookup a value","name":"lookup"}}]`
+
+		req, err := http.NewRequest(http.MethodPost, proxyBaseAddr+ChatCompletionsPath, bytes.NewReader([]byte(body)))
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Add(routing.PrefillEndpointHeader, testInfo.prefillBackend.URL[len("http://"):])
+
+		rp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		defer rp.Body.Close()
+		Expect(rp.StatusCode).To(Equal(http.StatusOK))
+
+		var prefillBody []byte
+		Eventually(prefillBodies).Should(Receive(&prefillBody))
+		Expect(string(prefillBody)).To(ContainSubstring(originalTools))
+
+		var decodeBody []byte
+		Eventually(decodeBodies).Should(Receive(&decodeBody))
+		Expect(string(decodeBody)).To(ContainSubstring(originalTools))
+	})
+
+	It("should reject duplicate SGLang bootstrap fields", func() {
+		body := []byte(`{"model":"Qwen","bootstrap_room":"client","bootstrap_room":"override","messages":[{"role":"user","content":"Hello"}]}`)
+
+		req, err := http.NewRequest(http.MethodPost, ChatCompletionsPath, bytes.NewReader(body))
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = testInfo.proxy.prepareSGLangRequest(req, "prefill.example:30080", 123)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`duplicate top-level SGLang field "bootstrap_room"`))
+	})
+
 	It("should successfully send concurrent requests to prefill and decode with bootstrap info", func() {
 		By("starting the proxy")
 		go func() {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

SGLang PD bootstrap injection currently unmarshals the full request into a Go map and marshals it back after adding bootstrap fields. That rewrites nested prompt-bearing fields such as tool schemas, which can change the prompt text SGLang derives from the request.

This PR preserves the original request bytes for nested fields and mutates only the top-level SGLang bootstrap fields. It also rejects duplicate top-level bootstrap fields because those make the gateway-controlled values ambiguous.

**Which issue(s) this PR fixes**:

None

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
The SGLang sidecar connector preserves prompt-bearing nested JSON fields when adding bootstrap metadata.
```

**Test Plan**:

- [x] Verified SGLang request forwarding preserves nested tool schema field order while adding bootstrap metadata.
- [x] Verified duplicate top-level SGLang bootstrap fields are rejected.
