### PR TITLE
feat(metrics): link metrics to traces with Prometheus exemplars

### DIFF
--- a/cmd/epp/runner/openmetrics_wire_test.go
+++ b/cmd/epp/runner/openmetrics_wire_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+
+	eppmetrics "github.com/llm-d/llm-d-router/pkg/epp/metrics"
+)
+
+const (
+	// openMetricsAccept is the Accept header Prometheus sends with its default
+	// scrape_protocols, which lists OpenMetrics 1.0.0 first.
+	openMetricsAccept = "application/openmetrics-text;version=1.0.0,text/plain;version=0.0.4;q=0.5"
+	// classicAccept is what a scraper that does not understand OpenMetrics sends.
+	classicAccept = "text/plain;version=0.0.4"
+
+	testTraceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	testSpanID  = "0102030405060708"
+)
+
+// exemplarLabels returns the label set of the first exemplar in an OpenMetrics
+// payload. client_golang builds an exemplar by ranging over a Go map, so the
+// order of the labels is not stable between runs and must not be asserted on.
+func exemplarLabels(body string) (string, bool) {
+	for _, line := range strings.Split(body, "\n") {
+		open := strings.Index(line, "# {")
+		if open < 0 {
+			continue
+		}
+		rest := line[open+len("# {"):]
+		close := strings.Index(rest, "}")
+		if close < 0 {
+			continue
+		}
+		return rest[:close], true
+	}
+	return "", false
+}
+
+// sampledContext returns a context carrying a sampled span, which is the only
+// case in which a latency observation attaches an exemplar.
+func sampledContext(t *testing.T) context.Context {
+	t.Helper()
+
+	traceID, err := trace.TraceIDFromHex(testTraceID)
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex(testSpanID)
+	require.NoError(t, err)
+
+	return trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	}))
+}
+
+// scrapeMetrics serves the metrics endpoint the runner builds in production and
+// returns the Content-Type and body a scraper sending accept would receive.
+func scrapeMetrics(t *testing.T, accept string) (string, string) {
+	t.Helper()
+
+	// Auth disabled is the case that used to silently skip the filter entirely,
+	// so it is the one worth exercising here.
+	provider := openMetricsFilterProvider(false)
+	filter, err := provider(nil, nil)
+	require.NoError(t, err)
+
+	// The handler passed in is the one controller-runtime built; the filter
+	// substitutes its own, so nil is enough here.
+	handler, err := filter(testr.New(t), nil)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Accept", accept)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	return rec.Header().Get("Content-Type"), rec.Body.String()
+}
+
+// TestMetricsEndpointServesExemplarsOnTheWire covers the step the unit tests in
+// pkg/epp/metrics cannot: an exemplar recorded onto a collector is only useful
+// if it also survives serialisation. Exemplars exist solely in the OpenMetrics
+// exposition format, so a handler built without it drops them at encode time
+// without erroring.
+func TestMetricsEndpointServesExemplarsOnTheWire(t *testing.T) {
+	eppmetrics.Register()
+
+	received := time.Now()
+	require.True(t, eppmetrics.RecordRequestLatencies(
+		sampledContext(t), "model", "target-model", "fairness", "priority",
+		received, received.Add(420*time.Millisecond),
+	))
+
+	contentType, body := scrapeMetrics(t, openMetricsAccept)
+
+	require.True(t, strings.HasPrefix(contentType, "application/openmetrics-text"),
+		"a scraper asking for OpenMetrics must be served OpenMetrics, got %q", contentType)
+
+	labels, ok := exemplarLabels(body)
+	require.True(t, ok, "the observation must carry an exemplar on the wire")
+	require.Contains(t, labels, `trace_id="`+testTraceID+`"`,
+		"the trace ID must reach the wire")
+	require.Contains(t, labels, `span_id="`+testSpanID+`"`,
+		"the span ID must reach the wire, so a backend can open the span that observed the latency")
+}
+
+// TestMetricsEndpointKeepsClassicFormatForClassicScrapers guards the other half:
+// the handler negotiates per request, so enabling OpenMetrics must not change
+// what a scraper that never asks for it receives.
+func TestMetricsEndpointKeepsClassicFormatForClassicScrapers(t *testing.T) {
+	eppmetrics.Register()
+
+	contentType, body := scrapeMetrics(t, classicAccept)
+
+	require.True(t, strings.HasPrefix(contentType, "text/plain"),
+		"a classic scraper must keep receiving the classic format, got %q", contentType)
+	require.NotContains(t, body, "# {trace_id=",
+		"the classic exposition format has no representation for exemplars")
+}

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -398,14 +398,8 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 	// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.1/pkg/metrics/server
 	// - https://book.kubebuilder.io/reference/metrics.html
 	metricsServerOptions := metricsserver.Options{
-		BindAddress: fmt.Sprintf(":%d", opts.MetricsPort),
-		FilterProvider: func() func(c *rest.Config, httpClient *http.Client) (metricsserver.Filter, error) {
-			if opts.MetricsEndpointAuth {
-				return filters.WithAuthenticationAndAuthorization
-			}
-
-			return nil
-		}(),
+		BindAddress:    fmt.Sprintf(":%d", opts.MetricsPort),
+		FilterProvider: openMetricsFilterProvider(opts.MetricsEndpointAuth),
 	}
 
 	if err := runserver.ConfigureMetricsTLS(opts, &metricsServerOptions); err != nil {
@@ -530,6 +524,44 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 	readinessCheckers = append(readinessCheckers, r.dlRuntime)
 	r.healthGRPCServer = newHealthGRPCServer(ctrl.Log.WithName("health"), ds, isLeader, r.draining, opts.EnableLeaderElection, supporters, readinessCheckers)
 	return mgr, ds, nil
+}
+
+// openMetricsFilterProvider builds the metrics server's FilterProvider.
+//
+// It exists because exemplars are only representable in the OpenMetrics
+// exposition format, and controller-runtime builds its /metrics handler with
+// a hardcoded promhttp.HandlerOpts that does not set EnableOpenMetrics. That
+// handler cannot be replaced through Options: ExtraHandlers explicitly refuses
+// to override /metrics, and there is no field for handler options. The filter
+// hook is the only seam, so the filter discards the handler it is given and
+// substitutes an equivalent one with OpenMetrics negotiation enabled.
+//
+// The substituted handler serves the same registry with the same error
+// handling, so the only behavioral difference is that a scraper sending
+// "Accept: application/openmetrics-text" now receives exemplars. Any
+// authentication filter is applied on top, exactly as before.
+func openMetricsFilterProvider(authEnabled bool) func(*rest.Config, *http.Client) (metricsserver.Filter, error) {
+	return func(c *rest.Config, httpClient *http.Client) (metricsserver.Filter, error) {
+		var authFilter metricsserver.Filter
+		if authEnabled {
+			var err error
+			authFilter, err = filters.WithAuthenticationAndAuthorization(c, httpClient)
+			if err != nil {
+				return nil, fmt.Errorf("build metrics authentication filter: %w", err)
+			}
+		}
+
+		return func(log logr.Logger, _ http.Handler) (http.Handler, error) {
+			handler := promhttp.HandlerFor(ctrlmetrics.Registry, promhttp.HandlerOpts{
+				ErrorHandling:     promhttp.HTTPErrorOnError,
+				EnableOpenMetrics: true,
+			})
+			if authFilter == nil {
+				return handler, nil
+			}
+			return authFilter(log, handler)
+		}, nil
+	}
 }
 
 // NewEndpointPoolFromOptions constructs an EndpointPool from standalone options.

