### PR TITLE
Attach per platform SBOMs to release assets

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -100,3 +100,32 @@ jobs:
             gh release create "${{ needs.set-params.outputs.tag }}" $files --draft --title "${{ needs.set-params.outputs.tag }}" --notes "Release ${{ needs.set-params.outputs.tag }}"
           fi
 
+  upload-sbom:
+    needs: [set-params, build-and-push, upload-artifacts]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Collect SBOMs
+        run: |
+          scripts/collect-sboms.sh "${{ needs.set-params.outputs.tag }}" \
+            "${{ needs.set-params.outputs.epp_name }}" \
+            "${{ needs.set-params.outputs.sidecar_name }}" \
+            "${{ needs.set-params.outputs.coordinator_name }}"
+
+      - name: Upload SBOMs to the release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ needs.set-params.outputs.tag }}" sbom/* --clobber

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -88,17 +88,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
+          # upload-sbom uploads to this release, so it has to exist even when
+          # there is nothing to attach here.
+          if ! gh release view "${{ needs.set-params.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Release ${{ needs.set-params.outputs.tag }} does not exist. Creating a draft release..."
+            gh release create "${{ needs.set-params.outputs.tag }}" --draft --title "${{ needs.set-params.outputs.tag }}" --notes "Release ${{ needs.set-params.outputs.tag }}"
+          fi
           files=$(find artifacts -type f -size +0c | tr '\n' ' ')
           if [ -z "$files" ]; then
             echo "No artifacts to upload."
             exit 0
           fi
-          if gh release view "${{ needs.set-params.outputs.tag }}" >/dev/null 2>&1; then
-            gh release upload "${{ needs.set-params.outputs.tag }}" $files --clobber
-          else
-            echo "Release ${{ needs.set-params.outputs.tag }} does not exist. Creating a draft release..."
-            gh release create "${{ needs.set-params.outputs.tag }}" $files --draft --title "${{ needs.set-params.outputs.tag }}" --notes "Release ${{ needs.set-params.outputs.tag }}"
-          fi
+          gh release upload "${{ needs.set-params.outputs.tag }}" $files --clobber
 
   upload-sbom:
     needs: [set-params, build-and-push, upload-artifacts]

--- a/scripts/collect-sboms.sh
+++ b/scripts/collect-sboms.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# collect-sboms.sh <tag> <image>...
+#
+# Extracts the SPDX documents buildx attached to each pushed image index and
+# writes them as release ready files. There is one per image per platform and a
+# sbom-digests.txt recording the image digest each file describes.
+#
+# Usage:
+#   REGISTRY=ghcr.io/llm-d OUTDIR=sbom ./scripts/collect-sboms.sh v0.11.0 \
+#     llm-d-router-endpoint-picker llm-d-router-disagg-sidecar llm-d-router-coordinator
+set -euo pipefail
+
+registry="${REGISTRY:-ghcr.io/llm-d}"
+outdir="${OUTDIR:-sbom}"
+platforms=(linux/amd64 linux/arm64)
+
+tag="${1:?tag required}"
+shift
+
+mkdir -p "$outdir"
+: > "$outdir/sbom-digests.txt"
+
+for image in "$@"; do
+  ref="$registry/$image:$tag"
+  digests=$(docker buildx imagetools inspect "$ref" --format \
+    '{{ range .Manifest.Manifests }}{{ if .Platform }}{{ .Platform.OS }}/{{ .Platform.Architecture }} {{ .Digest }}{{ println }}{{ end }}{{ end }}')
+
+  for platform in "${platforms[@]}"; do
+    file="$image-$tag-${platform//\//-}.spdx.json"
+    # Validate before moving into place so a failed run leaves no partial file.
+    docker buildx imagetools inspect "$ref" \
+      --format "{{ json (index .SBOM \"$platform\").SPDX }}" > "$outdir/.$file"
+    jq -e '.spdxVersion' "$outdir/.$file" > /dev/null
+    mv "$outdir/.$file" "$outdir/$file"
+
+    digest=$(awk -v p="$platform" '$1 == p { print $2 }' <<< "$digests")
+    printf '%s  %s@%s\n' "$file" "$ref" "$digest" >> "$outdir/sbom-digests.txt"
+  done
+done

--- a/scripts/collect-sboms.sh
+++ b/scripts/collect-sboms.sh
@@ -12,7 +12,6 @@ set -euo pipefail
 
 registry="${REGISTRY:-ghcr.io/llm-d}"
 outdir="${OUTDIR:-sbom}"
-platforms=(linux/amd64 linux/arm64)
 
 tag="${1:?tag required}"
 shift
@@ -22,18 +21,25 @@ mkdir -p "$outdir"
 
 for image in "$@"; do
   ref="$registry/$image:$tag"
+  # The index listing drives the loop so the platforms collected are the ones
+  # the image was built for.
   digests=$(docker buildx imagetools inspect "$ref" --format \
     '{{ range .Manifest.Manifests }}{{ if .Platform }}{{ .Platform.OS }}/{{ .Platform.Architecture }} {{ .Digest }}{{ println }}{{ end }}{{ end }}')
+  [ -n "$digests" ] || { echo "$ref has no platform manifests" >&2; exit 1; }
 
-  for platform in "${platforms[@]}"; do
+  while read -r platform digest; do
+    # buildx lists its attestation manifests as unknown/unknown.
+    if [ "$platform" = "unknown/unknown" ]; then
+      continue
+    fi
+
     file="$image-$tag-${platform//\//-}.spdx.json"
-    # Validate before moving into place so a failed run leaves no partial file.
+    # Validate before moving so a failed extraction never lands at the final path.
     docker buildx imagetools inspect "$ref" \
       --format "{{ json (index .SBOM \"$platform\").SPDX }}" > "$outdir/.$file"
     jq -e '.spdxVersion' "$outdir/.$file" > /dev/null
     mv "$outdir/.$file" "$outdir/$file"
 
-    digest=$(awk -v p="$platform" '$1 == p { print $2 }' <<< "$digests")
     printf '%s  %s@%s\n' "$file" "$ref" "$digest" >> "$outdir/sbom-digests.txt"
-  done
+  done <<< "$digests"
 done


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Buildx already attaches an SPDX SBOM to each pushed image (#2729) but the release for that tag doesn't get a copy. Consumers that want one has to pull the image from GHCR first.

This adds `scripts/collect-sboms.sh` which pulls the already attested SPDX document out of the registry per image per platform with `docker buildx imagetools inspect`, rather than generating a new one at release time. Regenerating risks a release asset that disagrees with what the image actually attests. A new `upload-sbom` job in `ci-release.yaml` runs after the image push and the artifact upload, then uploads the six per-platform SPDX files plus a `sbom-digests.txt` digest manifest to the release with `gh release upload --clobber`.

(Optional) Signed SBOM attestations are a follow up, not part of this PR. The subject has to be the per platform manifest digest rather than the index digest, so signing means six `actions/attest` calls. 

AI assistance was used for implementation and verification.

/cc @elevran 

**Which issue(s) this PR fixes**:
Part of #956 (Phase 3)

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
GitHub Releases now include per platform SPDX SBOM files for each image and a digest manifest.
```