### PR TITLE
[ci]: Attach SBOM to published container images

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -60,6 +60,9 @@ runs:
       with:
         file: ${{ inputs.docker-file }}
         push: ${{ inputs.push == 'true' }}
+        # SBOM attestations turn the image into a manifest list which the
+        # docker exporter used by the no-push scan pass cannot write.
+        sbom: ${{ inputs.push == 'true' }}
         outputs: ${{ inputs.buildx-outputs }}
         platforms: ${{ inputs.push != 'true' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
         tags: |


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
Pushed images already carry a SLSA provenance predicate (buildx's default `mode=max`) and since #2285, a signature over it. What's still missing is a bill of materials. `docker buildx imagetools inspect <img> --format '{{ json .SBOM }}'` returns `{}` on every published image today.

This adds `sbom: ${{ inputs.push == 'true' }}` to the `Build image` step in the `docker-build-and-push` composite action. It's gated on push  because the same step also runs with `push: false` to produce the tarball the Trivy scan reads and the docker exporter that tarball uses can't carry attestations. Passing `sbom: true` unconditionally would turn that build into a manifest list and break the scan pass.

/cc @elevran

**Which issue(s) this PR fixes**:
Partial #956 (Phase 3, SBOM generation and attachment)

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