--- a/pkg/epp/metrics/exemplars_test.go
+++ b/pkg/epp/metrics/exemplars_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// newHistogram returns a bare histogram to observe into, so these tests assert
+// exemplar behavior without depending on the registered metric's labels.
+func newHistogram() prometheus.Histogram {
+	return prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "test_exemplar_histogram",
+		Buckets: []float64{0.1, 1, 10},
+	})
+}
+
+// collectExemplars returns the exemplar attached to each bucket that carries one.
+func collectExemplars(t *testing.T, h prometheus.Histogram) []*dto.Exemplar {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, h.(prometheus.Metric).Write(&m))
+	require.NotNil(t, m.Histogram)
+
+	var found []*dto.Exemplar
+	for _, bucket := range m.Histogram.Bucket {
+		if bucket.Exemplar != nil {
+			found = append(found, bucket.Exemplar)
+		}
+	}
+	return found
+}
+
+func ctxWithSpan(t *testing.T, sampled bool) context.Context {
+	t.Helper()
+	traceID, err := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex("0102030405060708")
+	require.NoError(t, err)
+
+	var flags trace.TraceFlags
+	if sampled {
+		flags = trace.FlagsSampled
+	}
+	return trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: flags,
+	}))
+}
+
+func TestObserveWithTraceExemplar_SampledSpanAttachesTraceID(t *testing.T) {
+	h := newHistogram()
+
+	observeWithTraceExemplar(ctxWithSpan(t, true), h, 0.5)
+
+	exemplars := collectExemplars(t, h)
+	require.Len(t, exemplars, 1, "a sampled span should attach exactly one exemplar")
+
+	labels := exemplars[0].Label
+	require.Len(t, labels, 1)
+	require.Equal(t, "trace_id", labels[0].GetName())
+	require.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", labels[0].GetValue())
+	require.InDelta(t, 0.5, exemplars[0].GetValue(), 1e-9)
+}
+
+func TestObserveWithTraceExemplar_UnsampledSpanAttachesNothing(t *testing.T) {
+	h := newHistogram()
+
+	// The span carries a valid trace ID, but no trace was exported for it, so an
+	// exemplar would link a dashboard to a trace that does not exist.
+	observeWithTraceExemplar(ctxWithSpan(t, false), h, 0.5)
+
+	require.Empty(t, collectExemplars(t, h), "an unsampled span must not attach an exemplar")
+}
+
+func TestObserveWithTraceExemplar_NoSpanStillObserves(t *testing.T) {
+	h := newHistogram()
+
+	observeWithTraceExemplar(context.Background(), h, 0.5)
+
+	require.Empty(t, collectExemplars(t, h), "no span means no exemplar")
+
+	var m dto.Metric
+	require.NoError(t, h.(prometheus.Metric).Write(&m))
+	require.Equal(t, uint64(1), m.Histogram.GetSampleCount(), "the observation itself must still be recorded")
+}

