### PR TITLE
feat(sidecar+coordinator):  add support for HTTPS  /metrics

### DIFF
--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -18,11 +18,13 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -32,6 +34,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
+	"github.com/llm-d/llm-d-router/pkg/common"
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/version"
 
@@ -47,9 +50,12 @@ import (
 // Scrapes are short; a small budget is enough and keeps process exit prompt.
 const metricsShutdownTimeout = 5 * time.Second
 
+var errMetricsTLS = errors.New("metrics TLS")
+
 func main() {
 	configPath := pflag.String("config", "config/coordinator/coordinator.yaml", "path to configuration file")
 	metricsPort := pflag.Int("metrics-port", 0, "port for the Prometheus /metrics endpoint. Non-positive disables the endpoint. Overrides server.metrics_port (default 9090).")
+	metricsCertPath := pflag.String("metrics-cert-path", "", "directory with tls.crt and tls.key for the metrics endpoint. Empty serves metrics over HTTP. Overrides server.metrics_cert_path.")
 
 	logOpts := logutil.NewOptions()
 	logOpts.AddFlags(pflag.CommandLine)
@@ -74,6 +80,10 @@ func main() {
 	// CLI --metrics-port wins over config server.metrics_port.
 	if f := pflag.CommandLine.Lookup("metrics-port"); f != nil && f.Changed {
 		cfg.Server.MetricsPort = *metricsPort
+	}
+	// CLI --metrics-cert-path wins over server.metrics_cert_path.
+	if f := pflag.CommandLine.Lookup("metrics-cert-path"); f != nil && f.Changed {
+		cfg.Server.MetricsCertPath = *metricsCertPath
 	}
 	if err := logOpts.Validate(); err != nil {
 		log.Error(err, "invalid logging options")
@@ -116,7 +126,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Info("starting coordinator", "addr", cfg.Server.ListenAddr, "metrics_port", cfg.Server.MetricsPort)
+	log.Info("starting coordinator",
+		"addr", cfg.Server.ListenAddr,
+		"metrics_port", cfg.Server.MetricsPort,
+		"metrics_tls", cfg.Server.MetricsCertPath != "")
 	if cfg.Server.MetricsPort <= 0 {
 		log.Info("metrics endpoint disabled", "reason", "server.metrics_port <= 0")
 	}
@@ -162,27 +175,35 @@ func run(ctx context.Context, srv *server.Server, cfg config.ServerConfig) error
 
 	if cfg.MetricsPort > 0 {
 		g.Go(func() error {
-			return serveMetrics(gctx, cfg.MetricsPort)
+			return serveMetrics(gctx, cfg.MetricsPort, cfg.MetricsCertPath)
 		})
 	}
 
 	return g.Wait()
 }
 
-// serveMetrics stands up a Prometheus /metrics HTTP server on port and blocks
+// serveMetrics stands up a Prometheus /metrics server on port and blocks
 // until ctx is cancelled or the underlying ListenAndServe returns
 // unexpectedly. On ctx cancellation the server is drained via Shutdown
 // bounded by metricsShutdownTimeout. Uses the shared controller-runtime
 // registry so every package that registers against it (this coordinator's
 // metrics, controller-runtime's process collectors) is exposed on the same
-// endpoint.
-func serveMetrics(ctx context.Context, port int) error {
+// endpoint. A non-empty certPath enables HTTPS with tls.crt and tls.key.
+func serveMetrics(ctx context.Context, port int, certPath string) error {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(ctrlmetrics.Registry, promhttp.HandlerOpts{EnableOpenMetrics: true}))
 	srv := &http.Server{
 		Addr:              fmt.Sprintf(":%d", port),
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
+	}
+	serveTLS := certPath != ""
+	if serveTLS {
+		tlsConfig, err := metricsTLSConfig(ctx, certPath)
+		if err != nil {
+			return err
+		}
+		srv.TLSConfig = tlsConfig
 	}
 
 	// Shutdown fires when ctx cancels (normal path) or when the local
@@ -199,7 +220,12 @@ func serveMetrics(ctx context.Context, port int) error {
 		_ = srv.Shutdown(graceCtx)
 	}()
 
-	err := srv.ListenAndServe()
+	var err error
+	if serveTLS {
+		err = srv.ListenAndServeTLS("", "")
+	} else {
+		err = srv.ListenAndServe()
+	}
 	cancel()
 	<-shutdownDone
 
@@ -207,4 +233,26 @@ func serveMetrics(ctx context.Context, port int) error {
 		return fmt.Errorf("metrics server: %w", err)
 	}
 	return nil
+}
+
+// metricsTLSConfig loads and reloads the certificate used by the metrics server.
+func metricsTLSConfig(ctx context.Context, certPath string) (*tls.Config, error) {
+	certFile := filepath.Join(certPath, "tls.crt")
+	keyFile := filepath.Join(certPath, "tls.key")
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("%w: load key pair from cert %q and key %q: %w", errMetricsTLS, certFile, keyFile, err)
+	}
+
+	reloader, err := common.NewCertReloader(ctx, certPath, &cert)
+	if err != nil {
+		return nil, fmt.Errorf("%w: start certificate reloader: %w", errMetricsTLS, err)
+	}
+
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return reloader.Get(), nil
+		},
+	}, nil
 }

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -55,7 +55,7 @@ var errMetricsTLS = errors.New("metrics TLS")
 func main() {
 	configPath := pflag.String("config", "config/coordinator/coordinator.yaml", "path to configuration file")
 	metricsPort := pflag.Int("metrics-port", 0, "port for the Prometheus /metrics endpoint. Non-positive disables the endpoint. Overrides server.metrics_port (default 9090).")
-	metricsCertPath := pflag.String("metrics-cert-path", "", "directory with tls.crt and tls.key for the metrics endpoint. Empty serves metrics over HTTP. Overrides server.metrics_cert_path.")
+	metricsCertDir := pflag.String("metrics-cert-dir", "", "directory with tls.crt and tls.key for the metrics endpoint. Empty serves metrics over HTTP. Overrides server.metrics_cert_dir.")
 
 	logOpts := logutil.NewOptions()
 	logOpts.AddFlags(pflag.CommandLine)
@@ -81,9 +81,9 @@ func main() {
 	if f := pflag.CommandLine.Lookup("metrics-port"); f != nil && f.Changed {
 		cfg.Server.MetricsPort = *metricsPort
 	}
-	// CLI --metrics-cert-path wins over server.metrics_cert_path.
-	if f := pflag.CommandLine.Lookup("metrics-cert-path"); f != nil && f.Changed {
-		cfg.Server.MetricsCertPath = *metricsCertPath
+	// CLI --metrics-cert-dir wins over server.metrics_cert_dir.
+	if f := pflag.CommandLine.Lookup("metrics-cert-dir"); f != nil && f.Changed {
+		cfg.Server.MetricsCertDir = *metricsCertDir
 	}
 	if err := logOpts.Validate(); err != nil {
 		log.Error(err, "invalid logging options")
@@ -129,7 +129,7 @@ func main() {
 	log.Info("starting coordinator",
 		"addr", cfg.Server.ListenAddr,
 		"metrics_port", cfg.Server.MetricsPort,
-		"metrics_tls", cfg.Server.MetricsCertPath != "")
+		"metrics_tls", cfg.Server.MetricsCertDir != "")
 	if cfg.Server.MetricsPort <= 0 {
 		log.Info("metrics endpoint disabled", "reason", "server.metrics_port <= 0")
 	}
@@ -175,7 +175,7 @@ func run(ctx context.Context, srv *server.Server, cfg config.ServerConfig) error
 
 	if cfg.MetricsPort > 0 {
 		g.Go(func() error {
-			return serveMetrics(gctx, cfg.MetricsPort, cfg.MetricsCertPath)
+			return serveMetrics(gctx, cfg.MetricsPort, cfg.MetricsCertDir)
 		})
 	}
 
@@ -188,8 +188,8 @@ func run(ctx context.Context, srv *server.Server, cfg config.ServerConfig) error
 // bounded by metricsShutdownTimeout. Uses the shared controller-runtime
 // registry so every package that registers against it (this coordinator's
 // metrics, controller-runtime's process collectors) is exposed on the same
-// endpoint. A non-empty certPath enables HTTPS with tls.crt and tls.key.
-func serveMetrics(ctx context.Context, port int, certPath string) error {
+// endpoint. A non-empty certDir enables TLS with tls.crt and tls.key.
+func serveMetrics(ctx context.Context, port int, certDir string) error {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(ctrlmetrics.Registry, promhttp.HandlerOpts{EnableOpenMetrics: true}))
 	srv := &http.Server{
@@ -197,9 +197,9 @@ func serveMetrics(ctx context.Context, port int, certPath string) error {
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
-	serveTLS := certPath != ""
+	serveTLS := certDir != ""
 	if serveTLS {
-		tlsConfig, err := metricsTLSConfig(ctx, certPath)
+		tlsConfig, err := metricsTLSConfig(ctx, certDir)
 		if err != nil {
 			return err
 		}
@@ -236,15 +236,15 @@ func serveMetrics(ctx context.Context, port int, certPath string) error {
 }
 
 // metricsTLSConfig loads and reloads the certificate used by the metrics server.
-func metricsTLSConfig(ctx context.Context, certPath string) (*tls.Config, error) {
-	certFile := filepath.Join(certPath, "tls.crt")
-	keyFile := filepath.Join(certPath, "tls.key")
+func metricsTLSConfig(ctx context.Context, certDir string) (*tls.Config, error) {
+	certFile := filepath.Join(certDir, "tls.crt")
+	keyFile := filepath.Join(certDir, "tls.key")
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("%w: load key pair from cert %q and key %q: %w", errMetricsTLS, certFile, keyFile, err)
 	}
 
-	reloader, err := common.NewCertReloader(ctx, certPath, &cert)
+	reloader, err := common.NewCertReloader(ctx, certDir, &cert)
 	if err != nil {
 		return nil, fmt.Errorf("%w: start certificate reloader: %w", errMetricsTLS, err)
 	}

--- a/cmd/coordinator/main_test.go
+++ b/cmd/coordinator/main_test.go
@@ -18,7 +18,18 @@ package main
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"net"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -56,6 +67,108 @@ func waitForDial(t *testing.T, addr string, timeout time.Duration) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatalf("no listener came up on %s within %s", addr, timeout)
+}
+
+func writeMetricsCertificate(t *testing.T, dir string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tls.crt"), pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tls.key"), pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600))
+}
+
+func TestServeMetricsHTTP(t *testing.T) {
+	port, err := fwknet.GetFreePort()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- serveMetrics(ctx, port, "") }()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	require.Eventually(t, func() bool {
+		resp, err := client.Get("http://127.0.0.1:" + strconv.Itoa(port) + "/metrics")
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 2*time.Second, 20*time.Millisecond)
+
+	cancel()
+	require.NoError(t, <-errCh)
+}
+
+func TestServeMetricsHTTPS(t *testing.T) {
+	certDir := t.TempDir()
+	writeMetricsCertificate(t, certDir)
+	port, err := fwknet.GetFreePort()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- serveMetrics(ctx, port, certDir) }()
+
+	client := &http.Client{
+		Timeout:   2 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, //nolint:gosec // test certificate
+	}
+	require.Eventually(t, func() bool {
+		resp, err := client.Get("https://127.0.0.1:" + strconv.Itoa(port) + "/metrics")
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 2*time.Second, 20*time.Millisecond)
+
+	resp, err := (&http.Client{Timeout: 500 * time.Millisecond}).Get("http://127.0.0.1:" + strconv.Itoa(port) + "/metrics")
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	cancel()
+	require.NoError(t, <-errCh)
+}
+
+func TestServeMetricsInvalidTLSFiles(t *testing.T) {
+	tests := []struct {
+		name  string
+		write bool
+	}{
+		{name: "missing"},
+		{name: "invalid", write: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			certDir := t.TempDir()
+			if tt.write {
+				require.NoError(t, os.WriteFile(filepath.Join(certDir, "tls.crt"), []byte("invalid"), 0o600))
+				require.NoError(t, os.WriteFile(filepath.Join(certDir, "tls.key"), []byte("invalid"), 0o600))
+			}
+			port, err := fwknet.GetFreePort()
+			require.NoError(t, err)
+
+			err = serveMetrics(context.Background(), port, certDir)
+			require.ErrorIs(t, err, errMetricsTLS)
+		})
+	}
 }
 
 // With MetricsPort <= 0 no metrics goroutine joins the errgroup, so the only
@@ -127,6 +240,42 @@ func TestRun_MetricsPortCollision_DrainsCoordinatorServer(t *testing.T) {
 	case err := <-done:
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "metrics server:")
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return within 5s")
+	}
+
+	conn, dialErr := net.DialTimeout("tcp", listenAddr, 100*time.Millisecond)
+	if dialErr == nil {
+		_ = conn.Close()
+		t.Fatalf("coordinator server at %s still accepts connections after run returned", listenAddr)
+	}
+}
+
+func TestRun_InvalidMetricsTLSDrainsCoordinatorServer(t *testing.T) {
+	metricsPort, err := fwknet.GetFreePort()
+	require.NoError(t, err)
+	inferencePort, err := fwknet.GetFreePort()
+	require.NoError(t, err)
+	listenAddr := "127.0.0.1:" + strconv.Itoa(inferencePort)
+
+	cfg := config.ServerConfig{
+		ListenAddr:      listenAddr,
+		ShutdownTimeout: time.Second,
+		ReadTimeout:     time.Second,
+		WriteTimeout:    time.Second,
+		MetricsPort:     metricsPort,
+		MetricsCertPath: t.TempDir(),
+	}
+	srv := newTestServer(t, listenAddr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- run(ctx, srv, cfg) }()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, errMetricsTLS)
 	case <-time.After(5 * time.Second):
 		t.Fatal("run did not return within 5s")
 	}

--- a/cmd/coordinator/main_test.go
+++ b/cmd/coordinator/main_test.go
@@ -18,14 +18,9 @@ package main
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/pem"
-	"math/big"
 	"net"
 	"net/http"
 	"os"
@@ -34,8 +29,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 
+	tlsutil "github.com/llm-d/llm-d-router/internal/tls"
 	"github.com/llm-d/llm-d-router/pkg/coordinator/config"
 	"github.com/llm-d/llm-d-router/pkg/coordinator/gateway"
 	"github.com/llm-d/llm-d-router/pkg/coordinator/pipeline"
@@ -72,23 +69,16 @@ func waitForDial(t *testing.T, addr string, timeout time.Duration) {
 func writeMetricsCertificate(t *testing.T, dir string) {
 	t.Helper()
 
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "localhost"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-	}
-	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	require.NoError(t, err)
-	keyDER, err := x509.MarshalECPrivateKey(key)
+	cert, err := tlsutil.CreateSelfSignedTLSCertificate(logr.Discard())
 	require.NoError(t, err)
 
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "tls.crt"), pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "tls.key"), pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600))
+	keyDER, err := x509.MarshalPKCS8PrivateKey(cert.PrivateKey)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tls.crt"), certPEM, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tls.key"), keyPEM, 0o600))
 }
 
 func TestServeMetricsHTTP(t *testing.T) {

--- a/cmd/coordinator/main_test.go
+++ b/cmd/coordinator/main_test.go
@@ -264,7 +264,7 @@ func TestRun_InvalidMetricsTLSDrainsCoordinatorServer(t *testing.T) {
 		ReadTimeout:     time.Second,
 		WriteTimeout:    time.Second,
 		MetricsPort:     metricsPort,
-		MetricsCertPath: t.TempDir(),
+		MetricsCertDir:  t.TempDir(),
 	}
 	srv := newTestServer(t, listenAddr)
 

--- a/config/coordinator/coordinator.yaml
+++ b/config/coordinator/coordinator.yaml
@@ -30,6 +30,13 @@ server:
   # env: COORDINATOR_SERVER_METRICS_PORT
   # metrics_port: 9090
 
+  # metrics_cert_path is the directory containing tls.crt and tls.key for the
+  # metrics endpoint. Empty serves metrics over HTTP. If set, missing or invalid
+  # files stop the coordinator. The metrics listener does not fall back to HTTP.
+  # The --metrics-cert-path CLI flag overrides this field.
+  # env: COORDINATOR_SERVER_METRICS_CERT_PATH
+  # metrics_cert_path: ""
+
   # read_timeout caps how long the server waits for the full request body.
   # Long enough for HD images inlined as data URLs (~hundreds of KB).
   read_timeout: 30s

--- a/config/coordinator/coordinator.yaml
+++ b/config/coordinator/coordinator.yaml
@@ -30,12 +30,12 @@ server:
   # env: COORDINATOR_SERVER_METRICS_PORT
   # metrics_port: 9090
 
-  # metrics_cert_path is the directory containing tls.crt and tls.key for the
+  # metrics_cert_dir is the directory containing tls.crt and tls.key for the
   # metrics endpoint. Empty serves metrics over HTTP. If set, missing or invalid
   # files stop the coordinator. The metrics listener does not fall back to HTTP.
-  # The --metrics-cert-path CLI flag overrides this field.
-  # env: COORDINATOR_SERVER_METRICS_CERT_PATH
-  # metrics_cert_path: ""
+  # The --metrics-cert-dir CLI flag overrides this field.
+  # env: COORDINATOR_SERVER_METRICS_CERT_DIR
+  # metrics_cert_dir: ""
 
   # read_timeout caps how long the server waits for the full request body.
   # Long enough for HD images inlined as data URLs (~hundreds of KB).

--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -28,6 +28,11 @@ process on the metrics port (default 9090, configurable with `--metrics-port`), 
 carrying the inference paths and `/healthz` and `/readyz`. A non-positive port disables the
 endpoint.
 
+The endpoint serves HTTP when no certificate path is set. Set `--metrics-cert-path` or
+`server.metrics_cert_path` to a directory containing `tls.crt` and `tls.key` to serve HTTPS.
+If a certificate path is set, missing or invalid files stop the coordinator. The metrics listener does not fall back to HTTP.
+Valid certificate changes take effect without restarting the coordinator.
+
 The endpoint serves the shared controller-runtime registry, so controller-runtime's process
 collectors appear alongside the coordinator metrics. It is unauthenticated. Authenticating it costs
 RBAC for TokenReview and SubjectAccessReview on the coordinator's ServiceAccount.

--- a/docs/metrics.coord.md
+++ b/docs/metrics.coord.md
@@ -28,9 +28,9 @@ process on the metrics port (default 9090, configurable with `--metrics-port`), 
 carrying the inference paths and `/healthz` and `/readyz`. A non-positive port disables the
 endpoint.
 
-The endpoint serves HTTP when no certificate path is set. Set `--metrics-cert-path` or
-`server.metrics_cert_path` to a directory containing `tls.crt` and `tls.key` to serve HTTPS.
-If a certificate path is set, missing or invalid files stop the coordinator. The metrics listener does not fall back to HTTP.
+The endpoint serves HTTP when no certificate directory is set. Set `--metrics-cert-dir` or
+`server.metrics_cert_dir` to a directory containing `tls.crt` and `tls.key` to serve HTTPS.
+If a certificate directory is set, missing or invalid files stop the coordinator. The metrics listener does not fall back to HTTP.
 Valid certificate changes take effect without restarting the coordinator.
 
 The endpoint serves the shared controller-runtime registry, so controller-runtime's process

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -547,6 +547,11 @@ expose these counters at `/metrics` on that port; `0` (the default) disables it.
 The `MORIIO_METRICS_ADDR` env var (e.g. `:9090`) is a backward-compatible
 fallback, consulted only when `--metrics-port` is unset.
 
+The endpoint serves plain HTTP by default. Pass `--metrics-cert-path` with a
+directory containing `tls.crt` and `tls.key` to serve it over TLS instead.
+The metrics TLS setting is independent of `--secure-proxy` and `--cert-path`,
+which apply to the sidecar data-plane listener.
+
 | Full metric name | Type | Labels | Notes |
 |---|---|---|---|
 | `moriio_dns_reresolve_total` | Counter | - | Successful request-path re-resolutions of a peer DNS name (counted per actual lookup; concurrent lookups coalesced by singleflight count once). |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -53,10 +53,10 @@ metrics, not EPP metrics. The raw engine metrics remain available at the model s
 
 ### P/D sidecar: MoRI-IO metrics
 
-The P/D sidecar currently exposes only the `moriio_dns_*` MoRI-IO metrics through an HTTP `/metrics`
-endpoint. It exposes them only when `--metrics-port` or the backward-compatible
-`MORIIO_METRICS_ADDR` environment variable is set. The P/D sidecar metrics server does not configure
-TLS. `SecureServing` applies to the sidecar data-plane listener.
+The P/D sidecar currently exposes only the `moriio_dns_*` MoRI-IO metrics, and only when
+`--metrics-port` or the backward-compatible `MORIIO_METRICS_ADDR` environment variable is set. The
+endpoint serves plain HTTP unless `--metrics-cert-dir` is set; see
+[MoRI-IO DNS re-resolution](#mori-io-dns-re-resolution) for the enablement and TLS settings.
 
 This endpoint belongs to the sidecar process;
 its controller-runtime registry is separate from the router pod's EPP registry.
@@ -549,8 +549,9 @@ fallback, consulted only when `--metrics-port` is unset.
 
 The endpoint serves plain HTTP by default. Pass `--metrics-cert-dir` with a
 directory containing `tls.crt` and `tls.key` to serve it over TLS instead.
-The metrics TLS setting is independent of `--secure-proxy` and `--cert-path`,
-which apply to the sidecar data-plane listener.
+Missing or invalid files stop the sidecar; the metrics listener does not fall
+back to HTTP. The metrics TLS setting is independent of `--secure-proxy` and
+`--cert-path`, which apply to the sidecar data-plane listener.
 
 | Full metric name | Type | Labels | Notes |
 |---|---|---|---|

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -547,7 +547,7 @@ expose these counters at `/metrics` on that port; `0` (the default) disables it.
 The `MORIIO_METRICS_ADDR` env var (e.g. `:9090`) is a backward-compatible
 fallback, consulted only when `--metrics-port` is unset.
 
-The endpoint serves plain HTTP by default. Pass `--metrics-cert-path` with a
+The endpoint serves plain HTTP by default. Pass `--metrics-cert-dir` with a
 directory containing `tls.crt` and `tls.key` to serve it over TLS instead.
 The metrics TLS setting is independent of `--secure-proxy` and `--cert-path`,
 which apply to the sidecar data-plane listener.

--- a/pkg/coordinator/config/config.go
+++ b/pkg/coordinator/config/config.go
@@ -42,6 +42,7 @@ const DefaultMaxRequestBodySize = 64 // 64 MB
 type ServerConfig struct {
 	ListenAddr         string        `mapstructure:"listen_addr"`
 	MetricsPort        int           `mapstructure:"metrics_port"` // default 9090; non-positive disables the endpoint
+	MetricsCertPath    string        `mapstructure:"metrics_cert_path"`
 	ReadTimeout        time.Duration `mapstructure:"read_timeout"`
 	WriteTimeout       time.Duration `mapstructure:"write_timeout"`
 	ShutdownTimeout    time.Duration `mapstructure:"shutdown_timeout"`
@@ -77,6 +78,7 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("log_level", 2)
 	v.SetDefault("server.listen_addr", ":8080")
 	v.SetDefault("server.metrics_port", 9090)
+	v.SetDefault("server.metrics_cert_path", "")
 	v.SetDefault("server.read_timeout", 30*time.Second)
 	v.SetDefault("server.write_timeout", 120*time.Second)
 	v.SetDefault("server.shutdown_timeout", 25*time.Second)

--- a/pkg/coordinator/config/config.go
+++ b/pkg/coordinator/config/config.go
@@ -42,7 +42,7 @@ const DefaultMaxRequestBodySize = 64 // 64 MB
 type ServerConfig struct {
 	ListenAddr         string        `mapstructure:"listen_addr"`
 	MetricsPort        int           `mapstructure:"metrics_port"` // default 9090; non-positive disables the endpoint
-	MetricsCertPath    string        `mapstructure:"metrics_cert_path"`
+	MetricsCertDir     string        `mapstructure:"metrics_cert_dir"`
 	ReadTimeout        time.Duration `mapstructure:"read_timeout"`
 	WriteTimeout       time.Duration `mapstructure:"write_timeout"`
 	ShutdownTimeout    time.Duration `mapstructure:"shutdown_timeout"`
@@ -78,7 +78,7 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("log_level", 2)
 	v.SetDefault("server.listen_addr", ":8080")
 	v.SetDefault("server.metrics_port", 9090)
-	v.SetDefault("server.metrics_cert_path", "")
+	v.SetDefault("server.metrics_cert_dir", "")
 	v.SetDefault("server.read_timeout", 30*time.Second)
 	v.SetDefault("server.write_timeout", 120*time.Second)
 	v.SetDefault("server.shutdown_timeout", 25*time.Second)

--- a/pkg/coordinator/config/config_test.go
+++ b/pkg/coordinator/config/config_test.go
@@ -48,6 +48,7 @@ func TestLoadDefaults(t *testing.T) {
 		{"log_level", cfg.LogLevel, 2},
 		{"server.listen_addr", cfg.Server.ListenAddr, ":8080"},
 		{"server.metrics_port", cfg.Server.MetricsPort, 9090},
+		{"server.metrics_cert_path", cfg.Server.MetricsCertPath, ""},
 		{"server.read_timeout", cfg.Server.ReadTimeout, 30 * time.Second},
 		{"server.write_timeout", cfg.Server.WriteTimeout, 120 * time.Second},
 		{"server.shutdown_timeout", cfg.Server.ShutdownTimeout, 25 * time.Second},
@@ -87,6 +88,12 @@ func TestLoadEnvOverride(t *testing.T) {
 			envVal: "false",
 			check:  func(c *Config) (any, any) { return c.Pipeline.UseOpenAIFormat, false },
 		},
+		{
+			name:   "metrics certificate path",
+			envKey: "COORDINATOR_SERVER_METRICS_CERT_PATH",
+			envVal: "/etc/coordinator-metrics",
+			check:  func(c *Config) (any, any) { return c.Server.MetricsCertPath, "/etc/coordinator-metrics" },
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -99,6 +106,16 @@ func TestLoadEnvOverride(t *testing.T) {
 				t.Errorf("%s override: got %v, want %v", tt.envKey, got, want)
 			}
 		})
+	}
+}
+
+func TestLoadMetricsCertPath(t *testing.T) {
+	cfg, err := Load(writeConfig(t, "server:\n  metrics_cert_path: /etc/coordinator-metrics\n"))
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got, want := cfg.Server.MetricsCertPath, "/etc/coordinator-metrics"; got != want {
+		t.Errorf("server.metrics_cert_path = %q, want %q", got, want)
 	}
 }
 

--- a/pkg/coordinator/config/config_test.go
+++ b/pkg/coordinator/config/config_test.go
@@ -48,7 +48,7 @@ func TestLoadDefaults(t *testing.T) {
 		{"log_level", cfg.LogLevel, 2},
 		{"server.listen_addr", cfg.Server.ListenAddr, ":8080"},
 		{"server.metrics_port", cfg.Server.MetricsPort, 9090},
-		{"server.metrics_cert_path", cfg.Server.MetricsCertPath, ""},
+		{"server.metrics_cert_dir", cfg.Server.MetricsCertDir, ""},
 		{"server.read_timeout", cfg.Server.ReadTimeout, 30 * time.Second},
 		{"server.write_timeout", cfg.Server.WriteTimeout, 120 * time.Second},
 		{"server.shutdown_timeout", cfg.Server.ShutdownTimeout, 25 * time.Second},
@@ -90,9 +90,9 @@ func TestLoadEnvOverride(t *testing.T) {
 		},
 		{
 			name:   "metrics certificate path",
-			envKey: "COORDINATOR_SERVER_METRICS_CERT_PATH",
+			envKey: "COORDINATOR_SERVER_METRICS_CERT_DIR",
 			envVal: "/etc/coordinator-metrics",
-			check:  func(c *Config) (any, any) { return c.Server.MetricsCertPath, "/etc/coordinator-metrics" },
+			check:  func(c *Config) (any, any) { return c.Server.MetricsCertDir, "/etc/coordinator-metrics" },
 		},
 	}
 	for _, tt := range tests {
@@ -109,13 +109,13 @@ func TestLoadEnvOverride(t *testing.T) {
 	}
 }
 
-func TestLoadMetricsCertPath(t *testing.T) {
-	cfg, err := Load(writeConfig(t, "server:\n  metrics_cert_path: /etc/coordinator-metrics\n"))
+func TestLoadMetricsCertDir(t *testing.T) {
+	cfg, err := Load(writeConfig(t, "server:\n  metrics_cert_dir: /etc/coordinator-metrics\n"))
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
-	if got, want := cfg.Server.MetricsCertPath, "/etc/coordinator-metrics"; got != want {
-		t.Errorf("server.metrics_cert_path = %q, want %q", got, want)
+	if got, want := cfg.Server.MetricsCertDir, "/etc/coordinator-metrics"; got != want {
+		t.Errorf("server.metrics_cert_dir = %q, want %q", got, want)
 	}
 }
 

--- a/pkg/sidecar/proxy/MORIIO_README.md
+++ b/pkg/sidecar/proxy/MORIIO_README.md
@@ -140,6 +140,13 @@ endpoint, and any positive port serves metrics at `/metrics` on that port. The
 `MORIIO_METRICS_ADDR` env var remains as a backward-compatible fallback and is
 only consulted when `--metrics-port` is unset.
 
+The endpoint serves plain HTTP by default. Set **`--metrics-cert-path`** to a
+directory containing `tls.crt` and `tls.key` to serve it over TLS instead.
+There is no self-signed fallback. This flag is independent of
+`--secure-proxy`/`--cert-path`, which secure the data-plane listener. If
+either file is missing or invalid, the error is logged and the sidecar
+keeps running without a `/metrics` endpoint; it does not fall back to HTTP.
+
 When enabled, the following counters are exposed at `GET /metrics` (unlabeled):
 
 | Metric | Meaning |

--- a/pkg/sidecar/proxy/MORIIO_README.md
+++ b/pkg/sidecar/proxy/MORIIO_README.md
@@ -140,7 +140,7 @@ endpoint, and any positive port serves metrics at `/metrics` on that port. The
 `MORIIO_METRICS_ADDR` env var remains as a backward-compatible fallback and is
 only consulted when `--metrics-port` is unset.
 
-The endpoint serves plain HTTP by default. Set **`--metrics-cert-path`** to a
+The endpoint serves plain HTTP by default. Set **`--metrics-cert-dir`** to a
 directory containing `tls.crt` and `tls.key` to serve it over TLS instead.
 There is no self-signed fallback. This flag is independent of
 `--secure-proxy`/`--cert-path`, which secure the data-plane listener. If

--- a/pkg/sidecar/proxy/MORIIO_README.md
+++ b/pkg/sidecar/proxy/MORIIO_README.md
@@ -144,8 +144,8 @@ The endpoint serves plain HTTP by default. Set **`--metrics-cert-dir`** to a
 directory containing `tls.crt` and `tls.key` to serve it over TLS instead.
 There is no self-signed fallback. This flag is independent of
 `--secure-proxy`/`--cert-path`, which secure the data-plane listener. If
-either file is missing or invalid, the error is logged and the sidecar
-keeps running without a `/metrics` endpoint; it does not fall back to HTTP.
+either file is missing or invalid, the sidecar fails at startup; it does not
+fall back to HTTP.
 
 When enabled, the following counters are exposed at `GET /metrics` (unlabeled):
 

--- a/pkg/sidecar/proxy/dns_metrics.go
+++ b/pkg/sidecar/proxy/dns_metrics.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"os"
@@ -29,6 +30,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sync/errgroup"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/llm-d/llm-d-router/pkg/common"
 )
 
 // envMoRIIOMetricsAddr is a backward-compatible fallback for enabling the
@@ -103,21 +106,32 @@ func (s *Server) metricsAddr() string {
 // metrics address is configured (via --metrics-port or MORIIO_METRICS_ADDR),
 // registering the goroutine on grp so it shares the server lifecycle and shuts
 // down with ctx. When neither is set (the default) it is a no-op and the
-// counters simply go unscraped.
+// counters simply go unscraped. A metrics server failure (for example an
+// invalid --metrics-cert-path) is logged and never propagated to grp: the
+// data-plane proxy keeps running without a /metrics endpoint rather than
+// going down over an optional feature.
 func (s *Server) maybeStartMetrics(ctx context.Context, grp *errgroup.Group) {
 	addr := s.metricsAddr()
 	if addr == "" {
 		return
 	}
 	grp.Go(func() error {
-		return s.serveMetrics(ctx, addr)
+		if err := s.serveMetrics(ctx, addr); err != nil {
+			s.logger.Error(err, "metrics server failed; proxy continues without metrics")
+		}
+		return nil
 	})
 }
 
 // serveMetrics serves the shared controller-runtime metrics registry at
 // /metrics on addr until ctx is cancelled, then shuts the server down
 // gracefully. Registration of the moriio_dns_* counters is ensured here so they
-// are present even if no resolver has been constructed yet.
+// are present even if no resolver has been constructed yet. The metrics server
+// uses HTTP by default. When --metrics-cert-path is set, or metrics-cert-path
+// is set in the sidecar YAML, it serves /metrics over HTTPS using tls.crt and
+// tls.key from that directory, with no fallback to HTTP. Startup and serving
+// errors are returned to maybeStartMetrics, which logs them. The shutdown
+// goroutine logs shutdown errors.
 func (s *Server) serveMetrics(ctx context.Context, addr string) error {
 	registerDNSMetrics()
 
@@ -129,6 +143,15 @@ func (s *Server) serveMetrics(ctx context.Context, addr string) error {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
+	serveTLS := s.config.MetricsCertPath != ""
+	if serveTLS {
+		tlsConfig, err := s.metricsTLSConfig(ctx)
+		if err != nil {
+			return err
+		}
+		server.TLSConfig = tlsConfig
+	}
+
 	go func() {
 		<-ctx.Done()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -138,10 +161,39 @@ func (s *Server) serveMetrics(ctx context.Context, addr string) error {
 		}
 	}()
 
-	s.logger.Info("starting MoRI-IO metrics server", "addr", addr)
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		s.logger.Error(err, "metrics server failed")
+	s.logger.Info("starting MoRI-IO metrics server", "addr", addr, "tls", serveTLS)
+	var err error
+	if serveTLS {
+		err = server.ListenAndServeTLS("", "")
+	} else {
+		err = server.ListenAndServe()
+	}
+	if err != nil && err != http.ErrServerClosed {
 		return err
 	}
 	return nil
+}
+
+// metricsTLSConfig loads tls.crt and tls.key from Config.MetricsCertPath for
+// the HTTPS metrics server. Changes to either file take effect without
+// restarting the sidecar.
+func (s *Server) metricsTLSConfig(ctx context.Context) (*tls.Config, error) {
+	certFile := s.config.MetricsCertPath + "/tls.crt"
+	keyFile := s.config.MetricsCertPath + "/tls.key"
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load metrics TLS key pair from cert %q and key %q: %w", certFile, keyFile, err)
+	}
+
+	reloader, err := common.NewCertReloader(ctx, s.config.MetricsCertPath, &cert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start metrics cert reloader: %w", err)
+	}
+
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return reloader.Get(), nil
+		},
+	}, nil
 }

--- a/pkg/sidecar/proxy/dns_metrics.go
+++ b/pkg/sidecar/proxy/dns_metrics.go
@@ -107,7 +107,7 @@ func (s *Server) metricsAddr() string {
 // registering the goroutine on grp so it shares the server lifecycle and shuts
 // down with ctx. When neither is set (the default) it is a no-op and the
 // counters simply go unscraped. A metrics server failure (for example an
-// invalid --metrics-cert-path) is logged and never propagated to grp: the
+// invalid --metrics-cert-dir) is logged and never propagated to grp: the
 // data-plane proxy keeps running without a /metrics endpoint rather than
 // going down over an optional feature.
 func (s *Server) maybeStartMetrics(ctx context.Context, grp *errgroup.Group) {
@@ -127,7 +127,7 @@ func (s *Server) maybeStartMetrics(ctx context.Context, grp *errgroup.Group) {
 // /metrics on addr until ctx is cancelled, then shuts the server down
 // gracefully. Registration of the moriio_dns_* counters is ensured here so they
 // are present even if no resolver has been constructed yet. The metrics server
-// uses HTTP by default. When --metrics-cert-path is set, or metrics-cert-path
+// uses HTTP by default. When --metrics-cert-dir is set, or metrics-cert-dir
 // is set in the sidecar YAML, it serves /metrics over HTTPS using tls.crt and
 // tls.key from that directory, with no fallback to HTTP. Startup and serving
 // errors are returned to maybeStartMetrics, which logs them. The shutdown
@@ -143,7 +143,7 @@ func (s *Server) serveMetrics(ctx context.Context, addr string) error {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
-	serveTLS := s.config.MetricsCertPath != ""
+	serveTLS := s.config.MetricsCertDir != ""
 	if serveTLS {
 		tlsConfig, err := s.metricsTLSConfig(ctx)
 		if err != nil {
@@ -174,18 +174,18 @@ func (s *Server) serveMetrics(ctx context.Context, addr string) error {
 	return nil
 }
 
-// metricsTLSConfig loads tls.crt and tls.key from Config.MetricsCertPath for
+// metricsTLSConfig loads tls.crt and tls.key from Config.MetricsCertDir for
 // the HTTPS metrics server. Changes to either file take effect without
 // restarting the sidecar.
 func (s *Server) metricsTLSConfig(ctx context.Context) (*tls.Config, error) {
-	certFile := s.config.MetricsCertPath + "/tls.crt"
-	keyFile := s.config.MetricsCertPath + "/tls.key"
+	certFile := s.config.MetricsCertDir + "/tls.crt"
+	keyFile := s.config.MetricsCertDir + "/tls.key"
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load metrics TLS key pair from cert %q and key %q: %w", certFile, keyFile, err)
 	}
 
-	reloader, err := common.NewCertReloader(ctx, s.config.MetricsCertPath, &cert)
+	reloader, err := common.NewCertReloader(ctx, s.config.MetricsCertDir, &cert)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start metrics cert reloader: %w", err)
 	}

--- a/pkg/sidecar/proxy/dns_metrics.go
+++ b/pkg/sidecar/proxy/dns_metrics.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -106,20 +107,18 @@ func (s *Server) metricsAddr() string {
 // metrics address is configured (via --metrics-port or MORIIO_METRICS_ADDR),
 // registering the goroutine on grp so it shares the server lifecycle and shuts
 // down with ctx. When neither is set (the default) it is a no-op and the
-// counters simply go unscraped. A metrics server failure (for example an
-// invalid --metrics-cert-dir) is logged and never propagated to grp: the
-// data-plane proxy keeps running without a /metrics endpoint rather than
-// going down over an optional feature.
+// counters simply go unscraped. A metrics server failure propagates to grp and
+// stops the sidecar: the failures reachable here (an unusable
+// --metrics-cert-dir, an address already in use) are startup misconfigurations,
+// so failing immediately surfaces them during rollout instead of leaving the
+// sidecar serving traffic with no /metrics endpoint.
 func (s *Server) maybeStartMetrics(ctx context.Context, grp *errgroup.Group) {
 	addr := s.metricsAddr()
 	if addr == "" {
 		return
 	}
 	grp.Go(func() error {
-		if err := s.serveMetrics(ctx, addr); err != nil {
-			s.logger.Error(err, "metrics server failed; proxy continues without metrics")
-		}
-		return nil
+		return s.serveMetrics(ctx, addr)
 	})
 }
 
@@ -130,8 +129,8 @@ func (s *Server) maybeStartMetrics(ctx context.Context, grp *errgroup.Group) {
 // uses HTTP by default. When --metrics-cert-dir is set, or metrics-cert-dir
 // is set in the sidecar YAML, it serves /metrics over HTTPS using tls.crt and
 // tls.key from that directory, with no fallback to HTTP. Startup and serving
-// errors are returned to maybeStartMetrics, which logs them. The shutdown
-// goroutine logs shutdown errors.
+// errors are returned to maybeStartMetrics. The shutdown goroutine logs
+// shutdown errors.
 func (s *Server) serveMetrics(ctx context.Context, addr string) error {
 	registerDNSMetrics()
 
@@ -178,8 +177,8 @@ func (s *Server) serveMetrics(ctx context.Context, addr string) error {
 // the HTTPS metrics server. Changes to either file take effect without
 // restarting the sidecar.
 func (s *Server) metricsTLSConfig(ctx context.Context) (*tls.Config, error) {
-	certFile := s.config.MetricsCertDir + "/tls.crt"
-	keyFile := s.config.MetricsCertDir + "/tls.key"
+	certFile := filepath.Join(s.config.MetricsCertDir, "tls.crt")
+	keyFile := filepath.Join(s.config.MetricsCertDir, "tls.key")
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load metrics TLS key pair from cert %q and key %q: %w", certFile, keyFile, err)

--- a/pkg/sidecar/proxy/dns_metrics_test.go
+++ b/pkg/sidecar/proxy/dns_metrics_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+func writeSelfSignedCert(t *testing.T, dir string) {
+	t.Helper()
+
+	cert, err := CreateSelfSignedTLSCertificate()
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]})
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(cert.PrivateKey)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tls.crt"), certPEM, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tls.key"), keyPEM, 0o600))
+}
+
+func freeAddr(t *testing.T) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	return addr
+}
+
+func TestServeMetrics_PlainHTTP(t *testing.T) {
+	s := &Server{logger: logr.Discard()}
+	addr := freeAddr(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.serveMetrics(ctx, addr) }()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	require.Eventually(t, func() bool {
+		resp, err := client.Get("http://" + addr + "/metrics")
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 2*time.Second, 20*time.Millisecond, "expected plaintext /metrics to become reachable")
+
+	cancel()
+	require.NoError(t, <-errCh)
+}
+
+func TestServeMetrics_TLS(t *testing.T) {
+	certDir := t.TempDir()
+	writeSelfSignedCert(t, certDir)
+
+	s := &Server{
+		logger: logr.Discard(),
+		config: Config{MetricsCertPath: certDir},
+	}
+	addr := freeAddr(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.serveMetrics(ctx, addr) }()
+
+	client := &http.Client{
+		Timeout:   2 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, //nolint:gosec // self-signed test cert
+	}
+	require.Eventually(t, func() bool {
+		resp, err := client.Get("https://" + addr + "/metrics")
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 2*time.Second, 20*time.Millisecond, "expected TLS /metrics to become reachable")
+
+	// A plaintext request to the same address must not be served as /metrics
+	plainClient := &http.Client{Timeout: 500 * time.Millisecond}
+	resp, err := plainClient.Get("http://" + addr + "/metrics")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	cancel()
+	require.NoError(t, <-errCh)
+}
+
+// TestServeMetrics_TLSMissingCert checks three invalid --metrics-cert-path
+// directories. The metrics server rejects each case, while the data-plane
+// proxy continues running without a /metrics endpoint.
+func TestServeMetrics_TLSMissingCert(t *testing.T) {
+	tests := []struct {
+		name      string
+		writeCert bool
+		writeKey  bool
+	}{
+		{name: "both missing"},
+		{name: "key missing", writeCert: true},
+		{name: "cert missing", writeKey: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			certDir := t.TempDir()
+			if tt.writeCert || tt.writeKey {
+				cert, err := CreateSelfSignedTLSCertificate()
+				require.NoError(t, err)
+				if tt.writeCert {
+					certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]})
+					require.NoError(t, os.WriteFile(filepath.Join(certDir, "tls.crt"), certPEM, 0o600))
+				}
+				if tt.writeKey {
+					keyBytes, err := x509.MarshalPKCS8PrivateKey(cert.PrivateKey)
+					require.NoError(t, err)
+					keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+					require.NoError(t, os.WriteFile(filepath.Join(certDir, "tls.key"), keyPEM, 0o600))
+				}
+			}
+
+			s := &Server{
+				logger: logr.Discard(),
+				config: Config{MetricsPort: mustFreePort(t), MetricsCertPath: certDir},
+			}
+
+			// serveMetrics itself must detect this specific broken input.
+			err := s.serveMetrics(context.Background(), freeAddr(t))
+			require.Error(t, err)
+
+			// A metrics startup error must not stop the data-plane proxy.
+			// The proxy keeps running, but /metrics remains unavailable.
+			grp, ctx := errgroup.WithContext(context.Background())
+			s.maybeStartMetrics(ctx, grp)
+			require.NoError(t, grp.Wait())
+		})
+	}
+}
+
+// mustFreePort returns an ephemeral port number for Config.MetricsPort.
+func mustFreePort(t *testing.T) int {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}

--- a/pkg/sidecar/proxy/dns_metrics_test.go
+++ b/pkg/sidecar/proxy/dns_metrics_test.go
@@ -87,7 +87,7 @@ func TestServeMetrics_TLS(t *testing.T) {
 
 	s := &Server{
 		logger: logr.Discard(),
-		config: Config{MetricsCertPath: certDir},
+		config: Config{MetricsCertDir: certDir},
 	}
 	addr := freeAddr(t)
 
@@ -120,7 +120,7 @@ func TestServeMetrics_TLS(t *testing.T) {
 	require.NoError(t, <-errCh)
 }
 
-// TestServeMetrics_TLSMissingCert checks three invalid --metrics-cert-path
+// TestServeMetrics_TLSMissingCert checks three invalid --metrics-cert-dir
 // directories. The metrics server rejects each case, while the data-plane
 // proxy continues running without a /metrics endpoint.
 func TestServeMetrics_TLSMissingCert(t *testing.T) {
@@ -154,7 +154,7 @@ func TestServeMetrics_TLSMissingCert(t *testing.T) {
 
 			s := &Server{
 				logger: logr.Discard(),
-				config: Config{MetricsPort: mustFreePort(t), MetricsCertPath: certDir},
+				config: Config{MetricsPort: mustFreePort(t), MetricsCertDir: certDir},
 			}
 
 			// serveMetrics itself must detect this specific broken input.

--- a/pkg/sidecar/proxy/dns_metrics_test.go
+++ b/pkg/sidecar/proxy/dns_metrics_test.go
@@ -23,8 +23,10 @@ import (
 	"encoding/pem"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -120,9 +122,9 @@ func TestServeMetrics_TLS(t *testing.T) {
 	require.NoError(t, <-errCh)
 }
 
-// TestServeMetrics_TLSMissingCert checks three invalid --metrics-cert-dir
-// directories. The metrics server rejects each case, while the data-plane
-// proxy continues running without a /metrics endpoint.
+// TestServeMetrics_TLSMissingCert checks a --metrics-cert-dir missing tls.crt,
+// tls.key, or both. The metrics server rejects each case and the sidecar fails
+// to start.
 func TestServeMetrics_TLSMissingCert(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -161,11 +163,11 @@ func TestServeMetrics_TLSMissingCert(t *testing.T) {
 			err := s.serveMetrics(context.Background(), freeAddr(t))
 			require.Error(t, err)
 
-			// A metrics startup error must not stop the data-plane proxy.
-			// The proxy keeps running, but /metrics remains unavailable.
+			// The same error must reach the caller, so the sidecar
+			// fails at startup instead of running without metrics.
 			grp, ctx := errgroup.WithContext(context.Background())
 			s.maybeStartMetrics(ctx, grp)
-			require.NoError(t, grp.Wait())
+			require.Error(t, grp.Wait())
 		})
 	}
 }
@@ -179,4 +181,48 @@ func mustFreePort(t *testing.T) int {
 	port := ln.Addr().(*net.TCPAddr).Port
 	require.NoError(t, ln.Close())
 	return port
+}
+
+// TestStart_MetricsTLSFailureStopsDataPlane runs the full Start path with a
+// --metrics-cert-dir missing tls.crt and tls.key: Start returns the error and
+// the data-plane listener is closed.
+func TestStart_MetricsTLSFailureStopsDataPlane(t *testing.T) {
+	decoderURL, err := url.Parse("http://decoder.invalid:8000")
+	require.NoError(t, err)
+
+	s := NewProxy(Config{
+		Port:           strconv.Itoa(mustFreePort(t)),
+		DecoderURL:     decoderURL,
+		MetricsPort:    mustFreePort(t),
+		MetricsCertDir: t.TempDir(), // no tls.crt or tls.key
+	})
+	s.allowlistValidator = &AllowlistValidator{enabled: false}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Start(context.Background()) }()
+
+	// The data plane comes up before the metrics failure tears it down.
+	select {
+	case <-s.readyCh:
+	case err := <-errCh:
+		t.Fatalf("Start returned before the data plane was listening: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("data-plane listener never came up")
+	}
+	dataPlaneAddr := s.addr.String()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err, "expected the metrics TLS failure to fail Start")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start kept running after the metrics server failed")
+	}
+
+	// Start only returns once startHTTP has returned, so the data-plane
+	// listener is closed by then and the port accepts nothing.
+	conn, err := net.DialTimeout("tcp", dataPlaneAddr, time.Second)
+	if err == nil {
+		_ = conn.Close()
+		t.Fatalf("data-plane listener on %s still accepts connections", dataPlaneAddr)
+	}
 }

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -81,7 +81,7 @@ const (
 	configurationFile         = "configuration-file"
 	tracingFlag               = "tracing"
 	metricsPort               = "metrics-port"
-	metricsCertPath           = "metrics-cert-path"
+	metricsCertDir            = "metrics-cert-dir"
 
 	// Environment variables
 	envInferencePool           = "INFERENCE_POOL"
@@ -136,7 +136,7 @@ type yamlConfiguration struct {
 	DecodeChunkSize         int      `json:"decode-chunk-size,omitempty"`
 	Tracing                 *bool    `json:"tracing,omitempty"`
 	MetricsPort             int      `json:"metrics-port,omitempty"`
-	MetricsCertPath         string   `json:"metrics-cert-path,omitempty"`
+	MetricsCertDir          string   `json:"metrics-cert-dir,omitempty"`
 }
 
 // Options holds the CLI-facing configuration for the pd-sidecar proxy.
@@ -290,7 +290,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&opts.DecodeChunkSize, decodeChunkSize, opts.DecodeChunkSize, "enables chunked decode mode when > 0; value is the token budget per chunk. For best performance should be a multiple of the block size.")
 	fs.BoolVar(&opts.Tracing, tracingFlag, opts.Tracing, "Enable OpenTelemetry tracing")
 	fs.IntVar(&opts.MetricsPort, metricsPort, opts.MetricsPort, "Port for the Prometheus /metrics endpoint (exposes the moriio_dns_* counters). 0 (the default) disables it. Takes precedence over the MORIIO_METRICS_ADDR env var.")
-	fs.StringVar(&opts.MetricsCertPath, metricsCertPath, opts.MetricsCertPath, "Directory with tls.crt and tls.key for the metrics endpoint. Empty (the default) serves metrics over plain HTTP. Independent of --secure-proxy/--cert-path, which apply to the data-plane listener.")
+	fs.StringVar(&opts.MetricsCertDir, metricsCertDir, opts.MetricsCertDir, "Directory with tls.crt and tls.key for the metrics endpoint. Empty (the default) serves metrics over plain HTTP. Independent of --secure-proxy/--cert-path, which apply to the data-plane listener.")
 
 	// MoRI-IO WRITE-mode flags. Only meaningful with --kv-connector=nixlv2
 	// against vLLM engines running MoRI-IO in WRITE mode.
@@ -887,8 +887,8 @@ func (opts *Options) mergeYAMLConfiguration(cfg yamlConfiguration) {
 	if cfg.MetricsPort != 0 && !opts.isFlagSet(metricsPort) {
 		opts.MetricsPort = cfg.MetricsPort
 	}
-	if cfg.MetricsCertPath != "" && !opts.isFlagSet(metricsCertPath) {
-		opts.MetricsCertPath = cfg.MetricsCertPath
+	if cfg.MetricsCertDir != "" && !opts.isFlagSet(metricsCertDir) {
+		opts.MetricsCertDir = cfg.MetricsCertDir
 	}
 	if cfg.Tracing != nil && !opts.isFlagSet(tracingFlag) {
 		opts.Tracing = *cfg.Tracing

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -81,6 +81,7 @@ const (
 	configurationFile         = "configuration-file"
 	tracingFlag               = "tracing"
 	metricsPort               = "metrics-port"
+	metricsCertPath           = "metrics-cert-path"
 
 	// Environment variables
 	envInferencePool           = "INFERENCE_POOL"
@@ -135,6 +136,7 @@ type yamlConfiguration struct {
 	DecodeChunkSize         int      `json:"decode-chunk-size,omitempty"`
 	Tracing                 *bool    `json:"tracing,omitempty"`
 	MetricsPort             int      `json:"metrics-port,omitempty"`
+	MetricsCertPath         string   `json:"metrics-cert-path,omitempty"`
 }
 
 // Options holds the CLI-facing configuration for the pd-sidecar proxy.
@@ -288,6 +290,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&opts.DecodeChunkSize, decodeChunkSize, opts.DecodeChunkSize, "enables chunked decode mode when > 0; value is the token budget per chunk. For best performance should be a multiple of the block size.")
 	fs.BoolVar(&opts.Tracing, tracingFlag, opts.Tracing, "Enable OpenTelemetry tracing")
 	fs.IntVar(&opts.MetricsPort, metricsPort, opts.MetricsPort, "Port for the Prometheus /metrics endpoint (exposes the moriio_dns_* counters). 0 (the default) disables it. Takes precedence over the MORIIO_METRICS_ADDR env var.")
+	fs.StringVar(&opts.MetricsCertPath, metricsCertPath, opts.MetricsCertPath, "Directory with tls.crt and tls.key for the metrics endpoint. Empty (the default) serves metrics over plain HTTP. Independent of --secure-proxy/--cert-path, which apply to the data-plane listener.")
 
 	// MoRI-IO WRITE-mode flags. Only meaningful with --kv-connector=nixlv2
 	// against vLLM engines running MoRI-IO in WRITE mode.
@@ -883,6 +886,9 @@ func (opts *Options) mergeYAMLConfiguration(cfg yamlConfiguration) {
 	}
 	if cfg.MetricsPort != 0 && !opts.isFlagSet(metricsPort) {
 		opts.MetricsPort = cfg.MetricsPort
+	}
+	if cfg.MetricsCertPath != "" && !opts.isFlagSet(metricsCertPath) {
+		opts.MetricsCertPath = cfg.MetricsCertPath
 	}
 	if cfg.Tracing != nil && !opts.isFlagSet(tracingFlag) {
 		opts.Tracing = *cfg.Tracing

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -1205,6 +1205,28 @@ func TestModelServerPortFlagBeatsYAML(t *testing.T) {
 	require.Equal(t, "http://localhost:9001", opts.DecoderURL.String())
 }
 
+func TestMetricsCertPathYAML(t *testing.T) {
+	opts, testPFlagSet := newTestOptions(t)
+	yaml := "{metrics-cert-path: /etc/metrics-certs}"
+	setFlag(t, testPFlagSet, inlineConfiguration, &yaml)
+	require.NoError(t, testPFlagSet.Parse(nil))
+
+	require.NoError(t, opts.Complete())
+	require.Equal(t, "/etc/metrics-certs", opts.MetricsCertPath)
+}
+
+// A CLI flag overrides the metrics-cert-path YAML key.
+func TestMetricsCertPathFlagBeatsYAML(t *testing.T) {
+	opts, testPFlagSet := newTestOptions(t)
+	yaml := "{metrics-cert-path: /etc/metrics-certs}"
+	setFlag(t, testPFlagSet, inlineConfiguration, &yaml)
+	setFlag(t, testPFlagSet, metricsCertPath, "/etc/cli-flag-certs")
+	require.NoError(t, testPFlagSet.Parse(nil))
+
+	require.NoError(t, opts.Complete())
+	require.Equal(t, "/etc/cli-flag-certs", opts.MetricsCertPath)
+}
+
 func TestCompleteTLSConfiguration(t *testing.T) {
 	tests := []struct {
 		name                         string

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -1205,26 +1205,26 @@ func TestModelServerPortFlagBeatsYAML(t *testing.T) {
 	require.Equal(t, "http://localhost:9001", opts.DecoderURL.String())
 }
 
-func TestMetricsCertPathYAML(t *testing.T) {
+func TestMetricsCertDirYAML(t *testing.T) {
 	opts, testPFlagSet := newTestOptions(t)
-	yaml := "{metrics-cert-path: /etc/metrics-certs}"
+	yaml := "{metrics-cert-dir: /etc/metrics-certs}"
 	setFlag(t, testPFlagSet, inlineConfiguration, &yaml)
 	require.NoError(t, testPFlagSet.Parse(nil))
 
 	require.NoError(t, opts.Complete())
-	require.Equal(t, "/etc/metrics-certs", opts.MetricsCertPath)
+	require.Equal(t, "/etc/metrics-certs", opts.MetricsCertDir)
 }
 
-// A CLI flag overrides the metrics-cert-path YAML key.
-func TestMetricsCertPathFlagBeatsYAML(t *testing.T) {
+// A CLI flag overrides the metrics-cert-dir YAML key.
+func TestMetricsCertDirFlagBeatsYAML(t *testing.T) {
 	opts, testPFlagSet := newTestOptions(t)
-	yaml := "{metrics-cert-path: /etc/metrics-certs}"
+	yaml := "{metrics-cert-dir: /etc/metrics-certs}"
 	setFlag(t, testPFlagSet, inlineConfiguration, &yaml)
-	setFlag(t, testPFlagSet, metricsCertPath, "/etc/cli-flag-certs")
+	setFlag(t, testPFlagSet, metricsCertDir, "/etc/cli-flag-certs")
 	require.NoError(t, testPFlagSet.Parse(nil))
 
 	require.NoError(t, opts.Complete())
-	require.Equal(t, "/etc/cli-flag-certs", opts.MetricsCertPath)
+	require.Equal(t, "/etc/cli-flag-certs", opts.MetricsCertDir)
 }
 
 func TestCompleteTLSConfiguration(t *testing.T) {

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -217,6 +217,11 @@ type Config struct {
 	// on a separate address from the data-plane proxy port. Takes precedence
 	// over the MORIIO_METRICS_ADDR env var (kept for backward compatibility).
 	MetricsPort int
+	// MetricsCertPath is the directory holding tls.crt and tls.key for the
+	// metrics endpoint. Empty (the default) serves metrics over plain HTTP.
+	// Independent of SecureServing/CertPath, which apply to the data-plane
+	// listener.
+	MetricsCertPath string
 
 	// MooncakeBootstrapPort is the port used to query the Mooncake bootstrap endpoint on prefill pods.
 	MooncakeBootstrapPort int

--- a/pkg/sidecar/proxy/proxy.go
+++ b/pkg/sidecar/proxy/proxy.go
@@ -217,11 +217,11 @@ type Config struct {
 	// on a separate address from the data-plane proxy port. Takes precedence
 	// over the MORIIO_METRICS_ADDR env var (kept for backward compatibility).
 	MetricsPort int
-	// MetricsCertPath is the directory holding tls.crt and tls.key for the
+	// MetricsCertDir is the directory holding tls.crt and tls.key for the
 	// metrics endpoint. Empty (the default) serves metrics over plain HTTP.
 	// Independent of SecureServing/CertPath, which apply to the data-plane
 	// listener.
-	MetricsCertPath string
+	MetricsCertDir string
 
 	// MooncakeBootstrapPort is the port used to query the Mooncake bootstrap endpoint on prefill pods.
 	MooncakeBootstrapPort int


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
- Both the sidecar's and the coordinator's `/metrics` endpoint currently only support HTTP.
- Adds a `--metrics-cert-dir` flag to each, pointing to a directory with hardcoded file name `tls.crt`/`tls.key`. The flag matches the router's existing flag. Also settable as the sidecar YAML key `metrics-cert-dir` and as the coordinator's `server.metrics_cert_dir` (env `COORDINATOR_SERVER_METRICS_CERT_DIR`).
- If the flag is not set, both keep serving `/metrics` over HTTP.
- If the flag is set but the cert files are missing or invalid both **sidecar and coordinator**:shut down instead of serving (no fallback to HTTP). The coordinator exits non-zero; the sidecar logs the error and exits 0.
- Valid certs are hot-reloaded, so rotating `tls.crt`/`tls.key` doesn't need a restart.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Add --metrics-cert-dir to the disagg-sidecar and the coordinator to serve the /metrics endpoint over HTTPS. Missing or invalid certificate files stop the component at startup.
```
