### PR TITLE
fix(perf): honor tracing configuration and report scheduler p99

### DIFF
--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -52,6 +52,37 @@ python3 test/perf/run_nightly_perf.py \
 - `--gcs-bucket`: (Optional) Target GCS bucket name or URI (e.g. `gs://llm-d-perf-results`) to sync and preserve test results and profiling artifacts without committing them to the Git repository.
 - `--no-cleanup`: (Optional) Skip namespace deletion on test completion (useful for debugging).
 
+### Tracing and latency metrics
+
+Set the boolean `router.tracing.enabled` in the router config to control
+benchmark tracing. If it is omitted or null, the runner uses
+`router.epp.flags.tracing`, accepting Go boolean flag spellings. If both are
+omitted or null, tracing is disabled. The runner sets the Chart switch and
+EPP flag to the same value and rejects invalid tracing values before invoking
+Helm. Sampling and exporter settings come from `router.tracing` in the same
+config. The optimized baseline disables tracing.
+
+P50, P95, and P99 are interpolated from the change in the EPP scheduler's
+duration histogram and reported in milliseconds. They measure scheduler
+latency, not client request latency. Missing metrics or no new events produce
+zero values. A quantile in the unbounded bucket uses the highest finite
+bucket boundary.
+
+When appending to a report with a different table header, the writer starts
+a new table and preserves the historical rows.
+
+### Offline regression tests
+
+With Python and `pyyaml` installed, run from the repository root:
+
+```bash
+python3 -m unittest discover -s test/perf -p test_run_nightly_perf.py -v
+```
+
+These tests exercise configuration generation, histogram calculations, and
+report writing with cluster commands replaced by test doubles. They do not
+deploy workloads or measure tracing overhead.
+
 ---
 
 ## Nightly GitHub Actions Run
@@ -63,4 +94,3 @@ The benchmarking pipeline runs daily via GHA:
   1. Authenticates to GCP and configures `kubectl` to point to the GKE development cluster.
   2. Runs `run_nightly_perf.py` (specifying `--router-machine-family e2` and `--gcs-bucket`).
   3. Appends the metrics results and uploads profiling artifacts directly to the specified Google Cloud Storage bucket.
-

