### PR TITLE
docs(dataproducer): explain ProducerPlugin vs DataProducer

### DIFF
--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/README.md
@@ -10,6 +10,29 @@ Producers may also implement additional lifecycle hooks:
 - `PreRequest` — called after a routing decision is made; used to persist bookkeeping state (e.g., update a cache index, increment an in-flight counter).
 - `ResponseHeader` / `ResponseBody` — called as response data arrives; used to collect training data or release in-flight counters.
 
+## Choosing between ProducerPlugin and DataProducer
+
+[`plugin.ProducerPlugin`](../../../interface/plugin/plugins.go) declares the data keys a plugin writes, through `Produces()`. [`requestcontrol.DataProducer`](../../../interface/requestcontrol/plugins.go) embeds it and adds `Produce()`, which the director calls on every request.
+
+The framework reads `Produces()` and `Consumes()` at startup ([`data_graph.go`](../../../../datalayer/data_graph.go)). Startup fails when a producer and a consumer of the same key declare different types, or when the producer belongs to a later layer (flow control, request control, scheduling) than its consumer. A `Required` key that no configured plugin produces gets the default producer registered for that key; with no registered default, startup fails with `ErrNoDefaultProducer`.
+
+The same declarations limit the endpoint attributes a plugin reaches at request time ([`endpoint_scope.go`](../../../../datalayer/endpoint_scope.go)). A plugin writes only the keys in its `Produces()` and reads only the keys in its `Consumes()` or `Produces()`. A write to an undeclared key is dropped and returned as that producer's error, which the director logs. A read of an undeclared key finds nothing. A `DataProducer` with an empty `Produces()` writes no endpoint attributes and adds no DAG edges as a producer; it still reads the keys in its `Consumes()`.
+
+A plugin that only extracts data from model servers, such as the [models extractor](../../datalayer/extractor/models/extractor.go), implements `ProducerPlugin` and a datalayer extractor interface, without `DataProducer`. Extractors write to the datastore endpoint directly, outside the request-time scope. The [Data Layer](https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/router/epp/datalayer.md) doc describes extractors.
+
+`Produce()` runs after screeners and before admission. Each request gets its own copy of every candidate endpoint's attribute map, so a value a producer puts on an endpoint is visible to that request only. The copy is of the map entries: a `DynamicAttribute` entry keeps its getter and resolves the current value on every `Get` ([`attributemap.go`](../../../interface/datalayer/attributemap.go)). A value about the request as a whole goes in `InferenceRequest.PutAttribute`, with its key still declared in `Produces()` so that consumers are ordered after the producer, as in [`sessionid`](sessionid/producer.go).
+
+Per-endpoint state shared across requests lives in the plugin. In [`inflightload`](inflightload/producer.go), `Extract` (an `EndpointExtractor`) puts a `DynamicAttribute` over the plugin's counters on each datastore endpoint, `PreRequest` and `ResponseBody` update the counters, and `Produce` writes only the per-request `UncachedRequestTokens`.
+
+The DAG order applies to every request-control hook (`PreRequest`, `ResponseBody` and the rest). Plugins outside the DAG run after the ordered ones, sorted by name ([`request_control_config.go`](../../../../requestcontrol/request_control_config.go)).
+
+| What the data is | What to implement |
+|---|---|
+| Data scraped from model servers | `ProducerPlugin` with a datalayer extractor, as in the models extractor |
+| A value per candidate endpoint for this request | `DataProducer` that puts the value on the endpoints, as in `approx-prefix-cache-producer` |
+| A value for the request as a whole | `DataProducer` that calls `PutAttribute`, as in `session-id-producer` |
+| Per-endpoint state shared across requests | `EndpointExtractor` with a `DynamicAttribute` over state updated in `PreRequest` and `ResponseBody`, as in `inflight-load-producer` |
+
 ## Available Producers
 
 | Plugin type | Package | Produces | Summary |


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The dataproducer README lists the producers and how they're ordered, but doesn't say when a plugin should implement `plugin.ProducerPlugin` on its own and when it needs `requestcontrol.DataProducer`, or whether a value one request writes is visible to other requests.

Adds a "Choosing between ProducerPlugin and DataProducer" section above "Available Producers". It describes what startup checks against `Produces()`/`Consumes()`, how the same declarations confine endpoint reads and writes per request, and how per-request writes differ from `DynamicAttribute` state kept across requests, using `inflight-load-producer` as the example. A table at the end maps each kind of data to the interface to implement. Statements link the code they describe. No code change.

Verified: every linked file and named symbol exists at `main` (bb2113e4), lychee with the repo's `.lychee.toml` reports 31/31 links OK on the README, and `typos` passes.

**Which issue(s) this PR fixes**:

Fixes #1245

**Release note** _(write `NONE` if no user-facing change)_:
```release-note
NONE
```
