### PR TITLE
Publish the builder image from a content hash tag

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -13,6 +13,10 @@ inputs:
     required: false
     default: 'HIGH,CRITICAL'
     description: "Comma-separated severities that fail the scan (e.g. 'CRITICAL' or 'MEDIUM,HIGH,CRITICAL')."
+  exit-code:
+    required: false
+    default: '1'
+    description: "Exit code on a severity match: '1' fails the build, '0' reports only. SARIF uploads either way."
 
 runs:
   using: "composite"
@@ -25,7 +29,7 @@ runs:
         format: 'sarif'
         output: 'trivy-results.sarif'
         severity: ${{ inputs.severity }}
-        exit-code: '1'
+        exit-code: ${{ inputs.exit-code }}
         # trivy-action drops the severity filter for SARIF output unless told
         # otherwise, which fails the scan on findings outside `severity` (e.g.
         # UNKNOWN-severity Go vulndb notes).

--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -187,6 +187,85 @@ jobs:
           subject-digest: ${{ steps.push-coordinator.outputs.digest }}
           push-to-registry: true
 
+  # Gated on registry existence rather than a path filter, so a push that fails
+  # or is skipped is retried on the next call instead of never firing again.
+  # Not needed for push-helm-charts because the builder is unrelated to chart publishing.
+  build-builder:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+
+      - name: Compute builder tag
+        id: builder-tag
+        run: echo "tag=$(make print-builder-tag)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Check whether the builder image is already published
+        id: check
+        run: |
+          if docker manifest inspect ghcr.io/llm-d/llm-d-builder:${{ steps.builder-tag.outputs.tag }} > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build builder AMD64 image (no push)
+        if: steps.check.outputs.exists == 'false'
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          docker-file: Dockerfile.builder
+          tag: ${{ steps.builder-tag.outputs.tag }}
+          image-name: llm-d-builder
+          registry: ghcr.io/llm-d
+          push: 'false'
+          buildx-outputs: type=docker,dest=/tmp/builder-image.tar
+
+      # Findings in the Go toolchain, podman and the docker CLI never block this
+      # build. SARIF still uploads to the Security tab.
+      - name: Run Trivy scan for builder on AMD64
+        if: steps.check.outputs.exists == 'false'
+        uses: ./.github/actions/trivy-scan
+        with:
+          tarball: /tmp/builder-image.tar
+          exit-code: '0'
+
+      # prerelease: 'true' suppresses the composite action's floating :latest
+      # tag. The builder is addressed only by its content hash tag.
+      - name: Push builder image for both AMD64 and ARM64
+        if: steps.check.outputs.exists == 'false'
+        id: push-builder
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          docker-file: Dockerfile.builder
+          tag: ${{ steps.builder-tag.outputs.tag }}
+          image-name: llm-d-builder
+          registry: ghcr.io/llm-d
+          github-token: ${{ github.token }}
+          prerelease: 'true'
+          push: 'true'
+
+      - name: Attest builder image provenance
+        if: steps.check.outputs.exists == 'false'
+        uses: actions/attest@v4
+        with:
+          subject-name: ghcr.io/llm-d/llm-d-builder
+          subject-digest: ${{ steps.push-builder.outputs.digest }}
+          push-to-registry: true
+
   push-helm-charts:
     needs: [build-epp, build-sidecar, build-coordinator]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-coordinator.yaml
+++ b/.github/workflows/ci-coordinator.yaml
@@ -124,13 +124,21 @@ jobs:
         if: ${{ matrix.image.source == 'build' }}
         uses: actions/checkout@v7
 
+      # $(BUILDER_IMAGE) in the Makefile resolves to the content hash tag. The
+      # e2e artifact has to match or test-e2e-coordinator-run pulls a tag with
+      # nothing built.
+      - name: Compute builder tag
+        if: ${{ matrix.image.name == 'builder' }}
+        id: builder-tag
+        run: echo "tag=$(make -f Makefile.coord.mk print-builder-tag)" >> "$GITHUB_OUTPUT"
+
       - name: Build ${{ matrix.image.name }} image
         if: ${{ matrix.image.source == 'build' }}
         uses: ./.github/actions/docker-build-and-push
         with:
           docker-file: ${{ matrix.image.docker-file }}
           image-name: ${{ matrix.image.image-name }}
