### PR TITLE
feat(observability): add tenant trace attribution

### DIFF
--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -353,6 +353,13 @@ Configures metrics scraping via Prometheus (compatible with Google Managed Prome
 | `router.tracing.sampling.sampler` | Trace sampler type. | `parentbased_traceidratio` |
 | `router.tracing.sampling.samplerArg` | Sampler argument (e.g., sampling ratio `"0.1"`). | `"0.1"` |
 
+When tracing is enabled, EPP request-associated spans carry `llm_d.epp.tenant_id` and
+`llm_d.epp.tenant_id.source` together. Tenant identity comes only from the
+`x-llm-d-inference-fairness-id` header, with source `header`. If the header is absent,
+the pair is `default-flow` and `default`, even when an agent identity supplies the
+request's scheduling FairnessID. Source `header` identifies the resolution branch, not
+producer authentication. The pair is not propagated as request headers.
+
 #### Complete Monitoring & Tracing Example
 
 ```yaml

--- a/pkg/common/observability/semconv/llm_d.go
+++ b/pkg/common/observability/semconv/llm_d.go
@@ -87,6 +87,13 @@ const (
 	LLMDKVCacheTokenCountKey = attribute.Key("llm_d.kv_cache.token_count")
 	// LLMDKVCacheBlockKeysCountKey is the attribute key for KV cache block keys count.
 	LLMDKVCacheBlockKeysCountKey = attribute.Key("llm_d.kv_cache.block_keys.count")
+
+	// LLMDRequestAttributionIDKey is the resolved request attribution identity.
+	// Always paired with LLMDRequestAttributionSourceKey.
+	LLMDRequestAttributionIDKey = attribute.Key("llm_d.epp.tenant_id")
+	// LLMDRequestAttributionSourceKey is which branch resolved the identity.
+	// "header" is never evidence that the producer was authenticated.
+	LLMDRequestAttributionSourceKey = attribute.Key("llm_d.epp.tenant_id.source")
 )
 
 // Typed helper functions for llm-d internal attributes.
@@ -239,4 +246,14 @@ func LLMDKVCacheTokenCount(count int) attribute.KeyValue {
 // LLMDKVCacheBlockKeysCount returns an attribute for KV cache block keys count.
 func LLMDKVCacheBlockKeysCount(count int) attribute.KeyValue {
 	return LLMDKVCacheBlockKeysCountKey.Int(count)
+}
+
+// LLMDRequestAttributionID returns an attribute for the resolved request attribution identity.
+func LLMDRequestAttributionID(id string) attribute.KeyValue {
+	return LLMDRequestAttributionIDKey.String(id)
+}
+
+// LLMDRequestAttributionSource returns an attribute for how the attribution identity was resolved.
+func LLMDRequestAttributionSource(source string) attribute.KeyValue {
+	return LLMDRequestAttributionSourceKey.String(source)
 }

--- a/pkg/common/observability/tracing/attribution.go
+++ b/pkg/common/observability/tracing/attribution.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/semconv"
+)
+
+const (
+	// DefaultAttributionID marks requests for which no tenant header was provided.
+	DefaultAttributionID = "default-flow"
+
+	// AttributionSourceHeader is the fairness-header resolution branch, not
+	// producer authentication.
+	AttributionSourceHeader = "header"
+	// AttributionSourceDefault is used when no tenant header was provided.
+	AttributionSourceDefault = "default"
+)
+
+// requestAttribution is immutable per-request state shared by every span of
+// that request.
+type requestAttribution struct {
+	id     string
+	source string
+}
+
+// attributionKey avoids colliding with other packages' context keys.
+type attributionKey struct{}
+
+// BeginRequestAttribution attaches fresh per-request tenant attribution. Only
+// the fairness header is a tenant identity; an empty value is unattributed.
+// Call once at the request entry point, before starting spans.
+func BeginRequestAttribution(ctx context.Context, id string) context.Context {
+	attribution := requestAttribution{
+		id:     id,
+		source: AttributionSourceHeader,
+	}
+	if id == "" {
+		attribution.id = DefaultAttributionID
+		attribution.source = AttributionSourceDefault
+	}
+
+	return context.WithValue(ctx, attributionKey{}, attribution)
+}
+
+// RequestAttribution reports ok=false when ctx was never begun, which is
+// distinct from a request that resolved to default-flow.
+func RequestAttribution(ctx context.Context) (id, source string, ok bool) {
+	if ctx == nil {
+		return "", "", false
+	}
+
+	attribution, ok := ctx.Value(attributionKey{}).(requestAttribution)
+	if !ok {
+		return "", "", false
+	}
+
+	return attribution.id, attribution.source, true
+}
+
+func attributionAttributes(id, source string) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		semconv.LLMDRequestAttributionID(id),
+		semconv.LLMDRequestAttributionSource(source),
+	}
+}
+
+// attributionSpanProcessor attributes every span started within an EPP
+// request, including spans started outside Tracer.
+type attributionSpanProcessor struct{}
+
+var _ sdktrace.SpanProcessor = attributionSpanProcessor{}
+
+// NewRequestAttributionProcessor is installed by InitTracing and by tests that
+// build their own provider.
+func NewRequestAttributionProcessor() sdktrace.SpanProcessor { return attributionSpanProcessor{} }
+
+func (attributionSpanProcessor) OnStart(parent context.Context, s sdktrace.ReadWriteSpan) {
+	id, source, ok := RequestAttribution(parent)
+	if !ok || !s.IsRecording() {
+		return
+	}
+
+	s.SetAttributes(attributionAttributes(id, source)...)
+}
+
+func (attributionSpanProcessor) OnEnd(sdktrace.ReadOnlySpan) {}
+
+func (attributionSpanProcessor) Shutdown(context.Context) error { return nil }
+
+func (attributionSpanProcessor) ForceFlush(context.Context) error { return nil }

--- a/pkg/common/observability/tracing/attribution_test.go
+++ b/pkg/common/observability/tracing/attribution_test.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2025 The llm-d Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/llm-d/llm-d-router/pkg/common/observability/semconv"
+)
+
+// installAttributionRecorder makes a recording SDK provider global, with the
+// same attribution span processor InitTracing registers, and returns the
+// recorder.
+func installAttributionRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(NewRequestAttributionProcessor()),
+		sdktrace.WithSpanProcessor(recorder),
+	)
+	original := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(original)
+		_ = tp.Shutdown(context.Background())
+	})
+
+	return recorder
+}
+
+// endedAttribution returns the paired attribution values recorded on the
+// ended span named name.
+func endedAttribution(t *testing.T, recorder *tracetest.SpanRecorder, name string) (id, source string, present bool) {
+	t.Helper()
+
+	for _, span := range recorder.Ended() {
+		if span.Name() != name {
+			continue
+		}
+		var hasID, hasSource bool
+		for _, attr := range span.Attributes() {
+			switch attr.Key {
+			case semconv.LLMDRequestAttributionIDKey:
+				id, hasID = attr.Value.AsString(), true
+			case semconv.LLMDRequestAttributionSourceKey:
+				source, hasSource = attr.Value.AsString(), true
+			}
+		}
+		return id, source, hasID && hasSource
+	}
+
+	t.Fatalf("no ended span named %q; recorded %d spans", name, len(recorder.Ended()))
+	return "", "", false
+}
+
+func TestRequestAttributionResolution(t *testing.T) {
+	tests := []struct {
+		name       string
+		headerID   string
+		wantID     string
+		wantSource string
+	}{
+		{
+			name:       "empty header defaults",
+			wantID:     DefaultAttributionID,
+			wantSource: AttributionSourceDefault,
+		},
+		{
+			name:       "header becomes tenant identity",
+			headerID:   "tenant-a",
+			wantID:     "tenant-a",
+			wantSource: AttributionSourceHeader,
+		},
+		{
+			name:       "header identity preserved verbatim",
+			headerID:   "a-very-long-identity-with-/slashes-and-uppercase-KEPT-verbatim",
+			wantID:     "a-very-long-identity-with-/slashes-and-uppercase-KEPT-verbatim",
+			wantSource: AttributionSourceHeader,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := BeginRequestAttribution(context.Background(), tc.headerID)
+
+			id, source, ok := RequestAttribution(ctx)
+			if !ok {
+				t.Fatal("RequestAttribution() ok = false, want true after BeginRequestAttribution")
+			}
+			if id != tc.wantID || source != tc.wantSource {
+				t.Errorf("RequestAttribution() = (%q, %q), want (%q, %q)", id, source, tc.wantID, tc.wantSource)
+			}
+		})
+	}
+}
+
+// An unattributed context has to be distinguishable from one that resolved to
+// default-flow: background spans must not look like unattributed requests.
+func TestRequestAttributionAbsent(t *testing.T) {
+	if id, source, ok := RequestAttribution(context.Background()); ok {
+		t.Errorf("RequestAttribution() = (%q, %q, true), want ok = false on a plain context", id, source)
+	}
+}
+
+func TestRequestAttributionVisibleAcrossDerivedContexts(t *testing.T) {
+	root := BeginRequestAttribution(context.Background(), "tenant-a")
+	derived, cancel := context.WithCancel(root)
+	defer cancel()
+
+	for name, ctx := range map[string]context.Context{"entry point": root, "derived": derived} {
+		id, source, ok := RequestAttribution(ctx)
+		if !ok || id != "tenant-a" || source != AttributionSourceHeader {
+			t.Errorf("%s: RequestAttribution() = (%q, %q, %v), want (tenant-a, header, true)", name, id, source, ok)
+		}
+	}
+}
+
+func TestSpanProcessorAttributesRequestSpanTree(t *testing.T) {
+	recorder := installAttributionRecorder(t)
+	tracer := Tracer("attribution-test")
+
+	ctx := BeginRequestAttribution(context.Background(), "tenant-a")
+	ctx, root := tracer.Start(ctx, "request")
+	_, child := tracer.Start(ctx, "child")
+	child.End()
+	root.End()
+
+	for _, name := range []string{"request", "child"} {
+		id, source, present := endedAttribution(t, recorder, name)
+		if !present {
+			t.Fatalf("span %q carries no paired attribution", name)
+		}
+		if id != "tenant-a" || source != AttributionSourceHeader {
+			t.Errorf("span %q attribution = (%q, %q), want (tenant-a, header)", name, id, source)
+		}
+	}
+}
+
+// Spans of one concurrent request must never report another request's tenant.
+// Run under -race.
+func TestSpanAttributionIsolatedAcrossConcurrentRequests(t *testing.T) {
+	recorder := installAttributionRecorder(t)
+	tracer := Tracer("attribution-test")
+
+	const requests = 16
+
+	var wg sync.WaitGroup
+	for i := range requests {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			tenant := fmt.Sprintf("tenant-%02d", i)
+			ctx := BeginRequestAttribution(context.Background(), tenant)
+			ctx, root := tracer.Start(ctx, "request/"+tenant)
+			_, child := tracer.Start(ctx, "child/"+tenant)
+			child.End()
+			root.End()
+		}(i)
+	}
+	wg.Wait()
+
+	for _, span := range recorder.Ended() {
+		_, tenant, found := strings.Cut(span.Name(), "/")
+		if !found {
+			t.Fatalf("unexpected span %q", span.Name())
+		}
+
+		id, source, present := endedAttribution(t, recorder, span.Name())
+		if !present {
+			t.Errorf("span %q carries no paired attribution", span.Name())
+			continue
+		}
+		if id != tenant || source != AttributionSourceHeader {
+			t.Errorf("span %q attribution = (%q, %q), want (%q, header)", span.Name(), id, source, tenant)
+		}
+	}
+}
+
+// Background work is not a request and must not be attributed: a default
+// identity on a cache-refresh or metrics span would read as an unattributed
+// request.
+func TestBackgroundSpansCarryNoAttribution(t *testing.T) {
+	recorder := installAttributionRecorder(t)
+	tracer := Tracer("attribution-test")
+
+	_, span := tracer.Start(context.Background(), "background")
+	span.End()
+
+	for _, ended := range recorder.Ended() {
+		for _, attr := range ended.Attributes() {
+			if attr.Key == semconv.LLMDRequestAttributionIDKey || attr.Key == semconv.LLMDRequestAttributionSourceKey {
+				t.Errorf("background span carries %s = %q", attr.Key, attr.Value.AsString())
+			}
+		}
+	}
+}
+
+// Instrumentation that holds its own tracer from the global provider, such as
+// otelhttp's middleware, is attributed by the span processor rather than by
+// Tracer.
+func TestSpanProcessorAttributesRawProviderSpans(t *testing.T) {
+	recorder := installAttributionRecorder(t)
+
+	ctx := BeginRequestAttribution(context.Background(), "tenant-a")
+	_, span := otel.Tracer("raw-instrumentation").Start(ctx, "http-server")
+	span.End()
+
+	id, source, present := endedAttribution(t, recorder, "http-server")
+	if !present {
+		t.Fatal("span started outside Tracer carries no paired attribution")
+	}
+	if id != "tenant-a" || source != AttributionSourceHeader {
+		t.Errorf("attribution = (%q, %q), want (tenant-a, header)", id, source)
+	}
+}
+
+// With tracing off every span is non-recording, and attribution must neither
+// panic nor force the SDK's recording path.
+func TestAttributionWithTracingDisabled(t *testing.T) {
+	original := otel.GetTracerProvider()
+	otel.SetTracerProvider(tracenoop.NewTracerProvider())
+	t.Cleanup(func() { otel.SetTracerProvider(original) })
+
+	ctx := BeginRequestAttribution(context.Background(), "tenant-a")
+	ctx, span := Tracer("attribution-test").Start(ctx, "request")
+	if span.IsRecording() {
+		t.Fatal("noop provider returned a recording span")
+	}
+	span.End()
+
+	if id, source, ok := RequestAttribution(ctx); !ok || id != "tenant-a" || source != AttributionSourceHeader {
+		t.Errorf("RequestAttribution() = (%q, %q, %v), want (tenant-a, header, true)", id, source, ok)
+	}
+}

--- a/pkg/common/observability/tracing/telemetry.go
+++ b/pkg/common/observability/tracing/telemetry.go
@@ -73,10 +73,12 @@ func InitTracing(ctx context.Context, logger logr.Logger, defaultServiceName str
 	opt := []sdktrace.TracerProviderOption{
 		sdktrace.WithSampler(sampler),
 		sdktrace.WithResource(res),
+		// Registered ahead of the exporter's processor so attributes added at OnStart
+		// are present on the span the exporter later reads.
+		sdktrace.WithSpanProcessor(NewRequestAttributionProcessor()),
 	}
 
-	// "none" registers no span processor at all. Spans are still created and
-	// propagated, so instrumented code and context propagation are unaffected.
+	// "none" skips the exporter batcher. The attribution processor above still runs.
 	if exporterType == exporterTypeNone {
 		logger.Info("init OTel trace exporter", "type", exporterType)
 	} else {
@@ -373,6 +375,10 @@ const instrumentationName = "llm-d-router"
 // Tracer returns a tracer for the given instrumentation scope, defaulting to
 // "llm-d-router". Build version and commit SHA are attached so every span in a
 // trace carries consistent scope metadata.
+//
+// Spans started from a context carrying request attribution are enriched with the
+// attribution pair by the span processor InitTracing installs. See
+// BeginRequestAttribution.
 func Tracer(scope ...string) trace.Tracer {
 	name := instrumentationName
 	if len(scope) > 0 && scope[0] != "" {

--- a/pkg/epp/handlers/request_test.go
+++ b/pkg/epp/handlers/request_test.go
@@ -23,11 +23,17 @@ import (
 	configPb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/llm-d/llm-d-router/pkg/common/observability/semconv"
+	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 )
@@ -380,5 +386,50 @@ func (m *mockDirectorRequest) GetRandomEndpoint() *datalayer.EndpointMetadata {
 	return &datalayer.EndpointMetadata{
 		Address: "1.2.3.4",
 		Port:    "80",
+	}
+}
+
+// Attribution must be established from the incoming headers before the Director
+// runs, so a request that fails or returns early is still attributed.
+func TestRequestAttributionAtIngress(t *testing.T) {
+	previous := otel.GetTracerProvider()
+	recorder := tracetest.NewSpanRecorder()
+	// Mirror InitTracing: the processor is what attributes spans in production.
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(tracing.NewRequestAttributionProcessor()),
+		sdktrace.WithSpanProcessor(recorder),
+	)
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() { otel.SetTracerProvider(previous); _ = provider.Shutdown(context.Background()) })
+
+	for _, tc := range []struct {
+		name               string
+		headers            []*configPb.HeaderValue
+		wantID, wantSource string
+	}{
+		{"canonical header", []*configPb.HeaderValue{{Key: metadata.FlowFairnessIDKey, Value: "team-a"}}, "team-a", tracing.AttributionSourceHeader},
+		{"deprecated alias", []*configPb.HeaderValue{{Key: metadata.OldFlowFairnessIDKey, Value: "team-b"}}, "team-b", tracing.AttributionSourceHeader},
+		{"empty canonical shadows alias", []*configPb.HeaderValue{{Key: metadata.FlowFairnessIDKey, Value: ""}, {Key: metadata.OldFlowFairnessIDKey, Value: "team-b"}}, tracing.DefaultAttributionID, tracing.AttributionSourceDefault},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := extractTraceContext(context.Background(), &extProcPb.ProcessingRequest_RequestHeaders{
+				RequestHeaders: &extProcPb.HttpHeaders{
+					Headers:     &configPb.HeaderMap{Headers: tc.headers},
+					EndOfStream: true,
+				},
+			})
+
+			_, span := tracing.Tracer().Start(ctx, "request")
+			span.End()
+
+			ended := recorder.Ended()
+			attrs := attribute.NewSet(ended[len(ended)-1].Attributes()...)
+			id, hasID := attrs.Value(semconv.LLMDRequestAttributionIDKey)
+			source, hasSource := attrs.Value(semconv.LLMDRequestAttributionSourceKey)
+
+			require.True(t, hasID && hasSource, "identity and source are recorded together")
+			assert.Equal(t, tc.wantID, id.AsString())
+			assert.Equal(t, tc.wantSource, source.AsString())
+		})
 	}
 }

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -251,7 +251,9 @@ func extractTraceContext(ctx context.Context, req *extProcPb.ProcessingRequest_R
 			carrier[strings.ToLower(header.Key)] = envoy.GetHeaderValue(header)
 		}
 	}
-	return otel.GetTextMapPropagator().Extract(ctx, carrier)
+	ctx = otel.GetTextMapPropagator().Extract(ctx, carrier)
+	id, _ := metadata.GetLowerCaseHeaderValue(carrier, metadata.FlowFairnessIDKey)
+	return tracing.BeginRequestAttribution(ctx, id)
 }
 
 // terminationCause classifies a stream that ended without completing. ctxErr is the request

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -191,6 +191,10 @@ func (d *Director) getInferenceObjective(ctx context.Context, reqCtx *handlers.R
 // HandleRequest orchestrates the request lifecycle.
 // It always returns the requestContext even in the error case, as the request context is used in error handling.
 func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) (_ *handlers.RequestContext, err error) {
+	if _, _, ok := tracing.RequestAttribution(ctx); !ok {
+		id, _ := metadata.GetLowerCaseHeaderValue(reqCtx.Request.Headers, metadata.FlowFairnessIDKey)
+		ctx = tracing.BeginRequestAttribution(ctx, id)
+	}
 	tracer := tracing.Tracer("llm-d-router/pkg/epp/requestcontrol")
 	ctx, span := tracer.Start(ctx, "request_orchestration", trace.WithSpanKind(trace.SpanKindServer))
 	defer func() {

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -31,6 +31,10 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,6 +48,8 @@ import (
 	"github.com/llm-d/llm-d-router/apix/v1alpha2"
 	errcommon "github.com/llm-d/llm-d-router/pkg/common/error"
 	logutil "github.com/llm-d/llm-d-router/pkg/common/observability/logging"
+	"github.com/llm-d/llm-d-router/pkg/common/observability/semconv"
+	"github.com/llm-d/llm-d-router/pkg/common/observability/tracing"
 	reqcommon "github.com/llm-d/llm-d-router/pkg/common/request"
 	"github.com/llm-d/llm-d-router/pkg/common/routing"
 	"github.com/llm-d/llm-d-router/pkg/epp/datalayer"
@@ -426,6 +432,8 @@ func TestDirector_HandleRequest(t *testing.T) {
 		wantRawBodyUnchanged    bool   // If true, assert reqCtx.Request.RawBody is byte-identical to the marshaled reqBodyMap (no rewrite occurred).
 		fairnessIDHeader        string // If non-empty, set as metadata.FlowFairnessIDKey on the incoming request.
 		wantFairnessID          string // If non-empty, asserted against returnedReqCtx.SchedulingRequest.FairnessID.
+		wantTenantID            string // If non-empty, asserted against request_orchestration span tenant ID.
+		wantSource              string // If non-empty, asserted against request_orchestration span source.
 		rewrites                []*v1alpha2.InferenceModelRewrite
 	}{
 		{
@@ -500,6 +508,8 @@ func TestDirector_HandleRequest(t *testing.T) {
 			inferenceObjectiveName: objectiveName,
 			fairnessIDHeader:       "user-123",
 			wantFairnessID:         "user-123",
+			wantTenantID:           "user-123",
+			wantSource:             tracing.AttributionSourceHeader,
 		},
 		{
 			name: "fairness ID falls back to default when header absent",
@@ -514,9 +524,10 @@ func TestDirector_HandleRequest(t *testing.T) {
 			initialTargetModelName: model,
 			inferenceObjectiveName: objectiveName,
 			wantFairnessID:         metadata.DefaultFairnessID,
+			wantSource:             tracing.AttributionSourceDefault,
 		},
 		{
-			name: "fairness ID derived from agent-identity attribute",
+			name: "agent identity remains scheduling fallback but tenant defaults",
 			reqBodyMap: map[string]any{
 				"model":  model,
 				"prompt": "critical prompt",
@@ -533,6 +544,8 @@ func TestDirector_HandleRequest(t *testing.T) {
 				attributeValue: "session-abc",
 			},
 			wantFairnessID: "session-abc",
+			wantTenantID:   metadata.DefaultFairnessID,
+			wantSource:     tracing.AttributionSourceDefault,
 		},
 		{
 			name: "explicit fairness header takes precedence over agent-identity attribute",
@@ -553,6 +566,8 @@ func TestDirector_HandleRequest(t *testing.T) {
 				attributeValue: "session-abc",
 			},
 			wantFairnessID: "explicit-id",
+			wantTenantID:   "explicit-id",
+			wantSource:     tracing.AttributionSourceHeader,
 		},
 		{
 			name: "successful request with preRequest plugin adding key",
@@ -941,12 +956,14 @@ func TestDirector_HandleRequest(t *testing.T) {
 			inferenceObjectiveName:  objectiveNameSheddable,
 			mockAdmissionController: &mockAdmissionController{admitErr: errcommon.Error{Code: errcommon.ResourceExhausted, Msg: "simulated admission rejection"}},
 			wantErrCode:             errcommon.ResourceExhausted,
+			wantSource:              tracing.AttributionSourceDefault,
 		},
 		{
 			name:                    "model not found, expect err",
 			reqBodyMap:              map[string]any{"prompt": "p"},
 			mockAdmissionController: &mockAdmissionController{admitErr: nil},
 			wantErrCode:             errcommon.BadRequest,
+			wantSource:              tracing.AttributionSourceDefault,
 		},
 		{
 			name:                    "missing model field resolved by generic rewrite",
@@ -1113,6 +1130,17 @@ func TestDirector_HandleRequest(t *testing.T) {
 					datalayer.RegisterScopeSpecs([]fwkplugin.Plugin{test.dataProducerPlugin})
 					config = config.WithDataProducerPlugins(test.dataProducerPlugin)
 				}
+				var recorder *tracetest.SpanRecorder
+				if test.wantSource != "" {
+					recorder = tracetest.NewSpanRecorder()
+					previousProvider := otel.GetTracerProvider()
+					provider := sdktrace.NewTracerProvider(
+						sdktrace.WithSpanProcessor(tracing.NewRequestAttributionProcessor()),
+						sdktrace.WithSpanProcessor(recorder),
+					)
+					otel.SetTracerProvider(provider)
+					t.Cleanup(func() { otel.SetTracerProvider(previousProvider); _ = provider.Shutdown(context.Background()) })
+				}
 				if test.screener != nil {
 					config = config.WithScreeners(test.screener)
 				}
@@ -1176,6 +1204,26 @@ func TestDirector_HandleRequest(t *testing.T) {
 					err = errcommon.Error{Code: errcommon.BadRequest, Msg: parseErr.Error()}
 				} else {
 					returnedReqCtx, err = director.HandleRequest(ctx, reqCtx, parseResult.Body)
+				}
+				if parseErr == nil && test.wantSource != "" {
+					wantID := test.wantTenantID
+					if wantID == "" {
+						wantID = metadata.DefaultFairnessID
+					}
+					found := false
+					for _, span := range recorder.Ended() {
+						if span.Name() != "request_orchestration" {
+							continue
+						}
+						found = true
+						attrs := attribute.NewSet(span.Attributes()...)
+						id, hasID := attrs.Value(semconv.LLMDRequestAttributionIDKey)
+						source, hasSource := attrs.Value(semconv.LLMDRequestAttributionSourceKey)
+						require.True(t, hasID && hasSource, "attribution must be paired")
+						assert.Equal(t, wantID, id.AsString())
+						assert.Equal(t, test.wantSource, source.AsString())
+					}
+					require.True(t, found, "request orchestration span must exist")
 				}
 
 				if test.wantErrCode != "" {


### PR DESCRIPTION
## Summary

- resolve tenant trace attribution from the canonical fairness header, with compatibility for the deprecated header and a bounded default
- attach tenant attribution consistently across the complete EPP request and scheduling span tree
- keep agent session identity separate from tenant attribution
- document the new semantic attributes and their cardinality expectations

Related to #2793.

## Attribution behavior

| Request identity | `llm_d.epp.tenant_id` | `llm_d.epp.tenant_id.source` |
|---|---|---|
| `x-llm-d-inference-fairness-id` | canonical header value | `header` |
| Deprecated fairness header only | deprecated header value | `header` |
| Both fairness headers | canonical header value | `header` |
| No fairness identity | `default-flow` | `default` |
| Agent session only | `default-flow` | `default` |

Agent session identity remains available to scheduling but is not reported as tenant attribution.

## Release note

```release-note
EPP traces now include tenant identity and attribution-source attributes resolved from inference fairness headers, enabling tenant-filtered trace analysis.
```

## Testing

| Validation | Result |
|---|---|
| Local Kind inference through Istio, EPP, and the vLLM simulator | PASS - 5/5 requests |
| OTLP export to Jaeger | PASS - 5/5 traces |
| Tenant attributes across EPP scheduling spans | PASS - 40/40 spans |
| Conflicting deprecated value used as tenant | PASS - 0 occurrences |
| Agent session value used as tenant | PASS - 0 occurrences |
| EPP runtime errors during validation | PASS - 0/251 log entries |

### Canonical fairness header

<img width="3022" height="1558" alt="image" src="https://github.com/user-attachments/assets/8dd1e46f-4e0c-49f8-8bd9-824aca5529f5" />

The trace contains all eight EPP request and scheduling spans. Each span carries the canonical tenant value with `llm_d.epp.tenant_id.source=header`.

### Agent identity isolation

<img width="3022" height="1558" alt="image" src="https://github.com/user-attachments/assets/8a10d9c0-1867-4ccb-bff9-92e6e0c459e4" />

The trace contains all eight EPP spans with `llm_d.epp.tenant_id=default-flow` and `llm_d.epp.tenant_id.source=default`. The supplied agent session identity is not used as tenant attribution.