### PR TITLE
ci: skip gosec SARIF upload on merge_group events

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -118,10 +118,15 @@ jobs:
         run: make lint-security
 
       # Fork PRs run with a read only GITHUB_TOKEN that cannot upload SARIF.
+      # merge_group is excluded because the checked-out ref is the merge
+      # queue's ephemeral gh-readonly-queue branch, which GitHub can delete
+      # before the upload's processing wait completes, failing the call with
+      # "ref not found". The persistent pull_request/push runs already cover
+      # code scanning for the branch.
       # Pinned to a commit SHA rather than a tag, unlike other actions in this
       # workflow, per GitHub's guidance for actions that write security data.
       - name: Upload gosec SARIF
-        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ !cancelled() && github.event_name != 'merge_group' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: gosec.sarif


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The gosec SARIF upload step in CI - Lint runs on `merge_group` events, where the checked-out ref is the merge queue's ephemeral `refs/heads/gh-readonly-queue/main/pr-<N>-<sha>` branch. `codeql-action/upload-sarif` waits for SARIF processing (~15s+) before calling the Code Scanning API with that ref. If the merge queue entry resolves before the call lands, GitHub has already deleted the ref, and the upload fails with `ref '...' not found in this repository`.

This intermittently fails merge queue lint runs even though the underlying gosec scan and `make lint-security` step both passed. Observed on PR #2571 (run https://github.com/llm-d/llm-d-router/actions/runs/34239517155/job/102106063798), and on the same merge_group run for PR #1741 and #2591 around the same time; other `merge_group` runs in the same window succeeded, consistent with a timing race rather than a code issue.

**Which issue(s) this PR fixes**:
Refs #2257

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```