-          tag: dev
+          tag: ${{ matrix.image.name == 'builder' && steps.builder-tag.outputs.tag || 'dev' }}
           registry: ghcr.io/llm-d
           push: 'false'
           buildx-outputs: type=docker,dest=${{ runner.temp }}/${{ matrix.image.archive }}.tar

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -250,13 +250,20 @@ jobs:
         if: ${{ matrix.image.source == 'build' }}
         uses: actions/checkout@v7
 
+      # $(BUILDER_IMAGE) in the Makefile resolves to the content hash tag. The
+      # e2e artifact has to match or test-e2e-run pulls a tag with nothing built.
+      - name: Compute builder tag
+        if: ${{ matrix.image.name == 'builder' }}
+        id: builder-tag
+        run: echo "tag=$(make print-builder-tag)" >> "$GITHUB_OUTPUT"
+
       - name: Build ${{ matrix.image.name }} image
         if: ${{ matrix.image.source == 'build' }}
         uses: ./.github/actions/docker-build-and-push
         with:
           docker-file: ${{ matrix.image.docker-file }}
           image-name: ${{ matrix.image.image-name }}
-          tag: dev
+          tag: ${{ matrix.image.name == 'builder' && steps.builder-tag.outputs.tag || 'dev' }}
           registry: ghcr.io/llm-d
           push: 'false'
           buildx-outputs: type=docker,dest=${{ runner.temp }}/${{ matrix.image.archive }}.tar

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,15 @@ export VLLM_RENDER_IMAGE ?= vllm/vllm-openai-cpu:v0.21.0
 export VLLM_RENDER_PORT ?= 8082
 export VLLM_RENDER_URL ?= http://vllm-render:$(VLLM_RENDER_PORT)
 
-BUILDER_TAG ?= dev
+# A locally edited Dockerfile.builder hashes to a tag that
+# was never published, so image-build-builder misses the pull and falls back
+# to a local build instead of running against a stale published image.
+BUILDER_TAG ?= $(shell git hash-object Dockerfile.builder)
 BUILDER_TAG_BASE ?= $(IMAGE_REGISTRY)/$(BUILDER_IMAGE_NAME)
 export BUILDER_IMAGE ?= $(BUILDER_TAG_BASE):$(BUILDER_TAG)
+# Escape hatch for testing local Dockerfile.builder changes without a matching
+# published tag:. Set BUILDER_PULL=false to force a local build.
+BUILDER_PULL ?= true
 
 NAMESPACE ?= hc4ai-operator
 LINT_NEW_ONLY ?= false # Set to true to only lint new code, false to lint all code (default matches CI behavior)
@@ -246,7 +252,7 @@ tidy:
 
 .PHONY: clean
 clean: ## Clean build artifacts, tools and caches
-	rm -rf bin build $(BUILDER_STAMP)
+	rm -rf bin build
 	-$(BUILDER_RUN) 'go clean -testcache -cache'
 
 .PHONY: format
@@ -457,19 +463,17 @@ image-build-%: check-container-tool ## Build Container image using $(CONTAINER_R
 		$(if $(BASE_IMAGE),--build-arg BASE_IMAGE="$(BASE_IMAGE)") \
 		-t $($*_IMAGE) -f Dockerfile.$* .
 
-BUILDER_STAMP = build/.builder.stamp
-
 .PHONY: image-build-builder
-image-build-builder: check-container-tool ## Build builder image if missing locally, stamp missing, or Dockerfile.builder newer than stamp
+image-build-builder: check-container-tool ## Use local builder image, else pull the published tag, else build locally
 	@mkdir -p $(GO_MOD_CACHE_VOL) $(GO_BUILD_CACHE_VOL)
