### PR TITLE
fix(docs): repair broken links surfaced by quoted lychee glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/llm-d/llm-d-router)](https://goreportcard.com/report/github.com/llm-d/llm-d-router)
 [![Go Reference](https://pkg.go.dev/badge/github.com/llm-d/llm-d-router.svg)](https://pkg.go.dev/github.com/llm-d/llm-d-router)
-[![License](https://img.shields.io/github/license/llm-d/llm-d-router)](/LICENSE)
+[![License](https://img.shields.io/github/license/llm-d/llm-d-router)](./LICENSE)
 [![Join Slack](https://img.shields.io/badge/Join_Slack-blue?logo=slack)](https://llm-d.slack.com/archives/C08SBNRRSBD)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fllm-d%2Fllm-d-router.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fllm-d%2Fllm-d-router?ref=badge_shield)
 

--- a/pkg/epp/framework/plugins/datalayer/attribute/gpu/README.md
+++ b/pkg/epp/framework/plugins/datalayer/attribute/gpu/README.md
@@ -9,4 +9,4 @@ This package defines the data key for GPU hardware metrics collected from NVIDIA
 - **Value type**: `ScalarMetricValue` (from `attribute/metrics`)
 
 For usage instructions, cluster prerequisites, and EPP config examples see
-[`extractor/dcgm/README.md`](../../../extractor/dcgm/README.md).
+[`extractor/dcgm/README.md`](../../extractor/dcgm/README.md).


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind cleanup

**What this PR does / why we need it**:

  Since #2754 quoted the lychee glob, the checker now scans all markdown files recursively (previously only one level deep), which surfaced two pre-existing broken links on main:
  - https://github.com/llm-d/llm-d-router/blob/main/pkg/epp/framework/plugins/datalayer/attribute/gpu/README.md
  - Root README.md uses the root-relative /LICENSE, which lychee cannot resolve without --root-dir.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
