### PR TITLE
fix: quote lychee glob and exclude auth-walled URLs

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -55,5 +55,5 @@ jobs:
         with:
           # Exclude release-notes.d/ — fragments are sourced verbatim from
           # PR bodies; let the original PR's link check be authoritative.
-          args: '--config .lychee.toml --verbose --no-progress --exclude-path release-notes.d **/*.md'
+          args: '--config .lychee.toml --verbose --no-progress --exclude-path release-notes.d "**/*.md"'
           fail: true

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,7 +1,12 @@
 # Ignore transient failures on gnu.org (it sometimes refuses connections)
 exclude = [
   "^https://www.gnu.org/software/make/?$",
-  "^https://www.envoyproxy.io/"
+  "^https://www.envoyproxy.io/",
+  "^https://llm-d\\.slack\\.com/",
+  "^https://meet\\.google\\.com/",
+  "^https://docs\\.google\\.com/",
+  "^https://drive\\.google\\.com/",
+  "^https://app\\.fossa\\.com/"
 ]
 
 # Per-request timeout in seconds. Sized for slow upstream docs sites


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Quote the `**/*.md` glob so lychee receives it intact; exclude auth-walled slack/meet/docs/drive/fossa hosts. Test: TOML+YAML parse OK, CI is the gate.

**Which issue(s) this PR fixes**:
None

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
