### PR TITLE
perf(tokenload): guard debug logging in TokenLoadScorer

### DIFF
--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go
@@ -94,8 +94,10 @@ func (s *TokenLoadScorer) Score(ctx context.Context, _ *fwksched.InferenceReques
 	scores := make(map[fwksched.Endpoint]float64, len(endpoints))
 	logger := log.FromContext(ctx)
 
+	debugLogger := logger.V(logutil.DEBUG)
+	debugEnabled := debugLogger.Enabled()
+
 	for _, endpoint := range endpoints {
-		endpointID := endpoint.GetMetadata().ID.String()
 		tokenLoad := 0.0
 
 		// Read both accumulated in-flight load and the projected impact of the
@@ -123,7 +125,13 @@ func (s *TokenLoadScorer) Score(ctx context.Context, _ *fwksched.InferenceReques
 			score = 1.0 - (tokenLoad / s.queueThresholdTokens)
 		}
 		scores[endpoint] = score
-		logger.V(logutil.DEBUG).Info("TokenLoadScorer scoring", "endpoint", endpointID, "tokenLoad", tokenLoad, "score", score)
+		if debugEnabled {
+			endpointID := ""
+			if md := endpoint.GetMetadata(); md != nil {
+				endpointID = md.ID.String()
+			}
+			debugLogger.Info("TokenLoadScorer scoring", "endpoint", endpointID, "tokenLoad", tokenLoad, "score", score)
+		}
 	}
 
 	return scores

--- a/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
+++ b/pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load_test.go
@@ -18,6 +18,7 @@ package tokenload
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -119,4 +120,32 @@ func TestTokenLoadScorer(t *testing.T) {
 		scores := scorer.Score(context.Background(), &fwksched.InferenceRequest{}, endpoints)
 		assert.Equal(t, 1.0, scores[endpoints[0]], "Endpoint with typed nil attribute should have score 1.0 (0 load)")
 	})
+}
+
+func BenchmarkTokenLoadScorer_Score(b *testing.B) {
+	numPods := 8
+	endpoints := make([]fwksched.Endpoint, numPods)
+	scorer := &TokenLoadScorer{
+		typedName:                    fwkplugin.TypedName{Type: TokenLoadScorerType, Name: TokenLoadScorerType},
+		queueThresholdTokens:         1000.0,
+		inFlightLoadDataKey:          attrconcurrency.InFlightLoadDataKey.WithNonEmptyProducerName(""),
+		uncachedRequestTokensDataKey: attrconcurrency.UncachedRequestTokensDataKey.WithNonEmptyProducerName(""),
+	}
+
+	for i := 0; i < numPods; i++ {
+		ep := fwksched.NewEndpoint(&fwkdl.EndpointMetadata{
+			ID: types.NamespacedName{Namespace: "default", Name: fmt.Sprintf("pod%d", i)},
+		}, &fwkdl.Metrics{}, nil)
+		ep.Put(scorer.inFlightLoadDataKey, &attrconcurrency.InFlightLoad{Tokens: int64(i * 100)})
+		endpoints[i] = ep
+	}
+
+	req := &fwksched.InferenceRequest{}
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = scorer.Score(ctx, req, endpoints)
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Guards debug logging statements in `TokenLoadScorer.Score` behind `logger.V(logutil.DEBUG).Enabled()`.

### Problem & Root Cause

In `pkg/epp/framework/plugins/scheduling/scorer/tokenload/token_load.go`, inside the per-endpoint loop executed for every candidate endpoint on every inference request:
1. `endpoint.GetMetadata().ID.String()` was evaluated for every candidate even when DEBUG logging was disabled, contributing to the hot-path overhead.
2. `logger.V(logutil.DEBUG).Info(...)` evaluated variadic arguments (`"endpoint", endpointID, "tokenLoad", tokenLoad, "score", score`), boxing values into interface wrappers and allocating a variadic `[]any` slice even when DEBUG logging was disabled (the production default).

Guarding the debug block behind `if debugEnabled` eliminates these allocations when debug logging is off, following the pattern established in `scheduler_profile.go` and recently applied to pickers in #2806.

### Benchmark Comparison

Benchmarked using `BenchmarkTokenLoadScorer_Score` across 8 candidate endpoints per `Score` call (5 iterations):

| Metric | Before (Unpatched) | After (Guarded) | Delta |
| :--- | :--- | :--- | :--- |
| Execution Time | `2,637 ns/op` | `~1,431 ns/op` | **-45.7%** |
| Memory Allocated | `1,723 B/op` | `~559 B/op` | **-67.5%** |
| Heap Allocations | `51 allocs/op` | `12 allocs/op` | **-76.5% (-39 allocs/op)** |

### Changes Included

- Guarded debug logging and deferred `endpointID` string generation behind `if debugEnabled` in `TokenLoadScorer.Score`.
- Added `BenchmarkTokenLoadScorer_Score` in `token_load_test.go` to track hot-path allocations and prevent future regressions.

**Test Plan**:
- [x] Unit tests pass (`go test -v ./pkg/epp/framework/plugins/scheduling/scorer/tokenload/...`)
- [x] Benchmark executed across 5 iterations with stable allocation reduction (`go test -count=5 -bench=BenchmarkTokenLoadScorer_Score -benchmem ./pkg/epp/framework/plugins/scheduling/scorer/tokenload/...`)
- [x] Linter clean (`golangci-lint run ./pkg/epp/framework/plugins/scheduling/scorer/tokenload/...`)

**Which issue(s) this PR fixes**:
N/A

**Release note**:
```release-note
NONE
```