-	@if ! $(CONTAINER_RUNTIME) image inspect $(BUILDER_IMAGE) >/dev/null 2>&1 || \
-	    [ ! -f $(BUILDER_STAMP) ] || \
-	    [ Dockerfile.builder -nt $(BUILDER_STAMP) ]; then \
-		printf "\033[33;1m==== Building image $(BUILDER_IMAGE) ====\033[0m\n"; \
-		$(CONTAINER_RUNTIME) build -f Dockerfile.builder -t $(BUILDER_IMAGE) .; \
-		mkdir -p $(dir $(BUILDER_STAMP)); \
-		touch $(BUILDER_STAMP); \
-	fi
+	@if $(CONTAINER_RUNTIME) image inspect $(BUILDER_IMAGE) >/dev/null 2>&1; then \
+		exit 0; \
+	fi; \
+	if [ "$(BUILDER_PULL)" = "true" ] && $(CONTAINER_RUNTIME) pull --platform linux/$(TARGETARCH) $(BUILDER_IMAGE) >/dev/null 2>&1; then \
+		exit 0; \
+	fi; \
+	printf "\033[33;1m==== Building image $(BUILDER_IMAGE) ====\033[0m\n"; \
+	$(CONTAINER_RUNTIME) build -f Dockerfile.builder -t $(BUILDER_IMAGE) .
 
 .PHONY: image-push
 image-push: image-push-epp image-push-sidecar ## Push container images to registry using $(CONTAINER_RUNTIME)
@@ -522,6 +526,10 @@ print-namespace: ## Print the current namespace
 .PHONY: print-project-name
 print-project-name: ## Print the current project name
 	@echo "$(PROJECT_NAME)"
+
+.PHONY: print-builder-tag
+print-builder-tag: ## Print the builder image tag (content hash of Dockerfile.builder)
+	@echo "$(BUILDER_TAG)"
 
 ##@ Deprecated aliases for backwards compatibility
 .PHONY: install-docker

--- a/Makefile.coord.mk
+++ b/Makefile.coord.mk
@@ -30,9 +30,15 @@ epp_IMAGE         = $(EPP_IMAGE)
 export IMAGE_REGISTRY COORDINATOR_TAG VLLM_SIMULATOR_TAG EPP_TAG
 export COORDINATOR_IMAGE VLLM_IMAGE EPP_IMAGE VLLM_RENDER_IMAGE VLLM_RENDER_PORT
 
-BUILDER_TAG ?= dev
+# A locally edited Dockerfile.builder hashes to a tag that
+# was never published, so image-build-builder misses the pull and falls back
+# to a local build instead of running against a stale published image.
+BUILDER_TAG ?= $(shell git hash-object Dockerfile.builder)
 BUILDER_TAG_BASE ?= $(IMAGE_REGISTRY)/$(BUILDER_IMAGE_NAME)
 export BUILDER_IMAGE ?= $(BUILDER_TAG_BASE):$(BUILDER_TAG)
+# Escape hatch for testing local Dockerfile.builder changes without a matching
+# published tag:. Set BUILDER_PULL=false to force a local build.
+BUILDER_PULL ?= true
 
 CONTAINER_RUNTIME := $(shell { command -v docker >/dev/null 2>&1 && echo docker; } || { command -v podman >/dev/null 2>&1 && echo podman; } || echo "")
 export CONTAINER_RUNTIME
@@ -126,8 +132,6 @@ endif
 # and the container socket (for kind), but not the host kubeconfig.
 BUILDER_E2E_FLAGS = --network=host $(BUILDER_SOCK_FLAGS) $(BUILDER_E2E_ENV_FLAGS) $(BUILDER_E2E_KUBECONFIG_FLAGS)
 
-BUILDER_STAMP = build/.builder.stamp
-
 .PHONY: help
 help: ## Print help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -173,7 +177,7 @@ tidy: image-build-builder ## Tidy go modules
 
 .PHONY: clean
 clean: ## Clean build artifacts, tools and caches
