### PR TITLE
fix: omit unexecuted pipeline step timings

### DIFF
--- a/pkg/coordinator/pipeline/pipeline.go
+++ b/pkg/coordinator/pipeline/pipeline.go
@@ -106,7 +106,9 @@ func (p *Pipeline) Execute(ctx context.Context, reqCtx *RequestContext) error {
 			stats = append(stats, "parse", reqCtx.ParseDuration.String())
 		}
 		for _, t := range timings {
-			stats = append(stats, t.name, t.duration.String())
+			if t.name != "" && t.duration > 0 {
+				stats = append(stats, t.duration.String())
+			}
 		}
 		logger.V(logutil.DEFAULT).Info("pipeline step timings", stats...)
 


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->

/kind cleanup

**What this PR does / why we need it**:

When `conditional-decode` completes a request, the pipeline exits early without running the remaining EPD steps. The timing log still included zero-value entries for those unexecuted steps, producing empty fields such as:

```json
{"level":"info","ts":1788752454.3713067,"logger":"handler","caller":"pipeline/pipeline.go:111","msg":"pipeline step timings","x-request-id":"c66d3013-da9b-94d2-ba40-b72ed5a2b340","parse":"91.851µs","replace-media-urls":"224.247897ms","render":"18.292683ms","conditional-decode":"277.689852ms","":"0s","":"0s","":"0s"}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