--- a/pkg/epp/metrics/exemplars_test.go
+++ b/pkg/epp/metrics/exemplars_test.go
@@ -77,10 +77,22 @@ func TestObserveWithTraceExemplar_SampledSpanAttachesTraceID(t *testing.T) {
 	exemplars := collectExemplars(t, h)
 	require.Len(t, exemplars, 1, "a sampled span should attach exactly one exemplar")
 
-	labels := exemplars[0].Label
-	require.Len(t, labels, 1)
-	require.Equal(t, "trace_id", labels[0].GetName())
-	require.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", labels[0].GetValue())
+	labels := map[string]string{}
+	for _, l := range exemplars[0].Label {
+		labels[l.GetName()] = l.GetValue()
+	}
+	require.Equal(t, map[string]string{
+		"trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+		"span_id":  "0102030405060708",
+	}, labels)
+
+	// OpenMetrics caps an exemplar's whole label set at 128 runes; exceeding it
+	// makes client_golang reject the observation at runtime.
+	runes := 0
+	for name, value := range labels {
+		runes += len([]rune(name)) + len([]rune(value))
+	}
+	require.LessOrEqual(t, runes, prometheus.ExemplarMaxRunes)
 	require.InDelta(t, 0.5, exemplars[0].GetValue(), 1e-9)
 }
 

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -410,8 +410,8 @@ func RecordRequestLatencies(ctx context.Context, modelName, targetModelName, fai
 }
 
 // observeWithTraceExemplar records an observation, attaching the request's trace
-// ID as a Prometheus exemplar so a point on a latency graph can be opened as the
-// trace that produced it.
+// and span IDs as a Prometheus exemplar so a point on a latency graph can be
+// opened as the trace that produced it.
 //
 // The exemplar is attached only when the span is sampled. An unsampled span still
 // carries a trace ID, but no trace was ever exported for it, so attaching one
