### PR TITLE
Validate KV cache utilization threshold bounds

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin.go
@@ -79,8 +79,8 @@ func Factory(name string, rawParameters *json.Decoder, _ fwkplugin.Handle) (fwkp
 	if params.QueueDepthThreshold <= 0 {
 		return nil, fmt.Errorf("plugin '%s': queueDepthThreshold must be > 0, got %d", Type, params.QueueDepthThreshold)
 	}
-	if params.KVCacheUtilThreshold <= 0.0 {
-		return nil, fmt.Errorf("plugin '%s': kvCacheUtilThreshold must be > 0, got %g", Type, params.KVCacheUtilThreshold)
+	if params.KVCacheUtilThreshold <= 0.0 || params.KVCacheUtilThreshold > 1.0 {
+		return nil, fmt.Errorf("plugin '%s': kvCacheUtilThreshold must be in (0, 1], got %g", Type, params.KVCacheUtilThreshold)
 	}
 	if params.Power <= 0 {
 		return nil, fmt.Errorf("plugin '%s': power must be > 0, got %g", Type, params.Power)

--- a/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/admitter/probabilisticadmitter/plugin_test.go
@@ -96,6 +96,13 @@ func TestFactory_ZeroKVCacheUtilThreshold(t *testing.T) {
 	}
 }
 
+func TestFactory_KVCacheUtilThresholdAboveOne(t *testing.T) {
+	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{"kvCacheUtilThreshold":1.5}`)), nil)
+	if err == nil {
+		t.Fatal("expected error for kvCacheUtilThreshold=1.5")
+	}
+}
+
 func TestFactory_NegativePower(t *testing.T) {
 	_, err := Factory("test", fwkplugin.StrictDecoder(json.RawMessage(`{"power":-1}`)), nil)
 	if err == nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Validate `kvCacheUtilThreshold` against its documented `(0, 1]` range in the probabilistic admitter. Values above `1.0` are invalid but were previously accepted.

**Which issue(s) this PR fixes**:

None.

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```

**Test plan**:

- [x] Verify invalid `kvCacheUtilThreshold` values above `1.0` are rejected.