### PR TITLE
fix(cicd): move all lychee configuration to config file

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -53,7 +53,5 @@ jobs:
       - name: Run lychee link checker
         uses: lycheeverse/lychee-action@v2.9.0
         with:
-          # Exclude release-notes.d/ — fragments are sourced verbatim from
-          # PR bodies; let the original PR's link check be authoritative.
-          args: '--config .lychee.toml --verbose --no-progress --exclude-path release-notes.d "**/*.md"'
+          args: '--config .lychee.toml --verbose --no-progress "**/*.md"'
           fail: true

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -9,6 +9,18 @@ exclude = [
   "^https://app\\.fossa\\.com/"
 ]
 
+# release-notes.d/ — fragments are sourced verbatim from PR bodies; let
+# the original PR's link check be authoritative.
+#
+# .github/copilot-instructions.md is a symlink to ../AGENTS.md (as is
+# ./CLAUDE.md). GitHub dereferences the symlink for display so relative
+# links resolve from AGENTS.md at the repo root; lychee reads the raw
+# path and breaks on otherwise-correct links. Skip the duplicate.
+exclude_path = [
+  "release-notes.d",
+  ".github/copilot-instructions.md",
+]
+
 # Per-request timeout in seconds. Sized for slow upstream docs sites
 # (e.g. sigs.k8s.io subdomains under load); 20s was tight enough to fire
 # spurious timeouts on otherwise-reachable links.


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

The lychee markdown link checker was effectively dormant for most of its lifetime. Two stacked config bugs kept it from doing real work. They were fixed in #1914 and more recently in #2754.

Once #2754 made the scan recursive, three long-broken links surfaced and the workflow started failing on PRs that didn't touch those files at all (e.g. #2701). These were fixed in #2764.

This PR adds  excludes path to the lychee config (adding new and moving from workflow args to config).

**Which issue(s) this PR fixes**:
NA (no issue filed; discovered in passing while reviewing CI failure on #2701)

**Release note**:
```release-note
NONE
```
