### PR TITLE
ci: add DCO check that runs on merge_group

### DIFF
--- a/.github/workflows/ci-signed-commits.yaml
+++ b/.github/workflows/ci-signed-commits.yaml
@@ -2,17 +2,14 @@ name: Check Signed Commits in PR
 
 on:
   pull_request_target:
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   check-signed-commits:
     name: Check signed commits in PR
-    # Skip signed-commits enforcement for bot-authored release-notes branches:
-    # per-PR fragments under release-notes/pr-*, assembly under
-    # release-notes/assemble-*. The release-notes App can't sign commits;
-    # fragment content is sourced from already-reviewed PR bodies and
-    # assembly is a deterministic transform. Pin to the two specific prefixes
-    # so an unrelated bot pushing to release-notes/<other> doesn't bypass.
     if: |
+      github.event_name == 'pull_request_target' &&
       !(
         (startsWith(github.head_ref, 'release-notes/pr-') ||
          startsWith(github.head_ref, 'release-notes/assemble-')) &&
@@ -30,3 +27,58 @@ jobs:
             🚨 Unsigned commits detected! Please sign your commits.
 
             For instructions on how to set up GPG/SSH signing and verify your commits, please see [GitHub Documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+
+  dco-check:
+    name: dco-check
+    # Runs on pull_request_target (not merge_group) for the same bot-branch
+    # skip as check-signed-commits; merge_group entries never originate from
+    # those bot branches directly, so the skip only needs to guard the PR side.
+    if: |
+      github.event_name == 'merge_group' ||
+      (
+        github.event_name == 'pull_request_target' &&
+        !(
+          (startsWith(github.head_ref, 'release-notes/pr-') ||
+           startsWith(github.head_ref, 'release-notes/assemble-')) &&
+          endsWith(github.event.pull_request.user.login, '[bot]')
+        )
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Verify Signed-off-by trailer matches commit author email (DCO)
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            base="${{ github.event.merge_group.base_sha }}"
+            head="${{ github.event.merge_group.head_sha }}"
+          else
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          fi
+          fail=0
+          for c in $(git rev-list "$base..$head"); do
+            author_email=$(git show -s --format='%ae' "$c")
+            trailers=$(git show -s --format='%(trailers:key=Signed-off-by,valueonly)' "$c")
+            if [ -z "$trailers" ]; then
+              echo "::error::commit $c is missing a Signed-off-by trailer (author email: $author_email)"
+              fail=1
+              continue
+            fi
+            match=0
+            while IFS= read -r line; do
+              [ -z "$line" ] && continue
+              case "$line" in
+                *"<$author_email>"*) match=1 ;;
+              esac
+            done <<<"$trailers"
+            if [ "$match" -ne 1 ]; then
+              echo "::error::commit $c Signed-off-by email does not match commit author email. expected: $author_email, found: $trailers"
+              fail=1
+            fi
+          done
+          exit $fail


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The DCO probot app cannot report a check run against the synthetic `merge_group` ref that a queued PR is built on. With `DCO` listed in the branch ruleset's `required_status_checks`, every merge-queue entry gets dequeued almost immediately, since that required check can never be satisfied.

This adds a `dco-check` job to `ci-signed-commits.yaml`, triggered on both `pull_request_target` and `merge_group`, that verifies each commit's `Signed-off-by` trailer against its author email directly (no dependency on the probot app). It can replace the `DCO` context in the branch ruleset's required checks once merged, so the merge queue actually enforces DCO instead of dequeuing on it.

The existing `check-signed-commits` job (GPG/SSH commit signature verification) is unchanged and stays `pull_request_target`-only; it is not a required check and this PR does not change that.

Follow-up (repo settings, not part of this PR): once this workflow is on `main`, update the branch ruleset to require `dco-check` instead of `DCO`. Note that the DCO app can still run (if needed for compliance), it's just shouldn't be a required check.

Related to #2682, which added `merge_group` triggers to `lint`/`test`/`typos`/markdown-link-check for the same reason.

**Which issue(s) this PR fixes**:
Contributes to #2257

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```