-	rm -rf bin build $(BUILDER_STAMP)
+	rm -rf bin build
 	-$(BUILDER_RUN) 'go clean -testcache -cache'
 
 .PHONY: format
@@ -251,18 +255,22 @@ image-build-%: check-container-tool ## Build container image using $(CONTAINER_R
 		-t $($*_IMAGE) -f Dockerfile.$* .
 
 .PHONY: image-build-builder
-image-build-builder: check-container-tool ## Build builder image if missing locally, stamp missing, or Dockerfile.builder newer than stamp
-	@if ! $(CONTAINER_RUNTIME) image inspect $(BUILDER_IMAGE) >/dev/null 2>&1 || \
-	    [ ! -f $(BUILDER_STAMP) ] || \
-	    [ Dockerfile.builder -nt $(BUILDER_STAMP) ]; then \
-		printf "\033[33;1m==== Building image $(BUILDER_IMAGE) ====\033[0m\n"; \
-		$(CONTAINER_RUNTIME) build -f Dockerfile.builder -t $(BUILDER_IMAGE) .; \
-		mkdir -p $(dir $(BUILDER_STAMP)); \
-		touch $(BUILDER_STAMP); \
-	fi
+image-build-builder: check-container-tool ## Use local builder image, else pull the published tag, else build locally
+	@if $(CONTAINER_RUNTIME) image inspect $(BUILDER_IMAGE) >/dev/null 2>&1; then \
+		exit 0; \
+	fi; \
+	if [ "$(BUILDER_PULL)" = "true" ] && $(CONTAINER_RUNTIME) pull --platform linux/$(TARGETARCH) $(BUILDER_IMAGE) >/dev/null 2>&1; then \
+		exit 0; \
+	fi; \
+	printf "\033[33;1m==== Building image $(BUILDER_IMAGE) ====\033[0m\n"; \
+	$(CONTAINER_RUNTIME) build -f Dockerfile.builder -t $(BUILDER_IMAGE) .
 
 .PHONY: image-pull
 image-pull: check-container-tool ## Pull all related images using $(CONTAINER_RUNTIME)
 	@printf "\033[33;1m==== Pulling Container images ====\033[0m\n"
 	PULL_EPP_IMAGE=false PULL_SIDECAR_IMAGE=false ./scripts/pull_images.sh
+
+.PHONY: print-builder-tag
+print-builder-tag: ## Print the builder image tag (content hash of Dockerfile.builder)
+	@echo "$(BUILDER_TAG)"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The builder image is not rebuilt and published when `Dockerfile.builder` changes, so `ci-lint`, `ci-pr-checks` and `ci-coordinator` all build it from scratch on every run. That's three uncached builds per PR and most of them
reproduce a byte-identical toolchain . `Dockerfile.builder` has only changed 15 times in six months, mostly Go version bumps.

This adds a `build-builder` job to `ci-build-images.yaml` that tags the image by content hash (`git hash-object Dockerfile.builder`) and only builds and pushes when that tag isn't already in the registry. The Makefiles now try to
pull the published tag before falling back to a local build and the e2e matrices in `ci-pr-checks.yaml` / `ci-coordinator.yaml` build the builder leg under that same tag so it doesn't drift from what `$(BUILDER_IMAGE)` resolves to.

Using content hash instead of commit SHA means there's no `.builder-image-tag` file to keep in sync. A locally edited `Dockerfile.builder` just hashes to an unpublished tag and falls back to a local build on its own.

Trivy still scans the builder image but doesn't gate the push on findings. A Go toolchain plus podman plus the docker CLI would fail that gate constantly for CVEs that never run in production.

The publish only runs on pushes to `main` / `release-*` and on tags, so it never touches PR runs. After the first publish, `ghcr.io/llm-d/llm-d-builder` needs to be made public (maintainer settings access) or contributor pulls will fail.

AI assistance was used for implementation and verification.

/cc @elevran 

**Which issue(s) this PR fixes**:
Part of #956 (Phase 2)

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```