### PR TITLE
fix(kvcache): score unconfigured tiers zero and add storage tier weights

### DIFF
--- a/pkg/kvcache/backend.go
+++ b/pkg/kvcache/backend.go
@@ -23,9 +23,13 @@ type KVCacheBackendConfig struct {
 	Weight float64 `json:"weight"`
 }
 
+// DefaultKVCacheBackendConfig returns the default backend weights, tunable
+// via IndexerConfig.BackendConfigs.
 func DefaultKVCacheBackendConfig() []*KVCacheBackendConfig {
 	return []*KVCacheBackendConfig{
 		{Name: "gpu", Weight: 1.0},
 		{Name: "cpu", Weight: 0.8},
+		{Name: "shared_storage", Weight: 0.4},
+		{Name: "object_store", Weight: 0.2},
 	}
 }

--- a/pkg/kvcache/kvblock_scorer.go
+++ b/pkg/kvcache/kvblock_scorer.go
@@ -19,6 +19,7 @@ package kvcache
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
 )
@@ -76,7 +77,7 @@ func NewKVBlockScorer(config *KVBlockScorerConfig) (KVBlockScorer, error) {
 func tierWeightsFromBackends(backends []*KVCacheBackendConfig) map[string]float64 {
 	weights := make(map[string]float64, len(backends))
 	for _, medium := range backends {
-		weights[medium.Name] = medium.Weight
+		weights[strings.ToLower(medium.Name)] = medium.Weight
 	}
 	return weights
 }

--- a/pkg/kvcache/prefix_match.go
+++ b/pkg/kvcache/prefix_match.go
@@ -37,8 +37,12 @@ import (
 // same chain.
 const SpeculativeTier = "speculative"
 
-// defaultTierWeight scores blocks held in a tier without a configured weight.
-const defaultTierWeight = 1.0
+// speculativeTierWeight scores speculative entries when the speculative tier
+// has no configured weight.
+const speculativeTierWeight = 1.0
+
+// unknownTierWeight scores blocks held in a tier without a configured weight.
+const unknownTierWeight = 0.0
 
 // matchCancellationMask paces context-cancellation checks over key
 // positions: positions where pos&mask == 0 poll ctx.Err().
@@ -48,8 +52,9 @@ const matchCancellationMask = 255
 // the contiguous chain of keys the pod holds, counted from the first key.
 type PodMatch struct {
 	// WeightedScore sums, per block of the chain, the highest device-tier
-	// weight among the pod's entries for that block; tiers without a
-	// configured weight count defaultTierWeight.
+	// weight among the pod's entries for that block. Tiers without a
+	// configured weight count unknownTierWeight; speculative entries count
+	// speculativeTierWeight unless the speculative tier is configured.
 	WeightedScore float64
 	// MatchedBlocks is the chain length in blocks, regardless of tier.
 	MatchedBlocks int
@@ -352,7 +357,12 @@ func (a *prefixAccumulator) key(entries []kvblock.EntryRef) bool {
 		}
 		slot := &a.slots[s]
 
-		w := a.weightOf(ref.DeviceTier, ref.TierOrdinal)
+		tier, tierOrdinal := ref.DeviceTier, ref.TierOrdinal
+		if ref.Speculative || ref.DeviceTier == SpeculativeTier {
+			tier, tierOrdinal = SpeculativeTier, speculativeTierOrdinal
+		}
+
+		w := a.weightOf(tier, tierOrdinal)
 		switch {
 		case slot.seen != a.keyStamp:
 			slot.seen = a.keyStamp
@@ -361,10 +371,6 @@ func (a *prefixAccumulator) key(entries []kvblock.EntryRef) bool {
 			slot.weight = w
 		}
 
-		tier, tierOrdinal := ref.DeviceTier, ref.TierOrdinal
-		if ref.Speculative || ref.DeviceTier == SpeculativeTier {
-			tier, tierOrdinal = SpeculativeTier, speculativeTierOrdinal
-		}
 		if !a.stampTier(slot, tierOrdinal) && a.first {
 			slot.tiers = append(slot.tiers, tierChain{ordinal: tierOrdinal, name: tier, seen: a.keyStamp, alive: true})
 		}
@@ -460,7 +466,10 @@ func (a *prefixAccumulator) weightOf(tier string, ordinal uint32) float64 {
 			return a.weightCache[i].weight
 		}
 	}
-	w := defaultTierWeight
+	w := unknownTierWeight
+	if tier == SpeculativeTier {
+		w = speculativeTierWeight
+	}
 	if configured, ok := a.weights[tier]; ok {
 		w = configured
 	}

--- a/pkg/kvcache/prefix_match_test.go
+++ b/pkg/kvcache/prefix_match_test.go
@@ -139,13 +139,13 @@ func TestMatchBlockKeys(t *testing.T) {
 			},
 		},
 		{
-			name: "unconfigured tier weighs the default",
+			name: "unconfigured tier weighs zero",
 			entries: map[kvblock.BlockHash][]kvblock.PodEntry{
 				10: {{PodIdentifier: podA, DeviceTier: "disk"}},
 			},
 			requestKeys: []kvblock.BlockHash{10},
 			want: map[string]kvcache.PodMatch{
-				podA: {WeightedScore: 1.0, MatchedBlocks: 1, BlocksByTier: map[string]int{"disk": 1}},
+				podA: {WeightedScore: 0.0, MatchedBlocks: 1, BlocksByTier: map[string]int{"disk": 1}},
 			},
 		},
 		{
@@ -275,6 +275,58 @@ func TestMatchBlockKeysDeviceTierNamedSpeculative(t *testing.T) {
 	assertPodMatches(t, map[string]kvcache.PodMatch{
 		"pod-a": {WeightedScore: 3.0, MatchedBlocks: 3, BlocksByTier: map[string]int{kvcache.SpeculativeTier: 3}},
 	}, got)
+}
+
+func TestMatchBlockKeysConfiguredTierWeights(t *testing.T) {
+	tests := []struct {
+		name     string
+		backends []*kvcache.KVCacheBackendConfig
+		entry    kvblock.PodEntry
+		want     float64
+	}{
+		{
+			name:     "default backends score shared_storage at 0.4",
+			backends: kvcache.DefaultKVCacheBackendConfig(),
+			entry:    kvblock.PodEntry{PodIdentifier: "pod-a", DeviceTier: "shared_storage"},
+			want:     0.4,
+		},
+		{
+			name:     "default backends score object_store at 0.2",
+			backends: kvcache.DefaultKVCacheBackendConfig(),
+			entry:    kvblock.PodEntry{PodIdentifier: "pod-a", DeviceTier: "object_store"},
+			want:     0.2,
+		},
+		{
+			name:     "backend names match entry tiers case-insensitively",
+			backends: []*kvcache.KVCacheBackendConfig{{Name: "SHARED_STORAGE", Weight: 0.9}},
+			entry:    kvblock.PodEntry{PodIdentifier: "pod-a", DeviceTier: "shared_storage"},
+			want:     0.9,
+		},
+		{
+			name:     "configured speculative weight overrides the speculative default",
+			backends: []*kvcache.KVCacheBackendConfig{{Name: kvcache.SpeculativeTier, Weight: 0.5}},
+			entry:    kvblock.PodEntry{PodIdentifier: "pod-a", Speculative: true},
+			want:     0.5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := logging.NewTestLoggerIntoContext(t.Context())
+			indexer, idx := newMatcher(t, tt.backends)
+			populateIndex(t, idx, map[kvblock.BlockHash][]kvblock.PodEntry{10: {tt.entry}})
+
+			got, err := indexer.MatchBlockKeys(ctx, []kvblock.BlockHash{10}, nil)
+			require.NoError(t, err)
+			tier := tt.entry.DeviceTier
+			if tt.entry.Speculative {
+				tier = kvcache.SpeculativeTier
+			}
+			assertPodMatches(t, map[string]kvcache.PodMatch{
+				"pod-a": {WeightedScore: tt.want, MatchedBlocks: 1, BlocksByTier: map[string]int{tier: 1}},
+			}, got)
+		})
+	}
 }
 
 // lateCancelContext reports cancellation from its second poll after arm is
@@ -453,8 +505,11 @@ func legacyLongestPrefixScore(keys []kvblock.BlockHash, keyToPods map[kvblock.Bl
 	maxWeights := func(entries []kvblock.PodEntry) map[string]float64 {
 		out := map[string]float64{}
 		for _, e := range entries {
-			w := 1.0
-			if cw, ok := weights[e.DeviceTier]; ok {
+			tier, w := e.DeviceTier, 0.0
+			if e.Speculative || e.DeviceTier == kvcache.SpeculativeTier {
+				tier, w = kvcache.SpeculativeTier, 1.0
+			}
+			if cw, ok := weights[tier]; ok {
 				w = cw
 			}
 			if cur, ok := out[e.PodIdentifier]; !ok || w > cur {


### PR DESCRIPTION
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
-->
/kind feature
/kind bug
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/llm-d/llm-d-router/issues/2808

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
Prefix scoring: unconfigured device tiers now weigh 0 instead of 1.0 (speculative entries keep 1.0 by default); default weights added for shared_storage (0.4) and object_store (0.2). These values are heuristic estimates and can be overridden via kvCacheBackendConfigs.
```
