### PR TITLE
feat(chart): Gate Prometheus RBAC on authentication

### DIFF
--- a/config/charts/routerlib/templates/_rbac.yaml
+++ b/config/charts/routerlib/templates/_rbac.yaml
@@ -1,5 +1,5 @@
 {{- define "llm-d-router.rbac" -}}
-{{- if .Values.router.monitoring.prometheus.enabled }}
+{{- if and .Values.router.monitoring.prometheus.enabled .Values.router.monitoring.prometheus.auth.enabled }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/verify-helm.sh
+++ b/hack/verify-helm.sh
@@ -120,6 +120,24 @@ if grep -q -- '^kind: PodMonitoring$' "${gke_monitoring_render_output}"; then
   echo "GKE Gateway monitoring unexpectedly rendered PodMonitoring when the monitoring provider was unset"
   exit 1
 fi
+if grep -Eq -- '^kind: ClusterRole(Binding)?$' "${gke_monitoring_render_output}"; then
+  echo "GKE Gateway monitoring unexpectedly rendered cluster RBAC when Prometheus authentication was disabled"
+  exit 1
+fi
+
+echo "Verifying Prometheus authentication renders cluster RBAC..."
+prometheus_auth_render_output="${TEMP_DIR}/llm-d-router-gateway-prometheus-auth-render.yaml"
+prometheus_auth_render_command="${HELM} template prometheus-auth ${SCRIPT_ROOT}/config/charts/llm-d-router-gateway --set router.modelServers.matchLabels.app=llm-instance-gateway --set router.monitoring.prometheus.enabled=true --set router.monitoring.prometheus.auth.enabled=true > ${prometheus_auth_render_output}"
+echo "Executing: ${prometheus_auth_render_command}"
+eval "${prometheus_auth_render_command}"
+if ! grep -q -- '^kind: ClusterRole$' "${prometheus_auth_render_output}"; then
+  echo "Prometheus authentication did not render a ClusterRole"
+  exit 1
+fi
+if ! grep -q -- '^kind: ClusterRoleBinding$' "${prometheus_auth_render_output}"; then
+  echo "Prometheus authentication did not render a ClusterRoleBinding"
+  exit 1
+fi
 
 echo "Verifying explicit GMP monitoring renders PodMonitoring..."
 gmp_monitoring_render_output="${TEMP_DIR}/llm-d-router-gateway-gmp-monitoring-render.yaml"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Updates the Helm charts to create the Prometheus `ClusterRole` and `ClusterRoleBinding` only when both Prometheus monitoring and metrics endpoint authentication are enabled.

This avoids requiring cluster-scoped RBAC when Prometheus authentication is disabled. Helm verification covers both authentication settings.

**Which issue(s) this PR fixes**:

Fixes #<issue-number>

**Release note**:
```release-note
Avoid creating Prometheus ClusterRole and ClusterRoleBinding resources when metrics endpoint authentication is disabled.