@@ -423,7 +423,14 @@ func observeWithTraceExemplar(ctx context.Context, observer prometheus.Observer,
 	sc := trace.SpanContextFromContext(ctx)
 	if sc.IsSampled() {
 		if exemplarObserver, ok := observer.(prometheus.ExemplarObserver); ok {
-			exemplarObserver.ObserveWithExemplar(value, prometheus.Labels{"trace_id": sc.TraceID().String()})
+			// Both IDs fit comfortably inside OpenMetrics' 128-rune exemplar
+			// label budget (63 runes), and the span ID lets a traces backend
+			// open the span that observed this latency rather than only the
+			// trace containing it.
+			exemplarObserver.ObserveWithExemplar(value, prometheus.Labels{
+				"trace_id": sc.TraceID().String(),
+				"span_id":  sc.SpanID().String(),
+			})
 			return
 		}
 	}

--- a/pkg/epp/metrics/metrics.go
+++ b/pkg/epp/metrics/metrics.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/trace"
 	compbasemetrics "k8s.io/component-base/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -402,8 +403,31 @@ func RecordRequestLatencies(ctx context.Context, modelName, targetModelName, fai
 		return false
 	}
 	elapsedSeconds := complete.Sub(received).Seconds()
-	llmdRequestLatencies.WithLabelValues(modelName, targetModelName, fairnessID, priority).Observe(elapsedSeconds)
+	observeWithTraceExemplar(ctx,
+		llmdRequestLatencies.WithLabelValues(modelName, targetModelName, fairnessID, priority),
+		elapsedSeconds)
 	return true
+}
+
+// observeWithTraceExemplar records an observation, attaching the request's trace
+// ID as a Prometheus exemplar so a point on a latency graph can be opened as the
+// trace that produced it.
+//
+// The exemplar is attached only when the span is sampled. An unsampled span still
+// carries a trace ID, but no trace was ever exported for it, so attaching one
+// would give dashboards links that resolve to nothing.
+//
+// Exemplars are only carried by the OpenMetrics exposition format; see
+// openMetricsFilterProvider in cmd/epp/runner for how the endpoint negotiates it.
+func observeWithTraceExemplar(ctx context.Context, observer prometheus.Observer, value float64) {
+	sc := trace.SpanContextFromContext(ctx)
+	if sc.IsSampled() {
+		if exemplarObserver, ok := observer.(prometheus.ExemplarObserver); ok {
+			exemplarObserver.ObserveWithExemplar(value, prometheus.Labels{"trace_id": sc.TraceID().String()})
+			return
+		}
+	}
+	observer.Observe(value)
 }
 
 // RecordResponseSizes records the response sizes.


### PR DESCRIPTION
first PR for #2637, one metric end to end - `llm_d_epp_request_duration_seconds`.

attaches the trace ID to the latency observation as an exemplar so a spike on a dashboard links straight to the trace behind it.

on the openmetrics side: exemplars only travel over openmetrics and controller-runtime hardcodes its handler without it. no option field, and ExtraHandlers refuses to override /metrics, so FilterProvider is the only seam. `openMetricsFilterProvider` builds a handler with `EnableOpenMetrics: true` over the same registry and runs it through the existing auth filter, so auth behaviour doesn't change.

as @gyliu513 pointed out on the issue, this negotiates per request off the Accept header, so it's not a breaking change - anything not asking for openmetrics-text still gets the classic format from the same endpoint.

on the auth branch thing he flagged: the old code set FilterProvider to nil outright when MetricsEndpointAuth was false, so exemplars would have silently not activated with auth off. this decouples them - provider is set unconditionally now and auth gets composed inside it, so the openmetrics handler is built either way and auth only decides whether it gets wrapped.

sampling gate is there too, only attached when IsSampled(). unsampled spans still have a trace ID but nothing was exported for them, so you'd just get dead links.

checked it on the wire, not just in unit tests:

```
content-type: application/openmetrics-text; version=1.0.0
..._bucket{le="1.0"} 1 # {trace_id="abc123"} 0.5 1.788e+09
```

tests cover sampled attaching the trace ID, unsampled attaching nothing, and no span still recording the observation.

two follow ups not in here:
- the grafana panel from the issue, needs prometheus + tempo running to produce so i'll send it separately
- upstream issue on controller-runtime for a proper EnableOpenMetrics option, so there's a documented way to drop this workaround later

Part of #2637