### PR TITLE
fix(agentidentity): trim whitespace from extracted session headers

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity/agent_identity.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity/agent_identity.go
@@ -116,7 +116,7 @@ func (p *Plugin) TypedName() plugin.TypedName {
 
 func (p *Plugin) RequestHeader(_ context.Context, request *scheduling.InferenceRequest) error {
 	for _, header := range p.priorityHeaders {
-		if id := request.Headers[header]; id != "" {
+		if id := strings.TrimSpace(request.Headers[header]); id != "" {
 			request.PutAttribute(AgentIdentityKey, id)
 			return nil
 		}

--- a/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity/agent_identity_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity/agent_identity_test.go
@@ -107,6 +107,30 @@ func TestRequestHeader(t *testing.T) {
 			wantAttrFound: false,
 		},
 		{
+			name: "whitespace-only header falls through to next priority header",
+			headers: map[string]string{
+				ClaudeCodeSessionHeader: "   ",
+				OpenCodeSessionHeader:   "oc-session-1",
+			},
+			wantIdentity:  "oc-session-1",
+			wantAttrFound: true,
+		},
+		{
+			name: "whitespace-only header with no fallback leaves no attribute",
+			headers: map[string]string{
+				ClaudeCodeSessionHeader: "   ",
+			},
+			wantAttrFound: false,
+		},
+		{
+			name: "leading and trailing whitespace is trimmed",
+			headers: map[string]string{
+				ClaudeCodeSessionHeader: "  session-abc  ",
+			},
+			wantIdentity:  "session-abc",
+			wantAttrFound: true,
+		},
+		{
 			name:          "nil body does not panic",
 			headers:       map[string]string{},
 			body:          nil,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Trims leading and trailing whitespace from session headers extracted by the `agentidentity` plugin.

Previously, headers containing only whitespace (e.g., `"   "`) were treated as non-empty, which prevented fallback to lower-priority headers and set a whitespace string as the `agent-identity` attribute. Trimming ensures whitespace-only headers are ignored so subsequent priority headers can be evaluated, and valid IDs are stored clean.

**Test plan**:
- [x] Whitespace-only header falls through to lower-priority session header
- [x] Whitespace-only header with no fallback leaves no attribute
- [x] Leading and trailing whitespace is trimmed from session identity

**Which issue(s) this PR fixes**:
N/A

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