--- a/test/perf/run_nightly_perf.py
+++ b/test/perf/run_nightly_perf.py
@@ -114,6 +114,22 @@ def deploy_epp(ns, chart_path, chart_version, router_config_path, epp_cpu="2", e
     
     if not os.path.exists(router_config_path):
         raise FileNotFoundError(f"Router config file not found at: {router_config_path}")
+
+    with open(router_config_path, "r") as f:
+        guide_data = yaml.safe_load(f) or {}
+    guide_router = guide_data.get("router") or {}
+    tracing = (guide_router.get("tracing") or {}).get("enabled")
+    if tracing is None:
+        guide_epp = guide_router.get("epp") or {}
+        tracing = (guide_epp.get("flags") or {}).get("tracing")
+        if tracing is None:
+            tracing = False
+        elif str(tracing) in ("1", "t", "T", "true", "TRUE", "True"):
+            tracing = True
+        elif str(tracing) in ("0", "f", "F", "false", "FALSE", "False"):
+            tracing = False
+    if not isinstance(tracing, bool):
+        raise ValueError("tracing requires a boolean router.tracing.enabled or a boolean EPP flag")
         
     release_name = os.path.splitext(os.path.basename(router_config_path))[0]
     
@@ -136,7 +152,7 @@ def deploy_epp(ns, chart_path, chart_version, router_config_path, epp_cpu="2", e
                 "flags": {
                     "v": 4,
                     "enable-pprof": "true",
-                    "tracing": "false"
+                    "tracing": str(tracing).lower()
                 },
                 "resources": {
                     "requests": {
@@ -148,6 +164,9 @@ def deploy_epp(ns, chart_path, chart_version, router_config_path, epp_cpu="2", e
                         "memory": mem_limit
                     }
                 }
+            },
+            "tracing": {
+                "enabled": tracing
             },
             "monitoring": {
                 "prometheus": {
@@ -167,18 +186,11 @@ def deploy_epp(ns, chart_path, chart_version, router_config_path, epp_cpu="2", e
         }
     }
 
-    # Extract guide specific model server labels and nullify them in overrides to avoid helm deep merge keeping them
-    try:
-        with open(router_config_path, "r") as f:
-            guide_data = yaml.safe_load(f)
-            if (guide_data and "router" in guide_data 
-                    and "modelServers" in guide_data["router"] 
-                    and "matchLabels" in guide_data["router"]["modelServers"]):
-                for key in guide_data["router"]["modelServers"]["matchLabels"].keys():
-                    if key != "app":
-                        overrides["router"]["modelServers"]["matchLabels"][key] = None
-    except Exception as e:
-        print(f"Warning: Could not parse router config to extract modelServers labels for nullification: {e}")
+    # Clear model-server labels replaced by the simulator.
+    match_labels = (guide_router.get("modelServers") or {}).get("matchLabels") or {}
+    for key in match_labels:
+        if key != "app":
+            overrides["router"]["modelServers"]["matchLabels"][key] = None
     
     if machine_family:
         overrides["router"]["epp"]["affinity"] = {
@@ -402,12 +414,12 @@ def interpolate_percentile(sorted_buckets, total_count, percentile):
 
 def calculate_percentiles(before, after):
     if not before or not after:
-        return 0.0, 0.0
+        return 0.0, 0.0, 0.0
         
     diff_count = after['count'] - before['count']
     if diff_count <= 0:
         print("No new scheduler events recorded during the test.")
-        return 0.0, 0.0
+        return 0.0, 0.0, 0.0
         
     diff_buckets = {}
     for le in after['buckets']:
@@ -425,8 +437,9 @@ def calculate_percentiles(before, after):
     sorted_buckets = sorted(diff_buckets.items(), key=bucket_key)
     p50 = interpolate_percentile(sorted_buckets, diff_count, 0.50)
     p95 = interpolate_percentile(sorted_buckets, diff_count, 0.95)
+    p99 = interpolate_percentile(sorted_buckets, diff_count, 0.99)
     
-    return p50 * 1000, p95 * 1000  # Convert to milliseconds
+    return p50 * 1000, p95 * 1000, p99 * 1000  # Convert to milliseconds
 
 def run_benchmark(ns, job_values_path, chart_path, release_name):
     print(f"Deploying benchmark job in namespace: {ns}")
@@ -468,17 +481,26 @@ def cleanup_namespace(ns):
     print(f"Cleaning up namespace: {ns}")
     run_cmd(f"kubectl delete namespace {ns} --wait=false")
 
-def write_results_to_markdown_folder(results_dir, test_name, run_time, ns, router_config_path, perf_job, machine_family, sim_replicas, images, idle_metrics, peak_metrics, p50, p95, status, profile_results=None):
+def write_results_to_markdown_folder(results_dir, test_name, run_time, ns, router_config_path, perf_job, machine_family, sim_replicas, images, idle_metrics, peak_metrics, p50, p95, p99, status, profile_results=None):
     os.makedirs(results_dir, exist_ok=True)
     results_file = os.path.join(results_dir, f"{test_name}.md")
     file_exists = os.path.exists(results_file)
+    header = "| Timestamp | Namespace | Router Config | Perf Job | Machine Family | Sim Replicas | EPP Images | Container | Idle CPU (m) | Idle Mem (MiB) | Peak CPU (m) | Peak Mem (MiB) | P50 Latency (ms) | P95 Latency (ms) | P99 Latency (ms) | CPU Profile | Memory Profile | Status |"
+    last_header = None
+    if file_exists:
+        with open(results_file, "r") as f:
+            for line in f:
+                if line.startswith("| Timestamp |"):
+                    last_header = line.strip()
     
     with open(results_file, "a") as f:
         if not file_exists:
-            # Write header
             f.write(f"# EPP Router Performance Benchmarking Results: {test_name}\n\n")
-            f.write("| Timestamp | Namespace | Router Config | Perf Job | Machine Family | Sim Replicas | EPP Images | Container | Idle CPU (m) | Idle Mem (MiB) | Peak CPU (m) | Peak Mem (MiB) | P50 Latency (ms) | P95 Latency (ms) | CPU Profile | Memory Profile | Status |\n")
-            f.write("|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n")
+        if last_header != header:
+            if file_exists:
+                f.write("\n")
+            f.write(header + "\n")
+            f.write("|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n")
             
         epp_images = "<br>".join(images)
         mf_str = machine_family if machine_family else "-"
@@ -526,7 +548,7 @@ def write_results_to_markdown_folder(results_dir, test_name, run_time, ns, route
             peak_cpu = peak_metrics.get(container, {}).get('cpu', '-')
             peak_mem = peak_metrics.get(container, {}).get('mem', '-')
             
-            f.write(f"| {run_time} | {ns} | {config_link} | {job_link} | {mf_str} | {sim_replicas} | {epp_images} | {container} | {idle_cpu} | {idle_mem} | {peak_cpu} | {peak_mem} | {p50:.2f} | {p95:.2f} | {cpu_link} | {mem_link} | {status} |\n")
+            f.write(f"| {run_time} | {ns} | {config_link} | {job_link} | {mf_str} | {sim_replicas} | {epp_images} | {container} | {idle_cpu} | {idle_mem} | {peak_cpu} | {peak_mem} | {p50:.2f} | {p95:.2f} | {p99:.2f} | {cpu_link} | {mem_link} | {status} |\n")
 
 
 def collect_profiles(ns, epp_pod_name, results_dir, test_name, run_time_clean, profile_results):
@@ -706,7 +728,7 @@ def main():
     status = "SUCCESS"
     idle_metrics = {}
     peak_metrics = {}
-    p50, p95 = 0.0, 0.0
+    p50, p95, p99 = 0.0, 0.0, 0.0
     images = []
     profile_results = {
         'cpu_pprof': None,
@@ -821,8 +843,8 @@ def main():
 
         # Step 8: Scrape Post-Benchmark Metrics & Compute Latency
         metrics_after = scrape_scheduler_metrics(ns, pod_name)
-        p50, p95 = calculate_percentiles(metrics_before, metrics_after)
-        print(f"Benchmark latencies: P50 = {p50:.2f} ms, P95 = {p95:.2f} ms")
+        p50, p95, p99 = calculate_percentiles(metrics_before, metrics_after)
+        print(f"Benchmark latencies: P50 = {p50:.2f} ms, P95 = {p95:.2f} ms, P99 = {p99:.2f} ms")
         print(f"Peak resource usage: {peak_metrics}")
 
     except Exception as e:
@@ -861,6 +883,7 @@ def main():
                 peak_metrics, 
                 p50, 
                 p95, 
+                p99,
                 status,
                 profile_results=profile_results
             )

--- a/test/perf/run_nightly_perf.py
+++ b/test/perf/run_nightly_perf.py
@@ -118,10 +118,18 @@ def deploy_epp(ns, chart_path, chart_version, router_config_path, epp_cpu="2", e
     with open(router_config_path, "r") as f:
         guide_data = yaml.safe_load(f) or {}
     guide_router = guide_data.get("router") or {}
-    tracing = (guide_router.get("tracing") or {}).get("enabled")
+    tracing_cfg = guide_router.get("tracing")
+    if tracing_cfg is not None and not isinstance(tracing_cfg, dict):
+        raise ValueError("router.tracing must be a mapping")
+    tracing = (tracing_cfg or {}).get("enabled")
     if tracing is None:
-        guide_epp = guide_router.get("epp") or {}
-        tracing = (guide_epp.get("flags") or {}).get("tracing")
+        guide_epp = guide_router.get("epp")
+        if guide_epp is not None and not isinstance(guide_epp, dict):
+            raise ValueError("tracing requires router.epp to be a mapping")
+        flags_cfg = (guide_epp or {}).get("flags")
+        if flags_cfg is not None and not isinstance(flags_cfg, dict):
+            raise ValueError("tracing requires router.epp.flags to be a mapping")
+        tracing = (flags_cfg or {}).get("tracing")
         if tracing is None:
             tracing = False
         elif str(tracing) in ("1", "t", "T", "true", "TRUE", "True"):
@@ -187,10 +195,13 @@ def deploy_epp(ns, chart_path, chart_version, router_config_path, epp_cpu="2", e
     }
 
     # Clear model-server labels replaced by the simulator.
-    match_labels = (guide_router.get("modelServers") or {}).get("matchLabels") or {}
-    for key in match_labels:
-        if key != "app":
-            overrides["router"]["modelServers"]["matchLabels"][key] = None
+    try:
+        match_labels = (guide_router.get("modelServers") or {}).get("matchLabels") or {}
+        for key in match_labels.keys():
+            if key != "app":
+                overrides["router"]["modelServers"]["matchLabels"][key] = None
+    except AttributeError as e:
+        print(f"Warning: Could not parse router config to extract modelServers labels for nullification: {e}")
     
     if machine_family:
         overrides["router"]["epp"]["affinity"] = {

--- a/test/perf/test_run_nightly_perf.py
+++ b/test/perf/test_run_nightly_perf.py
@@ -1,0 +1,445 @@
+from contextlib import ExitStack
+import copy
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+import yaml
+
+import run_nightly_perf as perf
+
+
+LEGACY_HEADER = (
+    "| Timestamp | Namespace | Router Config | Perf Job | Machine Family | "
+    "Sim Replicas | EPP Images | Container | Idle CPU (m) | Idle Mem (MiB) | "
+    "Peak CPU (m) | Peak Mem (MiB) | P50 Latency (ms) | P95 Latency (ms) | "
+    "CPU Profile | Memory Profile | Status |\n"
+)
+
+
+def scheduler_metrics():
+    before = {
+        "count": 100,
+        "buckets": {"+Inf": 100, "0.1": 100, "0.001": 50, "0.01": 90},
+    }
+    after = {
+        "count": 200,
+        "buckets": {"+Inf": 200, "0.1": 200, "0.001": 100, "0.01": 180},
+    }
+    return before, after
+
+
+class OfflineTestCase(unittest.TestCase):
+    def setUp(self):
+        self.contexts = ExitStack()
+        self.addCleanup(self.contexts.close)
+        self.directory = Path(
+            self.contexts.enter_context(tempfile.TemporaryDirectory())
+        )
+        self.contexts.enter_context(mock.patch.object(perf, "print", create=True))
+        self.contexts.enter_context(
+            mock.patch.object(
+                perf.subprocess,
+                "run",
+                side_effect=AssertionError("Unexpected subprocess"),
+            )
+        )
+        self.contexts.enter_context(
+            mock.patch.object(
+                perf.subprocess,
+                "Popen",
+                side_effect=AssertionError("Unexpected subprocess"),
+            )
+        )
+
+
+class DeployEPPTests(OfflineTestCase):
+    def deploy(self, config, **kwargs):
+        config_path = self.directory / "router.yaml"
+        config_text = yaml.safe_dump(config)
+        config_path.write_text(config_text)
+        output_path = self.directory / "overrides.yaml"
+        namespace = "offline-tracing-preflight"
+        expected_path = f"/tmp/test-overrides-{namespace}.yaml"
+        real_open = open
+
+        def local_open(path, *args, **open_kwargs):
+            if os.fspath(path) == expected_path:
+                path = output_path
+            return real_open(path, *args, **open_kwargs)
+
+        with (
+            mock.patch.object(perf, "open", local_open, create=True),
+            mock.patch.object(perf, "run_cmd") as run_cmd,
+        ):
+            perf.deploy_epp(
+                namespace,
+                "oci://example.invalid/router",
+                "v0",
+                str(config_path),
+                **kwargs,
+            )
+        self.assertEqual(run_cmd.call_count, 2)
+        helm_command = run_cmd.call_args_list[0].args[0]
+        self.assertEqual(
+            helm_command[4:8], ["-f", str(config_path), "-f", expected_path]
+        )
+        self.assertEqual(config_path.read_text(), config_text)
+        return yaml.safe_load(output_path.read_text())
+
+    def test_explicit_tracing_enabled_for_sampling_ratios(self):
+        for ratio in ("0.01", "0.1", "1.0"):
+            with self.subTest(ratio=ratio):
+                config = {
+                    "router": {
+                        "epp": {"flags": {"tracing": "true"}},
+                        "tracing": {"sampling": {"samplerArg": ratio}},
+                    }
+                }
+                overrides = self.deploy(config)
+                self.assertEqual(overrides["router"]["epp"]["flags"]["tracing"], "true")
+                self.assertEqual(overrides["router"]["tracing"], {"enabled": True})
+
+    def test_boolean_tracing_enabled(self):
+        overrides = self.deploy({"router": {"epp": {"flags": {"tracing": True}}}})
+        self.assertEqual(overrides["router"]["epp"]["flags"]["tracing"], "true")
+        self.assertEqual(overrides["router"]["tracing"], {"enabled": True})
+
+    def test_explicit_tracing_disabled(self):
+        for value in ("false", False):
+            with self.subTest(value=value):
+                overrides = self.deploy(
+                    {"router": {"epp": {"flags": {"tracing": value}}}}
+                )
+                actual = overrides["router"]["epp"]["flags"]["tracing"]
+                self.assertEqual(actual, "false")
+                self.assertEqual(overrides["router"]["tracing"], {"enabled": False})
+
+    def test_chart_tracing_setting_takes_precedence(self):
+        for enabled in (True, False):
+            for flags in ({}, {"tracing": str(not enabled).lower()}):
+                with self.subTest(enabled=enabled, flags=flags):
+                    overrides = self.deploy(
+                        {
+                            "router": {
+                                "tracing": {"enabled": enabled},
+                                "epp": {"flags": flags},
+                            }
+                        }
+                    )
+                    self.assertEqual(
+                        overrides["router"]["tracing"], {"enabled": enabled}
+                    )
+                    self.assertEqual(
+                        overrides["router"]["epp"]["flags"]["tracing"],
+                        str(enabled).lower(),
+                    )
+
+    def test_legacy_flag_boolean_spellings(self):
+        for enabled, values in (
+            (True, (True, 1, "1", "t", "T", "true", "TRUE", "True")),
+            (False, (False, 0, "0", "f", "F", "false", "FALSE", "False")),
+        ):
+            for value in values:
+                with self.subTest(value=value):
+                    overrides = self.deploy(
+                        {"router": {"epp": {"flags": {"tracing": value}}}}
+                    )
+                    self.assertEqual(
+                        overrides["router"]["tracing"], {"enabled": enabled}
+                    )
+                    self.assertEqual(
+                        overrides["router"]["epp"]["flags"]["tracing"],
+                        str(enabled).lower(),
+                    )
+
+    def test_invalid_tracing_is_rejected_before_cluster_commands(self):
+        for config in (
+            {"router": {"tracing": {"enabled": "false"}}},
+            {"router": {"tracing": {"enabled": 1}}},
+            {"router": {"epp": {"flags": {"tracing": "invalid"}}}},
+            {"router": {"epp": {"flags": {"tracing": []}}}},
+        ):
+            with self.subTest(config=config):
+                config_path = self.directory / "invalid.yaml"
+                config_path.write_text(yaml.safe_dump(config))
+                with (
+                    mock.patch.object(perf, "run_cmd") as run_cmd,
+                    mock.patch.object(
+                        perf,
+                        "open",
+                        mock.mock_open(read_data=yaml.safe_dump(config)),
+                        create=True,
+                    ),
+                ):
+                    with self.assertRaisesRegex(ValueError, "tracing"):
+                        perf.deploy_epp(
+                            "offline-invalid", "unused", "unused", str(config_path)
+                        )
+                    run_cmd.assert_not_called()
+
+    def test_invalid_yaml_is_rejected_before_helm(self):
+        config_path = self.directory / "invalid.yaml"
+        config_path.write_text("router: [")
+        with (
+            mock.patch.object(perf, "run_cmd") as run_cmd,
+            mock.patch.object(
+                perf, "open", mock.mock_open(read_data="router: ["), create=True
+            ),
+        ):
+            with self.assertRaises(yaml.YAMLError):
+                perf.deploy_epp("offline-invalid", "unused", "unused", str(config_path))
+            run_cmd.assert_not_called()
+
+    def test_missing_or_null_tracing_remains_disabled(self):
+        for config in (
+            {},
+            {"router": {}},
+            {"router": {"epp": {}}},
+            {"router": {"epp": {"flags": {}}}},
+            {"router": {"epp": {"flags": {"tracing": None}}}},
+            {"router": {"tracing": {"enabled": None}}},
+        ):
+            with self.subTest(config=config):
+                overrides = self.deploy(config)
+                self.assertEqual(
+                    overrides["router"]["epp"]["flags"]["tracing"], "false"
+                )
+                self.assertEqual(overrides["router"]["tracing"], {"enabled": False})
+
+    def test_existing_router_recipes_remain_disabled(self):
+        config_dir = Path(perf.__file__).parent / "config" / "router-configs"
+        recipes = sorted(config_dir.glob("*.yaml"))
+        self.assertTrue(recipes)
+        for recipe in recipes:
+            with self.subTest(recipe=recipe.name):
+                config = yaml.safe_load(recipe.read_text())
+                overrides = self.deploy(config)
+                self.assertEqual(
+                    overrides["router"]["epp"]["flags"]["tracing"], "false"
+                )
+
+    def test_other_benchmark_overrides_are_preserved(self):
+        config = {
+            "router": {
+                "epp": {"flags": {"tracing": "true", "v": 9}},
+                "modelServers": {"matchLabels": {"app": "model", "role": "decode"}},
+            }
+        }
+        with mock.patch.dict(
+            os.environ,
+            {
+                "EPP_REGISTRY": "registry.example",
+                "EPP_REPOSITORY": "epp",
+                "EPP_TAG": "pinned",
+            },
+        ):
+            overrides = self.deploy(
+                config,
+                epp_cpu="750m",
+                epp_memory="3Gi",
+                epp_replicas=2,
+                machine_family="c3",
+            )
+        router = overrides["router"]
+        epp = router["epp"]
+        self.assertEqual(
+            epp["flags"], {"v": 4, "enable-pprof": "true", "tracing": "true"}
+        )
+        self.assertEqual(
+            epp["image"],
+            {
+                "registry": "registry.example",
+                "repository": "epp",
+                "tag": "pinned",
+            },
+        )
+        self.assertEqual(epp["replicas"], 2)
+        self.assertEqual(
+            epp["resources"],
+            {
+                "requests": {"cpu": "750m", "memory": "3Gi"},
+                "limits": {"cpu": "1500m", "memory": "6Gi"},
+            },
+        )
+        affinity = epp["affinity"]["nodeAffinity"][
+            "requiredDuringSchedulingIgnoredDuringExecution"
+        ]
+        self.assertEqual(
+            affinity["nodeSelectorTerms"][0]["matchExpressions"][0]["values"], ["c3"]
+        )
+        self.assertEqual(
+            router["modelServers"]["matchLabels"], {"app": "llm-d-sim", "role": None}
+        )
+        self.assertFalse(router["monitoring"]["prometheus"]["auth"]["enabled"])
+        self.assertTrue(router["proxy"]["enabled"])
+
+
+class PercentileTests(unittest.TestCase):
+    def test_scheduler_delta_percentiles_in_milliseconds(self):
+        before, after = scheduler_metrics()
+        original = copy.deepcopy((before, after))
+        result = perf.calculate_percentiles(before, after)
+        self.assertEqual(len(result), 3)
+        for actual, expected in zip(result, (1.0, 55.0, 91.0)):
+            self.assertAlmostEqual(actual, expected)
+        self.assertEqual((before, after), original)
+
+    def test_missing_metrics_return_three_zeros(self):
+        before, after = scheduler_metrics()
+        for first, second in ((None, after), (before, None), ({}, after), (before, {})):
+            with self.subTest(before=first, after=second):
+                self.assertEqual(
+                    perf.calculate_percentiles(first, second), (0.0, 0.0, 0.0)
+                )
+
+    def test_no_new_events_return_three_zeros(self):
+        before, _ = scheduler_metrics()
+        for count in (100, 0):
+            with self.subTest(count=count):
+                after = {"count": count, "buckets": before["buckets"]}
+                self.assertEqual(
+                    perf.calculate_percentiles(before, after), (0.0, 0.0, 0.0)
+                )
+
+    def test_newly_observed_buckets(self):
+        _, after = scheduler_metrics()
+        before = {"count": 0, "buckets": {}}
+        result = perf.calculate_percentiles(before, after)
+        self.assertEqual(len(result), 3)
+        for actual, expected in zip(result, (1.0, 55.0, 91.0)):
+            self.assertAlmostEqual(actual, expected)
+
+    def test_unbounded_bucket_uses_existing_upper_bound_convention(self):
+        before = {"count": 0, "buckets": {}}
+        after = {"count": 100, "buckets": {"0.001": 80, "0.01": 90, "+Inf": 100}}
+        self.assertEqual(perf.calculate_percentiles(before, after), (0.625, 10.0, 10.0))
+
+
+class MarkdownReportTests(OfflineTestCase):
+    def write_report(self, **kwargs):
+        perf.write_results_to_markdown_folder(
+            str(self.directory),
+            "tracing",
+            "2026-09-07 00:00:00",
+            "offline",
+            "config/router.yaml",
+            "config/perf.yaml",
+            "c3",
+            10,
+            ["epp:pinned"],
+            {"epp": {"cpu": 10, "mem": 20}},
+            {"epp": {"cpu": 30, "mem": 40}},
+            p50=1.0,
+            p95=55.0,
+            p99=91.0,
+            status="SUCCESS",
+            **kwargs,
+        )
+        return (self.directory / "tracing.md").read_text()
+
+    def test_report_contains_p99_in_aligned_column(self):
+        report = self.write_report()
+        lines = [line for line in report.splitlines() if line.startswith("|")]
+        self.assertEqual(len(lines), 3)
+        self.assertTrue(all(len(line.strip("|").split("|")) == 18 for line in lines))
+        self.assertIn("P99 Latency (ms)", lines[0])
+        self.assertEqual(lines[2].split("|")[15].strip(), "91.00")
+        self.assertEqual(lines[2].split("|")[-2].strip(), "SUCCESS")
+
+    def test_repeated_append_uses_one_header(self):
+        first = self.write_report()
+        second = self.write_report()
+        self.assertTrue(second.startswith(first))
+        self.assertEqual(second.count("| Timestamp |"), 1)
+        self.assertEqual(second.count("| 91.00 |"), 2)
+
+    def test_legacy_table_is_preserved_and_new_table_is_appended(self):
+        legacy = "# Existing results\n\n" + LEGACY_HEADER
+        legacy += "|" + "---|" * 17 + "\n"
+        legacy += "| " + " | ".join(["historical"] * 17) + " |\n"
+        (self.directory / "tracing.md").write_text(legacy)
+        report = self.write_report()
+        self.assertTrue(report.startswith(legacy))
+        self.assertEqual(report.count("| Timestamp |"), 2)
+        self.assertIn("\n\n| Timestamp |", report[len(legacy) - 1 :])
+        self.assertIn("P99 Latency (ms)", report[len(legacy) :])
+        self.assertEqual(self.write_report().count("| Timestamp |"), 2)
+
+    def test_profile_links_and_status_follow_p99(self):
+        profile = {
+            name: str(self.directory / f"{name}.profile")
+            for name in (
+                "cpu_svg",
+                "cpu_png",
+                "cpu_pprof",
+                "mem_svg",
+                "mem_png",
+                "mem_pprof",
+            )
+        }
+        report = self.write_report(profile_results=profile)
+        row = report.splitlines()[-1].split("|")
+        self.assertEqual(row[15].strip(), "91.00")
+        self.assertIn("cpu_pprof.profile", row[16])
+        self.assertIn("mem_pprof.profile", row[17])
+        self.assertEqual(row[18].strip(), "SUCCESS")
+
+
+class MainWiringTests(OfflineTestCase):
+    def test_main_passes_scheduler_p99_to_report(self):
+        for name in (
+            "create_namespace",
+            "setup_hf_secret",
+            "setup_perf_sa",
+            "deploy_simulators",
+            "deploy_epp",
+            "run_benchmark",
+            "cleanup_namespace",
+        ):
+            self.contexts.enter_context(mock.patch.object(perf, name))
+        self.contexts.enter_context(mock.patch.object(perf, "Thread"))
+        self.contexts.enter_context(mock.patch.object(perf.time, "sleep"))
+        self.contexts.enter_context(
+            mock.patch.object(perf, "get_epp_pod_name", return_value="epp-pod")
+        )
+        self.contexts.enter_context(
+            mock.patch.object(perf, "get_container_images", return_value=["epp:pinned"])
+        )
+        self.contexts.enter_context(
+            mock.patch.object(
+                perf, "sample_resources", return_value={"epp": {"cpu": 1, "mem": 2}}
+            )
+        )
+        self.contexts.enter_context(
+            mock.patch.object(
+                perf, "scrape_scheduler_metrics", side_effect=scheduler_metrics()
+            )
+        )
+        writer = self.contexts.enter_context(
+            mock.patch.object(perf, "write_results_to_markdown_folder", autospec=True)
+        )
+        self.contexts.enter_context(
+            mock.patch.object(
+                perf.sys,
+                "argv",
+                [
+                    "run_nightly_perf.py",
+                    "--gcp-project",
+                    "offline-project",
+                    "--results-dir",
+                    str(self.directory),
+                ],
+            )
+        )
+        self.contexts.enter_context(mock.patch.object(perf, "stop_monitoring", False))
+        perf.main()
+        writer.assert_called_once()
+        self.assertAlmostEqual(writer.call_args.args[13], 91.0)
+        self.assertEqual(writer.call_args.args[14], "SUCCESS")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/perf/test_run_nightly_perf.py
+++ b/test/perf/test_run_nightly_perf.py
@@ -156,12 +156,21 @@ class DeployEPPTests(OfflineTestCase):
                     )
 
     def test_invalid_tracing_is_rejected_before_cluster_commands(self):
-        for config in (
+        configs = [
             {"router": {"tracing": {"enabled": "false"}}},
             {"router": {"tracing": {"enabled": 1}}},
             {"router": {"epp": {"flags": {"tracing": "invalid"}}}},
             {"router": {"epp": {"flags": {"tracing": []}}}},
-        ):
+        ]
+        for value in (True, False, "invalid", "", 1, 0, ["invalid"], []):
+            configs.extend(
+                [
+                    {"router": {"tracing": value}},
+                    {"router": {"epp": value}},
+                    {"router": {"epp": {"flags": value}}},
+                ]
+            )
+        for config in configs:
             with self.subTest(config=config):
                 config_path = self.directory / "invalid.yaml"
                 config_path.write_text(yaml.safe_dump(config))
@@ -197,7 +206,10 @@ class DeployEPPTests(OfflineTestCase):
         for config in (
             {},
             {"router": {}},
+            {"router": {"tracing": None}},
+            {"router": {"epp": None}},
             {"router": {"epp": {}}},
+            {"router": {"epp": {"flags": None}}},
             {"router": {"epp": {"flags": {}}}},
             {"router": {"epp": {"flags": {"tracing": None}}}},
             {"router": {"tracing": {"enabled": None}}},
@@ -208,6 +220,39 @@ class DeployEPPTests(OfflineTestCase):
                     overrides["router"]["epp"]["flags"]["tracing"], "false"
                 )
                 self.assertEqual(overrides["router"]["tracing"], {"enabled": False})
+
+    def test_malformed_model_server_labels_warn_and_keep_simulator_overrides(self):
+        for model_servers in (
+            True,
+            1,
+            "invalid",
+            ["matchLabels"],
+            {"matchLabels": True},
+            {"matchLabels": 1},
+            {"matchLabels": ["role"]},
+        ):
+            with self.subTest(model_servers=model_servers):
+                with mock.patch.object(perf, "print") as output:
+                    overrides = self.deploy(
+                        {
+                            "router": {
+                                "tracing": {"enabled": True},
+                                "modelServers": model_servers,
+                            }
+                        }
+                    )
+                self.assertEqual(
+                    overrides["router"]["modelServers"]["matchLabels"],
+                    {"app": "llm-d-sim"},
+                )
+                self.assertEqual(overrides["router"]["tracing"], {"enabled": True})
+                warnings = [
+                    call.args[0]
+                    for call in output.call_args_list
+                    if call.args[0].startswith("Warning:")
+                ]
+                self.assertEqual(len(warnings), 1)
+                self.assertIn("modelServers labels for nullification", warnings[0])
 
     def test_existing_router_recipes_remain_disabled(self):
         config_dir = Path(perf.__file__).parent / "config" / "router-configs"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind test

**What this PR does / why we need it**:

The performance runner writes its Helm overrides after the selected router configuration. Its hard-coded tracing flag disables requested tracing, and setting only that flag does not enable the Chart's OTEL environment configuration.

Resolve `router.tracing.enabled`, fall back to the legacy EPP tracing flag when unset, and render both switches consistently. Preserve the configured sampler and exporter settings and the default-off behavior. Invalid tracing values and malformed YAML fail before Helm runs.

Carry scheduler histogram p99 through calculation and report output alongside p50 and p95. Append a new table when the existing report uses the older header, retaining historical rows. The change touches only the performance runner, its README and a new offline test file.

**Which issue(s) this PR fixes**:

Preparation for #2665 and llm-d/llm-d#2389. The requested tracing-overhead experiment remains open: no cluster measurement or sampling recommendation is included.

**Test plan**:

- [x] Verify tracing precedence, accepted flag values, default-off behavior, invalid-input rejection and preservation of unrelated overrides. The 20 offline tests also cover scheduler p99 interpolation, report layout/history and main-to-report wiring. All 20 passed on Python 3.10.20 and 3.12.13 with PyYAML 6.0.3, with zero skips or errors.
- [x] Inspect 18 source-Chart Helm renders generated from the actual runner overrides, covering off/1%/10%/100%, conflicting and missing settings, and the five checked-in recipes. All 18 passed with Helm v3.17.1 and a null kubeconfig. These local render checks do not validate the released OCI Chart or a live collector.

Reproduce the checked-in offline tests:

```bash
python3 -m unittest discover -s test/perf -p test_run_nightly_perf.py -v
```

Full `make presubmit` passed on the three-file snapshot based on `d8d22ea8f7d412f2a7e61ec415d11b24322a7938`. Lint reported zero issues; govulncheck found no called vulnerable symbols, while retaining its package/module-level findings. Publication commit `4fb7cc0d63eb1a08c66385d41539f71c1fe370ce` contains the exact same three validated file hashes. The repository's signature/DCO check and independent local `git verify-commit` both passed on this commit. GitHub currently reports `unknown_key` for the existing SSH signing key; account-level signing-key registration remains pending.

Validation used an isolated CPU-only builder, with no dependency changes or cluster access. No live EPP startup, exported traces, tracing-overhead measurements or full benchmark results are claimed. Development and self-checks were AI-assisted.

**Release note** _(write `NONE` if no user-facing change)_:

```release-note
The performance runner honors router tracing settings and includes scheduler histogram p99 in its reports.
```
