### PR TITLE
Rename completionRequest to body in sidecar proxy

### DIFF
--- a/pkg/sidecar/proxy/connector_ec_common.go
+++ b/pkg/sidecar/proxy/connector_ec_common.go
@@ -241,19 +241,19 @@ func (s *Server) fanoutEncoder(
 // runPDPipeline finalizes the post-encoder request and dispatches it to the
 // configured P/D connector or directly to the decoder. The caller has already
 // generated requestID and merged any encoder-side metadata into
-// completionRequest. On JSON-marshal failure, runPDPipeline writes the error
+// body. On JSON-marshal failure, runPDPipeline writes the error
 // response itself (matching the existing handler pattern) and returns.
 func (s *Server) runPDPipeline(
 	w http.ResponseWriter,
 	r *http.Request,
-	completionRequest map[string]any,
+	body map[string]any,
 	prefillEndPoint string,
 	requestID string,
 ) {
 	// Skip decode-first; the encoder has run and prefill must execute.
-	completionRequest[requestFieldCacheHitThreshold] = 0
+	body[requestFieldCacheHitThreshold] = 0
 
-	modifiedBody, err := json.Marshal(completionRequest)
+	modifiedBody, err := json.Marshal(body)
 	if err != nil {
 		if err := errorJSONInvalid(err, w); err != nil {
 			s.logger.Error(err, "failed to send error response to client")
@@ -277,7 +277,7 @@ func (s *Server) runPDPipeline(
 			"prefiller", prefillEndPoint,
 			"bodyBytes", len(modifiedBody),
 		}
-		if ec, ok := completionRequest[requestFieldECTransferParams]; ok {
+		if ec, ok := body[requestFieldECTransferParams]; ok {
 			kv = append(kv, requestFieldECTransferParams, truncateLongStrings(ec, 64))
 		}
 		v.Info("forwarding request after encoder", kv...)

--- a/pkg/sidecar/proxy/connector_ec_nixl.go
+++ b/pkg/sidecar/proxy/connector_ec_nixl.go
@@ -86,7 +86,7 @@ func (s *Server) fanoutEncoderCollect(
 func (s *Server) handleECNIXL(w http.ResponseWriter, r *http.Request, prefillEndPoint string, encodeEndPoints []string) {
 	s.logger.V(logging.DEBUG).Info("running EC-NIXL protocol", "prefiller", prefillEndPoint, "encoderCount", len(encodeEndPoints))
 
-	_, completionRequest, ok := s.readJSONBody(r, w)
+	_, body, ok := s.readJSONBody(r, w)
 	if !ok {
 		return
 	}
@@ -102,7 +102,7 @@ func (s *Server) handleECNIXL(w http.ResponseWriter, r *http.Request, prefillEnd
 
 	// Step 1: fan out to encoders, collect per-image ec_transfer_params.
 	if len(encodeEndPoints) > 0 {
-		params, contributed, total, err := s.fanoutEncoderCollect(r.Context(), completionRequest, encodeEndPoints, requestID)
+		params, contributed, total, err := s.fanoutEncoderCollect(r.Context(), body, encodeEndPoints, requestID)
 		if err != nil {
 			s.logger.Error(err, "encoder processing failed", "requestID", requestID)
 			if err := errorBadGateway(err, w); err != nil {
@@ -117,7 +117,7 @@ func (s *Server) handleECNIXL(w http.ResponseWriter, r *http.Request, prefillEnd
 				s.logger.Info("warning: no encoder response carried ec_transfer_params; forwarding prefill request without it",
 					"requestID", requestID, "items", total)
 			} else {
-				completionRequest[requestFieldECTransferParams] = params
+				body[requestFieldECTransferParams] = params
 				if contributed < total {
 					s.logger.Info("warning: ec_transfer_params partially populated; some items missing transfer metadata",
 						"requestID", requestID, "contributed", contributed, "items", total)
@@ -126,5 +126,5 @@ func (s *Server) handleECNIXL(w http.ResponseWriter, r *http.Request, prefillEnd
 		}
 	}
 
-	s.runPDPipeline(w, r, completionRequest, prefillEndPoint, requestID)
+	s.runPDPipeline(w, r, body, prefillEndPoint, requestID)
 }

--- a/pkg/sidecar/proxy/connector_ec_shared_storage.go
+++ b/pkg/sidecar/proxy/connector_ec_shared_storage.go
@@ -41,7 +41,7 @@ func (s *Server) fanoutEncoderPrimer(ctx context.Context, originalRequest map[st
 func (s *Server) handleECSharedStorage(w http.ResponseWriter, r *http.Request, prefillEndPoint string, encodeEndPoints []string) {
 	s.logger.V(logging.DEBUG).Info("running EPD protocol", "prefiller", prefillEndPoint, "encoderCount", len(encodeEndPoints))
 
-	_, completionRequest, ok := s.readJSONBody(r, w)
+	_, body, ok := s.readJSONBody(r, w)
 	if !ok {
 		return
 	}
@@ -58,7 +58,7 @@ func (s *Server) handleECSharedStorage(w http.ResponseWriter, r *http.Request, p
 
 	// Step 1: Process through Encoder cluster (if has MM input)
 	if len(encodeEndPoints) > 0 {
-		if err := s.fanoutEncoderPrimer(r.Context(), completionRequest, encodeEndPoints, requestID); err != nil {
+		if err := s.fanoutEncoderPrimer(r.Context(), body, encodeEndPoints, requestID); err != nil {
 			s.logger.Error(err, "encoder processing failed", "requestID", requestID)
 			if err := errorBadGateway(err, w); err != nil {
 				s.logger.Error(err, "failed to send error response to client")
@@ -67,5 +67,5 @@ func (s *Server) handleECSharedStorage(w http.ResponseWriter, r *http.Request, p
 		}
 	}
 
-	s.runPDPipeline(w, r, completionRequest, prefillEndPoint, requestID)
+	s.runPDPipeline(w, r, body, prefillEndPoint, requestID)
 }

--- a/pkg/sidecar/proxy/connector_nixlv2.go
+++ b/pkg/sidecar/proxy/connector_nixlv2.go
@@ -56,7 +56,7 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 	tokenLimitFields := tokenLimitFieldsForAPIType(apiType)
 	s.logger.V(logging.DEBUG).Info("running NIXL protocol V2", "url", prefillPodHostPort, "tokenLimitFields", tokenLimitFields)
 
-	original, completionRequest, ok := s.readJSONBody(r, w)
+	original, body, ok := s.readJSONBody(r, w)
 	if !ok {
 		return
 	}
@@ -76,7 +76,7 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 	if s.config.MoRIIOParallelDispatch && s.config.MoRIIOWriteMode {
 		// MoRI-IO requires transfer_id to carry the "tx" prefix for message routing.
 		transferID := "tx" + uuidStr
-		s.runNIXLProtocolV2WriteParallel(w, r, original, completionRequest, uuidStr, transferID, prefillPodHostPort, kvCacheSource)
+		s.runNIXLProtocolV2WriteParallel(w, r, original, body, uuidStr, transferID, prefillPodHostPort, kvCacheSource)
 		return
 	}
 
@@ -106,8 +106,8 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 	}
 
 	// Save original values based on API type
-	streamValue, streamOk := completionRequest[requestFieldStream]
-	streamOptionsValue, streamOptionsOk := completionRequest[requestFieldStreamOptions]
+	streamValue, streamOk := body[requestFieldStream]
+	streamOptionsValue, streamOptionsOk := body[requestFieldStreamOptions]
 
 	// Save and override token limit fields for prefill
 	type savedField struct {
@@ -115,7 +115,7 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 		val     any
 		present bool
 	}
-	tokenMap, createdSamplingParams := tokenLimitMap(completionRequest, apiType)
+	tokenMap, createdSamplingParams := tokenLimitMap(body, apiType)
 	savedTokenValues := make([]savedField, len(tokenLimitFields))
 	for i, field := range tokenLimitFields {
 		if v, ok := tokenMap[field]; ok {
@@ -130,7 +130,7 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 	if s.config.MoRIIOWriteMode {
 		// MoRI-IO requires transfer_id to carry the "tx" prefix for message routing.
 		transferID := "tx" + uuidStr
-		completionRequest[requestFieldKVTransferParams] = map[string]any{
+		body[requestFieldKVTransferParams] = map[string]any{
 			requestFieldDoRemoteDecode:       true,
 			requestFieldDoRemotePrefill:      false,
 			requestFieldRemoteEngineID:       nil,
@@ -149,7 +149,7 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 		// DECODE-side pod IPs so prefill handshakes the right pods. Re-resolved
 		// per request so peer restarts (new IP) are picked up within the TTL.
 		if decodeHosts := s.currentDecodeHosts(ctx); len(decodeHosts) > 0 {
-			pkv := completionRequest[requestFieldKVTransferParams].(map[string]any)
+			pkv := body[requestFieldKVTransferParams].(map[string]any)
 			hosts := make([]any, len(decodeHosts))
 			for i, h := range decodeHosts {
 				hosts[i] = h
@@ -160,7 +160,7 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 			}
 		}
 	} else {
-		completionRequest[requestFieldKVTransferParams] = map[string]any{
+		body[requestFieldKVTransferParams] = map[string]any{
 			requestFieldDoRemoteDecode:  true,
 			requestFieldDoRemotePrefill: false,
 			requestFieldRemoteEngineID:  nil,
@@ -171,16 +171,16 @@ func (s *Server) handleNIXLV2(w http.ResponseWriter, r *http.Request, prefillPod
 	}
 
 	// Compose the OffloadingConnector p2p pull onto the NIXL prefill leg.
-	s.addP2PPullToPrefill(completionRequest[requestFieldKVTransferParams].(map[string]any), kvCacheSource, prefillPodHostPort)
+	s.addP2PPullToPrefill(body[requestFieldKVTransferParams].(map[string]any), kvCacheSource, prefillPodHostPort)
 
-	completionRequest[requestFieldStream] = false
-	delete(completionRequest, requestFieldStreamOptions)
+	body[requestFieldStream] = false
+	delete(body, requestFieldStreamOptions)
 
 	for _, field := range tokenLimitFields {
 		tokenMap[field] = 1
 	}
 
-	pbody, err := json.Marshal(completionRequest)
+	pbody, err := json.Marshal(body)
 	if err != nil {
 		if err := errorJSONInvalid(err, w); err != nil {
 			s.logger.Error(err, "failed to send error response to client")
@@ -342,17 +342,17 @@ retryLoop:
 		}
 	}
 
-	delete(completionRequest, requestFieldStream)
+	delete(body, requestFieldStream)
 	streamingEnabled := false
 	if streamOk {
-		completionRequest[requestFieldStream] = streamValue
+		body[requestFieldStream] = streamValue
 		if streamBool, ok := streamValue.(bool); ok {
 			streamingEnabled = streamBool
 		}
 	}
 	decodeSpan.SetAttributes(attribute.Bool("llm_d.pd_proxy.decode.streaming", streamingEnabled))
 	if streamOptionsOk {
-		completionRequest[requestFieldStreamOptions] = streamOptionsValue
+		body[requestFieldStreamOptions] = streamOptionsValue
 	}
 
 	for i := range savedTokenValues {
@@ -365,7 +365,7 @@ retryLoop:
 	// Drop the sampling_params map synthesized for prefill capping if it ended up
 	// empty, so the decode request matches the caller's original (which omitted it).
 	if createdSamplingParams && len(tokenMap) == 0 {
-		delete(completionRequest, requestFieldSamplingParams)
+		delete(body, requestFieldSamplingParams)
 	}
 
 	// WRITE mode: backfill the decode-side kv_transfer_params fields that
@@ -410,9 +410,9 @@ retryLoop:
 			}
 		}
 	}
-	completionRequest[requestFieldKVTransferParams] = pKVTransferParams
+	body[requestFieldKVTransferParams] = pKVTransferParams
 
-	dbody, err := json.Marshal(completionRequest)
+	dbody, err := json.Marshal(body)
 	if err != nil {
 		if err := errorJSONInvalid(err, w); err != nil {
 			s.logger.Error(err, "failed to send error response to client")
@@ -434,7 +434,7 @@ retryLoop:
 	if !dataParallelUsed {
 		s.logger.V(logging.DEBUG).Info("sending request to decoder", "to", s.config.DecoderURL.Host)
 		decodeSpan.SetAttributes(attribute.String("llm_d.pd_proxy.decode.target", s.config.DecoderURL.Host))
-		s.dispatchDecode(decodeWriter, dreq, completionRequest)
+		s.dispatchDecode(decodeWriter, dreq, body)
 	}
 	if err := finalizeDecodeWriter(); err != nil {
 		s.logger.Error(err, "failed to flush cached token response writer")
@@ -477,7 +477,7 @@ retryLoop:
 // two upstream calls in parallel so decode's block allocation overlaps prefill.
 func (s *Server) runNIXLProtocolV2WriteParallel(
 	w http.ResponseWriter, r *http.Request, original []byte,
-	completionRequest map[string]any, uuidStr, transferID, prefillPodHostPort, kvCacheSource string,
+	body map[string]any, uuidStr, transferID, prefillPodHostPort, kvCacheSource string,
 ) {
 	s.logger.V(logging.DEBUG).Info("running NIXL protocol V2 (concurrent dispatch)",
 		"url", prefillPodHostPort, "request_id", uuidStr)
@@ -486,14 +486,14 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 	parentCtx := r.Context()
 	requestStartedAt := time.Now()
 
-	// Snapshot client fields before mutating completionRequest into the prefill
+	// Snapshot client fields before mutating body into the prefill
 	// body; they are restored when building the decode body.
-	streamValue, streamOk := completionRequest[requestFieldStream]
-	streamOptionsValue, streamOptionsOk := completionRequest[requestFieldStreamOptions]
-	maxTokensValue, maxTokensOk := completionRequest[requestFieldMaxTokens]
-	maxCompletionTokensValue, maxCompletionTokensOk := completionRequest[requestFieldMaxCompletionTokens]
-	maxOutputTokensValue, maxOutputTokensOk := completionRequest[requestFieldMaxOutputTokens]
-	minTokensValue, minTokensOk := completionRequest[requestFieldMinTokens]
+	streamValue, streamOk := body[requestFieldStream]
+	streamOptionsValue, streamOptionsOk := body[requestFieldStreamOptions]
+	maxTokensValue, maxTokensOk := body[requestFieldMaxTokens]
+	maxCompletionTokensValue, maxCompletionTokensOk := body[requestFieldMaxCompletionTokens]
+	maxOutputTokensValue, maxOutputTokensOk := body[requestFieldMaxOutputTokens]
+	minTokensValue, minTokensOk := body[requestFieldMinTokens]
 
 	// Pin both legs to the same DP rank (kv_transfer_params + HTTP header).
 	dpRank := pickDPRank(uuidStr, s.config.MoRIIODPSize)
@@ -501,7 +501,7 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 	// Build prefill body. remote_host points at the decode pod so prefill can
 	// RDMA-Write KV there; remote_dp_size gates the decode-side per-DP-rank
 	// handshake loop for Wide-EP.
-	completionRequest[requestFieldKVTransferParams] = map[string]any{
+	body[requestFieldKVTransferParams] = map[string]any{
 		requestFieldDoRemoteDecode:       true,
 		requestFieldDoRemotePrefill:      false,
 		requestFieldRemoteEngineID:       nil,
@@ -521,7 +521,7 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 	// to the single-host remote_host path. Re-resolved per request so peer
 	// restarts (new IP) are picked up within the TTL.
 	if decodeHosts := s.currentDecodeHosts(parentCtx); len(decodeHosts) > 0 {
-		pkv := completionRequest[requestFieldKVTransferParams].(map[string]any)
+		pkv := body[requestFieldKVTransferParams].(map[string]any)
 		hosts := make([]any, len(decodeHosts))
 		for i, h := range decodeHosts {
 			hosts[i] = h
@@ -532,16 +532,16 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 		}
 	}
 	// Compose the OffloadingConnector p2p pull onto the NIXL prefill leg.
-	s.addP2PPullToPrefill(completionRequest[requestFieldKVTransferParams].(map[string]any), kvCacheSource, prefillPodHostPort)
+	s.addP2PPullToPrefill(body[requestFieldKVTransferParams].(map[string]any), kvCacheSource, prefillPodHostPort)
 
-	completionRequest[requestFieldStream] = false
-	delete(completionRequest, requestFieldStreamOptions)
-	completionRequest[requestFieldMaxTokens] = 1
-	completionRequest[requestFieldMaxCompletionTokens] = 1
-	completionRequest[requestFieldMaxOutputTokens] = 1
-	completionRequest[requestFieldMinTokens] = 1
+	body[requestFieldStream] = false
+	delete(body, requestFieldStreamOptions)
+	body[requestFieldMaxTokens] = 1
+	body[requestFieldMaxCompletionTokens] = 1
+	body[requestFieldMaxOutputTokens] = 1
+	body[requestFieldMinTokens] = 1
 
-	pbody, err := json.Marshal(completionRequest)
+	pbody, err := json.Marshal(body)
 	if err != nil {
 		if err := errorJSONInvalid(err, w); err != nil {
 			s.logger.Error(err, "failed to send error response to client (concurrent-dispatch marshal P)")
@@ -551,28 +551,28 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 
 	// ---------- Build decode body ----------
 	// Restore the client's streaming flags and token-limit fields.
-	delete(completionRequest, requestFieldStream)
+	delete(body, requestFieldStream)
 	if streamOk {
-		completionRequest[requestFieldStream] = streamValue
+		body[requestFieldStream] = streamValue
 	}
 	if streamOptionsOk {
-		completionRequest[requestFieldStreamOptions] = streamOptionsValue
+		body[requestFieldStreamOptions] = streamOptionsValue
 	}
-	delete(completionRequest, requestFieldMaxTokens)
+	delete(body, requestFieldMaxTokens)
 	if maxTokensOk {
-		completionRequest[requestFieldMaxTokens] = maxTokensValue
+		body[requestFieldMaxTokens] = maxTokensValue
 	}
-	delete(completionRequest, requestFieldMaxCompletionTokens)
+	delete(body, requestFieldMaxCompletionTokens)
 	if maxCompletionTokensOk {
-		completionRequest[requestFieldMaxCompletionTokens] = maxCompletionTokensValue
+		body[requestFieldMaxCompletionTokens] = maxCompletionTokensValue
 	}
-	delete(completionRequest, requestFieldMaxOutputTokens)
+	delete(body, requestFieldMaxOutputTokens)
 	if maxOutputTokensOk {
-		completionRequest[requestFieldMaxOutputTokens] = maxOutputTokensValue
+		body[requestFieldMaxOutputTokens] = maxOutputTokensValue
 	}
-	delete(completionRequest, requestFieldMinTokens)
+	delete(body, requestFieldMinTokens)
 	if minTokensOk {
-		completionRequest[requestFieldMinTokens] = minTokensValue
+		body[requestFieldMinTokens] = minTokensValue
 	}
 
 	// Synthesise decode-leg kv_transfer_params that the serial path would
@@ -583,7 +583,7 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 		prefillHost = prefillPodHostPort
 	}
 
-	completionRequest[requestFieldKVTransferParams] = map[string]any{
+	body[requestFieldKVTransferParams] = map[string]any{
 		requestFieldDoRemotePrefill: true,
 		requestFieldDoRemoteDecode:  false,
 		requestFieldRemoteEngineID:  net.JoinHostPort(prefillHost, strconv.Itoa(s.config.MoRIIOPrefillHandshakePort)),
@@ -603,7 +603,7 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 	// pod IPs. A multi-pod deployment must set both host flags. Re-resolved per
 	// request so peer restarts (new IP) are picked up within the TTL.
 	if remoteHosts := s.currentRemoteHosts(parentCtx); len(remoteHosts) > 0 {
-		dkv := completionRequest[requestFieldKVTransferParams].(map[string]any)
+		dkv := body[requestFieldKVTransferParams].(map[string]any)
 		hosts := make([]any, len(remoteHosts))
 		for i, h := range remoteHosts {
 			hosts[i] = h
@@ -614,7 +614,7 @@ func (s *Server) runNIXLProtocolV2WriteParallel(
 		}
 	}
 
-	dbody, err := json.Marshal(completionRequest)
+	dbody, err := json.Marshal(body)
 	if err != nil {
 		if err := errorJSONInvalid(err, w); err != nil {
 			s.logger.Error(err, "failed to send error response to client (concurrent-dispatch marshal D)")

--- a/pkg/sidecar/proxy/connector_shared_storage.go
+++ b/pkg/sidecar/proxy/connector_shared_storage.go
@@ -31,7 +31,7 @@ import (
 func (s *Server) handleSharedStorage(w http.ResponseWriter, r *http.Request, prefillPodHostPort string) {
 	s.logger.V(logging.DEBUG).Info("running Shared Storage protocol", "url", prefillPodHostPort)
 
-	original, completionRequest, ok := s.readJSONBody(r, w)
+	original, body, ok := s.readJSONBody(r, w)
 	if !ok {
 		return
 	}
@@ -40,10 +40,10 @@ func (s *Server) handleSharedStorage(w http.ResponseWriter, r *http.Request, pre
 	// If the decode node is below the threshold, it won't process the request and return a "cache_threshold" finish reason. In that case,
 	// we fall back to P/D disaggregation: perform prefill and then decode.
 	// For more information refer to the RFC https://github.com/vllm-project/vllm/issues/24256
-	if cacheHitThreshold, hasCacheHitThreshold := completionRequest[requestFieldCacheHitThreshold]; hasCacheHitThreshold {
+	if cacheHitThreshold, hasCacheHitThreshold := body[requestFieldCacheHitThreshold]; hasCacheHitThreshold {
 		s.logger.V(logging.DEBUG).Info("cache_hit_threshold field found in the request, trying to decode first", requestFieldCacheHitThreshold, cacheHitThreshold)
 		decodeReq := cloneRequestWithBody(r.Context(), r, original)
-		needsPrefill, err := s.tryDecode(w, decodeReq, completionRequest)
+		needsPrefill, err := s.tryDecode(w, decodeReq, body)
 		if err != nil {
 			return
 		}
@@ -55,15 +55,15 @@ func (s *Server) handleSharedStorage(w http.ResponseWriter, r *http.Request, pre
 	}
 
 	// we clone the completion request to avoid modifying the original request
-	prefillRequest := maps.Clone(completionRequest)
+	prefillRequest := maps.Clone(body)
 	if err := s.prefill(w, r, prefillPodHostPort, prefillRequest); err != nil {
 		s.logger.Error(err, "prefill failed")
 		return
 	}
 
 	s.logger.V(logging.DEBUG).Info("forwarding to decoder after prefill")
-	completionRequest[requestFieldCacheHitThreshold] = 0
-	decodeRequestBody, err := json.Marshal(completionRequest)
+	body[requestFieldCacheHitThreshold] = 0
+	decodeRequestBody, err := json.Marshal(body)
 	if err != nil {
 		if err := errorJSONInvalid(err, w); err != nil {
 			s.logger.Error(err, "failed to send Invalid JSON error response to client")
@@ -76,8 +76,8 @@ func (s *Server) handleSharedStorage(w http.ResponseWriter, r *http.Request, pre
 }
 
 // tryDecode attempts to decode and returns whether prefill is needed.
-func (s *Server) tryDecode(w http.ResponseWriter, r *http.Request, completionRequest map[string]any) (bool, error) {
-	if isStreaming, _ := completionRequest[requestFieldStream].(bool); isStreaming {
+func (s *Server) tryDecode(w http.ResponseWriter, r *http.Request, body map[string]any) (bool, error) {
+	if isStreaming, _ := body[requestFieldStream].(bool); isStreaming {
 		if flusher, ok := w.(flushableResponseWriter); ok {
 			bw := newResponseWriterWithBuffer(flusher)
 			return s.tryDecodeStreaming(bw, r)
@@ -215,12 +215,12 @@ func (s *Server) checkBufferedResponseForCacheThreshold(data string) bool {
 }
 
 // prefill routes a request to a prefill node
-func (s *Server) prefill(w http.ResponseWriter, r *http.Request, prefillPodHostPort string, completionRequest map[string]any) error {
+func (s *Server) prefill(w http.ResponseWriter, r *http.Request, prefillPodHostPort string, body map[string]any) error {
 	// Prepare prefill request
-	reqcommon.PrimeSingleTokenRequest(completionRequest)
-	completionRequest[requestFieldCacheHitThreshold] = 0
+	reqcommon.PrimeSingleTokenRequest(body)
+	body[requestFieldCacheHitThreshold] = 0
 
-	pbody, err := json.Marshal(completionRequest)
+	pbody, err := json.Marshal(body)
 	if err != nil {
 		if err := errorJSONInvalid(err, w); err != nil {
 			s.logger.Error(err, "failed to send Invalid JSON error response to client")

--- a/pkg/sidecar/proxy/decode.go
+++ b/pkg/sidecar/proxy/decode.go
@@ -59,11 +59,11 @@ const (
 // dispatchDecode routes a fully-prepared decode request to either chunked
 // decode or the regular decoder proxy. Chunked decode is only used for
 // chat completions requests when s.config.DecodeChunkSize > 0.
-// completionRequest is the already-parsed JSON map; callers that hold it
+// body is the already-parsed JSON map; callers that hold it
 // should use this instead of calling s.decoderProxy directly.
-func (s *Server) dispatchDecode(w http.ResponseWriter, r *http.Request, completionRequest map[string]any) {
+func (s *Server) dispatchDecode(w http.ResponseWriter, r *http.Request, body map[string]any) {
 	if s.config.DecodeChunkSize > 0 && r.URL.Path == ChatCompletionsPath {
-		s.runChunkedDecodeFromMap(w, r, completionRequest)
+		s.runChunkedDecodeFromMap(w, r, body)
 		return
 	}
 	s.decoderProxy.ServeHTTP(w, r)
@@ -72,18 +72,18 @@ func (s *Server) dispatchDecode(w http.ResponseWriter, r *http.Request, completi
 // runChunkedDecode reads and parses the body, then delegates to
 // runChunkedDecodeFromMap.
 func (s *Server) runChunkedDecode(w http.ResponseWriter, r *http.Request) {
-	original, completionRequest, ok := s.readJSONBody(r, w)
+	original, body, ok := s.readJSONBody(r, w)
 	if !ok {
 		return
 	}
 
-	s.runChunkedDecodeFromMap(w, cloneRequestWithBody(r.Context(), r, original), completionRequest)
+	s.runChunkedDecodeFromMap(w, cloneRequestWithBody(r.Context(), r, original), body)
 }
 
-// runChunkedDecodeFromMap executes chunked decode given an already-parsed completionRequest map.
+// runChunkedDecodeFromMap executes chunked decode given an already-parsed body map.
 // Non-streaming: accumulated chunks are reassembled into a single JSON response.
 // Streaming: each chunk is re-emitted as an SSE event; [DONE] closes the stream.
-func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request, completionRequest map[string]any) {
+func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request, body map[string]any) {
 	s.logger.V(logging.DEBUG).Info("running chunked decode", "chunkSize", s.config.DecodeChunkSize)
 
 	ctx, span := tracing.Tracer(tracerScope).Start(r.Context(), "chunked_decode",
@@ -91,8 +91,8 @@ func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request,
 	)
 	defer span.End()
 
-	streamingEnabled, _ := completionRequest[requestFieldStream].(bool)
-	originalMaxTokens := resolveMaxTokens(completionRequest)
+	streamingEnabled, _ := body[requestFieldStream].(bool)
+	originalMaxTokens := resolveMaxTokens(body)
 
 	span.SetAttributes(
 		attribute.Int("llm_d.pd_proxy.chunked_decode.chunk_size", s.config.DecodeChunkSize),
@@ -146,7 +146,7 @@ func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request,
 			chunkBudget = remaining
 		}
 
-		chunkReq := maps.Clone(completionRequest)
+		chunkReq := maps.Clone(body)
 		chunkReq[requestFieldMaxTokens] = chunkBudget
 		chunkReq[requestFieldMaxCompletionTokens] = chunkBudget
 		chunkReq[requestFieldStream] = false
@@ -235,7 +235,7 @@ func (s *Server) runChunkedDecodeFromMap(w http.ResponseWriter, r *http.Request,
 		// Append the generated text to the request so the next chunk continues
 		// from where this one left off.
 		s.logger.V(logging.TRACE).Info("chunked decode: appending chunk text to request", "chunkText", chunkText)
-		appendChunkToRequest(s.logger, completionRequest, chunkText)
+		appendChunkToRequest(s.logger, body, chunkText)
 	}
 
 	span.SetAttributes(


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Renames `completionRequest` to `body` in the 6 files under `pkg/sidecar/proxy`. The variable holds the parsed body from any of the five API paths (chat completions, completions, messages, responses, generate), not only completions, and the old name points readers at the wrong token-limit fields on the responses and generate paths. `body` matches the coordinator convention (`pipeline.RequestContext.Body` and the `body map[string]any` step parameters).

Pure rename, no behavior change. The test mock (`test/sidecar/mock/chat_completions_handler.go`) is left out as discussed in the issue.

Note: this overlaps with the in-flight refactor #2743, mostly in `connector_nixlv2.go`. Happy to rebase once that merges (and pick up any `completionRequest` occurrences it introduces), or the other way around — whichever the maintainers prefer.

**Which issue(s) this PR fixes**:

Fixes #2761

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
