### PR TITLE
test(epp): wait for metrics delivery in endpoint scores test

### DIFF
--- a/test/integration/epp/endpoint_scores_test.go
+++ b/test/integration/epp/endpoint_scores_test.go
@@ -34,8 +34,10 @@ import (
 func TestEndpointScoresMetadata(t *testing.T) {
 	h := NewTestHarness(t.Context(), t, WithStandardMode(), WithEmitEndpointScores()).WithBaseResources()
 
-	pods := []PodState{P(0, 0, 0.1, modelMyModelTarget), P(1, 5, 0.5, modelMyModelTarget)}
-	h.WithPods(pods).WaitForSync(len(pods), modelMyModel)
+	// Both pods stay strictly below the utilization-detector limits (queue < 5, KV < 0.8)
+	// so the default filter drops neither and the scheduler scores both.
+	pods := []PodState{P(0, 0, 0.1, modelMyModelTarget), P(1, 4, 0.5, modelMyModelTarget)}
+	h.WithPods(pods).WaitForSync(len(pods), modelMyModel).WaitForMetricsDelivery()
 
 	envoyLb := requestHeaderEnvoyLbMetadata(t, h)
 
@@ -63,8 +65,8 @@ func TestEndpointScoresMetadata(t *testing.T) {
 func TestEndpointScoresMetadataOffByDefault(t *testing.T) {
 	h := NewTestHarness(t.Context(), t, WithStandardMode()).WithBaseResources()
 
-	pods := []PodState{P(0, 0, 0.1, modelMyModelTarget), P(1, 5, 0.5, modelMyModelTarget)}
-	h.WithPods(pods).WaitForSync(len(pods), modelMyModel)
+	pods := []PodState{P(0, 0, 0.1, modelMyModelTarget), P(1, 4, 0.5, modelMyModelTarget)}
+	h.WithPods(pods).WaitForSync(len(pods), modelMyModel).WaitForMetricsDelivery()
 
 	envoyLb := requestHeaderEnvoyLbMetadata(t, h)
 

--- a/test/integration/epp/harness.go
+++ b/test/integration/epp/harness.go
@@ -53,6 +53,7 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	dlmocks "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/mocks"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/flowcontrol/saturationdetector/utilization"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
 	eppServer "github.com/llm-d/llm-d-router/pkg/epp/server"
 	testutil "github.com/llm-d/llm-d-router/pkg/epp/util/testing"
@@ -437,6 +438,30 @@ func (h *TestHarness) WaitForSync(expectedPods int, checkModelObjective string) 
 		lastPodsFound,
 		expectedPods,
 	)
+	return h
+}
+
+// WaitForMetricsDelivery blocks until every tracked endpoint has received a metrics update.
+// Endpoints start with a zero UpdateTime, which the default utilization-detector filter
+// drops as stale; tests asserting on the full candidate set need it.
+func (h *TestHarness) WaitForMetricsDelivery() *TestHarness {
+	h.t.Helper()
+
+	require.Eventually(h.t, func() bool {
+		pods := h.Datastore.PodList(datastore.AllPodsPredicate)
+		if len(pods) == 0 {
+			return false
+		}
+		for _, pod := range pods {
+			// Half the staleness threshold: fresh enough that the filter still accepts
+			// the endpoint once the wait returns, loose enough to tolerate a slow polling tick.
+			if m := pod.GetMetrics(); m == nil || time.Since(m.UpdateTime) > utilization.DefaultMetricsStalenessThreshold/2 {
+				return false
+			}
+		}
+		return true
+	}, 10*time.Second, 50*time.Millisecond,
+		"Timed out waiting for endpoint metrics delivery")
 	return h
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind test


**What this PR does / why we need it**:

Addresses the flake in https://github.com/llm-d/llm-d-router/actions/runs/34443412537/job/102764109991?pr=2795

**Which issue(s) this PR fixes**:
Fixes #

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
